### PR TITLE
PR2 follow-up: add compiled runner path for bound specs

### DIFF
--- a/compiled_pipeline_runner.py
+++ b/compiled_pipeline_runner.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lark import Lark
+
+from ast_builder import ASTBuilder
+from binder import Binder
+from compiled_spec import CompiledProgramSpec
+from lowering import Lowerer
+from pipeline_runner import ESGPipelineRunner
+
+
+def load_compiled_program_spec_from_dsl(
+    *,
+    grammar_path: str | Path,
+    dsl_path: str | Path | None = None,
+    dsl_text: str | None = None,
+) -> CompiledProgramSpec:
+    if dsl_text is None and dsl_path is None:
+        raise ValueError("one of dsl_text or dsl_path must be provided")
+
+    grammar = Path(grammar_path).read_text(encoding="utf-8")
+    source = dsl_text if dsl_text is not None else Path(dsl_path).read_text(encoding="utf-8")
+
+    parser = Lark(
+        grammar,
+        parser="lalr",
+        lexer="contextual",
+        start="start",
+    )
+    tree = parser.parse(source)
+    program_ast = ASTBuilder().transform(tree)
+    program_spec = Lowerer().lower(program_ast)
+    return Binder().bind(program_spec)
+
+
+class CompiledESGPipelineRunner(ESGPipelineRunner):
+    def load_spec(
+        self,
+        *,
+        dsl_path: str | Path | None = None,
+        dsl_text: str | None = None,
+    ) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(
+            grammar_path=self.grammar_path,
+            dsl_path=dsl_path,
+            dsl_text=dsl_text,
+        )

--- a/tests/test_compiled_runner.py
+++ b/tests/test_compiled_runner.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from compiled_pipeline_runner import CompiledESGPipelineRunner, load_compiled_program_spec_from_dsl
+from compiled_spec import CompiledProgramSpec
+from pipeline_runner import ESGPipelineRunner
+from tests.fixtures.cases import CASES
+from tests.support.builders import GRAMMAR_PATH
+from tests.support.serialize import project_result
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.name for c in CASES])
+def test_compiled_runner_matches_existing_runner(case):
+    base_runner = ESGPipelineRunner(grammar_path=GRAMMAR_PATH)
+    compiled_runner = CompiledESGPipelineRunner(grammar_path=GRAMMAR_PATH)
+
+    base_result = base_runner.run(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+    compiled_result = compiled_runner.run(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+
+    assert project_result(compiled_result) == project_result(base_result)
+
+
+def test_compiled_loader_returns_compiled_program_spec():
+    case = CASES[0]
+    compiled_spec = load_compiled_program_spec_from_dsl(
+        grammar_path=GRAMMAR_PATH,
+        dsl_text=case.dsl_text,
+    )
+
+    assert isinstance(compiled_spec, CompiledProgramSpec)
+    assert compiled_spec.module_name == "test"
+    assert compiled_spec.compiled_constraints
+    assert compiled_spec.compiled_resolvers
+    assert compiled_spec.compiled_governances


### PR DESCRIPTION
### Motivation
- PR2 merged the binder/RuleIR scaffold, but the compiled rule-host path still needed an executable entrypoint.
- Add a low-risk compiled runner that exercises the binder path without rewriting the existing `pipeline_runner` load path yet.
- Prove that the compiled path is behavior-preserving by comparing it against the existing runner on the PR0/PR1 golden cases.

### Description
- Add `compiled_pipeline_runner.py` with:
  - `load_compiled_program_spec_from_dsl()`
  - `CompiledESGPipelineRunner`, which overrides `load_spec()` to return `CompiledProgramSpec`
- Add `tests/test_compiled_runner.py` to assert:
  - the compiled runner matches the existing runner on the current golden cases
  - the compiled loader returns `CompiledProgramSpec` and populates compiled rule-bearing fields

### Notes
- This keeps the current runtime path untouched.
- It gives PR2 an actual binder-connected entrypoint while staying additive and low-risk.
- The next step remains the same: migrate rule-host execution from the old runtime guess path to compiled RuleIR execution.

### Testing
- I did not run the test suite in this environment.
- Added compatibility-focused tests for local/CI execution.
