### PR TITLE
PR1: freeze artifact contracts and enable e2e tests

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -187,7 +187,9 @@ def diagnostic_codes(
 ) -> list[str]:
     codes: set[str] = set()
     for diag in diagnostics:
-        if isinstance(diag, DiagnosticArtifact) and diag.severity == severity and diag.code:
+        if not isinstance(diag, DiagnosticArtifact):
+            raise TypeError("diagnostics must contain DiagnosticArtifact only")
+        if diag.severity == severity and diag.code:
             codes.add(diag.code)
     return sorted(codes)
 

--- a/artifacts.py
+++ b/artifacts.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Any, Optional
 
 
-
 @dataclass
 class CalculationArtifact:
     calculation_id: str
@@ -33,6 +32,7 @@ class CalculationArtifact:
     metadata: dict[str, Any] = field(default_factory=dict)
     calculated_at: datetime = field(default_factory=datetime.utcnow)
 
+
 @dataclass
 class GovernanceDecisionArtifact:
     decision_id: str
@@ -50,6 +50,7 @@ class GovernanceDecisionArtifact:
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=datetime.utcnow)
 
+
 @dataclass
 class DiagnosticArtifact:
     diagnostic_id: str
@@ -66,13 +67,14 @@ class DiagnosticArtifact:
     fragment_id: Optional[str] = None
     span: Optional[tuple[int, int]] = None
 
-    rule_kind: Optional[str] = None   # require | forbid | diagnostic
+    rule_kind: Optional[str] = None   # require | forbid | diagnostic | inference
     source_key: Optional[str] = None  # e.g. require:3, warning:AggregateRow
-    phase: Optional[str] = None       # semantic_pre / semantic_post
+    phase: Optional[str] = None       # semantic_pre / semantic_post / inference
 
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=datetime.utcnow)
-    
+
+
 @dataclass
 class TokenOccurrence:
     token_id: str
@@ -137,6 +139,15 @@ class RoleSlotArtifact:
 
     metadata: dict[str, Any] = field(default_factory=dict)
 
+
+@dataclass
+class FrameRuntimeState:
+    resolution_score: float = 0.0
+    iteration_count: int = 0
+    stable_count: int = 0
+    termination_reason: Optional[str] = None
+
+
 @dataclass
 class PartialFrameArtifact:
     frame_id: str
@@ -148,6 +159,7 @@ class PartialFrameArtifact:
 
     diagnostics: list[DiagnosticArtifact] = field(default_factory=list)
     status: str = "resolving"
+    runtime: FrameRuntimeState = field(default_factory=FrameRuntimeState)
 
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=datetime.utcnow)
@@ -166,7 +178,27 @@ class CompileArtifacts:
     event_log: list[Any] = field(default_factory=list)
     commit_log: list[Any] = field(default_factory=list)
     merge_log: list[GovernanceDecisionArtifact] = field(default_factory=list)
-    
+
+
+def diagnostic_codes(
+    diagnostics: list[DiagnosticArtifact],
+    *,
+    severity: str,
+) -> list[str]:
+    codes: set[str] = set()
+    for diag in diagnostics:
+        if isinstance(diag, DiagnosticArtifact) and diag.severity == severity and diag.code:
+            codes.add(diag.code)
+    return sorted(codes)
+
+
+def warning_codes_from_diagnostics(diagnostics: list[DiagnosticArtifact]) -> list[str]:
+    return diagnostic_codes(diagnostics, severity="warning")
+
+
+def error_codes_from_diagnostics(diagnostics: list[DiagnosticArtifact]) -> list[str]:
+    return diagnostic_codes(diagnostics, severity="error")
+
 
 @dataclass
 class LineageEvidenceArtifact:

--- a/emit_pass.py
+++ b/emit_pass.py
@@ -11,6 +11,8 @@ from artifacts import (
     LineageEvidenceArtifact,
     PartialFrameArtifact,
     RoleLineageArtifact,
+    error_codes_from_diagnostics,
+    warning_codes_from_diagnostics,
 )
 from runtime_env import RuntimeEnv
 
@@ -91,20 +93,8 @@ class EmitPass:
 
         lineage = self._build_lineage(frame, claims_by_id)
 
-        warning_codes = sorted(
-            {
-                d.get("code")
-                for d in frame.diagnostics
-                if isinstance(d, dict) and d.get("severity") == "warning" and d.get("code")
-            }
-        )
-        error_codes = sorted(
-            {
-                d.get("code")
-                for d in frame.diagnostics
-                if isinstance(d, dict) and d.get("severity") == "error" and d.get("code")
-            }
-        )
+        warning_codes = warning_codes_from_diagnostics(frame.diagnostics)
+        error_codes = error_codes_from_diagnostics(frame.diagnostics)
 
         if self.config.skip_empty_rows:
             all_core_empty = (
@@ -135,7 +125,7 @@ class EmitPass:
             standardized_unit=standardized_unit,
 
             scope_category=scope_category,
-            resolution_score=float(frame.resolution_score),
+            resolution_score=float(frame.runtime.resolution_score),
             lineage=lineage,
 
             source_fragment_ids=list(frame.fragment_ids),
@@ -143,9 +133,9 @@ class EmitPass:
             error_codes=error_codes,
 
             metadata={
-                "iteration_count": frame.iteration_count,
-                "stable_count": frame.stable_count,
-                "termination_reason": frame.termination_reason,
+                "iteration_count": frame.runtime.iteration_count,
+                "stable_count": frame.runtime.stable_count,
+                "termination_reason": frame.runtime.termination_reason,
                 "repair_trace_len": len(frame.metadata.get("repair_trace", [])),
             },
         )

--- a/inference_pass.py
+++ b/inference_pass.py
@@ -8,8 +8,11 @@ from typing import Any, Optional
 from artifacts import (
     ClaimArtifact,
     CompileArtifacts,
+    DiagnosticArtifact,
     PartialFrameArtifact,
     RoleSlotArtifact,
+    error_codes_from_diagnostics,
+    warning_codes_from_diagnostics,
 )
 from expr_eval import EvalContext, ExprEvaluator
 from runtime_env import RuntimeEnv, ScopePath
@@ -55,6 +58,7 @@ class InferencePass:
         self.evaluator = evaluator or ExprEvaluator()
         self.config = config or InferencePassConfig()
         self._claim_seq = count(1)
+        self._diag_seq = count(1)
 
     def run(
         self,
@@ -155,12 +159,20 @@ class InferencePass:
 
         frame.frame_type = new_type
         frame.diagnostics.append(
-            {
-                "severity": "info",
-                "code": "FrameTypeInferred",
-                "message": f"frame_type inferred as {new_type}",
-                "rule_target": rule.target_name,
-            }
+            DiagnosticArtifact(
+                diagnostic_id=f"DGN-INF-{next(self._diag_seq):07d}",
+                severity="info",
+                code="FrameTypeInferred",
+                message=f"frame_type inferred as {new_type}",
+                scope_kind="frame",
+                scope_id=frame.frame_id,
+                frame_id=frame.frame_id,
+                fragment_id=frame.fragment_ids[0] if frame.fragment_ids else None,
+                rule_kind="inference",
+                source_key=f"infer:{rule.target_name}",
+                phase="inference",
+                metadata={"rule_target": rule.target_name},
+            )
         )
         return True
 
@@ -392,19 +404,7 @@ class InferencePass:
         return getattr(frag, "scope_path", tuple())
 
     def _frame_warning_codes(self, frame: PartialFrameArtifact) -> set[str]:
-        codes = set()
-        for d in getattr(frame, "diagnostics", []):
-            if isinstance(d, dict) and d.get("severity") == "warning":
-                code = d.get("code")
-                if code:
-                    codes.add(code)
-        return codes
+        return set(warning_codes_from_diagnostics(frame.diagnostics))
 
     def _frame_error_codes(self, frame: PartialFrameArtifact) -> set[str]:
-        codes = set()
-        for d in getattr(frame, "diagnostics", []):
-            if isinstance(d, dict) and d.get("severity") == "error":
-                code = d.get("code")
-                if code:
-                    codes.add(code)
-        return codes
+        return set(error_codes_from_diagnostics(frame.diagnostics))

--- a/repair_pass.py
+++ b/repair_pass.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from itertools import count
 from typing import Any, Optional
 
-from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
+from artifacts import (
+    ClaimArtifact,
+    CompileArtifacts,
+    PartialFrameArtifact,
+    RoleSlotArtifact,
+    diagnostic_codes,
+)
 from expr_eval import EvalContext, ExprEvaluator
 from runtime_env import RuntimeEnv
 from spec_nodes import ProgramSpec, ResolverPolicy
@@ -115,8 +121,11 @@ class RepairPass:
         state_history: list[tuple] = []
 
         termination_reason = None
+        last_iter_no = 0
 
         for iter_no in range(1, max_iter + 1):
+            last_iter_no = iter_no
+
             # 1) diagnostics snapshot
             warning_codes = self._diag_codes(frame, severity="warning")
             error_codes = self._diag_codes(frame, severity="error")
@@ -217,13 +226,18 @@ class RepairPass:
             prev_score = frame_score
             prev_signature = signature
 
+        if last_iter_no > 0 and termination_reason is None:
+            termination_reason = "max_iter_exhausted"
+
+        final_score = self._frame_score(frame, claims_by_id)
+
         # loop 종료 후 최종 판정
         final_ctx = EvalContext(
             env=env,
             frame=frame,
             claims_by_id=claims_by_id,
             local_vars={
-                "score": self._frame_score(frame, claims_by_id),
+                "score": final_score,
                 "stable": frame_stable,
                 "status": frame.status,
             },
@@ -240,8 +254,14 @@ class RepairPass:
             else:
                 frame.status = "resolving"
 
+        frame.runtime.resolution_score = final_score
+        frame.runtime.iteration_count = last_iter_no
+        frame.runtime.stable_count = frame_stable
+        frame.runtime.termination_reason = termination_reason
+
+        # backward-compatible mirrors; read paths should prefer frame.runtime.
         frame.metadata["termination_reason"] = termination_reason
-        frame.metadata["final_score"] = self._frame_score(frame, claims_by_id)
+        frame.metadata["final_score"] = final_score
 
     # ------------------------------------------------------------------
     # Slot repair
@@ -636,13 +656,7 @@ class RepairPass:
         *,
         severity: str,
     ) -> set[str]:
-        codes = set()
-        for d in frame.diagnostics:
-            if getattr(d, "severity", None) == severity:
-                code = getattr(d, "code", None)
-                if code:
-                    codes.add(code)
-        return codes
+        return set(diagnostic_codes(frame.diagnostics, severity=severity))
 
     def _extract_policy_params(
         self,

--- a/tests/support/serialize.py
+++ b/tests/support/serialize.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from artifacts import CompileArtifacts
-
-# NOTE(PR0): serializer intentionally tolerates mixed diagnostic shapes.
-# This is temporary and must be removed in PR1.
+from artifacts import CompileArtifacts, DiagnosticArtifact
 
 
 def project_result(result: Any) -> dict[str, Any]:
@@ -19,13 +16,7 @@ def project_artifacts(artifacts: CompileArtifacts) -> dict[str, Any]:
                 "parser_name": f.parser_name,
                 "frame_type": f.frame_type,
                 "status": f.status,
-                "diagnostic_codes": sorted(
-                    [
-                        _diag_get(d, "severity") + ":" + _diag_get(d, "code")
-                        for d in f.diagnostics
-                        if _diag_get(d, "severity") and _diag_get(d, "code")
-                    ]
-                ),
+                "diagnostic_codes": _diagnostic_codes(f.diagnostics),
             }
             for f in artifacts.frames
         ],
@@ -62,9 +53,11 @@ def project_artifacts(artifacts: CompileArtifacts) -> dict[str, Any]:
     }
 
 
-def _diag_get(diag: Any, key: str):
-    # TEMP(PR0): compatibility shim for mixed diagnostics representations.
-    # Remove in PR1 after frame.diagnostics becomes DiagnosticArtifact-only.
-    if isinstance(diag, dict):
-        return diag.get(key)
-    return getattr(diag, key, None)
+def _diagnostic_codes(diagnostics: list[DiagnosticArtifact]) -> list[str]:
+    codes: list[str] = []
+    for diag in diagnostics:
+        if not isinstance(diag, DiagnosticArtifact):
+            raise TypeError("frame.diagnostics must contain DiagnosticArtifact only")
+        if diag.severity and diag.code:
+            codes.append(f"{diag.severity}:{diag.code}")
+    return sorted(codes)

--- a/tests/test_artifact_contract.py
+++ b/tests/test_artifact_contract.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip("lark")
 
-from artifacts import DiagnosticArtifact
+from artifacts import DiagnosticArtifact, diagnostic_codes
 from tests.fixtures.cases import CASES
 from tests.support.builders import run_pipeline_full, run_pipeline_until
 
@@ -23,6 +23,11 @@ def test_frame_diagnostics_are_diagnostic_artifacts():
 
     for frame in result.artifacts.frames:
         assert all(isinstance(d, DiagnosticArtifact) for d in frame.diagnostics)
+
+
+def test_diagnostic_helpers_fail_fast_on_unexpected_types():
+    with pytest.raises(TypeError):
+        diagnostic_codes([{"severity": "warning", "code": "AggregateRow"}], severity="warning")
 
 
 def test_repair_populates_frame_runtime_state():

--- a/tests/test_artifact_contract.py
+++ b/tests/test_artifact_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from artifacts import DiagnosticArtifact
+from tests.fixtures.cases import CASES
+from tests.support.builders import run_pipeline_full, run_pipeline_until
+
+
+def _case(name: str):
+    return next(c for c in CASES if c.name == name)
+
+
+def test_frame_diagnostics_are_diagnostic_artifacts():
+    case = _case("aggregate_warning_calculation_excluded")
+    result = run_pipeline_full(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+
+    for frame in result.artifacts.frames:
+        assert all(isinstance(d, DiagnosticArtifact) for d in frame.diagnostics)
+
+
+def test_repair_populates_frame_runtime_state():
+    case = _case("happy_path_merge_and_calculate")
+    result = run_pipeline_until(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+        pass_name="RepairPass",
+    )
+
+    frame = result.artifacts.frames[0]
+    assert frame.status == "committed"
+    assert frame.runtime.iteration_count >= 1
+    assert isinstance(frame.runtime.resolution_score, float)
+    assert frame.runtime.termination_reason is not None
+
+
+def test_row_error_codes_come_from_frame_diagnostics():
+    case = _case("semantic_error_blocks_merge")
+    result = run_pipeline_full(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+
+    frame = result.artifacts.frames[0]
+    row = result.artifacts.rows[0]
+    frame_error_codes = sorted(
+        d.code for d in frame.diagnostics if d.severity == "error"
+    )
+
+    assert row.error_codes == frame_error_codes
+    assert result.artifacts.merge_log[0].action == "hold"

--- a/tests/test_e2e_contracts.py
+++ b/tests/test_e2e_contracts.py
@@ -12,11 +12,6 @@ from tests.support.serialize import project_result
 @pytest.mark.e2e
 @pytest.mark.golden
 @pytest.mark.parametrize("case", CASES, ids=[c.name for c in CASES])
-@pytest.mark.xfail(
-    raises=AttributeError,
-    reason="EmitPass reads undefined PartialFrameArtifact runtime fields",
-    strict=True,
-)
 def test_e2e_contracts(case, load_golden):
     result = run_pipeline_full(
         dsl_text=case.dsl_text,


### PR DESCRIPTION
### Motivation
- Freeze the artifact contract before binder/RuleIR work so later passes stop reading ad-hoc mixed shapes.
- Replace the current `EmitPass` runtime-field mismatch with an explicit frame runtime state.
- Turn PR0's expected-failure e2e coverage into real contract enforcement once the artifact boundary is fixed.

### Description
- Add `FrameRuntimeState` to `PartialFrameArtifact` and populate it from `RepairPass` (`resolution_score`, `iteration_count`, `stable_count`, `termination_reason`).
- Add shared diagnostic helper functions in `artifacts.py` and switch `EmitPass` to read warning/error codes from typed diagnostics rather than dict-shaped payloads.
- Change `InferencePass` frame-type inference notes from dict diagnostics to `DiagnosticArtifact`, so `frame.diagnostics` is object-only.
- Keep backward-compatible metadata mirrors in `RepairPass`, but move all read paths to `frame.runtime`.
- Tighten `tests/support/serialize.py` so mixed diagnostic shapes now fail loudly instead of being tolerated.
- Remove the PR0 `xfail` from `tests/test_e2e_contracts.py` and add `tests/test_artifact_contract.py` to assert:
  - `frame.diagnostics` contains only `DiagnosticArtifact`
  - `RepairPass` populates `frame.runtime`
  - row error codes are derived from frame diagnostics

### Testing
- I did not run the test suite in this environment.
- The intended acceptance criteria for this PR are:
  - `tests/test_repair_stage_smoke.py` stays green
  - `tests/test_e2e_contracts.py` turns green without `xfail`
  - `tests/test_artifact_contract.py` passes
