### PR TITLE
PR1: add judgment core primitives and tests

### DIFF
--- a/comp/judgment/__init__.py
+++ b/comp/judgment/__init__.py
@@ -1,9 +1,56 @@
-"""Future judgment-core package.
+"""Judgment-core exports for the next architecture step."""
 
-This namespace is reserved for the next architecture step:
-- fact/judgment core
-- compiled judgment program
-- fixpoint engine
-- frontier/arbitration
-- commit/receipts
-"""
+from comp.judgment.commit import (
+    DraftSnapshot,
+    blocking_hazards_clear,
+    committable,
+    project_public_row,
+    prov_enough,
+    resolved_required_bundles,
+)
+from comp.judgment.core import Fact, FactTag, JudgmentState, SubjectKind, SubjectRef
+from comp.judgment.engine import FixpointEngine
+from comp.judgment.frontier import (
+    CandidateSummary,
+    dominates,
+    frontier,
+    needs_review,
+    winner_or_none,
+)
+from comp.judgment.program import (
+    BundleSpec,
+    CommitSpec,
+    CompiledJudgmentProgram,
+    ProjectionSpec,
+    TransferEmitter,
+    TransferRule,
+)
+from comp.judgment.receipts import CommitReceipt, SelectionReceipt
+
+__all__ = [
+    "SubjectKind",
+    "FactTag",
+    "SubjectRef",
+    "Fact",
+    "JudgmentState",
+    "TransferEmitter",
+    "TransferRule",
+    "BundleSpec",
+    "CommitSpec",
+    "ProjectionSpec",
+    "CompiledJudgmentProgram",
+    "FixpointEngine",
+    "CandidateSummary",
+    "dominates",
+    "frontier",
+    "winner_or_none",
+    "needs_review",
+    "DraftSnapshot",
+    "resolved_required_bundles",
+    "blocking_hazards_clear",
+    "prov_enough",
+    "committable",
+    "project_public_row",
+    "SelectionReceipt",
+    "CommitReceipt",
+]

--- a/comp/judgment/commit.py
+++ b/comp/judgment/commit.py
@@ -1,3 +1,50 @@
-"""Judgment commit placeholder."""
+from __future__ import annotations
 
-__all__: list[str] = []
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from comp.judgment.program import CommitSpec, ProjectionSpec
+
+
+@dataclass(frozen=True, slots=True)
+class DraftSnapshot:
+    draft_id: str
+    resolved_bundles: frozenset[str] = frozenset()
+    active_hazards: frozenset[str] = frozenset()
+    fresh: bool = True
+    provenance_edges: int = 0
+
+
+def resolved_required_bundles(snapshot: DraftSnapshot, required_bundles: tuple[str, ...]) -> bool:
+    return all(bundle in snapshot.resolved_bundles for bundle in required_bundles)
+
+
+def blocking_hazards_clear(snapshot: DraftSnapshot, blocking_hazards: tuple[str, ...]) -> bool:
+    return snapshot.active_hazards.isdisjoint(blocking_hazards)
+
+
+def prov_enough(snapshot: DraftSnapshot, min_provenance_edges: int) -> bool:
+    return snapshot.provenance_edges >= min_provenance_edges
+
+
+def committable(snapshot: DraftSnapshot, spec: CommitSpec) -> bool:
+    return (
+        resolved_required_bundles(snapshot, spec.required_bundles)
+        and blocking_hazards_clear(snapshot, spec.blocking_hazards)
+        and prov_enough(snapshot, spec.min_provenance_edges)
+        and (snapshot.fresh or not spec.require_fresh)
+    )
+
+
+def project_public_row(field_values: Mapping[str, Any], projection: ProjectionSpec) -> dict[str, Any]:
+    return {field: field_values.get(field) for field in projection.output_fields}
+
+
+__all__ = [
+    "DraftSnapshot",
+    "resolved_required_bundles",
+    "blocking_hazards_clear",
+    "prov_enough",
+    "committable",
+    "project_public_row",
+]

--- a/comp/judgment/core.py
+++ b/comp/judgment/core.py
@@ -1,10 +1,88 @@
-"""Placeholder for the future judgment core.
+from __future__ import annotations
 
-Planned contents:
-- SubjectRef
-- Fact
-- JudgmentState
-- append-only hazard / provenance primitives
-"""
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Literal
 
-__all__: list[str] = []
+SubjectKind = Literal[
+    "raw",
+    "claim",
+    "bundle",
+    "draft",
+    "public_row",
+    "rule",
+    "policy",
+    "projection",
+]
+
+FactTag = Literal[
+    "proposed",
+    "evidence",
+    "hazard_open",
+    "hazard_discharge",
+    "prov_edge",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SubjectRef:
+    kind: SubjectKind
+    id: str
+
+
+@dataclass(frozen=True, slots=True)
+class Fact:
+    tag: FactTag
+    subject: SubjectRef
+    key: str
+    value: Any
+    witness: str | None = None
+    weight: float | None = None
+    meta: tuple[tuple[str, Any], ...] = ()
+
+
+@dataclass
+class JudgmentState:
+    facts: set[Fact] = field(default_factory=set)
+    subject_versions: dict[SubjectRef, int] = field(default_factory=dict)
+
+    def add_facts(self, new_facts: Iterable[Fact]) -> set[Fact]:
+        incoming = set(new_facts)
+        delta = incoming - self.facts
+        if not delta:
+            return set()
+
+        self.facts |= delta
+        for subject in {fact.subject for fact in delta}:
+            self.subject_versions[subject] = self.subject_versions.get(subject, 0) + 1
+        return delta
+
+    def version_of(self, subject: SubjectRef) -> int:
+        return self.subject_versions.get(subject, 0)
+
+    def facts_for(self, subject: SubjectRef) -> set[Fact]:
+        return {fact for fact in self.facts if fact.subject == subject}
+
+    def facts_by_tag(self, tag: FactTag) -> set[Fact]:
+        return {fact for fact in self.facts if fact.tag == tag}
+
+    def active_hazard_ids(self, subject: SubjectRef) -> set[Any]:
+        opened = {
+            fact.value
+            for fact in self.facts
+            if fact.tag == "hazard_open" and fact.subject == subject
+        }
+        discharged = {
+            fact.value
+            for fact in self.facts
+            if fact.tag == "hazard_discharge" and fact.subject == subject
+        }
+        return opened - discharged
+
+
+__all__ = [
+    "SubjectKind",
+    "FactTag",
+    "SubjectRef",
+    "Fact",
+    "JudgmentState",
+]

--- a/comp/judgment/engine.py
+++ b/comp/judgment/engine.py
@@ -1,3 +1,36 @@
-"""Judgment engine placeholder."""
+from __future__ import annotations
 
-__all__: list[str] = []
+from comp.judgment.core import Fact, JudgmentState
+from comp.judgment.program import CompiledJudgmentProgram, TransferRule
+
+
+class FixpointEngine:
+    def __init__(self, program: CompiledJudgmentProgram) -> None:
+        self.program = program
+
+    def run(self, seed_facts: set[Fact] | list[Fact] | tuple[Fact, ...]) -> JudgmentState:
+        state = JudgmentState()
+        delta = state.add_facts(seed_facts)
+
+        while delta:
+            new_facts: set[Fact] = set()
+            for rule in self.program.transfers:
+                triggered = self._triggered(rule, delta)
+                if not triggered:
+                    continue
+                emitted = set(rule.emit(state, triggered))
+                new_facts |= emitted
+            delta = state.add_facts(new_facts)
+
+        return state
+
+    def _triggered(self, rule: TransferRule, delta: set[Fact]) -> frozenset[Fact]:
+        return frozenset(
+            fact
+            for fact in delta
+            if fact.tag in rule.subscribe_tags
+            and (rule.match_kind is None or fact.subject.kind == rule.match_kind)
+        )
+
+
+__all__ = ["FixpointEngine"]

--- a/comp/judgment/frontier.py
+++ b/comp/judgment/frontier.py
@@ -1,3 +1,62 @@
-"""Judgment frontier placeholder."""
+from __future__ import annotations
 
-__all__: list[str] = []
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateSummary:
+    candidate_id: str
+    positive_evidence: float = 0.0
+    negative_evidence: float = 0.0
+    hazard_count: int = 0
+    specificity: int = 0
+    provenance_depth: int = 0
+
+
+def dominates(left: CandidateSummary, right: CandidateSummary) -> bool:
+    non_worse = (
+        left.positive_evidence >= right.positive_evidence
+        and left.negative_evidence <= right.negative_evidence
+        and left.hazard_count <= right.hazard_count
+        and left.specificity >= right.specificity
+        and left.provenance_depth >= right.provenance_depth
+    )
+    strictly_better = (
+        left.positive_evidence > right.positive_evidence
+        or left.negative_evidence < right.negative_evidence
+        or left.hazard_count < right.hazard_count
+        or left.specificity > right.specificity
+        or left.provenance_depth > right.provenance_depth
+    )
+    return non_worse and strictly_better
+
+
+def frontier(summaries: Iterable[CandidateSummary]) -> list[CandidateSummary]:
+    items = list(summaries)
+    out: list[CandidateSummary] = []
+    for item in items:
+        if any(dominates(other, item) for other in items if other != item):
+            continue
+        out.append(item)
+    return sorted(out, key=lambda item: item.candidate_id)
+
+
+def winner_or_none(summaries: Iterable[CandidateSummary]) -> str | None:
+    front = frontier(summaries)
+    if len(front) != 1:
+        return None
+    return front[0].candidate_id
+
+
+def needs_review(summaries: Iterable[CandidateSummary]) -> bool:
+    return len(frontier(summaries)) > 1
+
+
+__all__ = [
+    "CandidateSummary",
+    "dominates",
+    "frontier",
+    "winner_or_none",
+    "needs_review",
+]

--- a/comp/judgment/program.py
+++ b/comp/judgment/program.py
@@ -1,3 +1,59 @@
-"""Placeholder for compiled judgment program types."""
+from __future__ import annotations
 
-__all__: list[str] = []
+from dataclasses import dataclass, field
+from typing import Iterable, Protocol
+
+from comp.judgment.core import Fact, FactTag, JudgmentState, SubjectKind
+
+
+class TransferEmitter(Protocol):
+    def __call__(self, state: JudgmentState, triggered: frozenset[Fact]) -> Iterable[Fact]:
+        ...
+
+
+@dataclass(frozen=True)
+class TransferRule:
+    rule_id: str
+    subscribe_tags: tuple[FactTag, ...]
+    emit: TransferEmitter
+    match_kind: SubjectKind | None = None
+
+
+@dataclass(frozen=True)
+class BundleSpec:
+    bundle_id: str
+    candidate_key: str
+    required_for_commit: bool = True
+
+
+@dataclass(frozen=True)
+class CommitSpec:
+    commit_id: str
+    required_bundles: tuple[str, ...] = ()
+    blocking_hazards: tuple[str, ...] = ()
+    min_provenance_edges: int = 0
+    require_fresh: bool = True
+
+
+@dataclass(frozen=True)
+class ProjectionSpec:
+    projection_id: str
+    output_fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CompiledJudgmentProgram:
+    transfers: tuple[TransferRule, ...] = field(default_factory=tuple)
+    bundles: tuple[BundleSpec, ...] = field(default_factory=tuple)
+    commits: tuple[CommitSpec, ...] = field(default_factory=tuple)
+    projections: tuple[ProjectionSpec, ...] = field(default_factory=tuple)
+
+
+__all__ = [
+    "TransferEmitter",
+    "TransferRule",
+    "BundleSpec",
+    "CommitSpec",
+    "ProjectionSpec",
+    "CompiledJudgmentProgram",
+]

--- a/comp/judgment/receipts.py
+++ b/comp/judgment/receipts.py
@@ -1,3 +1,24 @@
-"""Judgment receipts placeholder."""
+from __future__ import annotations
 
-__all__: list[str] = []
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionReceipt:
+    bundle_id: str
+    frontier_ids: tuple[str, ...]
+    winner_id: str | None
+    bundle_version: int
+    reason: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class CommitReceipt:
+    draft_id: str
+    winner_receipt_ids: tuple[str, ...]
+    barrier_snapshot: tuple[tuple[str, Any], ...]
+    public_row_id: str
+
+
+__all__ = ["SelectionReceipt", "CommitReceipt"]

--- a/tests/test_judgment_core.py
+++ b/tests/test_judgment_core.py
@@ -1,0 +1,113 @@
+from comp.judgment import (
+    CandidateSummary,
+    CommitSpec,
+    CompiledJudgmentProgram,
+    DraftSnapshot,
+    Fact,
+    FixpointEngine,
+    JudgmentState,
+    ProjectionSpec,
+    SubjectRef,
+    TransferRule,
+    committable,
+    frontier,
+    needs_review,
+    winner_or_none,
+)
+
+
+def test_judgment_state_append_only_and_versions():
+    subject = SubjectRef("claim", "c1")
+    fact = Fact("proposed", subject, "amount", 100)
+
+    state = JudgmentState()
+    delta1 = state.add_facts([fact])
+    delta2 = state.add_facts([fact])
+
+    assert delta1 == {fact}
+    assert delta2 == set()
+    assert state.version_of(subject) == 1
+
+
+def test_active_hazards_respect_discharge_facts():
+    subject = SubjectRef("draft", "d1")
+    state = JudgmentState()
+    state.add_facts(
+        [
+            Fact("hazard_open", subject, "missing_unit", "obl-1"),
+            Fact("hazard_open", subject, "needs_review", "obl-2"),
+            Fact("hazard_discharge", subject, "missing_unit", "obl-1"),
+        ]
+    )
+
+    assert state.active_hazard_ids(subject) == {"obl-2"}
+
+
+def test_fixpoint_engine_chains_transfer_rules():
+    subject = SubjectRef("claim", "c1")
+
+    def emit_evidence(state, triggered):
+        return {
+            Fact("evidence", fact.subject, "support", fact.key, weight=1.0)
+            for fact in triggered
+        }
+
+    def emit_provenance(state, triggered):
+        return {
+            Fact("prov_edge", fact.subject, "edge", f"{fact.subject.id}:{fact.key}")
+            for fact in triggered
+        }
+
+    program = CompiledJudgmentProgram(
+        transfers=(
+            TransferRule(
+                rule_id="proposed_to_evidence",
+                subscribe_tags=("proposed",),
+                match_kind="claim",
+                emit=emit_evidence,
+            ),
+            TransferRule(
+                rule_id="evidence_to_prov",
+                subscribe_tags=("evidence",),
+                match_kind="claim",
+                emit=emit_provenance,
+            ),
+        )
+    )
+
+    engine = FixpointEngine(program)
+    state = engine.run({Fact("proposed", subject, "amount", 100)})
+
+    assert Fact("evidence", subject, "support", "amount", weight=1.0) in state.facts
+    assert Fact("prov_edge", subject, "edge", "c1:support") in state.facts
+
+
+def test_frontier_and_commit_helpers_work_together():
+    summaries = [
+        CandidateSummary("a", positive_evidence=3, specificity=2, provenance_depth=2),
+        CandidateSummary("b", positive_evidence=1, specificity=1, provenance_depth=1),
+        CandidateSummary("c", positive_evidence=3, specificity=2, provenance_depth=2),
+    ]
+
+    front = frontier(summaries)
+    assert [item.candidate_id for item in front] == ["a", "c"]
+    assert winner_or_none(summaries) is None
+    assert needs_review(summaries) is True
+
+    snapshot = DraftSnapshot(
+        draft_id="draft-1",
+        resolved_bundles=frozenset({"site", "amount"}),
+        active_hazards=frozenset(),
+        fresh=True,
+        provenance_edges=2,
+    )
+    spec = CommitSpec(
+        commit_id="row-commit",
+        required_bundles=("site", "amount"),
+        blocking_hazards=("missing_unit",),
+        min_provenance_edges=1,
+    )
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+
+    assert committable(snapshot, spec) is True
+    assert projection.output_fields == ("site", "amount")


### PR DESCRIPTION
## PR1

`comp.judgment` placeholder를 실제 코드로 바꾸는 PR입니다.

### 이번 PR에서 한 일
- `Fact`, `SubjectRef`, `JudgmentState` 구현
- `TransferRule`, `CompiledJudgmentProgram`, `BundleSpec`, `CommitSpec`, `ProjectionSpec` 구현
- `FixpointEngine` 추가
- `CandidateSummary`, `dominates`, `frontier`, `winner_or_none`, `needs_review` 추가
- `DraftSnapshot`, `committable`, `project_public_row` 추가
- `SelectionReceipt`, `CommitReceipt` 추가
- `comp.judgment` 패키지 export 정리
- `tests/test_judgment_core.py` 추가

### 의도
이번 PR은 judgment architecture의 최소 코어를 독립적으로 테스트 가능한 작은 라이브러리로 세우는 데 집중합니다.
resolver/governance/emit 재배치는 아직 하지 않습니다.

### 다음 단계
- judgment core를 pipeline/compat와 연결
- frontier/commit을 기존 repair/governance와 점진적으로 접속
- emit을 projection/view 쪽으로 이동
