### PR TITLE
PR3: compiled rule evaluator path for compiled runner

### DIFF
--- a/compiled_expr_eval.py
+++ b/compiled_expr_eval.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from types import SimpleNamespace
+
+from expr_eval import ExprEvaluator
+from rule_ir import RuleExpr
+from rule_eval import RuleEvaluator
+
+
+class CompiledExprEvaluator(ExprEvaluator):
+    def __init__(self, *, rule_evaluator: RuleEvaluator | None = None) -> None:
+        super().__init__()
+        self.rule_evaluator = RuleEvaluator() if rule_evaluator is None else rule_evaluator
+
+    def eval(self, expr, ctx):
+        if isinstance(expr, RuleExpr):
+            return self.rule_evaluator.eval(expr, self._ctx(ctx))
+        return super().eval(expr, ctx)
+
+    def eval_bool(self, expr, ctx):
+        if isinstance(expr, RuleExpr):
+            return self.rule_evaluator.eval_bool(expr, self._ctx(ctx))
+        return super().eval_bool(expr, ctx)
+
+    def _ctx(self, ctx):
+        row = getattr(ctx, "row", None)
+        if row in (None, {}):
+            row = getattr(ctx, "local_vars", {})
+        return SimpleNamespace(
+            env=ctx.env,
+            text=getattr(ctx, "text", ""),
+            scope_path=getattr(ctx, "scope_path", tuple()),
+            column_key=getattr(ctx, "column_key", None),
+            row=row,
+            frame=getattr(ctx, "frame", None),
+            claims_by_id=getattr(ctx, "claims_by_id", {}),
+            local_vars=getattr(ctx, "local_vars", {}),
+            warning_codes=set(getattr(ctx, "warning_codes", set()) or set()),
+            error_codes=set(getattr(ctx, "error_codes", set()) or set()),
+            approvals=getattr(ctx, "approvals", {}),
+        )

--- a/compiled_pipeline_runner.py
+++ b/compiled_pipeline_runner.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
 from lark import Lark
 
+from artifacts import CompileArtifacts
 from ast_builder import ASTBuilder
 from binder import Binder
+from calculation_pass import CalculationPass
+from compiled_expr_eval import CompiledExprEvaluator
 from compiled_spec import CompiledProgramSpec
+from emit_pass import EmitPass
+from governance_pass import GovernancePass
+from inference_pass import InferencePass
+from lex_pass import LexPass
 from lowering import Lowerer
-from pipeline_runner import ESGPipelineRunner
+from parse_pass import ParsePass
+from pipeline_runner import ESGPipelineRunner, PipelineRunResult
+from repair_pass import RepairPass
+from scope_resolution_pass import ScopeResolutionPass
+from semantic_pass import SemanticPass
 
 
 def load_compiled_program_spec_from_dsl(
@@ -19,31 +31,51 @@ def load_compiled_program_spec_from_dsl(
 ) -> CompiledProgramSpec:
     if dsl_text is None and dsl_path is None:
         raise ValueError("one of dsl_text or dsl_path must be provided")
-
     grammar = Path(grammar_path).read_text(encoding="utf-8")
     source = dsl_text if dsl_text is not None else Path(dsl_path).read_text(encoding="utf-8")
-
-    parser = Lark(
-        grammar,
-        parser="lalr",
-        lexer="contextual",
-        start="start",
-    )
+    parser = Lark(grammar, parser="lalr", lexer="contextual", start="start")
     tree = parser.parse(source)
-    program_ast = ASTBuilder().transform(tree)
-    program_spec = Lowerer().lower(program_ast)
-    return Binder().bind(program_spec)
+    return Binder().bind(Lowerer().lower(ASTBuilder().transform(tree)))
+
+
+def _materialize_runtime_spec(compiled_spec: CompiledProgramSpec):
+    spec = deepcopy(compiled_spec.syntax)
+    for dst, src in zip(spec.constraints, compiled_spec.compiled_constraints): dst.condition = src.condition_ir
+    for dst, src in zip(spec.diagnostics, compiled_spec.compiled_diagnostics): dst.condition = src.condition_ir
+    for dst, src in zip(spec.infer_rules, compiled_spec.compiled_infer_rules):
+        dst.value_expr = src.value_ir; dst.condition = src.condition_ir
+    for name, src in compiled_spec.compiled_resolvers.items():
+        if name not in spec.resolvers: continue
+        dst = spec.resolvers[name]
+        dst.assigns = dict(src.assigns_ir); dst.candidate_pool_assigns = dict(src.candidate_pool_assigns_ir)
+        dst.commit_condition = src.commit_condition_ir; dst.review_condition = src.review_condition_ir
+    for name, src in compiled_spec.compiled_governances.items():
+        if name not in spec.governances: continue
+        dst = spec.governances[name]
+        dst.emit_condition = src.emit_condition_ir
+        dst.merge_conditions = list(src.merge_conditions_ir)
+        dst.forbid_merge_conditions = list(src.forbid_merge_conditions_ir)
+    return spec
+
+
+def build_compiled_rule_passes():
+    ev = CompiledExprEvaluator()
+    return [LexPass(), ParsePass(evaluator=ev), ScopeResolutionPass(), InferencePass(evaluator=ev), SemanticPass(evaluator=ev), RepairPass(evaluator=ev), EmitPass(), GovernancePass(evaluator=ev), CalculationPass()]
 
 
 class CompiledESGPipelineRunner(ESGPipelineRunner):
-    def load_spec(
-        self,
-        *,
-        dsl_path: str | Path | None = None,
-        dsl_text: str | None = None,
-    ) -> CompiledProgramSpec:
-        return load_compiled_program_spec_from_dsl(
-            grammar_path=self.grammar_path,
-            dsl_path=dsl_path,
-            dsl_text=dsl_text,
-        )
+    def __init__(self, *, grammar_path: str | Path = "esgdl.lark", passes=None, fragmentizer=None) -> None:
+        super().__init__(grammar_path=grammar_path, passes=passes or build_compiled_rule_passes(), fragmentizer=fragmentizer)
+
+    def load_spec(self, *, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(grammar_path=self.grammar_path, dsl_path=dsl_path, dsl_text=dsl_text)
+
+    def run(self, *, spec=None, dsl_path: str | Path | None = None, dsl_text: str | None = None, fragments=None, documents=None, resources=None) -> PipelineRunResult:
+        compiled_spec = self.load_spec(dsl_path=dsl_path, dsl_text=dsl_text) if spec is None else (spec if isinstance(spec, CompiledProgramSpec) else Binder().bind(spec))
+        env = self.build_env(spec=compiled_spec.syntax, resources=resources)
+        prepared_fragments = self.prepare_fragments(fragments=fragments, documents=documents)
+        runtime_spec = _materialize_runtime_spec(compiled_spec)
+        artifacts = CompileArtifacts(fragments=prepared_fragments)
+        for p in self.passes:
+            artifacts = p.run(runtime_spec, artifacts, env)
+        return PipelineRunResult(spec=compiled_spec, env=env, artifacts=artifacts)

--- a/rule_builtins.py
+++ b/rule_builtins.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+from builtins import (
+    compatible as builtin_compatible,
+    dimension as builtin_dimension,
+    evidence as builtin_evidence,
+    missing as builtin_missing,
+    origin as builtin_origin,
+    valid as builtin_valid,
+    valid_period as builtin_valid_period,
+)
+
+if TYPE_CHECKING:
+    from rule_eval import RuleEvalContext
+
+
+@dataclass(frozen=True)
+class RuleBuiltinSpec:
+    name: str
+    arg_modes: tuple[str, ...]
+    impl: Callable[..., Any]
+
+
+# ------------------------------------------------------------------
+# Rule builtin implementations
+# ------------------------------------------------------------------
+
+
+def _missing(ctx: RuleEvalContext, role_name: str) -> bool:
+    return builtin_missing(role_name, ctx.frame)
+
+
+def _origin(ctx: RuleEvalContext, role_name: str):
+    return builtin_origin(role_name, ctx.frame, ctx.claims_by_id)
+
+
+def _evidence(ctx: RuleEvalContext, kind: str) -> int:
+    return builtin_evidence(kind, ctx.frame, ctx.claims_by_id)
+
+
+def _dimension(ctx: RuleEvalContext, raw_unit: Any):
+    return builtin_dimension(raw_unit, ctx.env)
+
+
+def _compatible(ctx: RuleEvalContext, activity_type: Any, raw_unit: Any) -> bool:
+    return builtin_compatible(activity_type, raw_unit, ctx.env)
+
+
+def _valid(ctx: RuleEvalContext, value: Any) -> bool:
+    return builtin_valid(value, ctx.env)
+
+
+def _valid_period(ctx: RuleEvalContext, value: Any) -> bool:
+    return builtin_valid_period(value)
+
+
+DEFAULT_RULE_BUILTIN_REGISTRY: dict[str, RuleBuiltinSpec] = {
+    "missing": RuleBuiltinSpec(
+        name="missing",
+        arg_modes=("slot_name",),
+        impl=_missing,
+    ),
+    "origin": RuleBuiltinSpec(
+        name="origin",
+        arg_modes=("slot_name",),
+        impl=_origin,
+    ),
+    "evidence": RuleBuiltinSpec(
+        name="evidence",
+        arg_modes=("symbol_name",),
+        impl=_evidence,
+    ),
+    "dimension": RuleBuiltinSpec(
+        name="dimension",
+        arg_modes=("value",),
+        impl=_dimension,
+    ),
+    "compatible": RuleBuiltinSpec(
+        name="compatible",
+        arg_modes=("value", "value"),
+        impl=_compatible,
+    ),
+    "valid": RuleBuiltinSpec(
+        name="valid",
+        arg_modes=("value",),
+        impl=_valid,
+    ),
+    "valid_period": RuleBuiltinSpec(
+        name="valid_period",
+        arg_modes=("value",),
+        impl=_valid_period,
+    ),
+}
+
+
+def get_default_rule_builtin_registry() -> dict[str, RuleBuiltinSpec]:
+    return dict(DEFAULT_RULE_BUILTIN_REGISTRY)

--- a/rule_eval.py
+++ b/rule_eval.py
@@ -1,0 +1,1 @@
+# placeholder

--- a/rule_eval.py
+++ b/rule_eval.py
@@ -1,1 +1,93 @@
-# placeholder
+from __future__ import annotations
+import re
+from rule_builtins import get_default_rule_builtin_registry
+from rule_ir import *
+
+class RuleEvalError(ValueError):
+    pass
+
+class RuleEvaluator:
+    def __init__(self, *, builtin_registry=None):
+        self.builtin_registry = get_default_rule_builtin_registry() if builtin_registry is None else builtin_registry
+
+    def eval(self, expr, ctx):
+        if not isinstance(expr, RuleExpr): return expr
+        if isinstance(expr, RuleLiteral): return expr.value
+        if isinstance(expr, LocalVarRef): return ctx.local_vars.get(expr.name)
+        if isinstance(expr, FrameSlotRef): return self._frame_value(ctx.frame, expr.role_name)
+        if isinstance(expr, RowFieldRef): return ctx.row.get(expr.field_name) if isinstance(ctx.row, dict) else getattr(ctx.row, expr.field_name, None)
+        if isinstance(expr, ContextValueRef):
+            res = ctx.env.context_store.resolve_best(expr.role_name, ctx.scope_path, column_key=getattr(ctx, "column_key", None))
+            return None if res.chosen is None else res.chosen.value
+        if isinstance(expr, PolicyRef): return ctx.env.policy_flags.get(expr.key)
+        if isinstance(expr, HasDiagnostic): return expr.code in (ctx.warning_codes if expr.severity == "warning" else ctx.error_codes)
+        if isinstance(expr, HasApproval): return bool(ctx.approvals.get(expr.key, False))
+        if isinstance(expr, SymbolConst): return expr.name
+        if isinstance(expr, RuleBuiltinCall): return self._call(expr, ctx)
+        if isinstance(expr, RuleSetExpr): return [self.eval(x, ctx) for x in expr.items]
+        if isinstance(expr, RuleCoalesce):
+            for x in expr.options:
+                v = self.eval(x, ctx)
+                if self._present(v): return v
+            return None
+        if isinstance(expr, RuleUnary):
+            if expr.op == "not": return not self.eval_bool(expr.operand, ctx)
+            raise RuleEvalError(f"unsupported unary op: {expr.op}")
+        if isinstance(expr, RuleBinary): return self._binary(expr, ctx)
+        raise RuleEvalError(f"unsupported RuleExpr type: {type(expr).__name__}")
+
+    def eval_bool(self, expr, ctx):
+        return self._present(self.eval(expr, ctx))
+
+    def _binary(self, expr, ctx):
+        l, r, op = self.eval(expr.left, ctx), self.eval(expr.right, ctx), expr.op
+        if op == "or": return self._present(l) or self._present(r)
+        if op == "and": return self._present(l) and self._present(r)
+        if op == "==": return l == r
+        if op == "!=": return l != r
+        if op == ">=": return l >= r
+        if op == "<=": return l <= r
+        if op == ">": return l > r
+        if op == "<": return l < r
+        if op == "in": return False if r is None else l in r
+        if op == "matches": return re.search(str(r), str(l or "")) is not None
+        raise RuleEvalError(f"unsupported binary op: {op}")
+
+    def _call(self, expr, ctx):
+        spec = self.builtin_registry.get(expr.name)
+        if spec is None: raise RuleEvalError(f"unknown rule builtin: {expr.name}")
+        if len(expr.args) != len(spec.arg_modes): raise RuleEvalError(f"builtin {expr.name} expected {len(spec.arg_modes)} args, got {len(expr.args)}")
+        args = [self._arg(a, m, ctx) for a, m in zip(expr.args, spec.arg_modes)]
+        return spec.impl(ctx, *args)
+
+    def _arg(self, arg, mode, ctx):
+        if mode == "value": return self.eval(arg, ctx)
+        if mode in {"slot_name", "symbol_name"}:
+            if isinstance(arg, FrameSlotRef): return arg.role_name
+            if isinstance(arg, SymbolConst): return arg.name
+            if isinstance(arg, RuleLiteral): return str(arg.value)
+            return str(self.eval(arg, ctx))
+        raise RuleEvalError(f"unsupported builtin arg mode: {mode}")
+
+    def _frame_value(self, frame, role_name):
+        if frame is None: return None
+        b = getattr(frame, "bindings", None)
+        if isinstance(b, dict) and role_name in b:
+            v = b[role_name]
+            return getattr(v, "value", v)
+        s = getattr(frame, "slots", None)
+        if isinstance(s, dict):
+            if role_name in s:
+                v = getattr(s[role_name], "resolved_value", None)
+                if v not in (None, ""): return v
+            for k, slot in s.items():
+                if getattr(k, "value", k) == role_name:
+                    v = getattr(slot, "resolved_value", None)
+                    if v not in (None, ""): return v
+        return None
+
+    def _present(self, v):
+        if v is None: return False
+        if isinstance(v, str): return v != ""
+        if isinstance(v, (list, tuple, set, dict)): return len(v) > 0
+        return bool(v)

--- a/tests/test_rule_eval.py
+++ b/tests/test_rule_eval.py
@@ -1,0 +1,1 @@
+# placeholder

--- a/tests/test_rule_eval.py
+++ b/tests/test_rule_eval.py
@@ -1,1 +1,25 @@
-# placeholder
+from types import SimpleNamespace
+from artifacts import CanonicalRowArtifact, ClaimArtifact, PartialFrameArtifact, RoleSlotArtifact
+from rule_eval import RuleEvaluator
+from rule_ir import FrameSlotRef, HasApproval, LocalVarRef, PolicyRef, RowFieldRef, RuleBinary, RuleBuiltinCall, RuleLiteral, SymbolConst
+from runtime_env import RuntimeEnv
+
+def _ctx():
+    env = RuntimeEnv(); env.policy_flags["auto_merge"] = True
+    c = ClaimArtifact(claim_id="CLM-1", frame_id="FRM-1", fragment_id="FRG-1", parser_name="p", role_name="raw_amount", value=42, extraction_mode="explicit", confidence=0.9, evidence_ids=["pair:raw_amount"])
+    s = RoleSlotArtifact(role_name="raw_amount", active_claim_id=c.claim_id, resolved_value=42)
+    f = PartialFrameArtifact(frame_id="FRM-1", parser_name="p", frame_type="ActivityObservation", slots={"raw_amount": s})
+    r = CanonicalRowArtifact(row_id="ROW-1", frame_id="FRM-1", parser_name="p", frame_type="ActivityObservation", raw_amount=42.0, status="committed")
+    return SimpleNamespace(env=env, scope_path=tuple(), column_key=None, row=r, frame=f, claims_by_id={c.claim_id: c}, local_vars={"status": "committed", "score": 0.9}, warning_codes={"AggregateRow"}, error_codes={"InvalidPeriod"}, approvals={"human_reviewer": False})
+
+def test_rule_refs():
+    ev, ctx = RuleEvaluator(), _ctx()
+    assert ev.eval_bool(RuleBinary(LocalVarRef("status"), "==", SymbolConst("committed")), ctx)
+    assert ev.eval_bool(RuleBinary(RowFieldRef("raw_amount"), ">", RuleLiteral(0)), ctx)
+    assert ev.eval_bool(RuleBinary(HasApproval("human_reviewer"), "or", PolicyRef("auto_merge")), ctx)
+
+def test_rule_builtins():
+    ev, ctx = RuleEvaluator(), _ctx()
+    assert ev.eval(RuleBuiltinCall("missing", [FrameSlotRef("raw_amount")]), ctx) is False
+    assert ev.eval(RuleBuiltinCall("origin", [FrameSlotRef("raw_amount")]), ctx) == "explicit"
+    assert ev.eval(RuleBuiltinCall("evidence", [RuleLiteral("pair")]), ctx) == 1


### PR DESCRIPTION
### Motivation
- Make the compiled runner actually execute rule hosts through compiled RuleIR instead of only loading a `CompiledProgramSpec` and then falling back to the old runtime-guess path.
- Introduce a minimal rule builtin registry and a dedicated `RuleEvaluator` so compiled rule hosts stop depending on `ExprEvaluator` name guessing.
- Keep the default runner untouched for now; this stays additive and scoped to the compiled runner path.

### Description
- Add `rule_builtins.py` with a minimal declarative rule builtin registry for:
  - `missing`
  - `origin`
  - `evidence`
  - `dimension`
  - `compatible`
  - `valid`
  - `valid_period`
- Add `rule_eval.py` with a compact `RuleEvaluator` that executes RuleIR refs/tests/coalesce/binary ops and dispatches builtins through the rule registry.
- Add `compiled_expr_eval.py`, an adapter that lets existing passes evaluate either legacy Expr nodes or compiled RuleIR nodes without touching the default path.
- Update `compiled_pipeline_runner.py` so the compiled runner:
  - uses a compiled-rule pass list wired with `CompiledExprEvaluator`
  - materializes a runtime spec view where rule-bearing fields are replaced with RuleIR
  - runs the existing pass pipeline against that materialized compiled rule path
- Add `tests/test_rule_eval.py` to directly lock basic ref/predicate/builtin execution for the new `RuleEvaluator`.

### Scope / non-goals
- The default `ESGPipelineRunner` is intentionally unchanged in this PR.
- Old rule-host execution remains in place for the default path and can be removed in the next PR.
- LexIR / SourceIR splitting is still deferred.

### Testing
- I did not run the test suite in this environment.
- Added direct rule-evaluator tests and kept the existing compiled-runner parity test path in place so CI/local can validate behavior.
