### PR TITLE
PR2: bridge repair and governance passes to judgment helpers

### DIFF
--- a/comp/compat/__init__.py
+++ b/comp/compat/__init__.py
@@ -1,4 +1,5 @@
 """Compatibility layer for existing top-level artifacts and specs."""
 
+from comp.compat.adapters import *
 from comp.compat.artifacts import *
 from comp.compat.compiled_spec import *

--- a/comp/compat/adapters.py
+++ b/comp/compat/adapters.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from artifacts import CanonicalRowArtifact, ClaimArtifact, PartialFrameArtifact, RoleLineageArtifact, RoleSlotArtifact
+from comp.judgment import CandidateSummary, CommitReceipt, CommitSpec, DraftSnapshot, SelectionReceipt, frontier, winner_or_none
+
+_MODE_SPECIFICITY = {
+    "explicit": 4,
+    "inherited": 3,
+    "backward_inferred": 2,
+    "derived": 1,
+}
+
+
+def _score_total(claim: ClaimArtifact) -> float:
+    data = claim.metadata.get("repair_score")
+    if isinstance(data, dict) and "total" in data:
+        return float(data["total"])
+    return float(claim.confidence)
+
+
+def summarize_claim_candidate(claim: ClaimArtifact) -> CandidateSummary:
+    negative = float(len(set(claim.reason_codes)))
+    if claim.candidate_state in {"frozen", "rejected"}:
+        negative += 1.0
+
+    return CandidateSummary(
+        candidate_id=claim.claim_id,
+        positive_evidence=_score_total(claim),
+        negative_evidence=negative,
+        hazard_count=len(set(claim.reason_codes)),
+        specificity=_MODE_SPECIFICITY.get(claim.extraction_mode, 0),
+        provenance_depth=max(1, len(claim.evidence_ids)),
+    )
+
+
+def slot_candidate_ids(slot: RoleSlotArtifact) -> list[str]:
+    ordered = []
+    for cid in [slot.active_claim_id, *slot.shadow_claim_ids, *slot.frozen_claim_ids, *slot.rejected_claim_ids]:
+        if cid and cid not in ordered:
+            ordered.append(cid)
+    return ordered
+
+
+def slot_candidate_summaries(slot: RoleSlotArtifact, claims_by_id: dict[str, ClaimArtifact]) -> list[CandidateSummary]:
+    out: list[CandidateSummary] = []
+    for cid in slot_candidate_ids(slot):
+        claim = claims_by_id.get(cid)
+        if claim is None:
+            continue
+        out.append(summarize_claim_candidate(claim))
+    return out
+
+
+def build_slot_selection_receipt(
+    *,
+    frame: PartialFrameArtifact,
+    role_name: str,
+    slot: RoleSlotArtifact,
+    claims_by_id: dict[str, ClaimArtifact],
+    bundle_version: int,
+) -> SelectionReceipt:
+    summaries = slot_candidate_summaries(slot, claims_by_id)
+    front = frontier(summaries)
+    return SelectionReceipt(
+        bundle_id=f"{frame.frame_id}:{role_name}",
+        frontier_ids=tuple(item.candidate_id for item in front),
+        winner_id=winner_or_none(summaries),
+        bundle_version=bundle_version,
+        reason=tuple(sorted(set(slot.reason_codes))),
+    )
+
+
+def _resolved_bundle_names(row: CanonicalRowArtifact) -> frozenset[str]:
+    resolved = set()
+    if row.site_id is not None:
+        resolved.add("site")
+    if row.entity_id is not None:
+        resolved.add("entity")
+    if row.period is not None:
+        resolved.add("period")
+    if row.activity_type is not None:
+        resolved.add("activity_type")
+    if row.raw_amount is not None:
+        resolved.add("raw_amount")
+    if row.raw_unit is not None:
+        resolved.add("raw_unit")
+    if row.standardized_amount is not None:
+        resolved.add("standardized_amount")
+    if row.standardized_unit is not None:
+        resolved.add("standardized_unit")
+    if row.scope_category is not None:
+        resolved.add("scope_category")
+    return frozenset(resolved)
+
+
+def _lineage_count(lineage: RoleLineageArtifact) -> int:
+    return (
+        len(lineage.direct)
+        + len(lineage.inherited)
+        + len(lineage.backward_inferred)
+        + len(lineage.derived)
+        + len(lineage.contradicted_by)
+    )
+
+
+def draft_snapshot_from_row(row: CanonicalRowArtifact) -> DraftSnapshot:
+    provenance_edges = len(row.source_fragment_ids) + sum(_lineage_count(l) for l in row.lineage.values())
+    return DraftSnapshot(
+        draft_id=row.frame_id,
+        resolved_bundles=_resolved_bundle_names(row),
+        active_hazards=frozenset(row.error_codes),
+        fresh=not bool(row.metadata.get("stale_selection", False)),
+        provenance_edges=provenance_edges,
+    )
+
+
+def commit_spec_from_row(row: CanonicalRowArtifact, *, block_on_any_error: bool = True) -> CommitSpec:
+    return CommitSpec(
+        commit_id=f"{row.frame_type}:commit",
+        required_bundles=tuple(),
+        blocking_hazards=tuple(sorted(set(row.error_codes))) if block_on_any_error else tuple(),
+        min_provenance_edges=0,
+        require_fresh=True,
+    )
+
+
+def build_commit_receipt(
+    *,
+    row: CanonicalRowArtifact,
+    decision_id: str,
+    matched_rule_keys: Iterable[str] = (),
+) -> CommitReceipt:
+    snapshot = draft_snapshot_from_row(row)
+    barrier_snapshot = (
+        ("fresh", snapshot.fresh),
+        ("active_hazard_count", len(snapshot.active_hazards)),
+        ("provenance_edges", snapshot.provenance_edges),
+    )
+    return CommitReceipt(
+        draft_id=row.frame_id,
+        winner_receipt_ids=tuple(matched_rule_keys),
+        barrier_snapshot=barrier_snapshot,
+        public_row_id=row.row_id,
+    )
+
+
+__all__ = [
+    "summarize_claim_candidate",
+    "slot_candidate_ids",
+    "slot_candidate_summaries",
+    "build_slot_selection_receipt",
+    "draft_snapshot_from_row",
+    "commit_spec_from_row",
+    "build_commit_receipt",
+]

--- a/governance_pass.py
+++ b/governance_pass.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from itertools import count
 
 from artifacts import CanonicalRowArtifact, CompileArtifacts, GovernanceDecisionArtifact
+from comp.compat.adapters import build_commit_receipt, commit_spec_from_row, draft_snapshot_from_row
+from comp.judgment import committable
 from compiled_spec import CompiledGovernancePolicy, CompiledProgramSpec
 from expr_eval import EvalContext
 from rule_eval import RuleEvaluator
@@ -38,7 +40,7 @@ class GovernancePass:
                 decisions.append(self._decision(row=row, from_status=row.status, to_status=row.status, action="hold", actor="policy_engine", reason_codes=["no_governance_policy"], matched_rule_keys=[]))
                 continue
 
-            decisions.append(self._apply_policy(row=row, policy=policy, env=env))
+            decisions.append(self._apply_policy(row=row, policy=policy, env=env, artifacts=artifacts))
 
         artifacts.merge_log.extend(decisions)
         for d in decisions:
@@ -55,7 +57,7 @@ class GovernancePass:
             })
         return artifacts
 
-    def _apply_policy(self, *, row: CanonicalRowArtifact, policy: CompiledGovernancePolicy, env: RuntimeEnv) -> GovernanceDecisionArtifact:
+    def _apply_policy(self, *, row: CanonicalRowArtifact, policy: CompiledGovernancePolicy, env: RuntimeEnv, artifacts: CompileArtifacts) -> GovernanceDecisionArtifact:
         ctx = self._build_eval_context(row, env)
         from_status = row.status
 
@@ -63,8 +65,28 @@ class GovernancePass:
             if not self._safe_eval_bool(policy.emit_condition_ir, ctx):
                 return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["emit_condition_not_satisfied"], matched_rule_keys=["emit_condition"])
 
-        if self.config.block_on_any_error and row.error_codes:
-            return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["row_has_error_diagnostics", *row.error_codes], matched_rule_keys=[])
+        snapshot = draft_snapshot_from_row(row)
+        commit_spec = commit_spec_from_row(row, block_on_any_error=self.config.block_on_any_error)
+        if not committable(snapshot, commit_spec):
+            reason_codes = self._commit_hold_reason_codes(snapshot, commit_spec)
+            row.metadata.setdefault("governance_trace", []).append({
+                "action": "hold",
+                "reason": "commit_barrier_not_satisfied",
+                "snapshot": {
+                    "fresh": snapshot.fresh,
+                    "active_hazards": sorted(snapshot.active_hazards),
+                    "provenance_edges": snapshot.provenance_edges,
+                },
+            })
+            return self._decision(
+                row=row,
+                from_status=from_status,
+                to_status=from_status,
+                action="hold",
+                actor="policy_engine",
+                reason_codes=reason_codes,
+                matched_rule_keys=["judgment_commit_barrier"],
+            )
 
         matched_forbid = [f"forbid_merge:{idx}" for idx, expr in enumerate(policy.forbid_merge_conditions_ir, start=1) if self._safe_eval_bool(expr, ctx)]
         if matched_forbid:
@@ -74,6 +96,9 @@ class GovernancePass:
         if matched_merge:
             row.status = "merged"
             actor = self._pick_actor(ctx)
+            commit_receipt = build_commit_receipt(row=row, decision_id=f"pending:{row.row_id}", matched_rule_keys=matched_merge)
+            artifacts.commit_log.append(commit_receipt)
+            row.metadata["commit_receipt"] = asdict(commit_receipt)
             row.metadata.setdefault("governance_trace", []).append({"action": "merge", "matched_rule_keys": matched_merge, "actor": actor})
             return self._decision(row=row, from_status=from_status, to_status="merged", action="merge", actor=actor, reason_codes=["merge_condition_satisfied"], matched_rule_keys=matched_merge)
 
@@ -143,3 +168,15 @@ class GovernancePass:
         if ctx.env.policy_flags.get("auto_merge", False):
             return "system"
         return "policy_engine"
+
+    def _commit_hold_reason_codes(self, snapshot, commit_spec) -> list[str]:
+        reason_codes: list[str] = []
+        if commit_spec.require_fresh and not snapshot.fresh:
+            reason_codes.append("stale_selection")
+        if commit_spec.blocking_hazards and snapshot.active_hazards:
+            reason_codes.extend(["commit_blocked_by_hazard", *sorted(snapshot.active_hazards)])
+        if snapshot.provenance_edges < commit_spec.min_provenance_edges:
+            reason_codes.append("insufficient_provenance")
+        if not reason_codes:
+            reason_codes.append("commit_barrier_not_satisfied")
+        return reason_codes

--- a/repair_pass.py
+++ b/repair_pass.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from itertools import count
 from typing import Any, Optional
 
@@ -11,6 +11,7 @@ from artifacts import (
     RoleSlotArtifact,
     diagnostic_codes,
 )
+from comp.compat.adapters import build_slot_selection_receipt
 from compiled_spec import CompiledProgramSpec, CompiledResolverPolicy
 from expr_eval import EvalContext
 from rule_eval import RuleEvaluator
@@ -265,6 +266,7 @@ class RepairPass:
         # backward-compatible mirrors; read paths should prefer frame.runtime.
         frame.metadata["termination_reason"] = termination_reason
         frame.metadata["final_score"] = final_score
+        self._store_selection_receipts(frame=frame, claims_by_id=claims_by_id, bundle_version=last_iter_no)
 
     # ------------------------------------------------------------------
     # Slot repair
@@ -494,6 +496,25 @@ class RepairPass:
 
         if claim.claim_id in slot.shadow_claim_ids:
             slot.shadow_claim_ids.remove(claim.claim_id)
+
+    def _store_selection_receipts(
+        self,
+        *,
+        frame: PartialFrameArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+        bundle_version: int,
+    ) -> None:
+        receipts = []
+        for role_name, slot in sorted(frame.slots.items()):
+            receipt = build_slot_selection_receipt(
+                frame=frame,
+                role_name=role_name,
+                slot=slot,
+                claims_by_id=claims_by_id,
+                bundle_version=bundle_version,
+            )
+            receipts.append(asdict(receipt))
+        frame.metadata["selection_receipts"] = receipts
 
     # ------------------------------------------------------------------
     # Scoring helpers

--- a/tests/test_judgment_bridge.py
+++ b/tests/test_judgment_bridge.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+
+from artifacts import CanonicalRowArtifact, ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
+from compiled_spec import CompiledGovernancePolicy, CompiledProgramSpec, CompiledResolverPolicy
+from governance_pass import GovernancePass
+from repair_pass import RepairPass
+from rule_ir import RuleLiteral
+from spec_nodes import GovernancePolicy, ProgramSpec, ResolverPolicy
+
+
+def test_repair_pass_records_selection_receipts():
+    frame = PartialFrameArtifact(
+        frame_id="frame-1",
+        parser_name="parser-a",
+        frame_type="ActivityFrame",
+        slots={
+            "raw_amount": RoleSlotArtifact(
+                role_name="raw_amount",
+                active_claim_id="claim-1",
+                shadow_claim_ids=["claim-2"],
+            )
+        },
+    )
+    claims = [
+        ClaimArtifact(
+            claim_id="claim-1",
+            frame_id="frame-1",
+            fragment_id="frag-1",
+            parser_name="parser-a",
+            role_name="raw_amount",
+            value=100.0,
+            confidence=0.8,
+            extraction_mode="explicit",
+            candidate_state="active",
+        ),
+        ClaimArtifact(
+            claim_id="claim-2",
+            frame_id="frame-1",
+            fragment_id="frag-1",
+            parser_name="parser-a",
+            role_name="raw_amount",
+            value=95.0,
+            confidence=0.4,
+            extraction_mode="derived",
+            candidate_state="shadow",
+        ),
+    ]
+    artifacts = CompileArtifacts(claims=claims, frames=[frame])
+    spec = CompiledProgramSpec(
+        syntax=ProgramSpec(module_name="m"),
+        compiled_resolvers={
+            "ActivityFrame": CompiledResolverPolicy(
+                syntax=ResolverPolicy(frame_name="ActivityFrame")
+            )
+        },
+    )
+    env = SimpleNamespace(policy_flags={})
+
+    RepairPass().run(spec, artifacts, env)
+
+    receipts = frame.metadata.get("selection_receipts")
+    assert isinstance(receipts, list)
+    assert len(receipts) == 1
+    assert receipts[0]["bundle_id"] == "frame-1:raw_amount"
+    assert receipts[0]["winner_id"] == "claim-1"
+
+
+def test_governance_pass_records_commit_receipt_on_merge():
+    row = CanonicalRowArtifact(
+        row_id="row-1",
+        frame_id="frame-1",
+        parser_name="parser-a",
+        frame_type="ActivityFrame",
+        status="committed",
+        site_id="site-1",
+        period="2025-03",
+        activity_type="electricity",
+        raw_amount=100.0,
+        raw_unit="kwh",
+        source_fragment_ids=["frag-1"],
+    )
+    artifacts = CompileArtifacts(rows=[row])
+    spec = CompiledProgramSpec(
+        syntax=ProgramSpec(module_name="m"),
+        compiled_governances={
+            "ActivityFrame": CompiledGovernancePolicy(
+                syntax=GovernancePolicy(frame_name="ActivityFrame"),
+                merge_conditions_ir=[RuleLiteral(True)],
+            )
+        },
+    )
+    env = SimpleNamespace(policy_flags={})
+
+    GovernancePass().run(spec, artifacts, env)
+
+    assert row.status == "merged"
+    assert len(artifacts.commit_log) == 1
+    assert row.metadata["commit_receipt"]["public_row_id"] == "row-1"
+    assert artifacts.merge_log[0].action == "merge"
+
+
+def test_governance_pass_uses_commit_barrier_for_error_rows():
+    row = CanonicalRowArtifact(
+        row_id="row-2",
+        frame_id="frame-2",
+        parser_name="parser-a",
+        frame_type="ActivityFrame",
+        status="committed",
+        site_id="site-1",
+        error_codes=["UnitActivityMismatch"],
+    )
+    artifacts = CompileArtifacts(rows=[row])
+    spec = CompiledProgramSpec(
+        syntax=ProgramSpec(module_name="m"),
+        compiled_governances={
+            "ActivityFrame": CompiledGovernancePolicy(
+                syntax=GovernancePolicy(frame_name="ActivityFrame"),
+                merge_conditions_ir=[RuleLiteral(True)],
+            )
+        },
+    )
+    env = SimpleNamespace(policy_flags={})
+
+    GovernancePass().run(spec, artifacts, env)
+
+    assert row.status == "committed"
+    assert artifacts.commit_log == []
+    assert artifacts.merge_log[0].action == "hold"
+    assert "commit_blocked_by_hazard" in artifacts.merge_log[0].reason_codes


### PR DESCRIPTION
## PR2

새로 만든 judgment core를 기존 파이프라인에 접속하는 첫 번째 PR입니다.

### 이번 PR에서 한 일
- `comp.compat.adapters` 추가
- `repair_pass`가 slot별 selection receipt를 metadata에 기록하도록 연결
- `governance_pass`가 judgment commit barrier helper를 사용하도록 연결
- merge 시 commit receipt를 `artifacts.commit_log`와 row metadata에 기록
- bridge 테스트 추가 (`tests/test_judgment_bridge.py`)

### 의도
이번 PR은 judgment core로 기존 pass를 전면 치환하지 않습니다.
대신 기존 repair/governance가 judgment language를 **기록과 판정 보조층**으로 사용하기 시작하게 만드는 데 집중합니다.

### 다음 단계
- repair frontier를 더 직접적으로 judgment frontier 구조로 이관
- emit/view 분리
- artifacts와 judgment state 사이 bridge 확장
