### PR TITLE
PR5: split LexIR and SourceIR from shared Expr path

### DIFF
--- a/binder.py
+++ b/binder.py
@@ -6,23 +6,44 @@ from typing import Iterable
 from ast_nodes import (
     AlternationExpr,
     BinaryExpr,
+    BindStmt,
+    BuildStmt,
     ColumnRefExpr,
     ContextRefExpr,
     Expr,
     FunctionCallExpr,
     LiteralExpr,
     NameExpr,
+    ParserInheritStmt,
     RowLabelRefExpr,
     SetExpr,
+    TagStmt,
     UnaryExpr,
 )
 from compiled_spec import (
+    CompiledBindAction,
     CompiledConstraintSpec,
     CompiledDiagnosticSpec,
     CompiledGovernancePolicy,
+    CompiledInheritSpec,
     CompiledInferSpec,
+    CompiledParserInheritAction,
+    CompiledParserSpec,
     CompiledProgramSpec,
     CompiledResolverPolicy,
+    CompiledTagAction,
+    CompiledTokenSpec,
+)
+from lex_ir import (
+    LexBuiltinCall,
+    LexColumnRef,
+    LexContextRef,
+    LexExpr,
+    LexLiteral,
+    LexRowLabelMatch,
+    LexSetExpr,
+    LexSymbolConst,
+    LexUnion,
 )
 from rule_ir import (
     ContextValueRef,
@@ -40,6 +61,18 @@ from rule_ir import (
     RuleSetExpr,
     RuleUnary,
     SymbolConst,
+)
+from source_ir import (
+    SourceBuiltinCall,
+    SourceColumnRef,
+    SourceContextRef,
+    SourceExpr,
+    SourceFirstOf,
+    SourceLiteral,
+    SourceRowLabelMatch,
+    SourceSetExpr,
+    SourceSymbolConst,
+    SourceTokenRef,
 )
 from spec_nodes import ProgramSpec
 
@@ -98,6 +131,8 @@ class Binder:
         "llm.fuzzy_lex",
     }
 
+    KNOWN_BUILTINS = RULE_BUILTINS | LEXICAL_BUILTINS
+
     SYMBOL_ALLOWLIST = {
         "committed",
         "merged",
@@ -133,6 +168,32 @@ class Binder:
 
         return CompiledProgramSpec(
             syntax=spec,
+            compiled_tokens={
+                token_name: self._bind_token_spec(token_spec, report=report)
+                for token_name, token_spec in spec.tokens.items()
+            },
+            compiled_parsers={
+                parser_name: self._bind_parser_spec(spec, parser_spec, report=report)
+                for parser_name, parser_spec in spec.parsers.items()
+            },
+            compiled_inherit_rules=[
+                CompiledInheritSpec(
+                    syntax=inherit_rule,
+                    source_ir=self._bind_source_expr(
+                        inherit_rule.source_expr,
+                        spec=spec,
+                        report=report,
+                        allow_token_ref=False,
+                    ),
+                    condition_ir=self._bind_expr(
+                        inherit_rule.condition,
+                        host=self._frame_rule_host(spec, None),
+                        spec=spec,
+                        report=report,
+                    ),
+                )
+                for inherit_rule in spec.inherit_rules
+            ],
             compiled_constraints=[
                 CompiledConstraintSpec(
                     syntax=constraint,
@@ -184,6 +245,93 @@ class Binder:
                 for frame_name, policy in spec.governances.items()
             },
             binding_warnings=report.messages(),
+        )
+
+    def _bind_token_spec(self, token_spec, *, report: BindingReport) -> CompiledTokenSpec:
+        return CompiledTokenSpec(
+            syntax=token_spec,
+            primary_ir=(
+                self._bind_token_expr(token_spec.primary_expr, report=report)
+                if token_spec.primary_expr is not None
+                else None
+            ),
+            fallback_ir=(
+                self._bind_token_expr(token_spec.fallback_expr, report=report)
+                if token_spec.fallback_expr is not None
+                else None
+            ),
+        )
+
+    def _bind_parser_spec(
+        self,
+        spec: ProgramSpec,
+        parser_spec,
+        report: BindingReport,
+    ) -> CompiledParserSpec:
+        host = self._frame_rule_host(spec, parser_spec.build_frame)
+        compiled_actions = []
+
+        for action in parser_spec.actions:
+            if isinstance(action, BuildStmt):
+                continue
+
+            if isinstance(action, BindStmt):
+                compiled_actions.append(
+                    CompiledBindAction(
+                        syntax=action,
+                        source_ir=self._bind_source_expr(
+                            action.source_expr,
+                            spec=spec,
+                            report=report,
+                            allow_token_ref=True,
+                        ),
+                    )
+                )
+                continue
+
+            if isinstance(action, ParserInheritStmt):
+                compiled_actions.append(
+                    CompiledParserInheritAction(
+                        syntax=action,
+                        source_ir=self._bind_source_expr(
+                            action.source_expr,
+                            spec=spec,
+                            report=report,
+                            allow_token_ref=True,
+                        ),
+                        condition_ir=(
+                            self._bind_expr(
+                                action.condition,
+                                host=host,
+                                spec=spec,
+                                report=report,
+                            )
+                            if action.condition is not None
+                            else None
+                        ),
+                    )
+                )
+                continue
+
+            if isinstance(action, TagStmt):
+                compiled_actions.append(
+                    CompiledTagAction(
+                        syntax=action,
+                        source_ir=self._bind_source_expr(
+                            action.source_expr,
+                            spec=spec,
+                            report=report,
+                            allow_token_ref=True,
+                        ),
+                    )
+                )
+                continue
+
+            raise BindingError(f"unsupported parser action for binding: {type(action).__name__}")
+
+        return CompiledParserSpec(
+            syntax=parser_spec,
+            actions=compiled_actions,
         )
 
     def _bind_resolver_policy(
@@ -420,4 +568,134 @@ class Binder:
         return RuleBuiltinCall(
             name=expr.name,
             args=[self._bind_expr(arg, host=host, spec=spec, report=report) for arg in expr.args],
+        )
+
+    def _bind_token_expr(self, expr: Expr, *, report: BindingReport) -> LexExpr:
+        if isinstance(expr, LiteralExpr):
+            return LexLiteral(value=expr.value)
+
+        if isinstance(expr, NameExpr):
+            return LexSymbolConst(name=expr.name)
+
+        if isinstance(expr, FunctionCallExpr):
+            if expr.name not in self.KNOWN_BUILTINS:
+                raise BindingError(f"unknown builtin in token expression: {expr.name}")
+            return LexBuiltinCall(
+                name=expr.name,
+                args=[self._bind_token_value_expr(arg, report=report) for arg in expr.args],
+            )
+
+        if isinstance(expr, SetExpr):
+            return LexSetExpr(
+                items=[self._bind_token_value_expr(item, report=report) for item in expr.items]
+            )
+
+        if isinstance(expr, ColumnRefExpr):
+            return LexColumnRef(column_name=expr.column_name)
+
+        if isinstance(expr, ContextRefExpr):
+            return LexContextRef(role_name=expr.role_name)
+
+        if isinstance(expr, RowLabelRefExpr):
+            return LexRowLabelMatch(label=expr.label)
+
+        if isinstance(expr, AlternationExpr):
+            return LexUnion(
+                options=[self._bind_token_expr(option, report=report) for option in expr.options]
+            )
+
+        if isinstance(expr, (UnaryExpr, BinaryExpr)):
+            raise BindingError(f"boolean/comparison expression is not allowed in token host: {type(expr).__name__}")
+
+        raise BindingError(f"unsupported token expression: {type(expr).__name__}")
+
+    def _bind_token_value_expr(self, expr: Expr, *, report: BindingReport) -> LexExpr:
+        if isinstance(expr, AlternationExpr):
+            raise BindingError("alternation is not allowed inside token builtin arguments")
+        return self._bind_token_expr(expr, report=report)
+
+    def _bind_source_expr(
+        self,
+        expr: Expr,
+        *,
+        spec: ProgramSpec,
+        report: BindingReport,
+        allow_token_ref: bool,
+    ) -> SourceExpr:
+        if isinstance(expr, LiteralExpr):
+            return SourceLiteral(value=expr.value)
+
+        if isinstance(expr, NameExpr):
+            if allow_token_ref and expr.name in spec.tokens:
+                return SourceTokenRef(token_name=expr.name)
+            return SourceSymbolConst(name=expr.name)
+
+        if isinstance(expr, FunctionCallExpr):
+            if expr.name not in self.KNOWN_BUILTINS:
+                raise BindingError(f"unknown builtin in source expression: {expr.name}")
+            return SourceBuiltinCall(
+                name=expr.name,
+                args=[
+                    self._bind_source_value_expr(
+                        arg,
+                        spec=spec,
+                        report=report,
+                    )
+                    for arg in expr.args
+                ],
+            )
+
+        if isinstance(expr, SetExpr):
+            return SourceSetExpr(
+                items=[
+                    self._bind_source_value_expr(
+                        item,
+                        spec=spec,
+                        report=report,
+                    )
+                    for item in expr.items
+                ]
+            )
+
+        if isinstance(expr, ColumnRefExpr):
+            return SourceColumnRef(column_name=expr.column_name)
+
+        if isinstance(expr, ContextRefExpr):
+            return SourceContextRef(role_name=expr.role_name)
+
+        if isinstance(expr, RowLabelRefExpr):
+            return SourceRowLabelMatch(label=expr.label)
+
+        if isinstance(expr, AlternationExpr):
+            return SourceFirstOf(
+                options=[
+                    self._bind_source_expr(
+                        option,
+                        spec=spec,
+                        report=report,
+                        allow_token_ref=allow_token_ref,
+                    )
+                    for option in expr.options
+                ]
+            )
+
+        if isinstance(expr, (UnaryExpr, BinaryExpr)):
+            raise BindingError(f"boolean/comparison expression is not allowed in source host: {type(expr).__name__}")
+
+        raise BindingError(f"unsupported source expression: {type(expr).__name__}")
+
+    def _bind_source_value_expr(
+        self,
+        expr: Expr,
+        *,
+        spec: ProgramSpec,
+        report: BindingReport,
+    ) -> SourceExpr:
+        if isinstance(expr, AlternationExpr):
+            raise BindingError("alternation is not allowed inside source builtin arguments")
+        return self._bind_source_expr(
+            expr,
+            spec=spec,
+            report=report,
+            allow_token_ref=False,
         )

--- a/binder.py
+++ b/binder.py
@@ -3,77 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Iterable
 
-from ast_nodes import (
-    AlternationExpr,
-    BinaryExpr,
-    BindStmt,
-    BuildStmt,
-    ColumnRefExpr,
-    ContextRefExpr,
-    Expr,
-    FunctionCallExpr,
-    LiteralExpr,
-    NameExpr,
-    ParserInheritStmt,
-    RowLabelRefExpr,
-    SetExpr,
-    TagStmt,
-    UnaryExpr,
-)
-from compiled_spec import (
-    CompiledBindAction,
-    CompiledConstraintSpec,
-    CompiledDiagnosticSpec,
-    CompiledGovernancePolicy,
-    CompiledInheritSpec,
-    CompiledInferSpec,
-    CompiledParserInheritAction,
-    CompiledParserSpec,
-    CompiledProgramSpec,
-    CompiledResolverPolicy,
-    CompiledTagAction,
-    CompiledTokenSpec,
-)
-from lex_ir import (
-    LexBuiltinCall,
-    LexColumnRef,
-    LexContextRef,
-    LexExpr,
-    LexLiteral,
-    LexRowLabelMatch,
-    LexSetExpr,
-    LexSymbolConst,
-    LexUnion,
-)
-from rule_ir import (
-    ContextValueRef,
-    FrameSlotRef,
-    HasApproval,
-    HasDiagnostic,
-    LocalVarRef,
-    PolicyRef,
-    RowFieldRef,
-    RuleBinary,
-    RuleBuiltinCall,
-    RuleCoalesce,
-    RuleExpr,
-    RuleLiteral,
-    RuleSetExpr,
-    RuleUnary,
-    SymbolConst,
-)
-from source_ir import (
-    SourceBuiltinCall,
-    SourceColumnRef,
-    SourceContextRef,
-    SourceExpr,
-    SourceFirstOf,
-    SourceLiteral,
-    SourceRowLabelMatch,
-    SourceSetExpr,
-    SourceSymbolConst,
-    SourceTokenRef,
-)
+from ast_nodes import AlternationExpr, BinaryExpr, BindStmt, BuildStmt, ColumnRefExpr, ContextRefExpr, Expr, FunctionCallExpr, LiteralExpr, NameExpr, ParserInheritStmt, RowLabelRefExpr, SetExpr, TagStmt, UnaryExpr
+from compiled_spec import CompiledBindAction, CompiledConstraintSpec, CompiledDiagnosticSpec, CompiledGovernancePolicy, CompiledInheritSpec, CompiledInferSpec, CompiledParserInheritAction, CompiledParserSpec, CompiledProgramSpec, CompiledResolverPolicy, CompiledTagAction, CompiledTokenSpec
+from lex_ir import LexBuiltinCall, LexColumnRef, LexContextRef, LexExpr, LexLiteral, LexRowLabelMatch, LexSetExpr, LexSymbolConst, LexUnion
+from rule_ir import ContextValueRef, FrameSlotRef, HasApproval, HasDiagnostic, LocalVarRef, PolicyRef, RowFieldRef, RuleBinary, RuleBuiltinCall, RuleCoalesce, RuleExpr, RuleLiteral, RuleSetExpr, RuleUnary, SymbolConst
+from source_ir import SourceBuiltinCall, SourceColumnRef, SourceContextRef, SourceExpr, SourceFirstOf, SourceLiteral, SourceRowLabelMatch, SourceSetExpr, SourceSymbolConst, SourceTokenRef
 from spec_nodes import ProgramSpec
 
 
@@ -105,326 +39,77 @@ class BindingHost:
 
 
 class Binder:
-    RULE_BUILTINS = {
-        "dimension",
-        "compatible",
-        "valid",
-        "valid_period",
-        "missing",
-        "origin",
-        "evidence",
-    }
-
-    FRAME_ONLY_RULE_BUILTINS = {
-        "missing",
-        "origin",
-        "evidence",
-    }
-
-    LEXICAL_BUILTINS = {
-        "site_alias",
-        "activity_alias",
-        "unit_symbol",
-        "period_expr",
-        "number",
-        "one_of",
-        "llm.fuzzy_lex",
-    }
-
+    RULE_BUILTINS = {"dimension", "compatible", "valid", "valid_period", "missing", "origin", "evidence"}
+    FRAME_ONLY_RULE_BUILTINS = {"missing", "origin", "evidence"}
+    LEXICAL_BUILTINS = {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number", "one_of", "llm.fuzzy_lex"}
+    TOKEN_BUILTINS = set(LEXICAL_BUILTINS)
+    SOURCE_BUILTINS = set(LEXICAL_BUILTINS)
     KNOWN_BUILTINS = RULE_BUILTINS | LEXICAL_BUILTINS
-
-    SYMBOL_ALLOWLIST = {
-        "committed",
-        "merged",
-        "review_required",
-        "rejected",
-        "resolving",
-    }
-
-    GOVERNANCE_ROW_FIELDS = {
-        "row_id": "row_id",
-        "frame_id": "frame_id",
-        "frame_type": "frame_type",
-        "status": "status",
-        "score": "resolution_score",
-        "resolution_score": "resolution_score",
-        "site_id": "site_id",
-        "entity_id": "entity_id",
-        "period": "period",
-        "activity_type": "activity_type",
-        "raw_amount": "raw_amount",
-        "raw_unit": "raw_unit",
-        "standardized_amount": "standardized_amount",
-        "standardized_unit": "standardized_unit",
-        "scope_category": "scope_category",
-        "parser_name": "parser_name",
-    }
-
+    SYMBOL_ALLOWLIST = {"committed", "merged", "review_required", "rejected", "resolving"}
+    GOVERNANCE_ROW_FIELDS = {"row_id": "row_id", "frame_id": "frame_id", "frame_type": "frame_type", "status": "status", "score": "resolution_score", "resolution_score": "resolution_score", "site_id": "site_id", "entity_id": "entity_id", "period": "period", "activity_type": "activity_type", "raw_amount": "raw_amount", "raw_unit": "raw_unit", "standardized_amount": "standardized_amount", "standardized_unit": "standardized_unit", "scope_category": "scope_category", "parser_name": "parser_name"}
     FRAME_RULE_LOCALS = {"frame_type", "status"}
     RESOLVER_LOCALS = {"score", "stable", "status", "iteration", "no_improve_count"}
 
     def bind(self, spec: ProgramSpec) -> CompiledProgramSpec:
         report = BindingReport()
-
         return CompiledProgramSpec(
             syntax=spec,
-            compiled_tokens={
-                token_name: self._bind_token_spec(token_spec, report=report)
-                for token_name, token_spec in spec.tokens.items()
-            },
-            compiled_parsers={
-                parser_name: self._bind_parser_spec(spec, parser_spec, report=report)
-                for parser_name, parser_spec in spec.parsers.items()
-            },
-            compiled_inherit_rules=[
-                CompiledInheritSpec(
-                    syntax=inherit_rule,
-                    source_ir=self._bind_source_expr(
-                        inherit_rule.source_expr,
-                        spec=spec,
-                        report=report,
-                        allow_token_ref=False,
-                    ),
-                    condition_ir=self._bind_expr(
-                        inherit_rule.condition,
-                        host=self._frame_rule_host(spec, None),
-                        spec=spec,
-                        report=report,
-                    ),
-                )
-                for inherit_rule in spec.inherit_rules
-            ],
-            compiled_constraints=[
-                CompiledConstraintSpec(
-                    syntax=constraint,
-                    condition_ir=self._bind_expr(
-                        constraint.condition,
-                        host=self._frame_rule_host(spec, constraint.frame_name),
-                        spec=spec,
-                        report=report,
-                    ),
-                )
-                for constraint in spec.constraints
-            ],
-            compiled_diagnostics=[
-                CompiledDiagnosticSpec(
-                    syntax=diagnostic,
-                    condition_ir=self._bind_expr(
-                        diagnostic.condition,
-                        host=self._frame_rule_host(spec, None),
-                        spec=spec,
-                        report=report,
-                    ),
-                )
-                for diagnostic in spec.diagnostics
-            ],
-            compiled_infer_rules=[
-                CompiledInferSpec(
-                    syntax=rule,
-                    value_ir=self._bind_expr(
-                        rule.value_expr,
-                        host=self._frame_rule_host(spec, None),
-                        spec=spec,
-                        report=report,
-                    ),
-                    condition_ir=self._bind_expr(
-                        rule.condition,
-                        host=self._frame_rule_host(spec, None),
-                        spec=spec,
-                        report=report,
-                    ),
-                )
-                for rule in spec.infer_rules
-            ],
-            compiled_resolvers={
-                frame_name: self._bind_resolver_policy(spec, frame_name, policy, report)
-                for frame_name, policy in spec.resolvers.items()
-            },
-            compiled_governances={
-                frame_name: self._bind_governance_policy(spec, frame_name, policy, report)
-                for frame_name, policy in spec.governances.items()
-            },
+            compiled_tokens={name: self._bind_token_spec(spec, token_spec) for name, token_spec in spec.tokens.items()},
+            compiled_parsers={name: self._bind_parser_spec(spec, parser_spec) for name, parser_spec in spec.parsers.items()},
+            compiled_inherit_rules=[CompiledInheritSpec(syntax=rule, source_ir=self._bind_source_expr(rule.source_expr, spec=spec, allow_token_ref=False), condition_ir=self._bind_expr(rule.condition, host=self._frame_rule_host(spec, None), spec=spec)) for rule in spec.inherit_rules],
+            compiled_constraints=[CompiledConstraintSpec(syntax=constraint, condition_ir=self._bind_expr(constraint.condition, host=self._frame_rule_host(spec, constraint.frame_name), spec=spec)) for constraint in spec.constraints],
+            compiled_diagnostics=[CompiledDiagnosticSpec(syntax=diagnostic, condition_ir=self._bind_expr(diagnostic.condition, host=self._frame_rule_host(spec, None), spec=spec)) for diagnostic in spec.diagnostics],
+            compiled_infer_rules=[CompiledInferSpec(syntax=rule, value_ir=self._bind_expr(rule.value_expr, host=self._frame_rule_host(spec, None), spec=spec), condition_ir=self._bind_expr(rule.condition, host=self._frame_rule_host(spec, None), spec=spec)) for rule in spec.infer_rules],
+            compiled_resolvers={frame_name: self._bind_resolver_policy(spec, frame_name, policy) for frame_name, policy in spec.resolvers.items()},
+            compiled_governances={frame_name: self._bind_governance_policy(spec, frame_name, policy) for frame_name, policy in spec.governances.items()},
             binding_warnings=report.messages(),
         )
 
-    def _bind_token_spec(self, token_spec, *, report: BindingReport) -> CompiledTokenSpec:
-        return CompiledTokenSpec(
-            syntax=token_spec,
-            primary_ir=(
-                self._bind_token_expr(token_spec.primary_expr, report=report)
-                if token_spec.primary_expr is not None
-                else None
-            ),
-            fallback_ir=(
-                self._bind_token_expr(token_spec.fallback_expr, report=report)
-                if token_spec.fallback_expr is not None
-                else None
-            ),
-        )
+    def _bind_token_spec(self, spec: ProgramSpec, token_spec) -> CompiledTokenSpec:
+        return CompiledTokenSpec(syntax=token_spec, primary_ir=self._bind_token_expr(token_spec.primary_expr, spec=spec) if token_spec.primary_expr is not None else None, fallback_ir=self._bind_token_expr(token_spec.fallback_expr, spec=spec) if token_spec.fallback_expr is not None else None)
 
-    def _bind_parser_spec(
-        self,
-        spec: ProgramSpec,
-        parser_spec,
-        report: BindingReport,
-    ) -> CompiledParserSpec:
+    def _bind_parser_spec(self, spec: ProgramSpec, parser_spec) -> CompiledParserSpec:
         host = self._frame_rule_host(spec, parser_spec.build_frame)
-        compiled_actions = []
-
+        actions = []
         for action in parser_spec.actions:
             if isinstance(action, BuildStmt):
                 continue
-
             if isinstance(action, BindStmt):
-                compiled_actions.append(
-                    CompiledBindAction(
-                        syntax=action,
-                        source_ir=self._bind_source_expr(
-                            action.source_expr,
-                            spec=spec,
-                            report=report,
-                            allow_token_ref=True,
-                        ),
-                    )
-                )
+                actions.append(CompiledBindAction(syntax=action, source_ir=self._bind_source_expr(action.source_expr, spec=spec, allow_token_ref=True)))
                 continue
-
             if isinstance(action, ParserInheritStmt):
-                compiled_actions.append(
-                    CompiledParserInheritAction(
-                        syntax=action,
-                        source_ir=self._bind_source_expr(
-                            action.source_expr,
-                            spec=spec,
-                            report=report,
-                            allow_token_ref=True,
-                        ),
-                        condition_ir=(
-                            self._bind_expr(
-                                action.condition,
-                                host=host,
-                                spec=spec,
-                                report=report,
-                            )
-                            if action.condition is not None
-                            else None
-                        ),
-                    )
-                )
+                actions.append(CompiledParserInheritAction(syntax=action, source_ir=self._bind_source_expr(action.source_expr, spec=spec, allow_token_ref=True), condition_ir=self._bind_expr(action.condition, host=host, spec=spec) if action.condition is not None else None))
                 continue
-
             if isinstance(action, TagStmt):
-                compiled_actions.append(
-                    CompiledTagAction(
-                        syntax=action,
-                        source_ir=self._bind_source_expr(
-                            action.source_expr,
-                            spec=spec,
-                            report=report,
-                            allow_token_ref=True,
-                        ),
-                    )
-                )
+                actions.append(CompiledTagAction(syntax=action, source_ir=self._bind_source_expr(action.source_expr, spec=spec, allow_token_ref=True)))
                 continue
-
             raise BindingError(f"unsupported parser action for binding: {type(action).__name__}")
+        return CompiledParserSpec(syntax=parser_spec, actions=actions)
 
-        return CompiledParserSpec(
-            syntax=parser_spec,
-            actions=compiled_actions,
-        )
-
-    def _bind_resolver_policy(
-        self,
-        spec: ProgramSpec,
-        frame_name: str,
-        policy,
-        report: BindingReport,
-    ) -> CompiledResolverPolicy:
+    def _bind_resolver_policy(self, spec: ProgramSpec, frame_name: str, policy) -> CompiledResolverPolicy:
         host = self._resolver_host(spec, frame_name)
-        return CompiledResolverPolicy(
-            syntax=policy,
-            assigns_ir={
-                name: self._bind_expr(expr, host=host, spec=spec, report=report)
-                for name, expr in policy.assigns.items()
-            },
-            candidate_pool_assigns_ir={
-                name: self._bind_expr(expr, host=host, spec=spec, report=report)
-                for name, expr in policy.candidate_pool_assigns.items()
-            },
-            commit_condition_ir=(
-                self._bind_expr(policy.commit_condition, host=host, spec=spec, report=report)
-                if policy.commit_condition is not None
-                else None
-            ),
-            review_condition_ir=(
-                self._bind_expr(policy.review_condition, host=host, spec=spec, report=report)
-                if policy.review_condition is not None
-                else None
-            ),
-        )
+        return CompiledResolverPolicy(syntax=policy, assigns_ir={name: self._bind_expr(expr, host=host, spec=spec) for name, expr in policy.assigns.items()}, candidate_pool_assigns_ir={name: self._bind_expr(expr, host=host, spec=spec) for name, expr in policy.candidate_pool_assigns.items()}, commit_condition_ir=self._bind_expr(policy.commit_condition, host=host, spec=spec) if policy.commit_condition is not None else None, review_condition_ir=self._bind_expr(policy.review_condition, host=host, spec=spec) if policy.review_condition is not None else None)
 
-    def _bind_governance_policy(
-        self,
-        spec: ProgramSpec,
-        frame_name: str,
-        policy,
-        report: BindingReport,
-    ) -> CompiledGovernancePolicy:
+    def _bind_governance_policy(self, spec: ProgramSpec, frame_name: str, policy) -> CompiledGovernancePolicy:
         host = self._governance_host(frame_name)
-        return CompiledGovernancePolicy(
-            syntax=policy,
-            emit_condition_ir=(
-                self._bind_expr(policy.emit_condition, host=host, spec=spec, report=report)
-                if policy.emit_condition is not None
-                else None
-            ),
-            merge_conditions_ir=[
-                self._bind_expr(expr, host=host, spec=spec, report=report)
-                for expr in policy.merge_conditions
-            ],
-            forbid_merge_conditions_ir=[
-                self._bind_expr(expr, host=host, spec=spec, report=report)
-                for expr in policy.forbid_merge_conditions
-            ],
-        )
+        return CompiledGovernancePolicy(syntax=policy, emit_condition_ir=self._bind_expr(policy.emit_condition, host=host, spec=spec) if policy.emit_condition is not None else None, merge_conditions_ir=[self._bind_expr(expr, host=host, spec=spec) for expr in policy.merge_conditions], forbid_merge_conditions_ir=[self._bind_expr(expr, host=host, spec=spec) for expr in policy.forbid_merge_conditions])
 
     def _frame_rule_host(self, spec: ProgramSpec, frame_name: str | None) -> BindingHost:
-        return BindingHost(
-            kind="frame_rule",
-            frame_name=frame_name,
-            local_vars=set(self.FRAME_RULE_LOCALS),
-            frame_slots=self._frame_slots(spec, frame_name),
-        )
+        return BindingHost(kind="frame_rule", frame_name=frame_name, local_vars=set(self.FRAME_RULE_LOCALS), frame_slots=self._frame_slots(spec, frame_name))
 
     def _resolver_host(self, spec: ProgramSpec, frame_name: str) -> BindingHost:
-        return BindingHost(
-            kind="resolver",
-            frame_name=frame_name,
-            local_vars=set(self.RESOLVER_LOCALS),
-            frame_slots=self._frame_slots(spec, frame_name),
-        )
+        return BindingHost(kind="resolver", frame_name=frame_name, local_vars=set(self.RESOLVER_LOCALS), frame_slots=self._frame_slots(spec, frame_name))
 
     def _governance_host(self, frame_name: str) -> BindingHost:
-        return BindingHost(
-            kind="governance",
-            frame_name=frame_name,
-            row_field_aliases=dict(self.GOVERNANCE_ROW_FIELDS),
-        )
+        return BindingHost(kind="governance", frame_name=frame_name, row_field_aliases=dict(self.GOVERNANCE_ROW_FIELDS))
 
     def _frame_slots(self, spec: ProgramSpec, frame_name: str | None) -> set[str]:
-        frame_names: Iterable[str]
-        if frame_name is None:
-            frame_names = spec.frames.keys()
-        else:
-            frame_names = [frame_name]
-
+        frame_names: Iterable[str] = spec.frames.keys() if frame_name is None else [frame_name]
         names: set[str] = set()
         for target_frame_name in frame_names:
             frame_spec = spec.frames.get(target_frame_name)
             if frame_spec is not None:
                 names.update(field.name for field in frame_spec.fields)
-
             for parser in spec.parsers.values():
                 if parser.build_frame != target_frame_name:
                     continue
@@ -432,270 +117,140 @@ class Binder:
                     role_name = getattr(action, "role_name", None)
                     if role_name:
                         names.add(role_name)
-
         names.update(rule.target_name for rule in spec.infer_rules if rule.target_name)
         return names
 
     def _declared_symbol_names(self, spec: ProgramSpec) -> set[str]:
-        return (
-            set(spec.frames.keys())
-            | set(spec.activities.keys())
-            | set(spec.units.keys())
-            | set(spec.dimensions.keys())
-        )
+        return set(spec.frames.keys()) | set(spec.activities.keys()) | set(spec.units.keys()) | set(spec.dimensions.keys())
 
-    def _bind_expr(
-        self,
-        expr: Expr,
-        *,
-        host: BindingHost,
-        spec: ProgramSpec,
-        report: BindingReport,
-    ) -> RuleExpr:
+    def _is_symbol_const_name(self, name: str, spec: ProgramSpec) -> bool:
+        return name in self._declared_symbol_names(spec) or name in self.SYMBOL_ALLOWLIST
+
+    def _bind_expr(self, expr: Expr, *, host: BindingHost, spec: ProgramSpec) -> RuleExpr:
         if isinstance(expr, LiteralExpr):
             return RuleLiteral(value=expr.value)
-
         if isinstance(expr, NameExpr):
-            return self._bind_name(expr.name, host=host, spec=spec, report=report)
-
+            return self._bind_name(expr.name, host=host, spec=spec)
         if isinstance(expr, FunctionCallExpr):
-            return self._bind_call(expr, host=host, spec=spec, report=report)
-
+            return self._bind_call(expr, host=host, spec=spec)
         if isinstance(expr, SetExpr):
-            return RuleSetExpr(
-                items=[self._bind_expr(item, host=host, spec=spec, report=report) for item in expr.items]
-            )
-
+            return RuleSetExpr(items=[self._bind_expr(item, host=host, spec=spec) for item in expr.items])
         if isinstance(expr, ContextRefExpr):
             return ContextValueRef(role_name=expr.role_name)
-
         if isinstance(expr, AlternationExpr):
-            return RuleCoalesce(
-                options=[self._bind_expr(option, host=host, spec=spec, report=report) for option in expr.options]
-            )
-
+            return RuleCoalesce(options=[self._bind_expr(option, host=host, spec=spec) for option in expr.options])
         if isinstance(expr, UnaryExpr):
-            return RuleUnary(
-                op=expr.op,
-                operand=self._bind_expr(expr.operand, host=host, spec=spec, report=report),
-            )
-
+            return RuleUnary(op=expr.op, operand=self._bind_expr(expr.operand, host=host, spec=spec))
         if isinstance(expr, BinaryExpr):
-            return RuleBinary(
-                left=self._bind_expr(expr.left, host=host, spec=spec, report=report),
-                op=expr.op,
-                right=self._bind_expr(expr.right, host=host, spec=spec, report=report),
-            )
-
+            return RuleBinary(left=self._bind_expr(expr.left, host=host, spec=spec), op=expr.op, right=self._bind_expr(expr.right, host=host, spec=spec))
         if isinstance(expr, ColumnRefExpr):
             raise BindingError(f"column(...) is not allowed in rule host {host.kind}")
-
         if isinstance(expr, RowLabelRefExpr):
             raise BindingError(f"row_label(...) is not allowed in rule host {host.kind}")
-
         raise BindingError(f"unsupported rule expression: {type(expr).__name__}")
 
-    def _bind_name(
-        self,
-        name: str,
-        *,
-        host: BindingHost,
-        spec: ProgramSpec,
-        report: BindingReport,
-    ) -> RuleExpr:
+    def _bind_name(self, name: str, *, host: BindingHost, spec: ProgramSpec) -> RuleExpr:
         if name.startswith("policy."):
             key = name.split(".", 1)[1]
             if not key:
                 raise BindingError("policy reference must include a key")
             return PolicyRef(key=key)
-
         if name.startswith("warning."):
             code = name.split(".", 1)[1]
             if not code:
                 raise BindingError("warning reference must include a code")
             return HasDiagnostic(severity="warning", code=code)
-
         if name.startswith("error."):
             code = name.split(".", 1)[1]
             if not code:
                 raise BindingError("error reference must include a code")
             return HasDiagnostic(severity="error", code=code)
-
         if name.startswith("approval."):
             key = name.split(".", 1)[1]
             if not key:
                 raise BindingError("approval reference must include a key")
             return HasApproval(key=key)
-
         if name in host.local_vars:
             return LocalVarRef(name=name)
-
         if name in host.row_field_aliases:
             return RowFieldRef(field_name=host.row_field_aliases[name])
-
         if name in host.frame_slots:
             return FrameSlotRef(role_name=name)
-
-        if name in self._declared_symbol_names(spec) or name in self.SYMBOL_ALLOWLIST:
+        if self._is_symbol_const_name(name, spec):
             return SymbolConst(name=name)
+        raise BindingError(f"unable to bind name '{name}' in host {host.kind}" + (f" for frame {host.frame_name}" if host.frame_name else ""))
 
-        raise BindingError(
-            f"unable to bind name '{name}' in host {host.kind}"
-            + (f" for frame {host.frame_name}" if host.frame_name else "")
-        )
-
-    def _bind_call(
-        self,
-        expr: FunctionCallExpr,
-        *,
-        host: BindingHost,
-        spec: ProgramSpec,
-        report: BindingReport,
-    ) -> RuleBuiltinCall:
+    def _bind_call(self, expr: FunctionCallExpr, *, host: BindingHost, spec: ProgramSpec) -> RuleBuiltinCall:
         if expr.name in self.LEXICAL_BUILTINS:
-            raise BindingError(
-                f"lexical builtin '{expr.name}' is not allowed in rule host {host.kind}"
-            )
-
+            raise BindingError(f"lexical builtin '{expr.name}' is not allowed in rule host {host.kind}")
         if expr.name not in self.RULE_BUILTINS:
             raise BindingError(f"unknown rule builtin: {expr.name}")
-
         if expr.name in self.FRAME_ONLY_RULE_BUILTINS and host.kind not in {"frame_rule", "resolver"}:
-            raise BindingError(
-                f"frame-only rule builtin '{expr.name}' is not allowed in rule host {host.kind}"
-            )
+            raise BindingError(f"frame-only rule builtin '{expr.name}' is not allowed in rule host {host.kind}")
+        return RuleBuiltinCall(name=expr.name, args=[self._bind_expr(arg, host=host, spec=spec) for arg in expr.args])
 
-        return RuleBuiltinCall(
-            name=expr.name,
-            args=[self._bind_expr(arg, host=host, spec=spec, report=report) for arg in expr.args],
-        )
-
-    def _bind_token_expr(self, expr: Expr, *, report: BindingReport) -> LexExpr:
+    def _bind_token_expr(self, expr: Expr, *, spec: ProgramSpec) -> LexExpr:
         if isinstance(expr, LiteralExpr):
             return LexLiteral(value=expr.value)
-
         if isinstance(expr, NameExpr):
+            if not self._is_symbol_const_name(expr.name, spec):
+                raise BindingError(f"unable to bind bare name '{expr.name}' in token host; use a quoted literal or declared symbol")
             return LexSymbolConst(name=expr.name)
-
         if isinstance(expr, FunctionCallExpr):
-            if expr.name not in self.KNOWN_BUILTINS:
+            if expr.name not in self.TOKEN_BUILTINS:
+                if expr.name in self.KNOWN_BUILTINS:
+                    raise BindingError(f"builtin '{expr.name}' is not allowed in token host")
                 raise BindingError(f"unknown builtin in token expression: {expr.name}")
-            return LexBuiltinCall(
-                name=expr.name,
-                args=[self._bind_token_value_expr(arg, report=report) for arg in expr.args],
-            )
-
+            return LexBuiltinCall(name=expr.name, args=[self._bind_token_value_expr(arg, spec=spec) for arg in expr.args])
         if isinstance(expr, SetExpr):
-            return LexSetExpr(
-                items=[self._bind_token_value_expr(item, report=report) for item in expr.items]
-            )
-
+            return LexSetExpr(items=[self._bind_token_value_expr(item, spec=spec) for item in expr.items])
         if isinstance(expr, ColumnRefExpr):
             return LexColumnRef(column_name=expr.column_name)
-
         if isinstance(expr, ContextRefExpr):
             return LexContextRef(role_name=expr.role_name)
-
         if isinstance(expr, RowLabelRefExpr):
             return LexRowLabelMatch(label=expr.label)
-
         if isinstance(expr, AlternationExpr):
-            return LexUnion(
-                options=[self._bind_token_expr(option, report=report) for option in expr.options]
-            )
-
+            return LexUnion(options=[self._bind_token_expr(option, spec=spec) for option in expr.options])
         if isinstance(expr, (UnaryExpr, BinaryExpr)):
             raise BindingError(f"boolean/comparison expression is not allowed in token host: {type(expr).__name__}")
-
         raise BindingError(f"unsupported token expression: {type(expr).__name__}")
 
-    def _bind_token_value_expr(self, expr: Expr, *, report: BindingReport) -> LexExpr:
+    def _bind_token_value_expr(self, expr: Expr, *, spec: ProgramSpec) -> LexExpr:
         if isinstance(expr, AlternationExpr):
             raise BindingError("alternation is not allowed inside token builtin arguments")
-        return self._bind_token_expr(expr, report=report)
+        return self._bind_token_expr(expr, spec=spec)
 
-    def _bind_source_expr(
-        self,
-        expr: Expr,
-        *,
-        spec: ProgramSpec,
-        report: BindingReport,
-        allow_token_ref: bool,
-    ) -> SourceExpr:
+    def _bind_source_expr(self, expr: Expr, *, spec: ProgramSpec, allow_token_ref: bool) -> SourceExpr:
         if isinstance(expr, LiteralExpr):
             return SourceLiteral(value=expr.value)
-
         if isinstance(expr, NameExpr):
             if allow_token_ref and expr.name in spec.tokens:
                 return SourceTokenRef(token_name=expr.name)
-            return SourceSymbolConst(name=expr.name)
-
+            if self._is_symbol_const_name(expr.name, spec):
+                return SourceSymbolConst(name=expr.name)
+            raise BindingError(f"unable to bind bare name '{expr.name}' in source host; use a declared token, quoted literal, or declared symbol")
         if isinstance(expr, FunctionCallExpr):
-            if expr.name not in self.KNOWN_BUILTINS:
+            if expr.name not in self.SOURCE_BUILTINS:
+                if expr.name in self.KNOWN_BUILTINS:
+                    raise BindingError(f"builtin '{expr.name}' is not allowed in source host")
                 raise BindingError(f"unknown builtin in source expression: {expr.name}")
-            return SourceBuiltinCall(
-                name=expr.name,
-                args=[
-                    self._bind_source_value_expr(
-                        arg,
-                        spec=spec,
-                        report=report,
-                    )
-                    for arg in expr.args
-                ],
-            )
-
+            return SourceBuiltinCall(name=expr.name, args=[self._bind_source_value_expr(arg, spec=spec) for arg in expr.args])
         if isinstance(expr, SetExpr):
-            return SourceSetExpr(
-                items=[
-                    self._bind_source_value_expr(
-                        item,
-                        spec=spec,
-                        report=report,
-                    )
-                    for item in expr.items
-                ]
-            )
-
+            return SourceSetExpr(items=[self._bind_source_value_expr(item, spec=spec) for item in expr.items])
         if isinstance(expr, ColumnRefExpr):
             return SourceColumnRef(column_name=expr.column_name)
-
         if isinstance(expr, ContextRefExpr):
             return SourceContextRef(role_name=expr.role_name)
-
         if isinstance(expr, RowLabelRefExpr):
             return SourceRowLabelMatch(label=expr.label)
-
         if isinstance(expr, AlternationExpr):
-            return SourceFirstOf(
-                options=[
-                    self._bind_source_expr(
-                        option,
-                        spec=spec,
-                        report=report,
-                        allow_token_ref=allow_token_ref,
-                    )
-                    for option in expr.options
-                ]
-            )
-
+            return SourceFirstOf(options=[self._bind_source_expr(option, spec=spec, allow_token_ref=allow_token_ref) for option in expr.options])
         if isinstance(expr, (UnaryExpr, BinaryExpr)):
             raise BindingError(f"boolean/comparison expression is not allowed in source host: {type(expr).__name__}")
-
         raise BindingError(f"unsupported source expression: {type(expr).__name__}")
 
-    def _bind_source_value_expr(
-        self,
-        expr: Expr,
-        *,
-        spec: ProgramSpec,
-        report: BindingReport,
-    ) -> SourceExpr:
+    def _bind_source_value_expr(self, expr: Expr, *, spec: ProgramSpec) -> SourceExpr:
         if isinstance(expr, AlternationExpr):
             raise BindingError("alternation is not allowed inside source builtin arguments")
-        return self._bind_source_expr(
-            expr,
-            spec=spec,
-            report=report,
-            allow_token_ref=False,
-        )
+        return self._bind_source_expr(expr, spec=spec, allow_token_ref=False)

--- a/compiled_spec.py
+++ b/compiled_spec.py
@@ -2,15 +2,35 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from ast_nodes import BindStmt, ParserInheritStmt, TagStmt
+from lex_ir import LexExpr
 from rule_ir import RuleExpr
+from source_ir import SourceExpr
 from spec_nodes import (
     ConstraintSpec,
     DiagnosticSpec,
     GovernancePolicy,
     InferSpec,
+    InheritSpec,
+    ParserSpec,
     ProgramSpec,
     ResolverPolicy,
+    TokenSpec,
 )
+
+
+@dataclass
+class CompiledTokenSpec:
+    syntax: TokenSpec
+    primary_ir: LexExpr | None = None
+    fallback_ir: LexExpr | None = None
+
+
+@dataclass
+class CompiledInheritSpec:
+    syntax: InheritSpec
+    source_ir: SourceExpr
+    condition_ir: RuleExpr
 
 
 @dataclass
@@ -33,6 +53,34 @@ class CompiledInferSpec:
 
 
 @dataclass
+class CompiledBindAction:
+    syntax: BindStmt
+    source_ir: SourceExpr
+
+
+@dataclass
+class CompiledParserInheritAction:
+    syntax: ParserInheritStmt
+    source_ir: SourceExpr
+    condition_ir: RuleExpr | None = None
+
+
+@dataclass
+class CompiledTagAction:
+    syntax: TagStmt
+    source_ir: SourceExpr
+
+
+CompiledParserAction = CompiledBindAction | CompiledParserInheritAction | CompiledTagAction
+
+
+@dataclass
+class CompiledParserSpec:
+    syntax: ParserSpec
+    actions: list[CompiledParserAction] = field(default_factory=list)
+
+
+@dataclass
 class CompiledResolverPolicy:
     syntax: ResolverPolicy
     assigns_ir: dict[str, RuleExpr] = field(default_factory=dict)
@@ -52,6 +100,10 @@ class CompiledGovernancePolicy:
 @dataclass
 class CompiledProgramSpec:
     syntax: ProgramSpec
+
+    compiled_tokens: dict[str, CompiledTokenSpec] = field(default_factory=dict)
+    compiled_parsers: dict[str, CompiledParserSpec] = field(default_factory=dict)
+    compiled_inherit_rules: list[CompiledInheritSpec] = field(default_factory=list)
 
     compiled_constraints: list[CompiledConstraintSpec] = field(default_factory=list)
     compiled_diagnostics: list[CompiledDiagnosticSpec] = field(default_factory=list)

--- a/lex_eval.py
+++ b/lex_eval.py
@@ -22,6 +22,16 @@ class LexEvalError(ValueError):
 
 
 class LexEvaluator:
+    ALLOWED_BUILTINS = {
+        "site_alias",
+        "activity_alias",
+        "unit_symbol",
+        "period_expr",
+        "number",
+        "one_of",
+        "llm.fuzzy_lex",
+    }
+
     def resolve(self, expr: LexExpr | None, ctx: EvalContext) -> list[LexCandidate]:
         if expr is None:
             return []
@@ -71,42 +81,24 @@ class LexEvaluator:
 
     def _call(self, expr: LexBuiltinCall, ctx: EvalContext) -> Any:
         name = expr.name
+        if name not in self.ALLOWED_BUILTINS:
+            raise LexEvalError(f"builtin '{name}' is not allowed in LexEvaluator")
 
-        if name == "missing":
-            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
-            fn = self._lookup_builtin(name, ctx)
-            return fn(role_name, ctx.frame)
-
-        if name == "origin":
-            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
-            fn = self._lookup_builtin(name, ctx)
-            return fn(role_name, ctx.frame, ctx.claims_by_id)
-
-        if name == "evidence":
-            kind = self._raw_identifier(expr.args, index=0, ctx=ctx)
-            fn = self._lookup_builtin(name, ctx)
-            return fn(kind, ctx.frame, ctx.claims_by_id)
+        fn = self._lookup_builtin(name, ctx)
 
         if name in {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number"}:
-            fn = self._lookup_builtin(name, ctx)
             return fn(ctx.text, ctx.env)
 
         if name == "one_of":
-            fn = self._lookup_builtin(name, ctx)
             choices = [self.eval_value(arg, ctx) for arg in expr.args]
             return fn(ctx.text, *choices, env=ctx.env)
 
         if name == "llm.fuzzy_lex":
-            fn = self._lookup_builtin(name, ctx)
             role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
             return fn(role_name, ctx.text, ctx.env)
 
-        fn = self._lookup_builtin(name, ctx)
         args = [self.eval_value(arg, ctx) for arg in expr.args]
-
         for pattern in (
-            lambda: fn(*args, env=ctx.env, frame=ctx.frame, claims_by_id=ctx.claims_by_id),
-            lambda: fn(*args, env=ctx.env, frame=ctx.frame),
             lambda: fn(*args, env=ctx.env),
             lambda: fn(*args),
         ):

--- a/lex_eval.py
+++ b/lex_eval.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import Any
+
+from expr_eval import EvalContext
+from lex_ir import (
+    LexBuiltinCall,
+    LexColumnRef,
+    LexContextRef,
+    LexExpr,
+    LexLiteral,
+    LexRowLabelMatch,
+    LexSetExpr,
+    LexSymbolConst,
+    LexUnion,
+)
+from runtime_env import LexCandidate
+
+
+class LexEvalError(ValueError):
+    pass
+
+
+class LexEvaluator:
+    def resolve(self, expr: LexExpr | None, ctx: EvalContext) -> list[LexCandidate]:
+        if expr is None:
+            return []
+
+        if isinstance(expr, LexUnion):
+            hits: list[LexCandidate] = []
+            for option in expr.options:
+                hits.extend(self.resolve(option, ctx))
+            return self._merge_hits(hits)
+
+        value = self.eval_value(expr, ctx)
+        return self._coerce_to_candidates(value)
+
+    def eval_value(self, expr: LexExpr | Any, ctx: EvalContext) -> Any:
+        if not isinstance(expr, LexExpr):
+            return expr
+
+        if isinstance(expr, LexLiteral):
+            return expr.value
+
+        if isinstance(expr, LexSymbolConst):
+            return expr.name
+
+        if isinstance(expr, LexSetExpr):
+            return [self.eval_value(item, ctx) for item in expr.items]
+
+        if isinstance(expr, LexBuiltinCall):
+            return self._call(expr, ctx)
+
+        if isinstance(expr, LexColumnRef):
+            return ctx.row.get(expr.column_name)
+
+        if isinstance(expr, LexContextRef):
+            res = ctx.env.context_store.resolve_best(
+                expr.role_name,
+                ctx.scope_path,
+                column_key=ctx.column_key,
+            )
+            return None if res.chosen is None else res.chosen.value
+
+        if isinstance(expr, LexRowLabelMatch):
+            if ctx.row_label is None:
+                return None
+            return expr.label if expr.label in ctx.row_label else None
+
+        raise LexEvalError(f"unsupported LexExpr type: {type(expr).__name__}")
+
+    def _call(self, expr: LexBuiltinCall, ctx: EvalContext) -> Any:
+        name = expr.name
+
+        if name == "missing":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(role_name, ctx.frame)
+
+        if name == "origin":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(role_name, ctx.frame, ctx.claims_by_id)
+
+        if name == "evidence":
+            kind = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(kind, ctx.frame, ctx.claims_by_id)
+
+        if name in {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number"}:
+            fn = self._lookup_builtin(name, ctx)
+            return fn(ctx.text, ctx.env)
+
+        if name == "one_of":
+            fn = self._lookup_builtin(name, ctx)
+            choices = [self.eval_value(arg, ctx) for arg in expr.args]
+            return fn(ctx.text, *choices, env=ctx.env)
+
+        if name == "llm.fuzzy_lex":
+            fn = self._lookup_builtin(name, ctx)
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            return fn(role_name, ctx.text, ctx.env)
+
+        fn = self._lookup_builtin(name, ctx)
+        args = [self.eval_value(arg, ctx) for arg in expr.args]
+
+        for pattern in (
+            lambda: fn(*args, env=ctx.env, frame=ctx.frame, claims_by_id=ctx.claims_by_id),
+            lambda: fn(*args, env=ctx.env, frame=ctx.frame),
+            lambda: fn(*args, env=ctx.env),
+            lambda: fn(*args),
+        ):
+            try:
+                return pattern()
+            except TypeError:
+                continue
+
+        raise LexEvalError(f"builtin call failed: {name}")
+
+    def _lookup_builtin(self, name: str, ctx: EvalContext):
+        fn = ctx.env.builtin_registry.get(name)
+        if fn is None:
+            raise LexEvalError(f"unknown builtin: {name}")
+        return fn
+
+    def _raw_identifier(self, args: list[LexExpr], index: int, ctx: EvalContext) -> str:
+        if index >= len(args):
+            raise LexEvalError("missing function arg")
+        value = self.eval_value(args[index], ctx)
+        return str(value)
+
+    def _coerce_to_candidates(self, value: Any) -> list[LexCandidate]:
+        if value is None:
+            return []
+
+        if isinstance(value, LexCandidate):
+            return [value]
+
+        if isinstance(value, list):
+            out: list[LexCandidate] = []
+            for item in value:
+                out.extend(self._coerce_to_candidates(item))
+            return out
+
+        if isinstance(value, tuple) and len(value) == 3:
+            return [
+                LexCandidate(
+                    value=value[0],
+                    start=value[1],
+                    end=value[2],
+                    confidence=0.80,
+                )
+            ]
+
+        return [
+            LexCandidate(
+                value=value,
+                start=None,
+                end=None,
+                confidence=0.50,
+            )
+        ]
+
+    def _merge_hits(self, hits: list[LexCandidate]) -> list[LexCandidate]:
+        by_key: dict[tuple[Any, int | None, int | None], LexCandidate] = {}
+        for hit in hits:
+            key = (hit.value, hit.start, hit.end)
+            prev = by_key.get(key)
+            if prev is None or hit.confidence > prev.confidence:
+                by_key[key] = hit
+        return list(by_key.values())

--- a/lex_ir.py
+++ b/lex_ir.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class LexExpr:
+    pass
+
+
+@dataclass
+class LexLiteral(LexExpr):
+    value: Any
+
+
+@dataclass
+class LexSymbolConst(LexExpr):
+    name: str
+
+
+@dataclass
+class LexSetExpr(LexExpr):
+    items: list[LexExpr] = field(default_factory=list)
+
+
+@dataclass
+class LexBuiltinCall(LexExpr):
+    name: str
+    args: list[LexExpr] = field(default_factory=list)
+
+
+@dataclass
+class LexColumnRef(LexExpr):
+    column_name: str
+
+
+@dataclass
+class LexContextRef(LexExpr):
+    role_name: str
+
+
+@dataclass
+class LexRowLabelMatch(LexExpr):
+    label: str
+
+
+@dataclass
+class LexUnion(LexExpr):
+    options: list[LexExpr] = field(default_factory=list)

--- a/lex_pass.py
+++ b/lex_pass.py
@@ -6,22 +6,16 @@ from itertools import count
 from typing import Any, Optional
 
 from artifacts import CompileArtifacts, TokenOccurrence
-from ast_nodes import AlternationExpr, Expr
-from expr_eval import EvalContext, ExprEvaluator
+from compiled_spec import CompiledProgramSpec
+from lex_eval import LexEvaluator
 from runtime_env import LexCandidate, RuntimeEnv
-from spec_nodes import ProgramSpec, TokenSpec
 
 
 @dataclass
 class LexPassConfig:
-    # primary hit가 너무 약하거나 모호하면 fallback(LLM)까지 호출
     min_primary_confidence: float = 0.80
     ambiguity_delta: float = 0.05
-
-    # token 하나당 fragment에서 너무 많은 후보를 남기지 않도록 자름
     max_hits_per_token_per_fragment: int = 8
-
-    # fallback hit는 기본적으로 primary보다 보수적으로 다룸
     fallback_confidence_multiplier: float = 0.90
 
 
@@ -32,36 +26,38 @@ class LexPass:
     설계 원칙:
     1) deterministic(primary) lexer 먼저
     2) 필요할 때만 fallback lexer(LLM) 호출
-    3) token expr의 AlternationExpr는 "left-biased fallback"이 아니라
-       "candidate union"으로 처리
+    3) token declaration의 alternation은 union semantics
     4) 이 단계에서는 role-claim으로 확정하지 않고 token occurrence만 뽑음
     """
 
     def __init__(
         self,
-        evaluator: Optional[ExprEvaluator] = None,
+        evaluator: Optional[LexEvaluator] = None,
         config: Optional[LexPassConfig] = None,
     ) -> None:
-        self.evaluator = evaluator or ExprEvaluator()
+        self.evaluator = evaluator or LexEvaluator()
         self.config = config or LexPassConfig()
         self._seq = count(1)
 
     def run(
         self,
-        spec: ProgramSpec,
+        spec: CompiledProgramSpec,
         artifacts: CompileArtifacts,
         env: RuntimeEnv,
     ) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("LexPass requires CompiledProgramSpec")
+
         out_tokens: list[TokenOccurrence] = []
 
         for fragment in artifacts.fragments:
             ctx = self._build_eval_context(fragment, env)
 
-            for token_spec in spec.tokens.values():
+            for token_spec in spec.compiled_tokens.values():
                 token_hits = self._lex_one_token(token_spec, ctx)
                 out_tokens.extend(
                     self._to_occurrences(
-                        token_name=token_spec.name,
+                        token_name=token_spec.syntax.name,
                         fragment=fragment,
                         hits=token_hits,
                     )
@@ -70,21 +66,17 @@ class LexPass:
         artifacts.tokens.extend(out_tokens)
         return artifacts
 
-    # ------------------------------------------------------------------
-    # Core
-    # ------------------------------------------------------------------
-
     def _lex_one_token(
         self,
-        token_spec: TokenSpec,
-        ctx: EvalContext,
+        token_spec,
+        ctx,
     ) -> list[LexCandidate]:
-        primary_hits = self._eval_token_expr(token_spec.primary_expr, ctx)
+        primary_hits = self.evaluator.resolve(token_spec.primary_ir, ctx)
         primary_hits = self._postprocess_hits(primary_hits, source_channel="primary")
 
         fallback_hits: list[LexCandidate] = []
-        if token_spec.fallback_expr is not None and self._should_use_fallback(primary_hits):
-            fallback_hits = self._eval_token_expr(token_spec.fallback_expr, ctx)
+        if token_spec.fallback_ir is not None and self._should_use_fallback(primary_hits):
+            fallback_hits = self.evaluator.resolve(token_spec.fallback_ir, ctx)
             fallback_hits = self._postprocess_hits(fallback_hits, source_channel="fallback")
 
         merged = self._merge_hits(primary_hits, fallback_hits)
@@ -96,63 +88,6 @@ class LexPass:
             )
         )
         return merged[: self.config.max_hits_per_token_per_fragment]
-
-    def _eval_token_expr(
-        self,
-        expr: Expr | None,
-        ctx: EvalContext,
-    ) -> list[LexCandidate]:
-        if expr is None:
-            return []
-
-        # token declaration에서 alternation은 union semantics
-        if isinstance(expr, AlternationExpr):
-            hits: list[LexCandidate] = []
-            for option in expr.options:
-                hits.extend(self._eval_token_expr(option, ctx))
-            return self._merge_hits(hits, [])
-
-        # 나머지는 evaluator에 맡기고 LexCandidate 리스트로 정규화
-        value = self.evaluator.eval(expr, ctx)
-        return self._coerce_to_lex_candidates(value)
-
-    # ------------------------------------------------------------------
-    # Candidate normalization
-    # ------------------------------------------------------------------
-
-    def _coerce_to_lex_candidates(self, value: Any) -> list[LexCandidate]:
-        if value is None:
-            return []
-
-        if isinstance(value, LexCandidate):
-            return [value]
-
-        if isinstance(value, list):
-            out: list[LexCandidate] = []
-            for item in value:
-                out.extend(self._coerce_to_lex_candidates(item))
-            return out
-
-        if isinstance(value, tuple) and len(value) == 3:
-            # convenience: (value, start, end)
-            return [
-                LexCandidate(
-                    value=value[0],
-                    start=value[1],
-                    end=value[2],
-                    confidence=0.80,
-                )
-            ]
-
-        # scalar는 매우 약한 후보로 래핑
-        return [
-            LexCandidate(
-                value=value,
-                start=None,
-                end=None,
-                confidence=0.50,
-            )
-        ]
 
     def _postprocess_hits(
         self,
@@ -188,9 +123,6 @@ class LexPass:
         primary_hits: list[LexCandidate],
         fallback_hits: list[LexCandidate],
     ) -> list[LexCandidate]:
-        """
-        동일 value/span 후보는 confidence가 높은 쪽을 남긴다.
-        """
         by_key: dict[tuple[Any, Optional[int], Optional[int]], LexCandidate] = {}
 
         for h in [*primary_hits, *fallback_hits]:
@@ -215,10 +147,6 @@ class LexPass:
                 return True
 
         return False
-
-    # ------------------------------------------------------------------
-    # Materialization
-    # ------------------------------------------------------------------
 
     def _to_occurrences(
         self,
@@ -265,11 +193,9 @@ class LexPass:
 
         return out
 
-    # ------------------------------------------------------------------
-    # Eval context
-    # ------------------------------------------------------------------
+    def _build_eval_context(self, fragment: Any, env: RuntimeEnv):
+        from expr_eval import EvalContext
 
-    def _build_eval_context(self, fragment: Any, env: RuntimeEnv) -> EvalContext:
         metadata = getattr(fragment, "metadata", {}) or {}
 
         row = metadata.get("row", {}) if isinstance(metadata, dict) else {}

--- a/parse_pass.py
+++ b/parse_pass.py
@@ -1,476 +1,111 @@
-# parse_pass.py
 from __future__ import annotations
 
-from dataclasses import dataclass
 from itertools import count
 from typing import Any, Optional
 
-from artifacts import (
-    ClaimArtifact,
-    CompileArtifacts,
-    PartialFrameArtifact,
-    RoleSlotArtifact,
-    TokenOccurrence,
-)
-from ast_nodes import (
-    AlternationExpr,
-    ColumnRefExpr,
-    ContextRefExpr,
-    Expr,
-    NameExpr,
-    ParserInheritStmt,
-    BindStmt,
-    RowLabelRefExpr,
-    TagStmt,
-)
-from expr_eval import EvalContext, ExprEvaluator
-from runtime_env import ContextEntry, RuntimeEnv
-from spec_nodes import ParserSpec, ProgramSpec
-
-
-@dataclass
-class SourceCandidate:
-    value: Any
-    confidence: float
-    extraction_mode: str             # explicit | inherited | derived ...
-    source_token_id: Optional[str] = None
-    source_fragment_id: Optional[str] = None
-    span: Optional[tuple[int, int]] = None
-    metadata: dict[str, Any] = None
-
-    def __post_init__(self):
-        if self.metadata is None:
-            self.metadata = {}
+from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact, TokenOccurrence
+from compiled_spec import CompiledBindAction, CompiledParserInheritAction, CompiledProgramSpec, CompiledTagAction
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv
+from source_eval import SourceEvaluator
 
 
 class ParsePass:
-    """
-    tokens -> partial frames
-
-    설계 원칙:
-    - parser source expr의 AlternationExpr는 left-biased fallback
-      예: column("항목") | ActivityToken
-    - token ref(NameExpr)는 현재 fragment의 token pool에서 찾음
-    - bind/tag/inherit는 모두 role slot을 갱신하지만,
-      extraction_mode와 missing_tag 정책이 다름
-    """
-
-    def __init__(
-        self,
-        evaluator: Optional[ExprEvaluator] = None,
-    ) -> None:
-        self.evaluator = evaluator or ExprEvaluator()
+    def __init__(self, source_evaluator: Optional[SourceEvaluator] = None, rule_evaluator: Optional[RuleEvaluator] = None) -> None:
+        self.source_evaluator = source_evaluator or SourceEvaluator()
+        self.rule_evaluator = rule_evaluator or RuleEvaluator()
         self._frame_seq = count(1)
         self._claim_seq = count(1)
 
-    def run(
-        self,
-        spec: ProgramSpec,
-        artifacts: CompileArtifacts,
-        env: RuntimeEnv,
-    ) -> CompileArtifacts:
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("ParsePass requires CompiledProgramSpec")
         tokens_by_fragment = self._index_tokens(artifacts.tokens)
-
         new_frames: list[PartialFrameArtifact] = []
         new_claims: list[ClaimArtifact] = []
-
         for fragment in artifacts.fragments:
             frag_kind = self._fragment_kind(fragment)
-
-            for parser_spec in spec.parsers.values():
-                if frag_kind not in parser_spec.source_selectors:
+            for parser_spec in spec.compiled_parsers.values():
+                if frag_kind not in parser_spec.syntax.source_selectors:
                     continue
-
                 frame = PartialFrameArtifact(
                     frame_id=f"FRM-{next(self._frame_seq):07d}",
-                    parser_name=parser_spec.name,
-                    frame_type=parser_spec.build_frame,
+                    parser_name=parser_spec.syntax.name,
+                    frame_type=parser_spec.syntax.build_frame,
                     fragment_ids=[getattr(fragment, "fragment_id", "FRG-UNKNOWN")],
                     slots={},
                 )
-
                 ctx = self._build_eval_context(fragment, env, frame)
-
                 for action in parser_spec.actions:
-                    # build action은 lowering에서 이미 parser_spec.build_frame으로 올라감
-                    if isinstance(action, BindStmt):
-                        claims = self._resolve_source_to_claims(
-                            source_expr=action.source_expr,
-                            fragment=fragment,
-                            tokens_by_fragment=tokens_by_fragment,
-                            ctx=ctx,
-                            parser_name=parser_spec.name,
-                            frame_id=frame.frame_id,
-                            role_name=action.role_name,
-                            extraction_mode_override="explicit",
-                        )
-                        self._apply_role_binding(
-                            frame=frame,
-                            role_name=action.role_name,
-                            claims=claims,
-                            claims_out=new_claims,
-                            optional=action.optional,
-                            missing_tag_if_empty="missing_parser_failed",
-                        )
-
-                    elif isinstance(action, ParserInheritStmt):
-                        if action.condition is not None:
-                            cond_ok = self.evaluator.eval_bool(action.condition, ctx)
-                            if not cond_ok:
-                                continue
-
-                        claims = self._resolve_source_to_claims(
-                            source_expr=action.source_expr,
-                            fragment=fragment,
-                            tokens_by_fragment=tokens_by_fragment,
-                            ctx=ctx,
-                            parser_name=parser_spec.name,
-                            frame_id=frame.frame_id,
-                            role_name=action.role_name,
-                            extraction_mode_override="inherited",
-                        )
-                        self._apply_role_binding(
-                            frame=frame,
-                            role_name=action.role_name,
-                            claims=claims,
-                            claims_out=new_claims,
-                            optional=True,
-                            missing_tag_if_empty="missing_waiting_context",
-                        )
-
-                    elif isinstance(action, TagStmt):
-                        claims = self._resolve_source_to_claims(
-                            source_expr=action.source_expr,
-                            fragment=fragment,
-                            tokens_by_fragment=tokens_by_fragment,
-                            ctx=ctx,
-                            parser_name=parser_spec.name,
-                            frame_id=frame.frame_id,
-                            role_name=action.role_name,
-                            extraction_mode_override="explicit",
-                        )
-                        self._apply_role_binding(
-                            frame=frame,
-                            role_name=action.role_name,
-                            claims=claims,
-                            claims_out=new_claims,
-                            optional=True,
-                            missing_tag_if_empty=None,
-                        )
-
-                    # frame이 갱신되었으니 ctx.frame도 최신 상태 유지
+                    if isinstance(action, CompiledBindAction):
+                        claims = self._resolve_source_to_claims(source_ir=action.source_ir, fragment=fragment, tokens_by_fragment=tokens_by_fragment, ctx=ctx, parser_name=parser_spec.syntax.name, frame_id=frame.frame_id, role_name=action.syntax.role_name, extraction_mode_override="explicit")
+                        self._apply_role_binding(frame=frame, role_name=action.syntax.role_name, claims=claims, claims_out=new_claims, optional=action.syntax.optional, missing_tag_if_empty="missing_parser_failed")
+                    elif isinstance(action, CompiledParserInheritAction):
+                        if action.condition_ir is not None and not self.rule_evaluator.eval_bool(action.condition_ir, ctx):
+                            continue
+                        claims = self._resolve_source_to_claims(source_ir=action.source_ir, fragment=fragment, tokens_by_fragment=tokens_by_fragment, ctx=ctx, parser_name=parser_spec.syntax.name, frame_id=frame.frame_id, role_name=action.syntax.role_name, extraction_mode_override="inherited")
+                        self._apply_role_binding(frame=frame, role_name=action.syntax.role_name, claims=claims, claims_out=new_claims, optional=True, missing_tag_if_empty="missing_waiting_context")
+                    elif isinstance(action, CompiledTagAction):
+                        claims = self._resolve_source_to_claims(source_ir=action.source_ir, fragment=fragment, tokens_by_fragment=tokens_by_fragment, ctx=ctx, parser_name=parser_spec.syntax.name, frame_id=frame.frame_id, role_name=action.syntax.role_name, extraction_mode_override="explicit")
+                        self._apply_role_binding(frame=frame, role_name=action.syntax.role_name, claims=claims, claims_out=new_claims, optional=True, missing_tag_if_empty=None)
                     ctx.frame = frame
-
+                    ctx.local_vars["status"] = frame.status
                 new_frames.append(frame)
-
         artifacts.claims.extend(new_claims)
         artifacts.frames.extend(new_frames)
         return artifacts
 
-    # ------------------------------------------------------------------
-    # Token indexing
-    # ------------------------------------------------------------------
-
-    def _index_tokens(
-        self,
-        tokens: list[TokenOccurrence],
-    ) -> dict[str, dict[str, list[TokenOccurrence]]]:
+    def _index_tokens(self, tokens: list[TokenOccurrence]) -> dict[str, dict[str, list[TokenOccurrence]]]:
         out: dict[str, dict[str, list[TokenOccurrence]]] = {}
-
         for tok in tokens:
             out.setdefault(tok.fragment_id, {}).setdefault(tok.token_name, []).append(tok)
-
         for frag_map in out.values():
-            for token_name, bucket in frag_map.items():
+            for bucket in frag_map.values():
                 bucket.sort(key=lambda t: (-t.confidence, t.rank))
         return out
 
-    # ------------------------------------------------------------------
-    # Source resolution
-    # ------------------------------------------------------------------
-
-    def _resolve_source_to_claims(
-        self,
-        *,
-        source_expr: Expr,
-        fragment: Any,
-        tokens_by_fragment: dict[str, dict[str, list[TokenOccurrence]]],
-        ctx: EvalContext,
-        parser_name: str,
-        frame_id: str,
-        role_name: str,
-        extraction_mode_override: Optional[str] = None,
-    ) -> list[ClaimArtifact]:
-        """
-        parser 단계 source expression은 left-biased fallback semantics.
-        """
-        candidates = self._resolve_source_expr(
-            source_expr=source_expr,
-            fragment=fragment,
-            tokens_by_fragment=tokens_by_fragment,
-            ctx=ctx,
-        )
-
+    def _resolve_source_to_claims(self, *, source_ir, fragment: Any, tokens_by_fragment: dict[str, dict[str, list[TokenOccurrence]]], ctx, parser_name: str, frame_id: str, role_name: str, extraction_mode_override: Optional[str] = None) -> list[ClaimArtifact]:
+        candidates = self.source_evaluator.resolve(source_ir, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
         claims: list[ClaimArtifact] = []
         fragment_id = getattr(fragment, "fragment_id", "FRG-UNKNOWN")
-
         for idx, cand in enumerate(candidates, start=1):
-            candidate_state = "active" if idx == 1 else "shadow"
-
-            claim = ClaimArtifact(
-                claim_id=f"CLM-{next(self._claim_seq):07d}",
-                frame_id=frame_id,
-                fragment_id=fragment_id,
-                parser_name=parser_name,
-                role_name=role_name,
-                value=cand.value,
-                extraction_mode=extraction_mode_override or cand.extraction_mode,
-                confidence=float(cand.confidence),
-                candidate_state=candidate_state,
-                source_token_id=cand.source_token_id,
-                source_fragment_id=cand.source_fragment_id or fragment_id,
-                span=cand.span,
-                metadata=dict(cand.metadata),
-            )
-            claims.append(claim)
-
+            claims.append(ClaimArtifact(claim_id=f"CLM-{next(self._claim_seq):07d}", frame_id=frame_id, fragment_id=fragment_id, parser_name=parser_name, role_name=role_name, value=cand.value, extraction_mode=extraction_mode_override or cand.extraction_mode, confidence=float(cand.confidence), candidate_state="active" if idx == 1 else "shadow", source_token_id=cand.source_token_id, source_fragment_id=cand.source_fragment_id or fragment_id, span=cand.span, metadata=dict(cand.metadata)))
         return claims
 
-    def _resolve_source_expr(
-        self,
-        *,
-        source_expr: Expr,
-        fragment: Any,
-        tokens_by_fragment: dict[str, dict[str, list[TokenOccurrence]]],
-        ctx: EvalContext,
-    ) -> list[SourceCandidate]:
-        # parser source에서 a | b | c 는 왼쪽부터 첫 성공 branch를 고름
-        if isinstance(source_expr, AlternationExpr):
-            for option in source_expr.options:
-                out = self._resolve_source_expr(
-                    source_expr=option,
-                    fragment=fragment,
-                    tokens_by_fragment=tokens_by_fragment,
-                    ctx=ctx,
-                )
-                if out:
-                    return out
-            return []
-
-        # 1) token ref: ActivityToken, SiteToken ...
-        if isinstance(source_expr, NameExpr):
-            return self._resolve_from_token_name(
-                token_name=source_expr.name,
-                fragment=fragment,
-                tokens_by_fragment=tokens_by_fragment,
-            )
-
-        # 2) column(...)
-        if isinstance(source_expr, ColumnRefExpr):
-            row = getattr(fragment, "metadata", {}).get("row", {}) or {}
-            value = row.get(source_expr.column_name)
-            if value in (None, ""):
-                return []
-            return [
-                SourceCandidate(
-                    value=value,
-                    confidence=0.95,
-                    extraction_mode="explicit",
-                    source_fragment_id=getattr(fragment, "fragment_id", "FRG-UNKNOWN"),
-                    span=None,
-                    metadata={
-                        "source_kind": "column",
-                        "column_name": source_expr.column_name,
-                    },
-                )
-            ]
-
-        # 3) context.role
-        if isinstance(source_expr, ContextRefExpr):
-            resolutions = ctx.env.context_store.resolve_all(
-                source_expr.role_name,
-                ctx.scope_path,
-                column_key=ctx.column_key,
-            )
-            out: list[SourceCandidate] = []
-            for entry in resolutions:
-                out.append(
-                    SourceCandidate(
-                        value=entry.value,
-                        confidence=float(entry.confidence),
-                        extraction_mode="inherited",
-                        source_fragment_id=entry.source_fragment_id,
-                        span=None,
-                        metadata={
-                            "source_kind": "context",
-                            "context_id": entry.context_id,
-                            "operation": entry.operation,
-                            "precedence": entry.precedence,
-                        },
-                    )
-                )
-            return out
-
-        # 4) row_label("총")
-        if isinstance(source_expr, RowLabelRefExpr):
-            row_label = getattr(fragment, "metadata", {}).get("row_label")
-            if row_label is None:
-                return []
-            if source_expr.label in str(row_label):
-                return [
-                    SourceCandidate(
-                        value=source_expr.label,
-                        confidence=0.92,
-                        extraction_mode="explicit",
-                        source_fragment_id=getattr(fragment, "fragment_id", "FRG-UNKNOWN"),
-                        metadata={
-                            "source_kind": "row_label",
-                            "row_label": row_label,
-                        },
-                    )
-                ]
-            return []
-
-        # 5) generic expr evaluation fallback
-        value = self.evaluator.eval_source(source_expr, ctx)
-        return self._coerce_generic_value_to_candidates(
-            value,
-            fragment_id=getattr(fragment, "fragment_id", "FRG-UNKNOWN"),
-        )
-
-    def _resolve_from_token_name(
-        self,
-        *,
-        token_name: str,
-        fragment: Any,
-        tokens_by_fragment: dict[str, dict[str, list[TokenOccurrence]]],
-    ) -> list[SourceCandidate]:
-        fragment_id = getattr(fragment, "fragment_id", "FRG-UNKNOWN")
-        token_bucket = tokens_by_fragment.get(fragment_id, {}).get(token_name, [])
-
-        out: list[SourceCandidate] = []
-        for tok in token_bucket:
-            out.append(
-                SourceCandidate(
-                    value=tok.value,
-                    confidence=tok.confidence,
-                    extraction_mode="explicit",
-                    source_token_id=tok.token_id,
-                    source_fragment_id=tok.fragment_id,
-                    span=(tok.start, tok.end) if tok.start is not None and tok.end is not None else None,
-                    metadata={
-                        "source_kind": "token",
-                        "token_name": tok.token_name,
-                        "source_channel": tok.source_channel,
-                        "rank": tok.rank,
-                    },
-                )
-            )
-        return out
-
-    def _coerce_generic_value_to_candidates(
-        self,
-        value: Any,
-        *,
-        fragment_id: str,
-    ) -> list[SourceCandidate]:
-        if value is None:
-            return []
-
-        if isinstance(value, list):
-            out: list[SourceCandidate] = []
-            for item in value:
-                out.extend(self._coerce_generic_value_to_candidates(item, fragment_id=fragment_id))
-            return out
-
-        return [
-            SourceCandidate(
-                value=value,
-                confidence=0.70,
-                extraction_mode="derived",
-                source_fragment_id=fragment_id,
-                metadata={"source_kind": "generic_expr"},
-            )
-        ]
-
-    # ------------------------------------------------------------------
-    # Role binding
-    # ------------------------------------------------------------------
-
-    def _apply_role_binding(
-        self,
-        *,
-        frame: PartialFrameArtifact,
-        role_name: str,
-        claims: list[ClaimArtifact],
-        claims_out: list[ClaimArtifact],
-        optional: bool,
-        missing_tag_if_empty: Optional[str],
-    ) -> None:
+    def _apply_role_binding(self, *, frame: PartialFrameArtifact, role_name: str, claims: list[ClaimArtifact], claims_out: list[ClaimArtifact], optional: bool, missing_tag_if_empty: Optional[str]) -> None:
         slot = frame.slots.get(role_name)
         if slot is None:
             slot = RoleSlotArtifact(role_name=role_name)
             frame.slots[role_name] = slot
-
         if not claims:
             if slot.active_claim_id is None and missing_tag_if_empty is not None:
                 slot.missing_tag = missing_tag_if_empty
                 if missing_tag_if_empty not in slot.reason_codes:
                     slot.reason_codes.append(missing_tag_if_empty)
             return
-
-        # 기존 active가 없으면 첫 후보를 active로, 나머지는 shadow로
         if slot.active_claim_id is None:
             claims[0].candidate_state = "active"
             slot.active_claim_id = claims[0].claim_id
             slot.resolved_value = claims[0].value
             slot.confidence = claims[0].confidence
-
             for c in claims[1:]:
                 c.candidate_state = "shadow"
                 slot.shadow_claim_ids.append(c.claim_id)
-
             slot.missing_tag = None
             claims_out.extend(claims)
             return
-
-        # 이미 active가 있으면 새 후보는 전부 shadow
         for c in claims:
             c.candidate_state = "shadow"
             slot.shadow_claim_ids.append(c.claim_id)
-
         claims_out.extend(claims)
 
-    # ------------------------------------------------------------------
-    # Context for evaluator
-    # ------------------------------------------------------------------
-
-    def _build_eval_context(
-        self,
-        fragment: Any,
-        env: RuntimeEnv,
-        frame: PartialFrameArtifact,
-    ) -> EvalContext:
+    def _build_eval_context(self, fragment: Any, env: RuntimeEnv, frame: PartialFrameArtifact):
+        from expr_eval import EvalContext
         metadata = getattr(fragment, "metadata", {}) or {}
         row = metadata.get("row", {}) if isinstance(metadata, dict) else {}
         row_label = metadata.get("row_label") if isinstance(metadata, dict) else None
         column_key = metadata.get("column_key") if isinstance(metadata, dict) else None
-
-        return EvalContext(
-            env=env,
-            text=getattr(fragment, "text", ""),
-            scope_path=getattr(fragment, "scope_path", tuple()),
-            row=row,
-            row_label=row_label,
-            column_key=column_key,
-            frame=frame,
-            claims_by_id={},
-            local_vars={},
-        )
-
-    # ------------------------------------------------------------------
-    # Misc
-    # ------------------------------------------------------------------
+        return EvalContext(env=env, text=getattr(fragment, "text", ""), scope_path=getattr(fragment, "scope_path", tuple()), row=row, row_label=row_label, column_key=column_key, frame=frame, claims_by_id={}, local_vars={"frame_type": frame.frame_type, "status": frame.status})
 
     def _fragment_kind(self, fragment: Any) -> str:
         value = getattr(fragment, "fragment_type", None)

--- a/scope_resolution_pass.py
+++ b/scope_resolution_pass.py
@@ -1,4 +1,3 @@
-# scope_resolution_pass.py
 from __future__ import annotations
 
 import re
@@ -7,10 +6,11 @@ from itertools import count
 from typing import Any, Optional
 
 from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
-from ast_nodes import Expr
-from expr_eval import EvalContext, ExprEvaluator
-from runtime_env import ContextEntry, RuntimeEnv, ScopePath
-from spec_nodes import ContextPolicy, InheritSpec, ProgramSpec
+from compiled_spec import CompiledProgramSpec
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv, ScopePath
+from source_eval import SourceEvaluator
+from spec_nodes import ContextPolicy
 
 
 YEAR_ONLY_RE = re.compile(r"^20\d{2}$")
@@ -27,326 +27,123 @@ class CandidateView:
 
 
 class ScopeResolutionPass:
-    """
-    partial frames + context store -> context-resolved partial frames
-
-    책임:
-    1) top-level inherit rules 적용
-    2) role-wise context precedence / ttl / refine / conflict 처리
-    3) slot의 active/shadow 재정렬
-    4) missing_waiting_context / missing_conflicted / conflict diagnostics 부여
-    """
-
-    def __init__(self, evaluator: Optional[ExprEvaluator] = None) -> None:
-        self.evaluator = evaluator or ExprEvaluator()
+    def __init__(self, rule_evaluator: Optional[RuleEvaluator] = None, source_evaluator: Optional[SourceEvaluator] = None) -> None:
+        self.rule_evaluator = rule_evaluator or RuleEvaluator()
+        self.source_evaluator = source_evaluator or SourceEvaluator()
         self._claim_seq = count(1)
 
-    def run(
-        self,
-        spec: ProgramSpec,
-        artifacts: CompileArtifacts,
-        env: RuntimeEnv,
-    ) -> CompileArtifacts:
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("ScopeResolutionPass requires CompiledProgramSpec")
         fragments_by_id = self._index_fragments(artifacts.fragments)
         claims_by_id = {c.claim_id: c for c in artifacts.claims}
         new_claims: list[ClaimArtifact] = []
-
         for frame in artifacts.frames:
             base_scope = self._frame_scope(frame, fragments_by_id)
-            frame_ctx = EvalContext(
-                env=env,
-                text="",
-                scope_path=base_scope,
-                frame=frame,
-                claims_by_id=claims_by_id,
-                local_vars={},
-            )
-
-            # 1) top-level inherit rules 적용
-            added = self._apply_inherit_rules(
-                spec=spec,
-                frame=frame,
-                frame_ctx=frame_ctx,
-                fragments_by_id=fragments_by_id,
-                claims_by_id=claims_by_id,
-            )
+            frame_ctx = self._make_eval_context(env=env, scope_path=base_scope, frame=frame, claims_by_id=claims_by_id)
+            added = self._apply_inherit_rules(spec=spec, frame=frame, frame_ctx=frame_ctx, fragments_by_id=fragments_by_id, claims_by_id=claims_by_id)
             for c in added:
                 claims_by_id[c.claim_id] = c
             new_claims.extend(added)
-
-            # 2) slot별 context resolution
             frame_fields = spec.frames.get(frame.frame_type)
             role_names = set(frame.slots.keys())
             if frame_fields is not None:
                 role_names.update(f.name for f in frame_fields.fields)
-
             for role_name in role_names:
                 slot = frame.slots.get(role_name)
                 if slot is None:
                     slot = RoleSlotArtifact(role_name=role_name)
                     frame.slots[role_name] = slot
-
                 policy = spec.contexts.get(role_name)
-                self._resolve_slot_with_policy(
-                    frame=frame,
-                    slot=slot,
-                    role_name=role_name,
-                    policy=policy,
-                    claims_by_id=claims_by_id,
-                    fragments_by_id=fragments_by_id,
-                )
-
+                self._resolve_slot_with_policy(frame=frame, slot=slot, role_name=role_name, policy=policy, claims_by_id=claims_by_id, fragments_by_id=fragments_by_id)
         artifacts.claims.extend(new_claims)
         return artifacts
 
-    # ------------------------------------------------------------------
-    # Inherit rules
-    # ------------------------------------------------------------------
-
-    def _apply_inherit_rules(
-        self,
-        *,
-        spec: ProgramSpec,
-        frame: PartialFrameArtifact,
-        frame_ctx: EvalContext,
-        fragments_by_id: dict[str, Any],
-        claims_by_id: dict[str, ClaimArtifact],
-    ) -> list[ClaimArtifact]:
+    def _apply_inherit_rules(self, *, spec: CompiledProgramSpec, frame: PartialFrameArtifact, frame_ctx, fragments_by_id: dict[str, Any], claims_by_id: dict[str, ClaimArtifact]) -> list[ClaimArtifact]:
         created: list[ClaimArtifact] = []
-
-        for rule in spec.inherit_rules:
-            slot = frame.slots.get(rule.role_name)
+        base_fragment = fragments_by_id.get(frame.fragment_ids[0]) if frame.fragment_ids else None
+        for rule in spec.compiled_inherit_rules:
+            role_name = rule.syntax.role_name
+            slot = frame.slots.get(role_name)
             if slot is None:
-                slot = RoleSlotArtifact(role_name=rule.role_name)
-                frame.slots[rule.role_name] = slot
-
-            # active가 이미 있으면 일단 skip
+                slot = RoleSlotArtifact(role_name=role_name)
+                frame.slots[role_name] = slot
             if slot.active_claim_id is not None:
                 continue
-
-            if not self.evaluator.eval_bool(rule.condition, frame_ctx):
+            if not self.rule_evaluator.eval_bool(rule.condition_ir, frame_ctx):
                 continue
-
-            source_candidates = self._resolve_inherit_source(
-                source_expr=rule.source_expr,
-                scope_path=frame_ctx.scope_path,
-                env=frame_ctx.env,
-            )
-
+            source_candidates = self.source_evaluator.resolve(rule.source_ir, ctx=frame_ctx, fragment=base_fragment, tokens_by_fragment=None)
             if not source_candidates:
                 if slot.missing_tag is None:
                     slot.missing_tag = "missing_waiting_context"
                 if "missing_waiting_context" not in slot.reason_codes:
                     slot.reason_codes.append("missing_waiting_context")
                 continue
-
             claims = []
             for idx, cand in enumerate(source_candidates, start=1):
-                claims.append(
-                    ClaimArtifact(
-                        claim_id=f"CLM-{next(self._claim_seq):07d}",
-                        frame_id=frame.frame_id,
-                        fragment_id=frame.fragment_ids[0] if frame.fragment_ids else "FRG-UNKNOWN",
-                        parser_name=frame.parser_name,
-                        role_name=rule.role_name,
-                        value=cand["value"],
-                        extraction_mode="inherited",
-                        confidence=float(cand["confidence"]),
-                        candidate_state="active" if idx == 1 else "shadow",
-                        source_fragment_id=cand.get("source_fragment_id"),
-                        span=None,
-                        reason_codes=["inherited_from_context"],
-                        metadata=dict(cand.get("metadata", {})),
-                    )
-                )
-
-            # slot에 반영
+                claims.append(ClaimArtifact(claim_id=f"CLM-{next(self._claim_seq):07d}", frame_id=frame.frame_id, fragment_id=frame.fragment_ids[0] if frame.fragment_ids else "FRG-UNKNOWN", parser_name=frame.parser_name, role_name=role_name, value=cand.value, extraction_mode=cand.extraction_mode or "inherited", confidence=float(cand.confidence), candidate_state="active" if idx == 1 else "shadow", source_token_id=cand.source_token_id, source_fragment_id=cand.source_fragment_id, span=cand.span, reason_codes=["inherited_from_context"], metadata=dict(cand.metadata)))
             slot.active_claim_id = claims[0].claim_id
             slot.resolved_value = claims[0].value
             slot.confidence = claims[0].confidence
             slot.missing_tag = None
-
             for c in claims[1:]:
                 slot.shadow_claim_ids.append(c.claim_id)
-
             created.extend(claims)
-
         return created
 
-    def _resolve_inherit_source(
-        self,
-        *,
-        source_expr: Expr,
-        scope_path: ScopePath,
-        env: RuntimeEnv,
-    ) -> list[dict[str, Any]]:
-        """
-        v0.1에서는 top-level inherit는 대부분 context.role 형태를 가정한다.
-        추후 generic source expr까지 확장 가능.
-        """
-        from ast_nodes import ContextRefExpr
-
-        if isinstance(source_expr, ContextRefExpr):
-            resolutions = env.context_store.resolve_all(
-                source_expr.role_name,
-                scope_path,
-                column_key=None,
-            )
-            return [
-                {
-                    "value": e.value,
-                    "confidence": e.confidence,
-                    "source_fragment_id": e.source_fragment_id,
-                    "metadata": {
-                        "context_id": e.context_id,
-                        "operation": e.operation,
-                        "precedence": e.precedence,
-                    },
-                }
-                for e in resolutions
-            ]
-
-        # generic fallback
-        value = self.evaluator.eval(
-            source_expr,
-            EvalContext(env=env, scope_path=scope_path),
-        )
-        if value in (None, ""):
-            return []
-        return [
-            {
-                "value": value,
-                "confidence": 0.70,
-                "source_fragment_id": None,
-                "metadata": {"source_kind": "generic_inherit_expr"},
-            }
-        ]
-
-    # ------------------------------------------------------------------
-    # Slot resolution
-    # ------------------------------------------------------------------
-
-    def _resolve_slot_with_policy(
-        self,
-        *,
-        frame: PartialFrameArtifact,
-        slot: RoleSlotArtifact,
-        role_name: str,
-        policy: Optional[ContextPolicy],
-        claims_by_id: dict[str, ClaimArtifact],
-        fragments_by_id: dict[str, Any],
-    ) -> None:
+    def _resolve_slot_with_policy(self, *, frame: PartialFrameArtifact, slot: RoleSlotArtifact, role_name: str, policy: Optional[ContextPolicy], claims_by_id: dict[str, ClaimArtifact], fragments_by_id: dict[str, Any]) -> None:
         candidate_ids = []
         if slot.active_claim_id:
             candidate_ids.append(slot.active_claim_id)
         candidate_ids.extend(slot.shadow_claim_ids)
-
         candidates = []
         for cid in candidate_ids:
             claim = claims_by_id.get(cid)
             if claim is None:
                 continue
-            candidates.append(
-                self._score_candidate(
-                    claim=claim,
-                    role_name=role_name,
-                    policy=policy,
-                    fragments_by_id=fragments_by_id,
-                )
-            )
-
+            candidates.append(self._score_candidate(claim=claim, role_name=role_name, policy=policy, fragments_by_id=fragments_by_id))
         if not candidates:
-            # 후보 없으면 missing_tag 유지 또는 기본값 설정
             if slot.missing_tag is None:
                 slot.missing_tag = "missing_waiting_context"
                 slot.reason_codes.append("missing_waiting_context")
             return
-
-        # refine / conflict 처리
         candidates = self._apply_refine_resolution(role_name, policy, candidates)
         best, shadows, conflicted = self._pick_best_and_shadows(candidates)
-
-        # claim state 갱신
         best.claim.candidate_state = "active"
         for s in shadows:
             s.claim.candidate_state = "shadow"
-
         slot.active_claim_id = best.claim.claim_id
         slot.shadow_claim_ids = [s.claim.claim_id for s in shadows]
         slot.resolved_value = best.claim.value
         slot.confidence = best.claim.confidence
-
-        # conflict 반영
         if conflicted:
             slot.reason_codes.append("context_conflict")
             if slot.missing_tag is None and best.mode_rank < 3:
-                # inherited들끼리 충돌이면 stronger missing/conflict 태그
                 slot.missing_tag = "missing_conflicted"
-        else:
-            if slot.missing_tag == "missing_conflicted":
-                slot.missing_tag = None
+        elif slot.missing_tag == "missing_conflicted":
+            slot.missing_tag = None
 
-    def _score_candidate(
-        self,
-        *,
-        claim: ClaimArtifact,
-        role_name: str,
-        policy: Optional[ContextPolicy],
-        fragments_by_id: dict[str, Any],
-    ) -> CandidateView:
+    def _score_candidate(self, *, claim: ClaimArtifact, role_name: str, policy: Optional[ContextPolicy], fragments_by_id: dict[str, Any]) -> CandidateView:
         mode_rank = self._mode_rank(claim.extraction_mode)
-
         source_scope_rank = 0
         if policy is not None and claim.source_fragment_id is not None:
-            source_scope_rank = self._scope_rank_for_claim(
-                claim=claim,
-                policy=policy,
-                fragments_by_id=fragments_by_id,
-            )
-
+            source_scope_rank = self._scope_rank_for_claim(claim=claim, policy=policy, fragments_by_id=fragments_by_id)
         specificity_rank = self._specificity_rank(role_name, claim.value)
-
-        score = (
-            mode_rank * 100.0
-            + float(claim.confidence) * 10.0
-            + source_scope_rank * 1.0
-            + specificity_rank * 0.1
-        )
-
-        return CandidateView(
-            claim=claim,
-            score=score,
-            source_scope_rank=source_scope_rank,
-            mode_rank=mode_rank,
-            specificity_rank=specificity_rank,
-        )
+        score = mode_rank * 100.0 + float(claim.confidence) * 10.0 + source_scope_rank * 1.0 + specificity_rank * 0.1
+        return CandidateView(claim=claim, score=score, source_scope_rank=source_scope_rank, mode_rank=mode_rank, specificity_rank=specificity_rank)
 
     def _mode_rank(self, extraction_mode: str) -> int:
-        return {
-            "explicit": 4,
-            "inherited": 3,
-            "backward_inferred": 2,
-            "derived": 1,
-        }.get(extraction_mode, 0)
+        return {"explicit": 4, "inherited": 3, "backward_inferred": 2, "derived": 1}.get(extraction_mode, 0)
 
-    def _scope_rank_for_claim(
-        self,
-        *,
-        claim: ClaimArtifact,
-        policy: ContextPolicy,
-        fragments_by_id: dict[str, Any],
-    ) -> int:
+    def _scope_rank_for_claim(self, *, claim: ClaimArtifact, policy: ContextPolicy, fragments_by_id: dict[str, Any]) -> int:
         frag = fragments_by_id.get(claim.source_fragment_id)
         if frag is None:
             return 0
-
         scope_path = getattr(frag, "scope_path", tuple())
         levels = [getattr(s, "level", None) for s in scope_path]
         precedence = policy.precedence_chain or []
-
         for idx, label in enumerate(precedence):
             if label in levels:
-                # 앞쪽이 더 강하므로 큰 점수
                 return len(precedence) - idx
         return 0
 
@@ -358,81 +155,46 @@ class ScopeResolutionPass:
                 return 1
         return 0
 
-    def _apply_refine_resolution(
-        self,
-        role_name: str,
-        policy: Optional[ContextPolicy],
-        candidates: list[CandidateView],
-    ) -> list[CandidateView]:
+    def _apply_refine_resolution(self, role_name: str, policy: Optional[ContextPolicy], candidates: list[CandidateView]) -> list[CandidateView]:
         if not candidates:
             return candidates
-
-        # v0.1: period refine만 구현
         if role_name != "period" or policy is None:
             return candidates
-
-        # YYYY_MM over YYYY 형태의 refine가 있으면 broad candidate 점수 약간 낮춤
         has_period_refine = any(pair == ("YYYY_MM", "YYYY") for pair in policy.refine_pairs)
         if not has_period_refine:
             return candidates
-
         year_month_vals = {c.claim.value for c in candidates if isinstance(c.claim.value, str) and YEAR_MONTH_RE.fullmatch(c.claim.value)}
         out = []
-
         for c in candidates:
             if isinstance(c.claim.value, str) and YEAR_ONLY_RE.fullmatch(c.claim.value):
                 year = c.claim.value
-                # 같은 연도의 YYYY-MM이 있으면 broad value는 refinement 당한 것으로 봄
                 if any(str(v).startswith(year + "-") for v in year_month_vals):
-                    c = CandidateView(
-                        claim=c.claim,
-                        score=c.score - 0.5,
-                        source_scope_rank=c.source_scope_rank,
-                        mode_rank=c.mode_rank,
-                        specificity_rank=c.specificity_rank,
-                    )
+                    c = CandidateView(claim=c.claim, score=c.score - 0.5, source_scope_rank=c.source_scope_rank, mode_rank=c.mode_rank, specificity_rank=c.specificity_rank)
             out.append(c)
-
         return out
 
-    def _pick_best_and_shadows(
-        self,
-        candidates: list[CandidateView],
-    ) -> tuple[CandidateView, list[CandidateView], bool]:
+    def _pick_best_and_shadows(self, candidates: list[CandidateView]) -> tuple[CandidateView, list[CandidateView], bool]:
         candidates = sorted(candidates, key=lambda c: c.score, reverse=True)
         best = candidates[0]
         shadows = candidates[1:]
-
         conflicted = False
         if len(candidates) >= 2:
             second = candidates[1]
-            if best.claim.value != second.claim.value:
-                # 점수가 너무 비슷하면 conflict로 본다
-                if abs(best.score - second.score) < 0.75:
-                    conflicted = True
-
+            if best.claim.value != second.claim.value and abs(best.score - second.score) < 0.75:
+                conflicted = True
         return best, shadows, conflicted
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
     def _index_fragments(self, fragments: list[Any]) -> dict[str, Any]:
-        return {
-            getattr(f, "fragment_id", f"FRG-{i:06d}"): f
-            for i, f in enumerate(fragments, start=1)
-        }
+        return {getattr(f, "fragment_id", f"FRG-{i:06d}"): f for i, f in enumerate(fragments, start=1)}
 
-    def _frame_scope(
-        self,
-        frame: PartialFrameArtifact,
-        fragments_by_id: dict[str, Any],
-    ) -> ScopePath:
+    def _frame_scope(self, frame: PartialFrameArtifact, fragments_by_id: dict[str, Any]) -> ScopePath:
         if not frame.fragment_ids:
             return tuple()
-
         frag = fragments_by_id.get(frame.fragment_ids[0])
         if frag is None:
             return tuple()
-
         return getattr(frag, "scope_path", tuple())
+
+    def _make_eval_context(self, *, env: RuntimeEnv, scope_path: ScopePath, frame: PartialFrameArtifact, claims_by_id: dict[str, ClaimArtifact]):
+        from expr_eval import EvalContext
+        return EvalContext(env=env, text="", scope_path=scope_path, frame=frame, claims_by_id=claims_by_id, local_vars={"frame_type": frame.frame_type, "status": frame.status})

--- a/source_eval.py
+++ b/source_eval.py
@@ -24,6 +24,16 @@ class SourceEvalError(ValueError):
 
 
 class SourceEvaluator:
+    ALLOWED_BUILTINS = {
+        "site_alias",
+        "activity_alias",
+        "unit_symbol",
+        "period_expr",
+        "number",
+        "one_of",
+        "llm.fuzzy_lex",
+    }
+
     def resolve(
         self,
         expr: SourceExpr | None,
@@ -224,28 +234,15 @@ class SourceEvaluator:
         tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
     ) -> Any:
         name = expr.name
+        if name not in self.ALLOWED_BUILTINS:
+            raise SourceEvalError(f"builtin '{name}' is not allowed in SourceEvaluator")
 
-        if name == "missing":
-            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
-            fn = self._lookup_builtin(name, ctx)
-            return fn(role_name, ctx.frame)
-
-        if name == "origin":
-            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
-            fn = self._lookup_builtin(name, ctx)
-            return fn(role_name, ctx.frame, ctx.claims_by_id)
-
-        if name == "evidence":
-            kind = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
-            fn = self._lookup_builtin(name, ctx)
-            return fn(kind, ctx.frame, ctx.claims_by_id)
+        fn = self._lookup_builtin(name, ctx)
 
         if name in {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number"}:
-            fn = self._lookup_builtin(name, ctx)
             return fn(ctx.text, ctx.env)
 
         if name == "one_of":
-            fn = self._lookup_builtin(name, ctx)
             choices = [
                 self.eval_value(arg, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
                 for arg in expr.args
@@ -253,19 +250,14 @@ class SourceEvaluator:
             return fn(ctx.text, *choices, env=ctx.env)
 
         if name == "llm.fuzzy_lex":
-            fn = self._lookup_builtin(name, ctx)
             role_name = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
             return fn(role_name, ctx.text, ctx.env)
 
-        fn = self._lookup_builtin(name, ctx)
         args = [
             self.eval_value(arg, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
             for arg in expr.args
         ]
-
         for pattern in (
-            lambda: fn(*args, env=ctx.env, frame=ctx.frame, claims_by_id=ctx.claims_by_id),
-            lambda: fn(*args, env=ctx.env, frame=ctx.frame),
             lambda: fn(*args, env=ctx.env),
             lambda: fn(*args),
         ):

--- a/source_eval.py
+++ b/source_eval.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from expr_eval import EvalContext
+from runtime_env import LexCandidate
+from source_ir import (
+    SourceBuiltinCall,
+    SourceCandidate,
+    SourceColumnRef,
+    SourceContextRef,
+    SourceExpr,
+    SourceFirstOf,
+    SourceLiteral,
+    SourceRowLabelMatch,
+    SourceSetExpr,
+    SourceSymbolConst,
+    SourceTokenRef,
+)
+
+
+class SourceEvalError(ValueError):
+    pass
+
+
+class SourceEvaluator:
+    def resolve(
+        self,
+        expr: SourceExpr | None,
+        *,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> list[SourceCandidate]:
+        if expr is None:
+            return []
+
+        if isinstance(expr, SourceFirstOf):
+            for option in expr.options:
+                out = self.resolve(
+                    option,
+                    ctx=ctx,
+                    fragment=fragment,
+                    tokens_by_fragment=tokens_by_fragment,
+                )
+                if out:
+                    return out
+            return []
+
+        if isinstance(expr, SourceTokenRef):
+            return self._resolve_token(expr.token_name, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+
+        if isinstance(expr, SourceColumnRef):
+            row = self._row(fragment, ctx)
+            value = row.get(expr.column_name)
+            if value in (None, ""):
+                return []
+            return [
+                SourceCandidate(
+                    value=value,
+                    confidence=0.95,
+                    extraction_mode="explicit",
+                    source_fragment_id=self._fragment_id(fragment),
+                    metadata={
+                        "source_kind": "column",
+                        "column_name": expr.column_name,
+                    },
+                )
+            ]
+
+        if isinstance(expr, SourceContextRef):
+            resolutions = ctx.env.context_store.resolve_all(
+                expr.role_name,
+                ctx.scope_path,
+                column_key=ctx.column_key,
+            )
+            return [
+                SourceCandidate(
+                    value=entry.value,
+                    confidence=float(entry.confidence),
+                    extraction_mode="inherited",
+                    source_fragment_id=entry.source_fragment_id,
+                    metadata={
+                        "source_kind": "context",
+                        "context_id": entry.context_id,
+                        "operation": entry.operation,
+                        "precedence": entry.precedence,
+                    },
+                )
+                for entry in resolutions
+            ]
+
+        if isinstance(expr, SourceRowLabelMatch):
+            row_label = self._row_label(fragment, ctx)
+            if row_label is None or expr.label not in str(row_label):
+                return []
+            return [
+                SourceCandidate(
+                    value=expr.label,
+                    confidence=0.92,
+                    extraction_mode="explicit",
+                    source_fragment_id=self._fragment_id(fragment),
+                    metadata={
+                        "source_kind": "row_label",
+                        "row_label": row_label,
+                    },
+                )
+            ]
+
+        value = self.eval_value(
+            expr,
+            ctx=ctx,
+            fragment=fragment,
+            tokens_by_fragment=tokens_by_fragment,
+        )
+        return self._coerce_to_candidates(value, fragment_id=self._fragment_id(fragment))
+
+    def eval_value(
+        self,
+        expr: SourceExpr | Any,
+        *,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> Any:
+        if not isinstance(expr, SourceExpr):
+            return expr
+
+        if isinstance(expr, SourceLiteral):
+            return expr.value
+
+        if isinstance(expr, SourceSymbolConst):
+            return expr.name
+
+        if isinstance(expr, SourceSetExpr):
+            return [
+                self.eval_value(item, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+                for item in expr.items
+            ]
+
+        if isinstance(expr, SourceBuiltinCall):
+            return self._call(
+                expr,
+                ctx=ctx,
+                fragment=fragment,
+                tokens_by_fragment=tokens_by_fragment,
+            )
+
+        if isinstance(expr, SourceTokenRef):
+            candidates = self._resolve_token(expr.token_name, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            return None if not candidates else candidates[0].value
+
+        if isinstance(expr, SourceColumnRef):
+            return self._row(fragment, ctx).get(expr.column_name)
+
+        if isinstance(expr, SourceContextRef):
+            res = ctx.env.context_store.resolve_best(
+                expr.role_name,
+                ctx.scope_path,
+                column_key=ctx.column_key,
+            )
+            return None if res.chosen is None else res.chosen.value
+
+        if isinstance(expr, SourceRowLabelMatch):
+            row_label = self._row_label(fragment, ctx)
+            if row_label is None:
+                return None
+            return expr.label if expr.label in str(row_label) else None
+
+        if isinstance(expr, SourceFirstOf):
+            for option in expr.options:
+                value = self.eval_value(
+                    option,
+                    ctx=ctx,
+                    fragment=fragment,
+                    tokens_by_fragment=tokens_by_fragment,
+                )
+                if self._present(value):
+                    return value
+            return None
+
+        raise SourceEvalError(f"unsupported SourceExpr type: {type(expr).__name__}")
+
+    def _resolve_token(
+        self,
+        token_name: str,
+        *,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> list[SourceCandidate]:
+        if fragment is None or not tokens_by_fragment:
+            return []
+
+        fragment_id = self._fragment_id(fragment)
+        token_bucket = tokens_by_fragment.get(fragment_id, {}).get(token_name, [])
+
+        out: list[SourceCandidate] = []
+        for tok in token_bucket:
+            span = (tok.start, tok.end) if tok.start is not None and tok.end is not None else None
+            out.append(
+                SourceCandidate(
+                    value=tok.value,
+                    confidence=float(tok.confidence),
+                    extraction_mode="explicit",
+                    source_token_id=tok.token_id,
+                    source_fragment_id=tok.fragment_id,
+                    span=span,
+                    metadata={
+                        "source_kind": "token",
+                        "token_name": tok.token_name,
+                        "source_channel": tok.source_channel,
+                        "rank": tok.rank,
+                    },
+                )
+            )
+        return out
+
+    def _call(
+        self,
+        expr: SourceBuiltinCall,
+        *,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> Any:
+        name = expr.name
+
+        if name == "missing":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(role_name, ctx.frame)
+
+        if name == "origin":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(role_name, ctx.frame, ctx.claims_by_id)
+
+        if name == "evidence":
+            kind = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(kind, ctx.frame, ctx.claims_by_id)
+
+        if name in {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number"}:
+            fn = self._lookup_builtin(name, ctx)
+            return fn(ctx.text, ctx.env)
+
+        if name == "one_of":
+            fn = self._lookup_builtin(name, ctx)
+            choices = [
+                self.eval_value(arg, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+                for arg in expr.args
+            ]
+            return fn(ctx.text, *choices, env=ctx.env)
+
+        if name == "llm.fuzzy_lex":
+            fn = self._lookup_builtin(name, ctx)
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            return fn(role_name, ctx.text, ctx.env)
+
+        fn = self._lookup_builtin(name, ctx)
+        args = [
+            self.eval_value(arg, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            for arg in expr.args
+        ]
+
+        for pattern in (
+            lambda: fn(*args, env=ctx.env, frame=ctx.frame, claims_by_id=ctx.claims_by_id),
+            lambda: fn(*args, env=ctx.env, frame=ctx.frame),
+            lambda: fn(*args, env=ctx.env),
+            lambda: fn(*args),
+        ):
+            try:
+                return pattern()
+            except TypeError:
+                continue
+
+        raise SourceEvalError(f"builtin call failed: {name}")
+
+    def _lookup_builtin(self, name: str, ctx: EvalContext):
+        fn = ctx.env.builtin_registry.get(name)
+        if fn is None:
+            raise SourceEvalError(f"unknown builtin: {name}")
+        return fn
+
+    def _raw_identifier(
+        self,
+        args: list[SourceExpr],
+        *,
+        index: int,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> str:
+        if index >= len(args):
+            raise SourceEvalError("missing function arg")
+        value = self.eval_value(
+            args[index],
+            ctx=ctx,
+            fragment=fragment,
+            tokens_by_fragment=tokens_by_fragment,
+        )
+        return str(value)
+
+    def _coerce_to_candidates(self, value: Any, *, fragment_id: Optional[str]) -> list[SourceCandidate]:
+        if value is None:
+            return []
+
+        if isinstance(value, SourceCandidate):
+            return [value]
+
+        if isinstance(value, LexCandidate):
+            span = (value.start, value.end) if value.start is not None and value.end is not None else None
+            return [
+                SourceCandidate(
+                    value=value.value,
+                    confidence=float(value.confidence),
+                    extraction_mode="explicit",
+                    source_fragment_id=fragment_id,
+                    span=span,
+                    metadata=dict(value.metadata),
+                )
+            ]
+
+        if isinstance(value, list):
+            out: list[SourceCandidate] = []
+            for item in value:
+                out.extend(self._coerce_to_candidates(item, fragment_id=fragment_id))
+            return out
+
+        if isinstance(value, tuple) and len(value) == 3:
+            return [
+                SourceCandidate(
+                    value=value[0],
+                    confidence=0.80,
+                    extraction_mode="derived",
+                    source_fragment_id=fragment_id,
+                    span=(value[1], value[2]),
+                    metadata={"source_kind": "tuple_expr"},
+                )
+            ]
+
+        return [
+            SourceCandidate(
+                value=value,
+                confidence=0.70,
+                extraction_mode="derived",
+                source_fragment_id=fragment_id,
+                metadata={"source_kind": "generic_expr"},
+            )
+        ]
+
+    def _row(self, fragment: Any, ctx: EvalContext) -> dict[str, Any]:
+        if fragment is None:
+            return ctx.row
+        metadata = getattr(fragment, "metadata", {}) or {}
+        row = metadata.get("row", {}) if isinstance(metadata, dict) else {}
+        return row or ctx.row
+
+    def _row_label(self, fragment: Any, ctx: EvalContext) -> Any:
+        if fragment is None:
+            return ctx.row_label
+        metadata = getattr(fragment, "metadata", {}) or {}
+        row_label = metadata.get("row_label") if isinstance(metadata, dict) else None
+        return row_label if row_label is not None else ctx.row_label
+
+    def _fragment_id(self, fragment: Any) -> Optional[str]:
+        if fragment is None:
+            return None
+        return getattr(fragment, "fragment_id", None)
+
+    def _present(self, value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return value != ""
+        if isinstance(value, (list, tuple, set, dict)):
+            return len(value) > 0
+        return bool(value)

--- a/source_ir.py
+++ b/source_ir.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class SourceCandidate:
+    value: Any
+    confidence: float
+    extraction_mode: str
+    source_token_id: Optional[str] = None
+    source_fragment_id: Optional[str] = None
+    span: Optional[tuple[int, int]] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class SourceExpr:
+    pass
+
+
+@dataclass
+class SourceLiteral(SourceExpr):
+    value: Any
+
+
+@dataclass
+class SourceSymbolConst(SourceExpr):
+    name: str
+
+
+@dataclass
+class SourceSetExpr(SourceExpr):
+    items: list[SourceExpr] = field(default_factory=list)
+
+
+@dataclass
+class SourceBuiltinCall(SourceExpr):
+    name: str
+    args: list[SourceExpr] = field(default_factory=list)
+
+
+@dataclass
+class SourceTokenRef(SourceExpr):
+    token_name: str
+
+
+@dataclass
+class SourceColumnRef(SourceExpr):
+    column_name: str
+
+
+@dataclass
+class SourceContextRef(SourceExpr):
+    role_name: str
+
+
+@dataclass
+class SourceRowLabelMatch(SourceExpr):
+    label: str
+
+
+@dataclass
+class SourceFirstOf(SourceExpr):
+    options: list[SourceExpr] = field(default_factory=list)

--- a/tests/test_lex_source_ir.py
+++ b/tests/test_lex_source_ir.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from binder import Binder
+from compiled_spec import CompiledBindAction, CompiledParserInheritAction, CompiledProgramSpec
+from lex_ir import LexBuiltinCall, LexUnion
+from pipeline_runner import load_program_spec_from_dsl
+from rule_ir import LocalVarRef, RuleBinary, SymbolConst
+from source_ir import SourceColumnRef, SourceContextRef, SourceFirstOf, SourceTokenRef
+from tests.support.builders import GRAMMAR_PATH
+
+
+LEX_SOURCE_DSL = """
+module lex_source_split
+
+dimension amount
+unit kwh: amount
+activity electricity: amount -> scope2
+
+context site {}
+context period {}
+
+frame ActivityObservation {
+  site: String
+  period: String?
+  raw_amount: Number
+  raw_unit: String
+}
+
+token SiteToken := one_of("alpha") | one_of("beta")
+token AmountToken := number()
+token UnitToken := one_of("kwh")
+
+parser LineParser on line {
+  build ActivityObservation
+  bind site from column("site_name") | SiteToken
+  inherit period from context.period when frame_type == ActivityObservation
+  bind raw_amount from AmountToken
+  bind raw_unit from UnitToken
+}
+
+inherit site from context.site when frame_type == ActivityObservation
+
+resolver ActivityObservation {
+  commit when true
+}
+
+governance ActivityObservation {
+  emit row when true
+  merge when true
+}
+""".strip()
+
+
+def _load_program_spec():
+    return load_program_spec_from_dsl(grammar_path=GRAMMAR_PATH, dsl_text=LEX_SOURCE_DSL)
+
+
+def test_binder_compiles_token_and_source_hosts_into_stage_specific_ir():
+    compiled = Binder().bind(_load_program_spec())
+
+    assert isinstance(compiled, CompiledProgramSpec)
+
+    compiled_token = compiled.compiled_tokens["SiteToken"]
+    assert isinstance(compiled_token.primary_ir, LexUnion)
+    assert [type(option) for option in compiled_token.primary_ir.options] == [LexBuiltinCall, LexBuiltinCall]
+
+    compiled_parser = compiled.compiled_parsers["LineParser"]
+    bind_action = compiled_parser.actions[0]
+    assert isinstance(bind_action, CompiledBindAction)
+    assert isinstance(bind_action.source_ir, SourceFirstOf)
+    assert isinstance(bind_action.source_ir.options[0], SourceColumnRef)
+    assert isinstance(bind_action.source_ir.options[1], SourceTokenRef)
+
+    inherit_action = compiled_parser.actions[1]
+    assert isinstance(inherit_action, CompiledParserInheritAction)
+    assert isinstance(inherit_action.source_ir, SourceContextRef)
+    assert isinstance(inherit_action.condition_ir, RuleBinary)
+    assert isinstance(inherit_action.condition_ir.left, LocalVarRef)
+    assert inherit_action.condition_ir.left.name == "frame_type"
+    assert isinstance(inherit_action.condition_ir.right, SymbolConst)
+    assert inherit_action.condition_ir.right.name == "ActivityObservation"
+
+    compiled_inherit = compiled.compiled_inherit_rules[0]
+    assert isinstance(compiled_inherit.source_ir, SourceContextRef)

--- a/tests/test_lex_source_ir.py
+++ b/tests/test_lex_source_ir.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip("lark")
 
-from binder import Binder
+from binder import Binder, BindingError
 from compiled_spec import CompiledBindAction, CompiledParserInheritAction, CompiledProgramSpec
 from lex_ir import LexBuiltinCall, LexUnion
 from pipeline_runner import load_program_spec_from_dsl
@@ -55,12 +55,12 @@ governance ActivityObservation {
 """.strip()
 
 
-def _load_program_spec():
-    return load_program_spec_from_dsl(grammar_path=GRAMMAR_PATH, dsl_text=LEX_SOURCE_DSL)
+def _bind_dsl(dsl_text: str):
+    return Binder().bind(load_program_spec_from_dsl(grammar_path=GRAMMAR_PATH, dsl_text=dsl_text))
 
 
 def test_binder_compiles_token_and_source_hosts_into_stage_specific_ir():
-    compiled = Binder().bind(_load_program_spec())
+    compiled = _bind_dsl(LEX_SOURCE_DSL)
 
     assert isinstance(compiled, CompiledProgramSpec)
 
@@ -86,3 +86,45 @@ def test_binder_compiles_token_and_source_hosts_into_stage_specific_ir():
 
     compiled_inherit = compiled.compiled_inherit_rules[0]
     assert isinstance(compiled_inherit.source_ir, SourceContextRef)
+
+
+def test_binder_rejects_unknown_bare_name_in_token_host():
+    bad_dsl = LEX_SOURCE_DSL.replace(
+        'token SiteToken := one_of("alpha") | one_of("beta")',
+        "token SiteToken := UnknownAlias",
+    )
+    with pytest.raises(BindingError, match="UnknownAlias"):
+        _bind_dsl(bad_dsl)
+
+
+def test_binder_rejects_unknown_bare_name_in_source_host():
+    bad_dsl = LEX_SOURCE_DSL.replace(
+        'bind site from column("site_name") | SiteToken',
+        'bind site from column("site_name") | SiteTokne',
+    )
+    with pytest.raises(BindingError, match="SiteTokne"):
+        _bind_dsl(bad_dsl)
+
+
+@pytest.mark.parametrize(
+    "bad_dsl, expected",
+    [
+        (
+            LEX_SOURCE_DSL.replace(
+                'token SiteToken := one_of("alpha") | one_of("beta")',
+                'token SiteToken := missing("site")',
+            ),
+            "token host",
+        ),
+        (
+            LEX_SOURCE_DSL.replace(
+                'bind site from column("site_name") | SiteToken',
+                'bind site from missing("site")',
+            ),
+            "source host",
+        ),
+    ],
+)
+def test_binder_rejects_rule_builtins_in_lex_and_source_hosts(bad_dsl: str, expected: str):
+    with pytest.raises(BindingError, match=expected):
+        _bind_dsl(bad_dsl)

--- a/tests/test_lex_source_stage_semantics.py
+++ b/tests/test_lex_source_stage_semantics.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from tests.support.builders import make_fragment, make_resources, run_pipeline_until
+
+
+DSL = """
+module lex_source_stage_semantics
+
+dimension amount
+unit kwh: amount
+activity electricity: amount -> scope2
+
+frame ActivityObservation {
+  site: String
+  raw_amount: Number
+  raw_unit: String
+}
+
+token SiteToken := one_of("alpha") | one_of("beta")
+token AmountToken := number()
+token UnitToken := one_of("kwh")
+
+parser LineParser on line {
+  build ActivityObservation
+  bind site from column("site_name") | SiteToken
+  bind raw_amount from AmountToken
+  bind raw_unit from UnitToken
+}
+
+resolver ActivityObservation {
+  commit when true
+}
+
+governance ActivityObservation {
+  emit row when true
+  merge when true
+}
+""".strip()
+
+
+def test_lex_union_and_source_first_of_are_preserved_end_to_end():
+    fragments = [
+        make_fragment(
+            fragment_id="FRG-1",
+            text="alpha beta 10 kwh",
+            metadata={"row": {"site_name": "COLUMN-SITE"}},
+        )
+    ]
+    resources = make_resources()
+
+    lex_result = run_pipeline_until(
+        dsl_text=DSL,
+        fragments=fragments,
+        resources=resources,
+        pass_name="LexPass",
+    )
+    site_values = {tok.value for tok in lex_result.artifacts.tokens if tok.token_name == "SiteToken"}
+    assert site_values == {"alpha", "beta"}
+
+    parse_result = run_pipeline_until(
+        dsl_text=DSL,
+        fragments=fragments,
+        resources=resources,
+        pass_name="ParsePass",
+    )
+    frame = parse_result.artifacts.frames[0]
+
+    assert frame.slots["site"].resolved_value == "COLUMN-SITE"
+    assert frame.slots["raw_amount"].resolved_value == 10
+    assert frame.slots["raw_unit"].resolved_value == "kwh"


### PR DESCRIPTION
### Motivation
- PR4 finished the compiled-first rule path, but token expressions and parser/top-level source expressions were still sharing the generic `Expr` tree and legacy evaluator semantics.
- The remaining stage smell was that token alternation, parser source fallback, and generic expr evaluation still lived on one shared AST/evaluator surface.
- This PR starts the next split by compiling token hosts into `LexIR` and source hosts into `SourceIR`, then routing the relevant passes through dedicated evaluators.

### What changed
- Add `lex_ir.py` with token-stage nodes (`LexUnion`, `LexBuiltinCall`, `LexColumnRef`, `LexContextRef`, `LexRowLabelMatch`, ...).
- Add `source_ir.py` with source-stage nodes (`SourceFirstOf`, `SourceTokenRef`, `SourceColumnRef`, `SourceContextRef`, `SourceRowLabelMatch`, ...) plus a shared `SourceCandidate` type.
- Extend `compiled_spec.py` so `CompiledProgramSpec` now carries:
  - `compiled_tokens`
  - `compiled_parsers`
  - `compiled_inherit_rules`
- Extend `binder.py` so it now compiles:
  - token hosts -> `LexIR`
  - parser bind/tag/inherit source hosts -> `SourceIR`
  - top-level inherit source hosts -> `SourceIR`
  - parser/top-level inherit conditions -> existing `RuleIR`
- Add `lex_eval.py` and route `LexPass` through the compiled `LexIR` path.
- Add `source_eval.py` and route:
  - `ParsePass` source resolution through `SourceIR`
  - `ScopeResolutionPass` top-level inherit resolution through `SourceIR`
- Preserve stage semantics explicitly:
  - token alternation => union semantics
  - parser/source alternation => first-success fallback semantics

### Tests added
- `tests/test_lex_source_ir.py`
  - binder-level test that token and source hosts are compiled into stage-specific IR
- `tests/test_lex_source_stage_semantics.py`
  - end-to-end check that:
    - token alternation still behaves like union
    - parser source alternation still behaves like left-biased first-of

### Scope / non-goals
- This PR does **not** change surface DSL syntax.
- This PR does **not** attempt a full front-end AST split.
- This PR does **not** introduce a separate lex/source builtin registry yet; it keeps builtin lookup on the existing runtime registry while removing the shared generic `Expr` path for token/source hosts.

### Testing
- I did not run the full test suite in this environment.
- Added focused binder/stage-semantics tests so local/CI can validate the split.
