### PR TITLE
PR0: bootstrap packaging and package skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# comp
+
+`comp`는 ESGDL 기반의 **실험적 evidence compiler**입니다.
+
+이 레포는 raw fragment를 곧바로 “정답 표”로 바꾸는 도구라기보다, 후보·근거·충돌·정책을 축적한 뒤 **정당한 public row만 안전하게 승격**하는 구조를 목표로 합니다.
+
+## 이 레포가 하려는 일
+
+`comp`의 목표는 다음과 같습니다.
+
+- ESG 관련 raw/반정형 입력에서 의미 있는 후보를 추출합니다.
+- 후보 사이의 근거, 충돌, 보류 사유를 함께 보존합니다.
+- 대표 후보를 고르고, 충분히 안전한 경우에만 public row를 만듭니다.
+- provenance, hazard, governance를 잃지 않는 작은 compiler를 만듭니다.
+
+즉 이 레포는 단순 parser나 ETL 스크립트가 아니라, **증거를 보존하면서 정제된 데이터를 public 상태로 승격하는 컴파일러**를 지향합니다.
+
+## 현재 구현된 흐름
+
+현재 레포는 stage pipeline 형태를 가지고 있습니다.
+
+```text
+LexPass
+→ ParsePass
+→ ScopeResolutionPass
+→ InferencePass
+→ SemanticPass
+→ RepairPass
+→ EmitPass
+→ GovernancePass
+→ CalculationPass
+```
+
+이 흐름에서 다음과 같은 중간 산출물을 다룹니다.
+
+- fragments
+- tokens
+- claims
+- frames
+- rows
+- calculations
+- merge_log
+- diagnostics
+
+## 앞으로의 설계 방향
+
+장기적으로 `comp`는 단순 pass chain을 넘어서, **같은 judgment language로 data와 spec을 함께 다루는 구조**를 목표로 합니다.
+
+핵심 아이디어는 다음과 같습니다.
+
+- raw 입력은 seed fact로 올립니다.
+- DSL/spec는 monotone transfer rule로 컴파일합니다.
+- core는 fixpoint engine 위에서 동작합니다.
+- candidate selection은 frontier 계산으로 다룹니다.
+- public row는 commit barrier를 통과한 projection만 허용합니다.
+- provenance / hazard / receipt는 append-only 기록으로 남깁니다.
+
+## 핵심 원칙
+
+1. row-first가 아니라 judgment-first
+2. append-only core
+3. draft와 public row의 분리
+4. emit은 source of truth가 아니라 projection
+5. spec과 data를 같은 판정 어휘로 검증
+
+## 패키지 구조
+
+```text
+comp/
+  dsl/        # ESGDL grammar, DSL 관련 진입점
+  judgment/   # future judgment core, fixpoint engine, frontier, commit
+  pipeline/   # 현재 staged pass 공개 진입점
+  eval/       # expression / rule / source evaluator 공개 진입점
+  builtins/   # builtin 공개 진입점
+  compat/     # 기존 artifacts/spec와의 bridge
+  views/      # future draft/review/public projection
+```
+
+## 현재 상태
+
+이 레포는 아직 **실험 단계**입니다.
+
+- 구조 정리와 패키징이 진행 중입니다.
+- API/CLI는 아직 안정화되지 않았습니다.
+- 내부 파이프라인과 judgment core의 경계를 정리하는 중입니다.
+
+즉 지금은 “완성된 제품”보다 **작은 evidence compiler의 올바른 구조를 찾는 단계**에 가깝습니다.
+
+## 로드맵
+
+### PR0
+- 루트 `comp/` 패키지 도입
+- `pyproject.toml` 추가
+- 기존 top-level 모듈과의 호환 래퍼 추가
+- 한글 README 추가
+
+### PR1
+- judgment core 뼈대 추가
+- frontier / commit / receipts 자리 고정
+- compat layer 정리
+
+### PR2+
+- 기존 pass를 judgment program 쪽으로 점진적으로 내리기
+- emit/governance를 projection/commit 쪽으로 분리하기
+
+## 지향점
+
+`comp`는 결과 표만 맞는 시스템보다, **그 결과가 왜 정당한지까지 설명 가능한 시스템**을 지향합니다.
+
+즉 이 레포의 목표는 단순 변환기가 아니라,
+
+- 무엇이 후보인가
+- 어떤 근거가 붙었는가
+- 왜 이 값이 선택되었는가
+- 왜 아직 public row가 되지 못하는가
+- 어떤 조건에서 commit이 허용되는가
+
+를 함께 다룰 수 있는 **작은 judgment machine**을 만드는 것입니다.

--- a/comp/__init__.py
+++ b/comp/__init__.py
@@ -1,0 +1,21 @@
+"""Top-level package entrypoint for the experimental comp package."""
+
+from comp.runner import (
+    ESGPipelineRunner,
+    CompiledESGPipelineRunner,
+    PipelineResources,
+    PipelineRunResult,
+    compile_program_spec,
+    load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl,
+)
+
+__all__ = [
+    "ESGPipelineRunner",
+    "CompiledESGPipelineRunner",
+    "PipelineResources",
+    "PipelineRunResult",
+    "compile_program_spec",
+    "load_program_spec_from_dsl",
+    "load_compiled_program_spec_from_dsl",
+]

--- a/comp/builtins/__init__.py
+++ b/comp/builtins/__init__.py
@@ -1,0 +1,9 @@
+"""Builtin registries and helpers."""
+
+from esg_builtins import register_default_builtins
+from rule_builtins import get_default_rule_builtin_registry
+
+__all__ = [
+    "register_default_builtins",
+    "get_default_rule_builtin_registry",
+]

--- a/comp/compat/__init__.py
+++ b/comp/compat/__init__.py
@@ -1,0 +1,4 @@
+"""Compatibility layer for existing top-level artifacts and specs."""
+
+from comp.compat.artifacts import *
+from comp.compat.compiled_spec import *

--- a/comp/compat/artifacts.py
+++ b/comp/compat/artifacts.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for legacy artifact types."""
+
+from artifacts import *

--- a/comp/compat/compiled_spec.py
+++ b/comp/compat/compiled_spec.py
@@ -1,0 +1,33 @@
+"""Compatibility wrapper for legacy compiled spec types."""
+
+from compiled_spec import (
+    CompiledBindAction,
+    CompiledConstraintSpec,
+    CompiledDiagnosticSpec,
+    CompiledGovernancePolicy,
+    CompiledInheritSpec,
+    CompiledInferSpec,
+    CompiledParserAction,
+    CompiledParserInheritAction,
+    CompiledParserSpec,
+    CompiledProgramSpec,
+    CompiledResolverPolicy,
+    CompiledTagAction,
+    CompiledTokenSpec,
+)
+
+__all__ = [
+    "CompiledTokenSpec",
+    "CompiledInheritSpec",
+    "CompiledConstraintSpec",
+    "CompiledDiagnosticSpec",
+    "CompiledInferSpec",
+    "CompiledBindAction",
+    "CompiledParserInheritAction",
+    "CompiledTagAction",
+    "CompiledParserAction",
+    "CompiledParserSpec",
+    "CompiledResolverPolicy",
+    "CompiledGovernancePolicy",
+    "CompiledProgramSpec",
+]

--- a/comp/dsl/__init__.py
+++ b/comp/dsl/__init__.py
@@ -1,0 +1,14 @@
+"""DSL-facing package exports for ESGDL."""
+
+from ast_builder import ASTBuilder
+from binder import Binder, BindingError
+from lowering import Lowerer
+from spec_nodes import ProgramSpec
+
+__all__ = [
+    "ASTBuilder",
+    "Binder",
+    "BindingError",
+    "Lowerer",
+    "ProgramSpec",
+]

--- a/comp/dsl/esgdl.lark
+++ b/comp/dsl/esgdl.lark
@@ -1,0 +1,188 @@
+start: program
+
+program: statement*
+
+?statement: module_decl
+          | import_decl
+          | dimension_decl
+          | unit_decl
+          | activity_decl
+          | scope_decl
+          | context_decl
+          | frame_decl
+          | token_decl
+          | fallback_token_decl
+          | parser_decl
+          | inherit_rule
+          | infer_rule
+          | require_rule
+          | forbid_rule
+          | diagnostic_rule
+          | resolver_decl
+          | governance_decl
+
+module_decl: "module" qname                         -> module_decl
+import_decl: "import" qname                         -> import_decl
+
+dimension_decl: "dimension" IDENT                   -> dimension_decl
+
+unit_decl: "unit" IDENT ":" IDENT normalize_clause? -> unit_decl
+normalize_clause: "normalize" "(" IDENT "," NORM_OP NUMBER ")" -> normalize_clause
+
+activity_decl: "activity" IDENT ":" IDENT "->" IDENT -> activity_decl
+
+scope_decl: "scope" scope_chain                     -> scope_decl
+scope_chain: IDENT (">" IDENT)+
+
+context_decl: "context" IDENT "{" context_stmt* "}" -> context_decl
+?context_stmt: precedence_stmt
+             | refine_stmt
+             | ttl_stmt
+             | supports_stmt
+
+precedence_stmt: "precedence" precedence_chain      -> precedence_stmt
+precedence_chain: IDENT (">" IDENT)+
+
+refine_stmt: "refine" IDENT "over" IDENT            -> refine_stmt
+
+ttl_stmt: "ttl" ttl_chain                           -> ttl_stmt
+ttl_chain: IDENT ("|" IDENT)+
+
+supports_stmt: "supports" supports_chain            -> supports_stmt
+supports_chain: IDENT ("," IDENT)*
+
+frame_decl: "frame" IDENT "{" field_decl* "}"       -> frame_decl
+field_decl: IDENT ":" type_ref optional_marker?     -> field_decl
+optional_marker: "?"
+type_ref: IDENT generic_arg?                        -> type_ref
+generic_arg: "<" IDENT ">"
+
+token_decl: "token" IDENT ":=" token_expr           -> token_decl
+fallback_token_decl: "fallback" "token" IDENT ":=" token_expr -> fallback_token_decl
+
+token_expr: source_expr
+
+parser_decl: "parser" IDENT "on" selector_chain "{" parser_stmt* "}" -> parser_decl
+selector_chain: IDENT ("|" IDENT)*
+
+?parser_stmt: build_stmt
+            | bind_stmt
+            | parser_inherit_stmt
+            | tag_stmt
+
+build_stmt: "build" IDENT                           -> build_stmt
+bind_stmt: "bind" IDENT optional_marker? "from" source_expr -> bind_stmt
+parser_inherit_stmt: "inherit" IDENT "from" source_expr ("when" bool_expr)? -> parser_inherit_stmt
+tag_stmt: "tag" IDENT "from" source_expr            -> tag_stmt
+
+inherit_rule: "inherit" IDENT "from" source_expr "when" bool_expr -> inherit_rule
+
+infer_rule: "infer" IDENT INFER_OP expr infer_weight? "when" bool_expr -> infer_rule
+infer_weight: "weight" NUMBER
+
+require_rule: "require" bool_expr                   -> require_rule
+forbid_rule: "forbid" bool_expr ("for" "frame" IDENT)? -> forbid_rule
+
+diagnostic_rule: DIAG_LEVEL IDENT "when" bool_expr -> diagnostic_rule
+
+resolver_decl: "resolver" IDENT "{" resolver_stmt* "}" -> resolver_decl
+?resolver_stmt: assign_stmt
+              | candidate_pool_block
+              | commit_stmt
+              | review_stmt
+              | reject_stmt
+
+assign_stmt: IDENT "=" expr                         -> assign_stmt
+
+candidate_pool_block: "candidate_pool" "{" assign_stmt* "}" -> candidate_pool_block
+
+commit_stmt: "commit" "when" bool_expr             -> commit_stmt
+review_stmt: "review" "when" bool_expr             -> review_stmt
+reject_stmt: "reject" "otherwise"                  -> reject_stmt
+
+governance_decl: "governance" IDENT "{" governance_stmt* "}" -> governance_decl
+?governance_stmt: emit_stmt
+                | merge_stmt
+                | forbid_merge_stmt
+
+emit_stmt: "emit" "row" "when" bool_expr           -> emit_stmt
+merge_stmt: "merge" "when" bool_expr               -> merge_stmt
+forbid_merge_stmt: "forbid" "merge" "when" bool_expr -> forbid_merge_stmt
+
+
+// -----------------------------
+// Expressions
+// -----------------------------
+
+?source_expr: source_atom ("|" source_atom)*        -> source_expr
+
+?source_atom: function_call
+            | column_ref
+            | context_ref
+            | row_label_ref
+            | qname
+            | literal
+
+?expr: function_call
+     | column_ref
+     | context_ref
+     | row_label_ref
+     | set_literal
+     | qname
+     | literal
+
+?bool_expr: bool_or
+
+?bool_or: bool_or "or" bool_and                     -> bool_or
+        | bool_and
+
+?bool_and: bool_and "and" bool_not                  -> bool_and
+         | bool_not
+
+?bool_not: "not" bool_not                           -> bool_not
+         | comparison
+         | predicate
+         | "(" bool_expr ")"                        -> grouped_bool
+
+?comparison: expr COMP_OP expr                      -> comparison
+           | expr "in" set_literal                  -> in_expr
+           | expr "matches" expr                    -> matches_expr
+
+?predicate: function_call                           -> bool_call
+          | qname                                   -> bool_ref
+
+function_call: qname "(" [arg_list] ")"            -> function_call
+arg_list: expr ("," expr)*
+
+set_literal: "{" [expr ("," expr)*] "}"            -> set_literal
+
+column_ref: "column" "(" STRING ")"                -> column_ref
+context_ref: "context" "." IDENT                   -> context_ref
+row_label_ref: "row_label" "(" STRING ")"          -> row_label_ref
+
+qname: IDENT ("." IDENT)*                          -> qname
+
+literal: STRING                                    -> string_lit
+       | NUMBER                                    -> number_lit
+       | BOOL                                      -> bool_lit
+
+
+// -----------------------------
+// Tokens
+// -----------------------------
+
+BOOL: "true" | "false"
+COMP_OP: "==" | "!=" | ">=" | "<=" | ">" | "<"
+NORM_OP: "*" | "/" | "+" | "-"
+INFER_OP: "=" | "~"
+DIAG_LEVEL: "error" | "warning"
+
+IDENT: /[A-Za-z_][A-Za-z0-9_]*/
+NUMBER: /-?[0-9]+(\.[0-9]+)?/
+
+%import common.ESCAPED_STRING -> STRING
+%import common.WS
+
+%ignore WS
+%ignore /\/\/[^\n]*/
+%ignore /\#[^\n]*/

--- a/comp/eval/__init__.py
+++ b/comp/eval/__init__.py
@@ -1,0 +1,15 @@
+"""Public evaluator exports."""
+
+from compiled_expr_eval import CompiledExprEvaluator
+from expr_eval import ExprEvaluator
+from lex_eval import LexEvaluator
+from rule_eval import RuleEvaluator
+from source_eval import SourceEvaluator
+
+__all__ = [
+    "ExprEvaluator",
+    "CompiledExprEvaluator",
+    "LexEvaluator",
+    "SourceEvaluator",
+    "RuleEvaluator",
+]

--- a/comp/judgment/__init__.py
+++ b/comp/judgment/__init__.py
@@ -1,0 +1,9 @@
+"""Future judgment-core package.
+
+This namespace is reserved for the next architecture step:
+- fact/judgment core
+- compiled judgment program
+- fixpoint engine
+- frontier/arbitration
+- commit/receipts
+"""

--- a/comp/judgment/commit.py
+++ b/comp/judgment/commit.py
@@ -1,0 +1,3 @@
+"""Judgment commit placeholder."""
+
+__all__: list[str] = []

--- a/comp/judgment/core.py
+++ b/comp/judgment/core.py
@@ -1,0 +1,10 @@
+"""Placeholder for the future judgment core.
+
+Planned contents:
+- SubjectRef
+- Fact
+- JudgmentState
+- append-only hazard / provenance primitives
+"""
+
+__all__: list[str] = []

--- a/comp/judgment/engine.py
+++ b/comp/judgment/engine.py
@@ -1,0 +1,3 @@
+"""Judgment engine placeholder."""
+
+__all__: list[str] = []

--- a/comp/judgment/frontier.py
+++ b/comp/judgment/frontier.py
@@ -1,0 +1,3 @@
+"""Judgment frontier placeholder."""
+
+__all__: list[str] = []

--- a/comp/judgment/program.py
+++ b/comp/judgment/program.py
@@ -1,0 +1,3 @@
+"""Placeholder for compiled judgment program types."""
+
+__all__: list[str] = []

--- a/comp/judgment/receipts.py
+++ b/comp/judgment/receipts.py
@@ -1,0 +1,3 @@
+"""Judgment receipts placeholder."""
+
+__all__: list[str] = []

--- a/comp/pipeline/__init__.py
+++ b/comp/pipeline/__init__.py
@@ -1,0 +1,24 @@
+"""Public pass exports for the current staged pipeline."""
+
+from calculation_pass import CalculationPass
+from emit_pass import EmitPass
+from governance_pass import GovernancePass
+from inference_pass import InferencePass
+from lex_pass import LexPass
+from parse_pass import ParsePass
+from repair_pass import RepairPass
+from scope_resolution_pass import ScopeResolutionPass
+from semantic_pass import SemanticPass, SemanticPassConfig
+
+__all__ = [
+    "LexPass",
+    "ParsePass",
+    "ScopeResolutionPass",
+    "InferencePass",
+    "SemanticPass",
+    "SemanticPassConfig",
+    "RepairPass",
+    "EmitPass",
+    "GovernancePass",
+    "CalculationPass",
+]

--- a/comp/runner.py
+++ b/comp/runner.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from compiled_pipeline_runner import CompiledESGPipelineRunner as _LegacyCompiledRunner
+from pipeline_runner import (
+    ESGPipelineRunner as _LegacyRunner,
+    PipelineResources,
+    PipelineRunResult,
+    compile_program_spec,
+    load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl,
+)
+
+_DEFAULT_GRAMMAR_PATH = Path(__file__).resolve().parent / "dsl" / "esgdl.lark"
+
+
+class ESGPipelineRunner(_LegacyRunner):
+    def __init__(
+        self,
+        *,
+        grammar_path: str | Path | None = None,
+        passes: Optional[list[Any]] = None,
+        fragmentizer: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            grammar_path=grammar_path or _DEFAULT_GRAMMAR_PATH,
+            passes=passes,
+            fragmentizer=fragmentizer,
+        )
+
+
+class CompiledESGPipelineRunner(_LegacyCompiledRunner):
+    def __init__(
+        self,
+        *,
+        grammar_path: str | Path | None = None,
+        passes: Optional[list[Any]] = None,
+        fragmentizer: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            grammar_path=grammar_path or _DEFAULT_GRAMMAR_PATH,
+            passes=passes,
+            fragmentizer=fragmentizer,
+        )
+
+
+__all__ = [
+    "ESGPipelineRunner",
+    "CompiledESGPipelineRunner",
+    "PipelineResources",
+    "PipelineRunResult",
+    "compile_program_spec",
+    "load_program_spec_from_dsl",
+    "load_compiled_program_spec_from_dsl",
+]

--- a/comp/views/__init__.py
+++ b/comp/views/__init__.py
@@ -1,0 +1,1 @@
+"""Future projection/view package."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "comp"
+version = "0.1.0a0"
+description = "Experimental ESG evidence compiler driven by ESGDL"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "lark>=1.1.8",
+]
+
+[tool.setuptools]
+packages = [
+  "comp",
+  "comp.dsl",
+  "comp.pipeline",
+  "comp.eval",
+  "comp.builtins",
+  "comp.compat",
+  "comp.judgment",
+  "comp.views",
+]
+py-modules = [
+  "artifacts",
+  "ast_builder",
+  "ast_nodes",
+  "binder",
+  "calculation_pass",
+  "compiled_expr_eval",
+  "compiled_pipeline_runner",
+  "compiled_spec",
+  "emit_pass",
+  "esg_builtins",
+  "expr_eval",
+  "governance_pass",
+  "inference_pass",
+  "lex_eval",
+  "lex_ir",
+  "lex_pass",
+  "lowering",
+  "parse_pass",
+  "pipeline_runner",
+  "repair_pass",
+  "rule_builtins",
+  "rule_eval",
+  "rule_ir",
+  "runtime_env",
+  "scope_resolution_pass",
+  "semantic_pass",
+  "source_eval",
+  "source_ir",
+  "spec_nodes",
+]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"comp.dsl" = ["*.lark"]

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,0 +1,13 @@
+from comp import CompiledESGPipelineRunner, ESGPipelineRunner
+from comp.compat.artifacts import CompileArtifacts
+from comp.compat.compiled_spec import CompiledProgramSpec
+from comp.pipeline import LexPass, ParsePass
+
+
+def test_package_smoke_imports():
+    assert ESGPipelineRunner is not None
+    assert CompiledESGPipelineRunner is not None
+    assert CompileArtifacts is not None
+    assert CompiledProgramSpec is not None
+    assert LexPass is not None
+    assert ParsePass is not None


### PR DESCRIPTION
## PR0

패키징과 구조 정리를 위한 첫 번째 PR입니다.

### 이번 PR에서 한 일
- `README.md` 추가 (한글)
- `pyproject.toml` 추가
- 루트 `comp/` 패키지 신설
- `comp.runner` 진입점 추가
- `comp.dsl`, `comp.pipeline`, `comp.eval`, `comp.builtins`, `comp.compat` 공개 진입점 추가
- 향후 설계를 위한 `comp.judgment`, `comp.views` 자리 고정
- `tests/test_package_smoke.py` 추가

### 의도
이 PR은 기존 top-level 모듈을 바로 전부 옮기지 않고, 기존 import를 깨지 않는 범위에서 **packaging bootstrap**만 먼저 수행합니다.

### 다음 단계
- judgment core 초안 추가
- emit/governance 분리
- top-level 모듈의 점진적 이동
