### PR TITLE
PR4 (draft): switch default runner to compiled rule path

### DIFF
--- a/binder.py
+++ b/binder.py
@@ -82,6 +82,12 @@ class Binder:
         "evidence",
     }
 
+    FRAME_ONLY_RULE_BUILTINS = {
+        "missing",
+        "origin",
+        "evidence",
+    }
+
     LEXICAL_BUILTINS = {
         "site_alias",
         "activity_alias",
@@ -125,7 +131,7 @@ class Binder:
     def bind(self, spec: ProgramSpec) -> CompiledProgramSpec:
         report = BindingReport()
 
-        compiled = CompiledProgramSpec(
+        return CompiledProgramSpec(
             syntax=spec,
             compiled_constraints=[
                 CompiledConstraintSpec(
@@ -179,7 +185,6 @@ class Binder:
             },
             binding_warnings=report.messages(),
         )
-        return compiled
 
     def _bind_resolver_policy(
         self,
@@ -335,14 +340,10 @@ class Binder:
             )
 
         if isinstance(expr, ColumnRefExpr):
-            raise BindingError(
-                f"column(...) is not allowed in rule host {host.kind}"
-            )
+            raise BindingError(f"column(...) is not allowed in rule host {host.kind}")
 
         if isinstance(expr, RowLabelRefExpr):
-            raise BindingError(
-                f"row_label(...) is not allowed in rule host {host.kind}"
-            )
+            raise BindingError(f"row_label(...) is not allowed in rule host {host.kind}")
 
         raise BindingError(f"unsupported rule expression: {type(expr).__name__}")
 
@@ -410,6 +411,11 @@ class Binder:
 
         if expr.name not in self.RULE_BUILTINS:
             raise BindingError(f"unknown rule builtin: {expr.name}")
+
+        if expr.name in self.FRAME_ONLY_RULE_BUILTINS and host.kind not in {"frame_rule", "resolver"}:
+            raise BindingError(
+                f"frame-only rule builtin '{expr.name}' is not allowed in rule host {host.kind}"
+            )
 
         return RuleBuiltinCall(
             name=expr.name,

--- a/compiled_pipeline_runner.py
+++ b/compiled_pipeline_runner.py
@@ -1,81 +1,20 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from pathlib import Path
 
-from lark import Lark
-
-from artifacts import CompileArtifacts
-from ast_builder import ASTBuilder
-from binder import Binder
-from calculation_pass import CalculationPass
-from compiled_expr_eval import CompiledExprEvaluator
 from compiled_spec import CompiledProgramSpec
-from emit_pass import EmitPass
-from governance_pass import GovernancePass
-from inference_pass import InferencePass
-from lex_pass import LexPass
-from lowering import Lowerer
-from parse_pass import ParsePass
-from pipeline_runner import ESGPipelineRunner, PipelineRunResult
-from repair_pass import RepairPass
-from scope_resolution_pass import ScopeResolutionPass
-from semantic_pass import SemanticPass
-
-
-def load_compiled_program_spec_from_dsl(
-    *,
-    grammar_path: str | Path,
-    dsl_path: str | Path | None = None,
-    dsl_text: str | None = None,
-) -> CompiledProgramSpec:
-    if dsl_text is None and dsl_path is None:
-        raise ValueError("one of dsl_text or dsl_path must be provided")
-    grammar = Path(grammar_path).read_text(encoding="utf-8")
-    source = dsl_text if dsl_text is not None else Path(dsl_path).read_text(encoding="utf-8")
-    parser = Lark(grammar, parser="lalr", lexer="contextual", start="start")
-    tree = parser.parse(source)
-    return Binder().bind(Lowerer().lower(ASTBuilder().transform(tree)))
-
-
-def _materialize_runtime_spec(compiled_spec: CompiledProgramSpec):
-    spec = deepcopy(compiled_spec.syntax)
-    for dst, src in zip(spec.constraints, compiled_spec.compiled_constraints): dst.condition = src.condition_ir
-    for dst, src in zip(spec.diagnostics, compiled_spec.compiled_diagnostics): dst.condition = src.condition_ir
-    for dst, src in zip(spec.infer_rules, compiled_spec.compiled_infer_rules):
-        dst.value_expr = src.value_ir; dst.condition = src.condition_ir
-    for name, src in compiled_spec.compiled_resolvers.items():
-        if name not in spec.resolvers: continue
-        dst = spec.resolvers[name]
-        dst.assigns = dict(src.assigns_ir); dst.candidate_pool_assigns = dict(src.candidate_pool_assigns_ir)
-        dst.commit_condition = src.commit_condition_ir; dst.review_condition = src.review_condition_ir
-    for name, src in compiled_spec.compiled_governances.items():
-        if name not in spec.governances: continue
-        dst = spec.governances[name]
-        dst.emit_condition = src.emit_condition_ir
-        dst.merge_conditions = list(src.merge_conditions_ir)
-        dst.forbid_merge_conditions = list(src.forbid_merge_conditions_ir)
-    return spec
-
-
-def build_compiled_rule_passes():
-    ev = CompiledExprEvaluator()
-    return [LexPass(), ParsePass(evaluator=ev), ScopeResolutionPass(), InferencePass(evaluator=ev), SemanticPass(evaluator=ev), RepairPass(evaluator=ev), EmitPass(), GovernancePass(evaluator=ev), CalculationPass()]
+from pipeline_runner import ESGPipelineRunner, load_compiled_program_spec_from_dsl
 
 
 class CompiledESGPipelineRunner(ESGPipelineRunner):
-    def __init__(self, *, grammar_path: str | Path = "esgdl.lark", passes=None, fragmentizer=None) -> None:
-        super().__init__(grammar_path=grammar_path, passes=passes or build_compiled_rule_passes(), fragmentizer=fragmentizer)
-
-    def load_spec(self, *, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
-        return load_compiled_program_spec_from_dsl(grammar_path=self.grammar_path, dsl_path=dsl_path, dsl_text=dsl_text)
-
-    def run(self, *, spec=None, dsl_path: str | Path | None = None, dsl_text: str | None = None, fragments=None, documents=None, resources=None) -> PipelineRunResult:
-        compiled_spec = self.load_spec(dsl_path=dsl_path, dsl_text=dsl_text) if spec is None else (spec if isinstance(spec, CompiledProgramSpec) else Binder().bind(spec))
-        env = self.build_env(spec=compiled_spec.syntax, resources=resources)
-        prepared_fragments = self.prepare_fragments(fragments=fragments, documents=documents)
-        runtime_spec = _materialize_runtime_spec(compiled_spec)
-        artifacts = CompileArtifacts(fragments=prepared_fragments)
-        for p in self.passes:
-            artifacts = p.run(runtime_spec, artifacts, env)
-        return PipelineRunResult(spec=compiled_spec, env=env, artifacts=artifacts)
+    def load_spec(
+        self,
+        *,
+        dsl_path: str | Path | None = None,
+        dsl_text: str | None = None,
+    ) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(
+            grammar_path=self.grammar_path,
+            dsl_path=dsl_path,
+            dsl_text=dsl_text,
+        )

--- a/governance_pass.py
+++ b/governance_pass.py
@@ -1,244 +1,117 @@
-# governance_pass.py
 from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import count
-from typing import Any, Optional
 
 from artifacts import CanonicalRowArtifact, CompileArtifacts, GovernanceDecisionArtifact
-from expr_eval import EvalContext, ExprEvaluator
+from compiled_spec import CompiledGovernancePolicy, CompiledProgramSpec
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
 from runtime_env import RuntimeEnv
-from spec_nodes import GovernancePolicy, ProgramSpec
 
 
 @dataclass
 class GovernancePassConfig:
-    """
-    기본 철학:
-    - error가 있으면 기본적으로 merge 금지
-    - forbid merge rule이 우선
-    - merge rule이 만족돼도 forbid가 걸리면 hold
-    """
     block_on_any_error: bool = True
     enforce_emit_condition: bool = True
     skip_non_committed_rows: bool = True
 
 
 class GovernancePass:
-    def __init__(
-        self,
-        evaluator: Optional[ExprEvaluator] = None,
-        config: Optional[GovernancePassConfig] = None,
-    ) -> None:
-        self.evaluator = evaluator or ExprEvaluator()
+    def __init__(self, evaluator: RuleEvaluator | None = None, config: GovernancePassConfig | None = None) -> None:
+        self.evaluator = evaluator or RuleEvaluator()
         self.config = config or GovernancePassConfig()
         self._decision_seq = count(1)
 
-    def run(
-        self,
-        spec: ProgramSpec,
-        artifacts: CompileArtifacts,
-        env: RuntimeEnv,
-    ) -> CompileArtifacts:
-        decisions: list[GovernanceDecisionArtifact] = []
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("GovernancePass requires CompiledProgramSpec")
 
+        decisions: list[GovernanceDecisionArtifact] = []
         for row in artifacts.rows:
             if self.config.skip_non_committed_rows and row.status != "committed":
-                decisions.append(
-                    self._decision(
-                        row=row,
-                        from_status=row.status,
-                        to_status=row.status,
-                        action="skip",
-                        actor="policy_engine",
-                        reason_codes=["row_not_committed"],
-                        matched_rule_keys=[],
-                    )
-                )
+                decisions.append(self._decision(row=row, from_status=row.status, to_status=row.status, action="skip", actor="policy_engine", reason_codes=["row_not_committed"], matched_rule_keys=[]))
                 continue
 
-            policy = spec.governances.get(row.frame_type)
+            policy = spec.compiled_governances.get(row.frame_type)
             if policy is None:
-                decisions.append(
-                    self._decision(
-                        row=row,
-                        from_status=row.status,
-                        to_status=row.status,
-                        action="hold",
-                        actor="policy_engine",
-                        reason_codes=["no_governance_policy"],
-                        matched_rule_keys=[],
-                    )
-                )
+                decisions.append(self._decision(row=row, from_status=row.status, to_status=row.status, action="hold", actor="policy_engine", reason_codes=["no_governance_policy"], matched_rule_keys=[]))
                 continue
 
-            decision = self._apply_policy(row=row, policy=policy, env=env)
-            decisions.append(decision)
+            decisions.append(self._apply_policy(row=row, policy=policy, env=env))
 
         artifacts.merge_log.extend(decisions)
-
-        # event_log에도 간단 이벤트 추가
         for d in decisions:
-            artifacts.event_log.append(
-                {
-                    "event_id": f"EVT-GOV-{d.decision_id}",
-                    "record_id": d.row_id,
-                    "event_type": "MERGED" if d.action == "merge" else "MERGE_HELD" if d.action == "hold" else "SKIPPED",
-                    "from_status": d.from_status,
-                    "to_status": d.to_status,
-                    "actor": d.actor,
-                    "reason_codes": list(d.reason_codes),
-                    "matched_rule_keys": list(d.matched_rule_keys),
-                    "created_at": d.created_at.isoformat() + "Z",
-                }
-            )
-
+            artifacts.event_log.append({
+                "event_id": f"EVT-GOV-{d.decision_id}",
+                "record_id": d.row_id,
+                "event_type": "MERGED" if d.action == "merge" else "MERGE_HELD" if d.action == "hold" else "SKIPPED",
+                "from_status": d.from_status,
+                "to_status": d.to_status,
+                "actor": d.actor,
+                "reason_codes": list(d.reason_codes),
+                "matched_rule_keys": list(d.matched_rule_keys),
+                "created_at": d.created_at.isoformat() + "Z",
+            })
         return artifacts
 
-    # ------------------------------------------------------------------
-    # Core policy application
-    # ------------------------------------------------------------------
-
-    def _apply_policy(
-        self,
-        *,
-        row: CanonicalRowArtifact,
-        policy: GovernancePolicy,
-        env: RuntimeEnv,
-    ) -> GovernanceDecisionArtifact:
+    def _apply_policy(self, *, row: CanonicalRowArtifact, policy: CompiledGovernancePolicy, env: RuntimeEnv) -> GovernanceDecisionArtifact:
         ctx = self._build_eval_context(row, env)
-
         from_status = row.status
 
-        # 0) emit condition 재검증 (선택)
-        if self.config.enforce_emit_condition and policy.emit_condition is not None:
-            emit_ok = self._safe_eval_bool(policy.emit_condition, ctx)
-            if not emit_ok:
-                return self._decision(
-                    row=row,
-                    from_status=from_status,
-                    to_status=from_status,
-                    action="hold",
-                    actor="policy_engine",
-                    reason_codes=["emit_condition_not_satisfied"],
-                    matched_rule_keys=["emit_condition"],
-                )
+        if self.config.enforce_emit_condition and policy.emit_condition_ir is not None:
+            if not self._safe_eval_bool(policy.emit_condition_ir, ctx):
+                return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["emit_condition_not_satisfied"], matched_rule_keys=["emit_condition"])
 
-        # 1) 기본 safety: any error => hold
         if self.config.block_on_any_error and row.error_codes:
-            return self._decision(
-                row=row,
-                from_status=from_status,
-                to_status=from_status,
-                action="hold",
-                actor="policy_engine",
-                reason_codes=["row_has_error_diagnostics", *row.error_codes],
-                matched_rule_keys=[],
-            )
+            return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["row_has_error_diagnostics", *row.error_codes], matched_rule_keys=[])
 
-        # 2) forbid merge 먼저
-        matched_forbid: list[str] = []
-        for idx, expr in enumerate(policy.forbid_merge_conditions, start=1):
-            if self._safe_eval_bool(expr, ctx):
-                matched_forbid.append(f"forbid_merge:{idx}")
-
+        matched_forbid = [f"forbid_merge:{idx}" for idx, expr in enumerate(policy.forbid_merge_conditions_ir, start=1) if self._safe_eval_bool(expr, ctx)]
         if matched_forbid:
-            # row는 committed 유지
-            return self._decision(
-                row=row,
-                from_status=from_status,
-                to_status=from_status,
-                action="hold",
-                actor="policy_engine",
-                reason_codes=["forbid_merge_matched"],
-                matched_rule_keys=matched_forbid,
-            )
+            return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["forbid_merge_matched"], matched_rule_keys=matched_forbid)
 
-        # 3) merge rule
-        matched_merge: list[str] = []
-        for idx, expr in enumerate(policy.merge_conditions, start=1):
-            if self._safe_eval_bool(expr, ctx):
-                matched_merge.append(f"merge:{idx}")
-
+        matched_merge = [f"merge:{idx}" for idx, expr in enumerate(policy.merge_conditions_ir, start=1) if self._safe_eval_bool(expr, ctx)]
         if matched_merge:
             row.status = "merged"
             actor = self._pick_actor(ctx)
-            row.metadata.setdefault("governance_trace", []).append(
-                {
-                    "action": "merge",
-                    "matched_rule_keys": matched_merge,
-                    "actor": actor,
-                }
-            )
-            return self._decision(
-                row=row,
-                from_status=from_status,
-                to_status="merged",
-                action="merge",
-                actor=actor,
-                reason_codes=["merge_condition_satisfied"],
-                matched_rule_keys=matched_merge,
-            )
+            row.metadata.setdefault("governance_trace", []).append({"action": "merge", "matched_rule_keys": matched_merge, "actor": actor})
+            return self._decision(row=row, from_status=from_status, to_status="merged", action="merge", actor=actor, reason_codes=["merge_condition_satisfied"], matched_rule_keys=matched_merge)
 
-        # 4) 아무 merge rule도 안 맞으면 hold
-        row.metadata.setdefault("governance_trace", []).append(
-            {
-                "action": "hold",
-                "reason": "no_merge_rule_matched",
-            }
-        )
-        return self._decision(
-            row=row,
-            from_status=from_status,
-            to_status=from_status,
-            action="hold",
-            actor="policy_engine",
-            reason_codes=["no_merge_rule_matched"],
-            matched_rule_keys=[],
-        )
+        row.metadata.setdefault("governance_trace", []).append({"action": "hold", "reason": "no_merge_rule_matched"})
+        return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["no_merge_rule_matched"], matched_rule_keys=[])
 
-    # ------------------------------------------------------------------
-    # Eval context
-    # ------------------------------------------------------------------
-
-    def _build_eval_context(
-        self,
-        row: CanonicalRowArtifact,
-        env: RuntimeEnv,
-    ) -> EvalContext:
+    def _build_eval_context(self, row: CanonicalRowArtifact, env: RuntimeEnv) -> EvalContext:
         approvals = {}
         if isinstance(env.policy_flags.get("approvals"), dict):
             approvals.update(env.policy_flags["approvals"])
         if isinstance(row.metadata.get("approvals"), dict):
             approvals.update(row.metadata["approvals"])
 
-        local_vars = {
-            "row_id": row.row_id,
-            "frame_id": row.frame_id,
-            "frame_type": row.frame_type,
-            "status": row.status,
-            "score": row.resolution_score,
-            "resolution_score": row.resolution_score,
-
-            "site_id": row.site_id,
-            "entity_id": row.entity_id,
-            "period": row.period,
-            "activity_type": row.activity_type,
-            "raw_amount": row.raw_amount,
-            "raw_unit": row.raw_unit,
-            "standardized_amount": row.standardized_amount,
-            "standardized_unit": row.standardized_unit,
-            "scope_category": row.scope_category,
-            "parser_name": row.parser_name,
-        }
-
         return EvalContext(
             env=env,
             text="",
             scope_path=tuple(),
+            row=row,
             frame=None,
             claims_by_id={},
-            local_vars=local_vars,
+            local_vars={
+                "row_id": row.row_id,
+                "frame_id": row.frame_id,
+                "frame_type": row.frame_type,
+                "status": row.status,
+                "score": row.resolution_score,
+                "resolution_score": row.resolution_score,
+                "site_id": row.site_id,
+                "entity_id": row.entity_id,
+                "period": row.period,
+                "activity_type": row.activity_type,
+                "raw_amount": row.raw_amount,
+                "raw_unit": row.raw_unit,
+                "standardized_amount": row.standardized_amount,
+                "standardized_unit": row.standardized_unit,
+                "scope_category": row.scope_category,
+                "parser_name": row.parser_name,
+            },
             warning_codes=set(row.warning_codes),
             error_codes=set(row.error_codes),
             approvals=approvals,
@@ -250,21 +123,7 @@ class GovernancePass:
         except Exception:
             return False
 
-    # ------------------------------------------------------------------
-    # Decision artifact
-    # ------------------------------------------------------------------
-
-    def _decision(
-        self,
-        *,
-        row: CanonicalRowArtifact,
-        from_status: str,
-        to_status: str,
-        action: str,
-        actor: str,
-        reason_codes: list[str],
-        matched_rule_keys: list[str],
-    ) -> GovernanceDecisionArtifact:
+    def _decision(self, *, row: CanonicalRowArtifact, from_status: str, to_status: str, action: str, actor: str, reason_codes: list[str], matched_rule_keys: list[str]) -> GovernanceDecisionArtifact:
         return GovernanceDecisionArtifact(
             decision_id=f"GOV-{next(self._decision_seq):07d}",
             row_id=row.row_id,
@@ -275,21 +134,12 @@ class GovernancePass:
             actor=actor,
             reason_codes=list(reason_codes),
             matched_rule_keys=list(matched_rule_keys),
-            metadata={
-                "frame_type": row.frame_type,
-                "warning_codes": list(row.warning_codes),
-                "error_codes": list(row.error_codes),
-            },
+            metadata={"frame_type": row.frame_type, "warning_codes": list(row.warning_codes), "error_codes": list(row.error_codes)},
         )
 
     def _pick_actor(self, ctx: EvalContext) -> str:
-        # human approval이 있으면 사람이 merge한 것으로 본다
         if ctx.approvals.get("human_reviewer"):
             return "human_reviewer"
-
-        # policy.auto_merge면 system
-        auto_merge = ctx.env.policy_flags.get("auto_merge", False)
-        if auto_merge:
+        if ctx.env.policy_flags.get("auto_merge", False):
             return "system"
-
         return "policy_engine"

--- a/inference_pass.py
+++ b/inference_pass.py
@@ -1,9 +1,8 @@
-# inference_pass.py
 from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import count
-from typing import Any, Optional
+from typing import Any
 
 from artifacts import (
     ClaimArtifact,
@@ -14,147 +13,81 @@ from artifacts import (
     error_codes_from_diagnostics,
     warning_codes_from_diagnostics,
 )
-from expr_eval import EvalContext, ExprEvaluator
+from compiled_spec import CompiledProgramSpec
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
 from runtime_env import RuntimeEnv, ScopePath
-from spec_nodes import InferSpec, ProgramSpec
 
 
 @dataclass
 class InferencePassConfig:
-    """
-    inference 결과를 기존 active와 비교할 때 쓰는 기본 마진.
-    실제 resolver loop의 replace_margin보다 보수적으로 유지하는 편이 낫다.
-    """
     strong_replace_margin: float = 0.05
-
-    # infer "~" 는 prior/shadow 성격이 강하므로 기본적으로 active를 바로 뒤집지 않게 둔다.
     weak_infer_promotes_when_empty: bool = True
-
-    # infer "=" 는 강한 inference이므로, 현 active가 매우 약하면 교체를 허용한다.
     strong_infer_can_replace_non_explicit: bool = True
 
 
 class InferencePass:
-    """
-    partial frames -> enriched partial frames
-
-    책임:
-    1) infer 규칙 실행
-    2) frame_type 강한 inference("=") 반영
-    3) role 후보 backward_inferred claim 생성
-    4) slot active/shadow 상태 업데이트
-
-    설계 원칙:
-    - infer "="  : strong inference
-    - infer "~"  : shadow prior
-    - 중복 value는 새 claim을 만들지 않고 기존 claim confidence를 보강
-    """
-
-    def __init__(
-        self,
-        evaluator: Optional[ExprEvaluator] = None,
-        config: Optional[InferencePassConfig] = None,
-    ) -> None:
-        self.evaluator = evaluator or ExprEvaluator()
+    def __init__(self, evaluator: RuleEvaluator | None = None, config: InferencePassConfig | None = None) -> None:
+        self.evaluator = evaluator or RuleEvaluator()
         self.config = config or InferencePassConfig()
         self._claim_seq = count(1)
         self._diag_seq = count(1)
 
-    def run(
-        self,
-        spec: ProgramSpec,
-        artifacts: CompileArtifacts,
-        env: RuntimeEnv,
-    ) -> CompileArtifacts:
-        claims_by_id = {c.claim_id: c for c in artifacts.claims}
-        fragments_by_id = {
-            getattr(f, "fragment_id", f"FRG-{i:06d}"): f
-            for i, f in enumerate(artifacts.fragments, start=1)
-        }
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("InferencePass requires CompiledProgramSpec")
 
+        claims_by_id = {c.claim_id: c for c in artifacts.claims}
+        fragments_by_id = {getattr(f, "fragment_id", f"FRG-{i:06d}"): f for i, f in enumerate(artifacts.fragments, start=1)}
         new_claims: list[ClaimArtifact] = []
 
         for frame in artifacts.frames:
-            scope_path = self._frame_scope(frame, fragments_by_id)
-
             ctx = EvalContext(
                 env=env,
                 text="",
-                scope_path=scope_path,
+                scope_path=self._frame_scope(frame, fragments_by_id),
                 frame=frame,
                 claims_by_id=claims_by_id,
-                local_vars={
-                    "frame_type": frame.frame_type,
-                    "status": frame.status,
-                },
+                local_vars={"frame_type": frame.frame_type, "status": frame.status},
                 warning_codes=self._frame_warning_codes(frame),
                 error_codes=self._frame_error_codes(frame),
             )
 
-            for rule in spec.infer_rules:
-                if not self.evaluator.eval_bool(rule.condition, ctx):
+            for compiled_rule in spec.compiled_infer_rules:
+                rule = compiled_rule.syntax
+                if not self.evaluator.eval_bool(compiled_rule.condition_ir, ctx):
                     continue
 
-                inferred_values = self._normalize_values(
-                    self.evaluator.eval(rule.value_expr, ctx)
-                )
+                inferred_values = self._normalize_values(self.evaluator.eval(compiled_rule.value_ir, ctx))
                 if not inferred_values:
                     continue
 
-                # 1) frame_type 강한 inference
                 if rule.target_name == "frame_type":
-                    changed = self._apply_frame_type_inference(
-                        frame=frame,
-                        rule=rule,
-                        inferred_values=inferred_values,
-                    )
+                    changed = self._apply_frame_type_inference(frame=frame, rule=rule, inferred_values=inferred_values)
                     if changed:
                         ctx.local_vars["frame_type"] = frame.frame_type
                     continue
 
-                # 2) role inference
                 created_or_updated = self._apply_role_inference(
                     frame=frame,
                     rule=rule,
                     inferred_values=inferred_values,
                     claims_by_id=claims_by_id,
                 )
-
                 for claim in created_or_updated:
-                    # 새 claim만 여기 들어온다. 기존 claim confidence boost는 skip.
                     if claim.claim_id not in claims_by_id:
                         claims_by_id[claim.claim_id] = claim
                         new_claims.append(claim)
-
-                # frame이 바뀌었으니 evaluator context 최신화
                 ctx.frame = frame
 
         artifacts.claims.extend(new_claims)
         return artifacts
 
-    # ------------------------------------------------------------------
-    # Frame-type inference
-    # ------------------------------------------------------------------
-
-    def _apply_frame_type_inference(
-        self,
-        *,
-        frame: PartialFrameArtifact,
-        rule: InferSpec,
-        inferred_values: list[Any],
-    ) -> bool:
-        """
-        frame_type inference는 보통 '='만 허용하는 게 자연스럽다.
-        값이 여러 개면 첫 번째만 사용.
-        """
+    def _apply_frame_type_inference(self, *, frame: PartialFrameArtifact, rule, inferred_values: list[Any]) -> bool:
         if rule.op != "=":
             return False
-
         new_type = str(inferred_values[0]).strip()
-        if not new_type:
-            return False
-
-        if frame.frame_type == new_type:
+        if not new_type or frame.frame_type == new_type:
             return False
 
         frame.frame_type = new_type
@@ -176,36 +109,18 @@ class InferencePass:
         )
         return True
 
-    # ------------------------------------------------------------------
-    # Role inference
-    # ------------------------------------------------------------------
-
-    def _apply_role_inference(
-        self,
-        *,
-        frame: PartialFrameArtifact,
-        rule: InferSpec,
-        inferred_values: list[Any],
-        claims_by_id: dict[str, ClaimArtifact],
-    ) -> list[ClaimArtifact]:
+    def _apply_role_inference(self, *, frame: PartialFrameArtifact, rule, inferred_values: list[Any], claims_by_id: dict[str, ClaimArtifact]) -> list[ClaimArtifact]:
         slot = frame.slots.get(rule.target_name)
         if slot is None:
             slot = RoleSlotArtifact(role_name=rule.target_name)
             frame.slots[rule.target_name] = slot
 
         created: list[ClaimArtifact] = []
-
         for idx, value in enumerate(inferred_values, start=1):
             if value in (None, ""):
                 continue
 
-            existing = self._find_existing_claim_with_same_value(
-                slot=slot,
-                value=value,
-                claims_by_id=claims_by_id,
-            )
-
-            # 같은 값이 이미 있으면 confidence만 보강
+            existing = self._find_existing_claim_with_same_value(slot=slot, value=value, claims_by_id=claims_by_id)
             if existing is not None:
                 self._boost_existing_claim(existing, rule)
                 continue
@@ -223,96 +138,42 @@ class InferencePass:
                 status="resolving",
                 source_fragment_id=frame.fragment_ids[0] if frame.fragment_ids else None,
                 span=None,
-                reason_codes=[
-                    f"inferred_by_rule:{rule.target_name}",
-                    f"infer_op:{rule.op}",
-                ],
-                evidence_ids=[
-                    f"pair:infer:{rule.target_name}:{rule.op}:{value}"
-                ],
-                metadata={
-                    "inference_weight": rule.weight,
-                    "inference_op": rule.op,
-                },
+                reason_codes=[f"inferred_by_rule:{rule.target_name}", f"infer_op:{rule.op}"],
+                evidence_ids=[f"pair:infer:{rule.target_name}:{rule.op}:{value}"],
+                metadata={"inference_weight": rule.weight, "inference_op": rule.op},
             )
 
-            promoted = self._maybe_promote_to_active(
-                slot=slot,
-                new_claim=new_claim,
-                claims_by_id=claims_by_id,
-                op=rule.op,
-            )
-
+            promoted = self._maybe_promote_to_active(slot=slot, new_claim=new_claim, claims_by_id=claims_by_id, op=rule.op)
             if not promoted:
                 new_claim.candidate_state = "shadow"
                 slot.shadow_claim_ids.append(new_claim.claim_id)
             else:
                 slot.missing_tag = None
-
             created.append(new_claim)
 
         return created
 
-    def _maybe_promote_to_active(
-        self,
-        *,
-        slot: RoleSlotArtifact,
-        new_claim: ClaimArtifact,
-        claims_by_id: dict[str, ClaimArtifact],
-        op: str,
-    ) -> bool:
-        """
-        promotion 정책:
-        - slot이 비어 있으면 infer "~" 도 active 허용 가능
-        - infer "=" 는 stronger candidate로 간주
-        - explicit active는 함부로 뒤집지 않는다
-        """
-        active_claim = (
-            claims_by_id.get(slot.active_claim_id)
-            if slot.active_claim_id is not None
-            else None
-        )
-
-        # active 없음
+    def _maybe_promote_to_active(self, *, slot: RoleSlotArtifact, new_claim: ClaimArtifact, claims_by_id: dict[str, ClaimArtifact], op: str) -> bool:
+        active_claim = claims_by_id.get(slot.active_claim_id) if slot.active_claim_id is not None else None
         if active_claim is None:
-            if op == "=":
+            if op == "=" or (op == "~" and self.config.weak_infer_promotes_when_empty):
                 self._promote(slot, new_claim, claims_by_id)
                 return True
-
-            if op == "~" and self.config.weak_infer_promotes_when_empty:
-                self._promote(slot, new_claim, claims_by_id)
-                return True
-
             return False
 
-        # active가 있는데, strong inference인지 확인
-        if op != "=":
+        if op != "=" or not self.config.strong_infer_can_replace_non_explicit or active_claim.extraction_mode == "explicit":
             return False
+        return self._promote_if_stronger(slot, active_claim, new_claim, claims_by_id)
 
-        if not self.config.strong_infer_can_replace_non_explicit:
-            return False
-
-        active_mode = active_claim.extraction_mode
+    def _promote_if_stronger(self, slot, active_claim, new_claim, claims_by_id) -> bool:
         active_conf = float(active_claim.confidence)
         new_conf = float(new_claim.confidence)
-
-        # explicit는 거의 보호
-        if active_mode == "explicit":
-            return False
-
-        # inherited / backward_inferred / derived는 stronger inference로 교체 가능
         if new_conf >= active_conf + self.config.strong_replace_margin:
             self._promote(slot, new_claim, claims_by_id)
             return True
-
         return False
 
-    def _promote(
-        self,
-        slot: RoleSlotArtifact,
-        new_claim: ClaimArtifact,
-        claims_by_id: dict[str, ClaimArtifact],
-    ) -> None:
+    def _promote(self, slot: RoleSlotArtifact, new_claim: ClaimArtifact, claims_by_id: dict[str, ClaimArtifact]) -> None:
         old_active_id = slot.active_claim_id
         if old_active_id is not None:
             old_active = claims_by_id.get(old_active_id)
@@ -320,55 +181,31 @@ class InferencePass:
                 old_active.candidate_state = "shadow"
             if old_active_id not in slot.shadow_claim_ids:
                 slot.shadow_claim_ids.append(old_active_id)
-
         new_claim.candidate_state = "active"
         slot.active_claim_id = new_claim.claim_id
         slot.resolved_value = new_claim.value
         slot.confidence = new_claim.confidence
 
-    def _find_existing_claim_with_same_value(
-        self,
-        *,
-        slot: RoleSlotArtifact,
-        value: Any,
-        claims_by_id: dict[str, ClaimArtifact],
-    ) -> Optional[ClaimArtifact]:
-        ids = []
-        if slot.active_claim_id:
-            ids.append(slot.active_claim_id)
-        ids.extend(slot.shadow_claim_ids)
-
+    def _find_existing_claim_with_same_value(self, *, slot: RoleSlotArtifact, value: Any, claims_by_id: dict[str, ClaimArtifact]) -> ClaimArtifact | None:
+        ids = ([slot.active_claim_id] if slot.active_claim_id else []) + list(slot.shadow_claim_ids)
         for cid in ids:
             claim = claims_by_id.get(cid)
-            if claim is None:
-                continue
-            if claim.value == value:
+            if claim is not None and claim.value == value:
                 return claim
         return None
 
-    def _boost_existing_claim(
-        self,
-        claim: ClaimArtifact,
-        rule: InferSpec,
-    ) -> None:
+    def _boost_existing_claim(self, claim: ClaimArtifact, rule) -> None:
         new_conf = self._infer_confidence(rule, rank=1)
         if new_conf > claim.confidence:
             claim.confidence = new_conf
-
         tag = f"inferred_by_rule:{rule.target_name}"
         if tag not in claim.reason_codes:
             claim.reason_codes.append(tag)
-
         ev = f"pair:infer:{rule.target_name}:{rule.op}:{claim.value}"
         if ev not in claim.evidence_ids:
             claim.evidence_ids.append(ev)
 
-    def _infer_confidence(self, rule: InferSpec, rank: int) -> float:
-        """
-        strong '=' inference는 좀 더 높게,
-        '~'는 prior/shadow이므로 조금 낮게 시작.
-        rank가 뒤로 갈수록 약간 감점.
-        """
+    def _infer_confidence(self, rule, rank: int) -> float:
         base = rule.weight if rule.weight is not None else (0.90 if rule.op == "=" else 0.70)
         penalty = (rank - 1) * 0.05
         return max(0.0, min(1.0, float(base) - penalty))
@@ -376,31 +213,19 @@ class InferencePass:
     def _normalize_values(self, value: Any) -> list[Any]:
         if value is None:
             return []
-
         if isinstance(value, (list, tuple, set)):
             out: list[Any] = []
             for item in value:
                 out.extend(self._normalize_values(item))
             return out
-
         return [value]
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    def _frame_scope(
-        self,
-        frame: PartialFrameArtifact,
-        fragments_by_id: dict[str, Any],
-    ) -> ScopePath:
+    def _frame_scope(self, frame: PartialFrameArtifact, fragments_by_id: dict[str, Any]) -> ScopePath:
         if not frame.fragment_ids:
             return tuple()
-
         frag = fragments_by_id.get(frame.fragment_ids[0])
         if frag is None:
             return tuple()
-
         return getattr(frag, "scope_path", tuple())
 
     def _frame_warning_codes(self, frame: PartialFrameArtifact) -> set[str]:

--- a/pipeline_runner.py
+++ b/pipeline_runner.py
@@ -1,4 +1,3 @@
-# pipeline_runner.py
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -9,8 +8,10 @@ from lark import Lark
 
 from artifacts import CompileArtifacts
 from ast_builder import ASTBuilder
+from binder import Binder
 from builtins import register_default_builtins
 from calculation_pass import CalculationPass
+from compiled_spec import CompiledProgramSpec
 from emit_pass import EmitPass
 from governance_pass import GovernancePass
 from inference_pass import InferencePass
@@ -25,26 +26,12 @@ from spec_nodes import ProgramSpec
 
 
 class Fragmentizer(Protocol):
-    """
-    documents -> fragments
-    반환 fragment는 최소한 아래 속성을 가져야 한다.
-    - fragment_id
-    - fragment_type
-    - text
-    - scope_path
-    - metadata (optional)
-    """
     def __call__(self, documents: Sequence[Any]) -> list[Any]:
         ...
 
 
 class CompilerPass(Protocol):
-    def run(
-        self,
-        spec: ProgramSpec,
-        artifacts: CompileArtifacts,
-        env: RuntimeEnv,
-    ) -> CompileArtifacts:
+    def run(self, spec: ProgramSpec | CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
         ...
 
 
@@ -52,19 +39,16 @@ class CompilerPass(Protocol):
 class PipelineResources:
     site_records: Sequence[SiteRecord] = field(default_factory=list)
     factor_rows: Sequence[dict[str, Any]] = field(default_factory=list)
-
     policy_flags: dict[str, Any] = field(default_factory=dict)
-
     activity_aliases: dict[str, list[str]] = field(default_factory=dict)
     unit_aliases: dict[str, list[str]] = field(default_factory=dict)
-
     llm_fallback: Optional[Any] = None
     llm_budget: int = 0
 
 
 @dataclass
 class PipelineRunResult:
-    spec: ProgramSpec
+    spec: ProgramSpec | CompiledProgramSpec
     env: RuntimeEnv
     artifacts: CompileArtifacts
 
@@ -99,155 +83,65 @@ class PipelineRunResult:
         }
 
 
-def load_program_spec_from_dsl(
-    *,
-    grammar_path: str | Path,
-    dsl_path: str | Path | None = None,
-    dsl_text: str | None = None,
-) -> ProgramSpec:
+def load_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> ProgramSpec:
     if dsl_text is None and dsl_path is None:
         raise ValueError("one of dsl_text or dsl_path must be provided")
-
     grammar = Path(grammar_path).read_text(encoding="utf-8")
     source = dsl_text if dsl_text is not None else Path(dsl_path).read_text(encoding="utf-8")
-
-    parser = Lark(
-        grammar,
-        parser="lalr",
-        lexer="contextual",
-        start="start",
-    )
+    parser = Lark(grammar, parser="lalr", lexer="contextual", start="start")
     tree = parser.parse(source)
-    program_ast = ASTBuilder().transform(tree)
-    program_spec = Lowerer().lower(program_ast)
-    return program_spec
+    return Lowerer().lower(ASTBuilder().transform(tree))
 
 
-def build_default_passes(
-    *,
-    include_post_repair_semantic: bool = False,
-) -> list[CompilerPass]:
-    passes: list[CompilerPass] = [
-        LexPass(),
-        ParsePass(),
-        ScopeResolutionPass(),
-        InferencePass(),
-        SemanticPass(),   # pre-repair semantic
-        RepairPass(),
-        EmitPass(),
-        GovernancePass(),
-        CalculationPass(),
-    ]
+def compile_program_spec(program_spec: ProgramSpec) -> CompiledProgramSpec:
+    return Binder().bind(program_spec)
 
-    # 참고:
-    # 현재 semantic pass는 stale diagnostics invalidation이 완전하지 않아서
-    # 기본은 pre-repair 1회로 둔다.
-    # 나중에 semantic_post를 정교화하면 RepairPass 뒤에 한 번 더 꽂을 수 있다.
+
+def load_compiled_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
+    return compile_program_spec(load_program_spec_from_dsl(grammar_path=grammar_path, dsl_path=dsl_path, dsl_text=dsl_text))
+
+
+def build_default_passes(*, include_post_repair_semantic: bool = False) -> list[CompilerPass]:
+    passes: list[CompilerPass] = [LexPass(), ParsePass(), ScopeResolutionPass(), InferencePass(), SemanticPass(), RepairPass(), EmitPass(), GovernancePass(), CalculationPass()]
     if include_post_repair_semantic:
-        passes = [
-            LexPass(),
-            ParsePass(),
-            ScopeResolutionPass(),
-            InferencePass(),
-            SemanticPass(),   # pre
-            RepairPass(),
-            SemanticPass(),   # post (현재는 실험적)
-            EmitPass(),
-            GovernancePass(),
-            CalculationPass(),
-        ]
-
+        passes = [LexPass(), ParsePass(), ScopeResolutionPass(), InferencePass(), SemanticPass(), RepairPass(), SemanticPass(), EmitPass(), GovernancePass(), CalculationPass()]
     return passes
 
 
 class ESGPipelineRunner:
-    def __init__(
-        self,
-        *,
-        grammar_path: str | Path = "esgdl.lark",
-        passes: Optional[list[CompilerPass]] = None,
-        fragmentizer: Optional[Fragmentizer] = None,
-    ) -> None:
+    def __init__(self, *, grammar_path: str | Path = "esgdl.lark", passes: Optional[list[CompilerPass]] = None, fragmentizer: Optional[Fragmentizer] = None) -> None:
         self.grammar_path = Path(grammar_path)
         self.fragmentizer = fragmentizer
         self.passes = passes or build_default_passes()
 
-    def load_spec(
-        self,
-        *,
-        dsl_path: str | Path | None = None,
-        dsl_text: str | None = None,
-    ) -> ProgramSpec:
-        return load_program_spec_from_dsl(
-            grammar_path=self.grammar_path,
-            dsl_path=dsl_path,
-            dsl_text=dsl_text,
-        )
+    def load_spec(self, *, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(grammar_path=self.grammar_path, dsl_path=dsl_path, dsl_text=dsl_text)
 
-    def build_env(
-        self,
-        *,
-        spec: ProgramSpec,
-        resources: Optional[PipelineResources] = None,
-    ) -> RuntimeEnv:
+    def build_env(self, *, spec: ProgramSpec | CompiledProgramSpec, resources: Optional[PipelineResources] = None) -> RuntimeEnv:
         resources = resources or PipelineResources()
-
-        env = build_runtime_env(
-            spec=spec,
-            site_records=list(resources.site_records),
-            factor_rows=list(resources.factor_rows),
-            policy_flags=dict(resources.policy_flags),
-            activity_aliases=dict(resources.activity_aliases),
-            unit_aliases=dict(resources.unit_aliases),
-            llm_fallback=resources.llm_fallback,
-            llm_budget=resources.llm_budget,
-        )
+        syntax_spec = spec.syntax if isinstance(spec, CompiledProgramSpec) else spec
+        env = build_runtime_env(spec=syntax_spec, site_records=list(resources.site_records), factor_rows=list(resources.factor_rows), policy_flags=dict(resources.policy_flags), activity_aliases=dict(resources.activity_aliases), unit_aliases=dict(resources.unit_aliases), llm_fallback=resources.llm_fallback, llm_budget=resources.llm_budget)
         register_default_builtins(env)
         return env
 
-    def prepare_fragments(
-        self,
-        *,
-        fragments: Optional[list[Any]] = None,
-        documents: Optional[Sequence[Any]] = None,
-    ) -> list[Any]:
+    def prepare_fragments(self, *, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None) -> list[Any]:
         if fragments is not None:
             return fragments
-
         if documents is None:
             raise ValueError("one of fragments or documents must be provided")
-
         if self.fragmentizer is None:
-            raise ValueError(
-                "documents were provided but no fragmentizer is configured. "
-                "Either pass pre-built fragments or inject a fragmentizer callable."
-            )
-
+            raise ValueError("documents were provided but no fragmentizer is configured. Either pass pre-built fragments or inject a fragmentizer callable.")
         return self.fragmentizer(documents)
 
-    def run(
-        self,
-        *,
-        spec: Optional[ProgramSpec] = None,
-        dsl_path: str | Path | None = None,
-        dsl_text: str | None = None,
-        fragments: Optional[list[Any]] = None,
-        documents: Optional[Sequence[Any]] = None,
-        resources: Optional[PipelineResources] = None,
-    ) -> PipelineRunResult:
+    def run(self, *, spec: Optional[ProgramSpec | CompiledProgramSpec] = None, dsl_path: str | Path | None = None, dsl_text: str | None = None, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None, resources: Optional[PipelineResources] = None) -> PipelineRunResult:
         if spec is None:
             spec = self.load_spec(dsl_path=dsl_path, dsl_text=dsl_text)
+        elif not isinstance(spec, CompiledProgramSpec):
+            spec = compile_program_spec(spec)
 
         env = self.build_env(spec=spec, resources=resources)
         prepared_fragments = self.prepare_fragments(fragments=fragments, documents=documents)
-
         artifacts = CompileArtifacts(fragments=prepared_fragments)
-
         for p in self.passes:
             artifacts = p.run(spec, artifacts, env)
-
-        return PipelineRunResult(
-            spec=spec,
-            env=env,
-            artifacts=artifacts,
-        )
+        return PipelineRunResult(spec=spec, env=env, artifacts=artifacts)

--- a/repair_pass.py
+++ b/repair_pass.py
@@ -1,4 +1,3 @@
-# repair_pass.py
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -12,9 +11,10 @@ from artifacts import (
     RoleSlotArtifact,
     diagnostic_codes,
 )
-from expr_eval import EvalContext, ExprEvaluator
+from compiled_spec import CompiledProgramSpec, CompiledResolverPolicy
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
 from runtime_env import RuntimeEnv
-from spec_nodes import ProgramSpec, ResolverPolicy
 
 
 @dataclass
@@ -59,23 +59,26 @@ class RepairPass:
 
     def __init__(
         self,
-        evaluator: Optional[ExprEvaluator] = None,
-        config: Optional[RepairPassConfig] = None,
+        evaluator: RuleEvaluator | None = None,
+        config: RepairPassConfig | None = None,
     ) -> None:
-        self.evaluator = evaluator or ExprEvaluator()
+        self.evaluator = evaluator or RuleEvaluator()
         self.config = config or RepairPassConfig()
         self._event_seq = count(1)
 
     def run(
         self,
-        spec: ProgramSpec,
+        spec: CompiledProgramSpec,
         artifacts: CompileArtifacts,
         env: RuntimeEnv,
     ) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("RepairPass requires CompiledProgramSpec")
+
         claims_by_id = {c.claim_id: c for c in artifacts.claims}
 
         for frame in artifacts.frames:
-            policy = spec.resolvers.get(frame.frame_type)
+            policy = spec.compiled_resolvers.get(frame.frame_type)
             if policy is None:
                 continue
 
@@ -96,7 +99,7 @@ class RepairPass:
         self,
         *,
         frame: PartialFrameArtifact,
-        policy: ResolverPolicy,
+        policy: CompiledResolverPolicy,
         claims_by_id: dict[str, ClaimArtifact],
         env: RuntimeEnv,
     ) -> None:
@@ -165,7 +168,6 @@ class RepairPass:
             else:
                 frame_stable = 0
 
-            # trace
             if self.config.trace_enabled:
                 frame.metadata["repair_trace"].append(
                     {
@@ -196,7 +198,7 @@ class RepairPass:
                 error_codes=error_codes,
             )
 
-            if policy.commit_condition is not None and self.evaluator.eval_bool(policy.commit_condition, eval_ctx):
+            if policy.commit_condition_ir is not None and self.evaluator.eval_bool(policy.commit_condition_ir, eval_ctx):
                 frame.status = "committed"
                 termination_reason = "commit_condition_satisfied"
                 break
@@ -240,16 +242,17 @@ class RepairPass:
                 "score": final_score,
                 "stable": frame_stable,
                 "status": frame.status,
+                "iteration": last_iter_no,
+                "no_improve_count": no_improve_count,
             },
             warning_codes=self._diag_codes(frame, severity="warning"),
             error_codes=self._diag_codes(frame, severity="error"),
         )
 
-        # 이미 committed면 유지
         if frame.status != "committed":
-            if policy.review_condition is not None and self.evaluator.eval_bool(policy.review_condition, final_ctx):
+            if policy.review_condition_ir is not None and self.evaluator.eval_bool(policy.review_condition_ir, final_ctx):
                 frame.status = "review_required"
-            elif policy.reject_otherwise:
+            elif policy.syntax.reject_otherwise:
                 frame.status = "rejected"
             else:
                 frame.status = "resolving"
@@ -283,7 +286,6 @@ class RepairPass:
     ) -> None:
         active_claim = claims_by_id.get(slot.active_claim_id) if slot.active_claim_id else None
 
-        # scoring pool = active + shadows
         pool_ids = []
         if slot.active_claim_id:
             pool_ids.append(slot.active_claim_id)
@@ -336,7 +338,6 @@ class RepairPass:
         best = scored[0]
         best_claim = claims_by_id[best.claim_id]
 
-        # active 교체 여부
         if active_claim is None:
             self._promote_to_active(slot, best_claim, claims_by_id)
         else:
@@ -353,7 +354,6 @@ class RepairPass:
                 ):
                     self._promote_to_active(slot, best_claim, claims_by_id)
 
-        # aging 업데이트 / frozen / rejected 정리
         self._update_candidate_lifecycle(
             slot=slot,
             claims_by_id=claims_by_id,
@@ -363,7 +363,6 @@ class RepairPass:
             shadow_limit=shadow_limit,
         )
 
-        # resolved value / confidence
         active = claims_by_id.get(slot.active_claim_id) if slot.active_claim_id else None
         if active is not None:
             slot.resolved_value = active.value
@@ -386,10 +385,6 @@ class RepairPass:
         if not allow_frozen:
             return
 
-        # revive 조건:
-        # - active 없음
-        # - context_conflict 있음
-        # - role 관련 diagnostic이 있음
         should_revive = False
 
         if slot.active_claim_id is None:
@@ -407,29 +402,21 @@ class RepairPass:
         if role_name == "site" and "MissingSite" in warning_codes:
             should_revive = True
 
-        if not should_revive:
+        if not should_revive or not slot.frozen_claim_ids:
             return
 
-        if not slot.frozen_claim_ids:
-            return
-
-        # frozen 중 confidence 가장 높은 1개만 shadow로 복귀
-        frozen_claims = [
-            claims_by_id[cid] for cid in slot.frozen_claim_ids
-            if cid in claims_by_id
-        ]
+        frozen_claims = [claims_by_id[cid] for cid in slot.frozen_claim_ids if cid in claims_by_id]
         frozen_claims.sort(key=lambda c: float(c.confidence), reverse=True)
 
         revive = frozen_claims[:1]
         revive_ids = {c.claim_id for c in revive}
 
         slot.frozen_claim_ids = [cid for cid in slot.frozen_claim_ids if cid not in revive_ids]
-        for c in revive:
-            c.candidate_state = "shadow"
-            c.metadata["not_selected_iters"] = 0
-            slot.shadow_claim_ids.append(c.claim_id)
+        for claim in revive:
+            claim.candidate_state = "shadow"
+            claim.metadata["not_selected_iters"] = 0
+            slot.shadow_claim_ids.append(claim.claim_id)
 
-        # shadow 길이 제한
         slot.shadow_claim_ids = slot.shadow_claim_ids[:shadow_limit]
 
     def _update_candidate_lifecycle(
@@ -442,7 +429,6 @@ class RepairPass:
         aging_cap: float,
         shadow_limit: int,
     ) -> None:
-        # shadow 정리: active 제거, 순서 유지
         slot.shadow_claim_ids = [cid for cid in slot.shadow_claim_ids if cid != active_claim_id]
 
         new_shadow: list[str] = []
@@ -476,17 +462,14 @@ class RepairPass:
             claim.candidate_state = "shadow"
             new_shadow.append(cid)
 
-        # active는 aging 리셋
         if active_claim_id and active_claim_id in claims_by_id:
             active = claims_by_id[active_claim_id]
             active.candidate_state = "active"
             active.metadata["aging_bonus"] = 0.0
             active.metadata["not_selected_iters"] = 0
 
-        # shadow score 순서대로 상위만 유지
         new_shadow.sort(
-            key=lambda cid: -self._claim_total_score(claims_by_id[cid])
-            if cid in claims_by_id else 0.0
+            key=lambda cid: -self._claim_total_score(claims_by_id[cid]) if cid in claims_by_id else 0.0
         )
         slot.shadow_claim_ids = new_shadow[:shadow_limit]
         slot.frozen_claim_ids = new_frozen
@@ -591,7 +574,6 @@ class RepairPass:
         challenger_score: float,
         replace_margin: float,
     ) -> bool:
-        # explicit active는 조금 더 보호
         margin = replace_margin
         if active_claim.extraction_mode == "explicit":
             margin += self.config.explicit_protection_margin
@@ -606,13 +588,7 @@ class RepairPass:
         items = []
         for role_name in sorted(frame.slots.keys()):
             slot = frame.slots[role_name]
-            items.append(
-                (
-                    role_name,
-                    slot.active_claim_id,
-                    slot.missing_tag,
-                )
-            )
+            items.append((role_name, slot.active_claim_id, slot.missing_tag))
         return tuple(items)
 
     def _detect_oscillation(self, state_history: list[tuple]) -> bool:
@@ -625,7 +601,6 @@ class RepairPass:
             a, b, c, d = tail
             return (a == c) and (b == d) and (a != b)
 
-        # generic fallback: 최근 window 안에서 두 상태가 번갈아 나오는지 느슨히 검사
         unique = list(dict.fromkeys(tail))
         return len(unique) == 2 and tail[0] == tail[2] and tail[1] == tail[3]
 
@@ -660,7 +635,7 @@ class RepairPass:
 
     def _extract_policy_params(
         self,
-        policy: ResolverPolicy,
+        policy: CompiledResolverPolicy,
         env: RuntimeEnv,
         frame: PartialFrameArtifact,
         claims_by_id: dict[str, ClaimArtifact],
@@ -677,10 +652,10 @@ class RepairPass:
             local_vars={},
         )
 
-        for k, expr in policy.assigns.items():
-            params[k] = self.evaluator.eval(expr, ctx)
+        for key, expr in policy.assigns_ir.items():
+            params[key] = self.evaluator.eval(expr, ctx)
 
-        for k, expr in policy.candidate_pool_assigns.items():
-            params[f"candidate_pool.{k}"] = self.evaluator.eval(expr, ctx)
+        for key, expr in policy.candidate_pool_assigns_ir.items():
+            params[f"candidate_pool.{key}"] = self.evaluator.eval(expr, ctx)
 
         return params

--- a/rule_eval.py
+++ b/rule_eval.py
@@ -1,39 +1,61 @@
 from __future__ import annotations
+
 import re
+from typing import Any
+
 from rule_builtins import get_default_rule_builtin_registry
 from rule_ir import *
 
+
+RuleEvalContext = Any
+
+
 class RuleEvalError(ValueError):
     pass
+
 
 class RuleEvaluator:
     def __init__(self, *, builtin_registry=None):
         self.builtin_registry = get_default_rule_builtin_registry() if builtin_registry is None else builtin_registry
 
     def eval(self, expr, ctx):
-        if not isinstance(expr, RuleExpr): return expr
-        if isinstance(expr, RuleLiteral): return expr.value
-        if isinstance(expr, LocalVarRef): return ctx.local_vars.get(expr.name)
-        if isinstance(expr, FrameSlotRef): return self._frame_value(ctx.frame, expr.role_name)
-        if isinstance(expr, RowFieldRef): return ctx.row.get(expr.field_name) if isinstance(ctx.row, dict) else getattr(ctx.row, expr.field_name, None)
+        if not isinstance(expr, RuleExpr):
+            return expr
+        if isinstance(expr, RuleLiteral):
+            return expr.value
+        if isinstance(expr, LocalVarRef):
+            return ctx.local_vars.get(expr.name)
+        if isinstance(expr, FrameSlotRef):
+            return self._frame_value(ctx.frame, expr.role_name)
+        if isinstance(expr, RowFieldRef):
+            return ctx.row.get(expr.field_name) if isinstance(ctx.row, dict) else getattr(ctx.row, expr.field_name, None)
         if isinstance(expr, ContextValueRef):
             res = ctx.env.context_store.resolve_best(expr.role_name, ctx.scope_path, column_key=getattr(ctx, "column_key", None))
             return None if res.chosen is None else res.chosen.value
-        if isinstance(expr, PolicyRef): return ctx.env.policy_flags.get(expr.key)
-        if isinstance(expr, HasDiagnostic): return expr.code in (ctx.warning_codes if expr.severity == "warning" else ctx.error_codes)
-        if isinstance(expr, HasApproval): return bool(ctx.approvals.get(expr.key, False))
-        if isinstance(expr, SymbolConst): return expr.name
-        if isinstance(expr, RuleBuiltinCall): return self._call(expr, ctx)
-        if isinstance(expr, RuleSetExpr): return [self.eval(x, ctx) for x in expr.items]
+        if isinstance(expr, PolicyRef):
+            return ctx.env.policy_flags.get(expr.key)
+        if isinstance(expr, HasDiagnostic):
+            return expr.code in (ctx.warning_codes if expr.severity == "warning" else ctx.error_codes)
+        if isinstance(expr, HasApproval):
+            return bool(ctx.approvals.get(expr.key, False))
+        if isinstance(expr, SymbolConst):
+            return expr.name
+        if isinstance(expr, RuleBuiltinCall):
+            return self._call(expr, ctx)
+        if isinstance(expr, RuleSetExpr):
+            return [self.eval(x, ctx) for x in expr.items]
         if isinstance(expr, RuleCoalesce):
             for x in expr.options:
                 v = self.eval(x, ctx)
-                if self._present(v): return v
+                if self._present(v):
+                    return v
             return None
         if isinstance(expr, RuleUnary):
-            if expr.op == "not": return not self.eval_bool(expr.operand, ctx)
+            if expr.op == "not":
+                return not self.eval_bool(expr.operand, ctx)
             raise RuleEvalError(f"unsupported unary op: {expr.op}")
-        if isinstance(expr, RuleBinary): return self._binary(expr, ctx)
+        if isinstance(expr, RuleBinary):
+            return self._binary(expr, ctx)
         raise RuleEvalError(f"unsupported RuleExpr type: {type(expr).__name__}")
 
     def eval_bool(self, expr, ctx):
@@ -41,36 +63,55 @@ class RuleEvaluator:
 
     def _binary(self, expr, ctx):
         l, r, op = self.eval(expr.left, ctx), self.eval(expr.right, ctx), expr.op
-        if op == "or": return self._present(l) or self._present(r)
-        if op == "and": return self._present(l) and self._present(r)
-        if op == "==": return l == r
-        if op == "!=": return l != r
-        if op == ">=": return l >= r
-        if op == "<=": return l <= r
-        if op == ">": return l > r
-        if op == "<": return l < r
-        if op == "in": return False if r is None else l in r
-        if op == "matches": return re.search(str(r), str(l or "")) is not None
+        if op == "or":
+            return self._present(l) or self._present(r)
+        if op == "and":
+            return self._present(l) and self._present(r)
+        if op == "==":
+            return l == r
+        if op == "!=":
+            return l != r
+        if op == ">=":
+            return l >= r
+        if op == "<=":
+            return l <= r
+        if op == ">":
+            return l > r
+        if op == "<":
+            return l < r
+        if op == "in":
+            return False if r is None else l in r
+        if op == "matches":
+            return re.search(str(r), str(l or "")) is not None
         raise RuleEvalError(f"unsupported binary op: {op}")
 
     def _call(self, expr, ctx):
         spec = self.builtin_registry.get(expr.name)
-        if spec is None: raise RuleEvalError(f"unknown rule builtin: {expr.name}")
-        if len(expr.args) != len(spec.arg_modes): raise RuleEvalError(f"builtin {expr.name} expected {len(spec.arg_modes)} args, got {len(expr.args)}")
+        if spec is None:
+            raise RuleEvalError(f"unknown rule builtin: {expr.name}")
+        if len(expr.args) != len(spec.arg_modes):
+            raise RuleEvalError(f"builtin {expr.name} expected {len(spec.arg_modes)} args, got {len(expr.args)}")
         args = [self._arg(a, m, ctx) for a, m in zip(expr.args, spec.arg_modes)]
         return spec.impl(ctx, *args)
 
     def _arg(self, arg, mode, ctx):
-        if mode == "value": return self.eval(arg, ctx)
+        if mode == "value":
+            return self.eval(arg, ctx)
         if mode in {"slot_name", "symbol_name"}:
-            if isinstance(arg, FrameSlotRef): return arg.role_name
-            if isinstance(arg, SymbolConst): return arg.name
-            if isinstance(arg, RuleLiteral): return str(arg.value)
+            if isinstance(arg, FrameSlotRef):
+                return arg.role_name
+            if isinstance(arg, RowFieldRef):
+                return arg.field_name
+            if isinstance(arg, SymbolConst):
+                return arg.name
+            if isinstance(arg, RuleLiteral):
+                return str(arg.value)
             return str(self.eval(arg, ctx))
         raise RuleEvalError(f"unsupported builtin arg mode: {mode}")
 
     def _frame_value(self, frame, role_name):
-        if frame is None: return None
+        if frame is None:
+            return None
         b = getattr(frame, "bindings", None)
         if isinstance(b, dict) and role_name in b:
             v = b[role_name]
@@ -79,15 +120,20 @@ class RuleEvaluator:
         if isinstance(s, dict):
             if role_name in s:
                 v = getattr(s[role_name], "resolved_value", None)
-                if v not in (None, ""): return v
+                if v not in (None, ""):
+                    return v
             for k, slot in s.items():
                 if getattr(k, "value", k) == role_name:
                     v = getattr(slot, "resolved_value", None)
-                    if v not in (None, ""): return v
+                    if v not in (None, ""):
+                        return v
         return None
 
     def _present(self, v):
-        if v is None: return False
-        if isinstance(v, str): return v != ""
-        if isinstance(v, (list, tuple, set, dict)): return len(v) > 0
+        if v is None:
+            return False
+        if isinstance(v, str):
+            return v != ""
+        if isinstance(v, (list, tuple, set, dict)):
+            return len(v) > 0
         return bool(v)

--- a/rule_eval.py
+++ b/rule_eval.py
@@ -98,10 +98,13 @@ class RuleEvaluator:
         if mode == "value":
             return self.eval(arg, ctx)
         if mode in {"slot_name", "symbol_name"}:
+            if isinstance(arg, RowFieldRef):
+                raise RuleEvalError(
+                    f"row field ref '{arg.field_name}' cannot be used as {mode}; "
+                    "bind a value expression instead or use a row-aware builtin"
+                )
             if isinstance(arg, FrameSlotRef):
                 return arg.role_name
-            if isinstance(arg, RowFieldRef):
-                return arg.field_name
             if isinstance(arg, SymbolConst):
                 return arg.name
             if isinstance(arg, RuleLiteral):

--- a/semantic_pass.py
+++ b/semantic_pass.py
@@ -1,60 +1,43 @@
-# semantic_pass.py
 from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import count
-from typing import Any, Optional
+from typing import Any
 
 from artifacts import CompileArtifacts, DiagnosticArtifact, PartialFrameArtifact
-from expr_eval import EvalContext, ExprEvaluator
+from compiled_spec import CompiledProgramSpec
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
 from runtime_env import RuntimeEnv
-from spec_nodes import ConstraintSpec, DiagnosticSpec, ProgramSpec
 
 
 @dataclass
 class SemanticPassConfig:
-    """
-    phase_label:
-      - semantic_pre  : repair 전에 돌릴 때
-      - semantic_post : repair 후 최종 검증 때
-    """
     phase_label: str = "semantic_pre"
-
-    # 같은 phase/source_key/code의 진단은 중복으로 안 쌓이게
     dedupe: bool = True
-
-    # rerun 가능하게 같은 phase diagnostics를 지우고 다시 생성
     clear_same_phase_before_run: bool = True
 
 
 class SemanticPass:
-    """
-    frames -> diagnostics attached frames
-
-    책임:
-    1) require 규칙 평가
-    2) forbid 규칙 평가
-    3) explicit diagnostic rules(error/warning) 평가
-    4) frame / global diagnostics 축적
-    """
-
     def __init__(
         self,
-        evaluator: Optional[ExprEvaluator] = None,
-        config: Optional[SemanticPassConfig] = None,
+        evaluator: RuleEvaluator | None = None,
+        config: SemanticPassConfig | None = None,
     ) -> None:
-        self.evaluator = evaluator or ExprEvaluator()
+        self.evaluator = evaluator or RuleEvaluator()
         self.config = config or SemanticPassConfig()
         self._diag_seq = count(1)
 
     def run(
         self,
-        spec: ProgramSpec,
+        spec: CompiledProgramSpec,
         artifacts: CompileArtifacts,
         env: RuntimeEnv,
     ) -> CompileArtifacts:
-        claims_by_id = {c.claim_id: c for c in artifacts.claims}
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("SemanticPass requires CompiledProgramSpec")
 
+        claims_by_id = {c.claim_id: c for c in artifacts.claims}
         if self.config.clear_same_phase_before_run:
             self._clear_same_phase(artifacts)
 
@@ -62,28 +45,24 @@ class SemanticPass:
 
         for frame in artifacts.frames:
             frame_diags: list[DiagnosticArtifact] = []
-
             ctx = EvalContext(
                 env=env,
                 text="",
                 scope_path=self._frame_scope(frame, artifacts.fragments),
                 frame=frame,
                 claims_by_id=claims_by_id,
-                local_vars={
-                    "frame_type": frame.frame_type,
-                    "status": frame.status,
-                },
+                local_vars={"frame_type": frame.frame_type, "status": frame.status},
                 warning_codes=self._existing_codes(frame, severity="warning"),
                 error_codes=self._existing_codes(frame, severity="error"),
             )
 
-            # 1) require / forbid
-            for idx, constraint in enumerate(spec.constraints, start=1):
+            for idx, compiled_constraint in enumerate(spec.compiled_constraints, start=1):
+                constraint = compiled_constraint.syntax
                 if constraint.frame_name is not None and constraint.frame_name != frame.frame_type:
                     continue
 
                 if constraint.kind == "require":
-                    passed = self.evaluator.eval_bool(constraint.condition, ctx)
+                    passed = self.evaluator.eval_bool(compiled_constraint.condition_ir, ctx)
                     if not passed:
                         diag = self._make_diagnostic(
                             severity="error",
@@ -96,9 +75,8 @@ class SemanticPass:
                         if self._accept_diag(frame, diag):
                             frame_diags.append(diag)
                             ctx.error_codes.add(diag.code)
-
                 elif constraint.kind == "forbid":
-                    violated = self.evaluator.eval_bool(constraint.condition, ctx)
+                    violated = self.evaluator.eval_bool(compiled_constraint.condition_ir, ctx)
                     if violated:
                         diag = self._make_diagnostic(
                             severity="error",
@@ -112,10 +90,9 @@ class SemanticPass:
                             frame_diags.append(diag)
                             ctx.error_codes.add(diag.code)
 
-            # 2) explicit diagnostic rules
-            for rule in spec.diagnostics:
-                triggered = self.evaluator.eval_bool(rule.condition, ctx)
-                if not triggered:
+            for compiled_rule in spec.compiled_diagnostics:
+                rule = compiled_rule.syntax
+                if not self.evaluator.eval_bool(compiled_rule.condition_ir, ctx):
                     continue
 
                 diag = self._make_diagnostic(
@@ -133,16 +110,11 @@ class SemanticPass:
                     elif rule.level == "error":
                         ctx.error_codes.add(rule.code)
 
-            # frame / global 반영
             frame.diagnostics.extend(frame_diags)
             new_global_diags.extend(frame_diags)
 
         artifacts.diagnostics.extend(new_global_diags)
         return artifacts
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
 
     def _make_diagnostic(
         self,
@@ -168,11 +140,7 @@ class SemanticPass:
             phase=self.config.phase_label,
         )
 
-    def _accept_diag(
-        self,
-        frame: PartialFrameArtifact,
-        diag: DiagnosticArtifact,
-    ) -> bool:
+    def _accept_diag(self, frame: PartialFrameArtifact, diag: DiagnosticArtifact) -> bool:
         if not self.config.dedupe:
             return True
 
@@ -190,24 +158,11 @@ class SemanticPass:
 
     def _clear_same_phase(self, artifacts: CompileArtifacts) -> None:
         phase = self.config.phase_label
-
         for frame in artifacts.frames:
-            frame.diagnostics = [
-                d for d in frame.diagnostics
-                if getattr(d, "phase", None) != phase
-            ]
+            frame.diagnostics = [d for d in frame.diagnostics if getattr(d, "phase", None) != phase]
+        artifacts.diagnostics = [d for d in artifacts.diagnostics if getattr(d, "phase", None) != phase]
 
-        artifacts.diagnostics = [
-            d for d in artifacts.diagnostics
-            if getattr(d, "phase", None) != phase
-        ]
-
-    def _existing_codes(
-        self,
-        frame: PartialFrameArtifact,
-        *,
-        severity: str,
-    ) -> set[str]:
+    def _existing_codes(self, frame: PartialFrameArtifact, *, severity: str) -> set[str]:
         codes = set()
         for d in frame.diagnostics:
             if getattr(d, "severity", None) == severity:
@@ -216,15 +171,8 @@ class SemanticPass:
                     codes.add(code)
         return codes
 
-    def _frame_scope(
-        self,
-        frame: PartialFrameArtifact,
-        fragments: list[Any],
-    ):
-        frag_map = {
-            getattr(f, "fragment_id", f"FRG-{i:06d}"): f
-            for i, f in enumerate(fragments, start=1)
-        }
+    def _frame_scope(self, frame: PartialFrameArtifact, fragments: list[Any]):
+        frag_map = {getattr(f, "fragment_id", f"FRG-{i:06d}"): f for i, f in enumerate(fragments, start=1)}
         if not frame.fragment_ids:
             return tuple()
         frag = frag_map.get(frame.fragment_ids[0])

--- a/tests/test_pr4_compiled_rule_path.py
+++ b/tests/test_pr4_compiled_rule_path.py
@@ -1,0 +1,152 @@
+import pytest
+
+from artifacts import (
+    CanonicalRowArtifact,
+    ClaimArtifact,
+    PartialFrameArtifact,
+    RoleSlotArtifact,
+)
+from ast_nodes import BinaryExpr, FunctionCallExpr, LiteralExpr, NameExpr
+from binder import BindingError
+from compiled_spec import CompiledProgramSpec
+from governance_pass import GovernancePass
+from pipeline_runner import ESGPipelineRunner, compile_program_spec
+from repair_pass import RepairPass
+from spec_nodes import FieldSpec, FrameSpec, GovernancePolicy, ProgramSpec, ResolverPolicy
+
+
+class SeedFramePass:
+    def run(self, spec, artifacts, env):
+        claim = ClaimArtifact(
+            claim_id="CLM-000001",
+            frame_id="FRM-000001",
+            fragment_id="FRG-000001",
+            parser_name="seed",
+            role_name="raw_amount",
+            value=100.0,
+            confidence=0.95,
+            extraction_mode="explicit",
+            candidate_state="active",
+        )
+        slot = RoleSlotArtifact(
+            role_name="raw_amount",
+            active_claim_id=claim.claim_id,
+            resolved_value=claim.value,
+            confidence=claim.confidence,
+        )
+        frame = PartialFrameArtifact(
+            frame_id="FRM-000001",
+            parser_name="seed",
+            frame_type="Observation",
+            slots={"raw_amount": slot},
+        )
+        artifacts.claims.append(claim)
+        artifacts.frames.append(frame)
+        return artifacts
+
+
+class SeedRowPass:
+    def run(self, spec, artifacts, env):
+        artifacts.rows.append(
+            CanonicalRowArtifact(
+                row_id="ROW-000001",
+                frame_id="FRM-000001",
+                parser_name="seed",
+                frame_type="Observation",
+                status="committed",
+                raw_amount=10.0,
+            )
+        )
+        return artifacts
+
+
+def make_base_spec() -> ProgramSpec:
+    spec = ProgramSpec(module_name="test_module")
+    spec.frames["Observation"] = FrameSpec(
+        name="Observation",
+        fields=[FieldSpec(name="raw_amount", type_name="number")],
+    )
+    return spec
+
+
+def test_repair_pass_uses_compiled_resolver_ir_even_if_syntax_policy_is_poisoned():
+    spec = make_base_spec()
+    spec.resolvers["Observation"] = ResolverPolicy(
+        frame_name="Observation",
+        commit_condition=BinaryExpr(NameExpr("score"), ">=", LiteralExpr(0.90)),
+    )
+
+    compiled = compile_program_spec(spec)
+    compiled.syntax.resolvers["Observation"].commit_condition = LiteralExpr(False)
+
+    runner = ESGPipelineRunner(passes=[SeedFramePass(), RepairPass()])
+    result = runner.run(spec=compiled, fragments=[])
+
+    frame = result.artifacts.frames[0]
+    assert frame.status == "committed"
+    assert frame.runtime.iteration_count >= 1
+    assert frame.runtime.resolution_score >= 0.90
+
+
+def test_default_runner_compiles_raw_spec_before_repair():
+    spec = make_base_spec()
+    spec.resolvers["Observation"] = ResolverPolicy(
+        frame_name="Observation",
+        commit_condition=BinaryExpr(NameExpr("score"), ">=", LiteralExpr(0.90)),
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedFramePass(), RepairPass()])
+    result = runner.run(spec=spec, fragments=[])
+
+    assert isinstance(result.spec, CompiledProgramSpec)
+    frame = result.artifacts.frames[0]
+    assert frame.status == "committed"
+    assert frame.runtime.resolution_score >= 0.90
+
+
+def test_default_runner_raises_binding_error_for_unresolved_resolver_name():
+    spec = make_base_spec()
+    spec.resolvers["Observation"] = ResolverPolicy(
+        frame_name="Observation",
+        commit_condition=BinaryExpr(NameExpr("mystery_name"), "==", LiteralExpr(True)),
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedFramePass(), RepairPass()])
+
+    with pytest.raises(BindingError):
+        runner.run(spec=spec, fragments=[])
+
+
+def test_default_runner_rejects_frame_only_builtin_in_governance_host():
+    spec = make_base_spec()
+    spec.governances["Observation"] = GovernancePolicy(
+        frame_name="Observation",
+        merge_conditions=[
+            FunctionCallExpr("missing", [NameExpr("raw_amount")]),
+        ],
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedRowPass(), GovernancePass()])
+
+    with pytest.raises(BindingError):
+        runner.run(spec=spec, fragments=[])
+
+
+def test_governance_row_field_rule_still_merges_via_compiled_default_path():
+    spec = make_base_spec()
+    spec.governances["Observation"] = GovernancePolicy(
+        frame_name="Observation",
+        merge_conditions=[
+            BinaryExpr(NameExpr("raw_amount"), ">", LiteralExpr(0)),
+        ],
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedRowPass(), GovernancePass()])
+    result = runner.run(spec=spec, fragments=[])
+
+    assert isinstance(result.spec, CompiledProgramSpec)
+    row = result.artifacts.rows[0]
+    decision = result.artifacts.merge_log[0]
+
+    assert row.status == "merged"
+    assert decision.action == "merge"


### PR DESCRIPTION
### Motivation
- Make the default `ESGPipelineRunner` compile rule hosts before execution instead of leaving compiled RuleIR on the side path only.
- Start removing the old runtime-guess rule-host path by switching rule-bearing passes onto `CompiledProgramSpec` + `RuleEvaluator`.
- Keep the separate compiled runner as a thin wrapper once the default path is compiled-first.

### What is in this draft
- `pipeline_runner.py`
  - adds `compile_program_spec()`
  - adds `load_compiled_program_spec_from_dsl()`
  - changes `ESGPipelineRunner.load_spec()` to return `CompiledProgramSpec`
  - compiles raw `ProgramSpec` inputs inside `run()` before pass execution
  - unwraps `spec.syntax` only for env construction
- `semantic_pass.py`
  - now requires `CompiledProgramSpec`
  - evaluates `compiled_constraints` / `compiled_diagnostics` through `RuleEvaluator`
- `inference_pass.py`
  - now requires `CompiledProgramSpec`
  - evaluates `compiled_infer_rules` through `RuleEvaluator`
- `governance_pass.py`
  - now requires `CompiledProgramSpec`
  - evaluates `compiled_governances` through `RuleEvaluator`
  - uses `row=` in `EvalContext` so `RowFieldRef` resolves directly
- `rule_eval.py`
  - tightens rule-eval context typing via `RuleEvalContext = Any`
  - allows `RowFieldRef` in builtin arg extraction where symbol/slot-like names are expected
- `compiled_pipeline_runner.py`
  - reduced to a thin wrapper over the default compiled loader path

### Still missing before PR4 is truly complete
- `repair_pass.py` is still on the old resolver path (`spec.resolvers` + old evaluator path)
- strict-binding coverage for the default runner still needs to be added
- optional cleanup of the old compiled adapter path can happen after the runtime switch-over is complete

### Why this is still useful as a draft
- It moves the default entrypoint onto compiled specs.
- It proves the switch-over shape for semantic / inference / governance.
- It isolates the remaining old-path holdout (`repair_pass`) very clearly.

### Testing
- I did not run the test suite in this environment.
- This is intentionally opened as a draft because the `repair_pass` migration and default-runner strict-binding tests are still pending.
