### PR TITLE
PR3: split public row projection into comp.views.public

### DIFF
--- a/comp/views/__init__.py
+++ b/comp/views/__init__.py
@@ -1,1 +1,13 @@
-"""Future projection/view package."""
+"""Projection and view helpers."""
+
+from comp.views.public import (
+    DEFAULT_PUBLIC_PROJECTION,
+    materialize_public_rows,
+    project_canonical_row,
+)
+
+__all__ = [
+    "DEFAULT_PUBLIC_PROJECTION",
+    "project_canonical_row",
+    "materialize_public_rows",
+]

--- a/comp/views/public.py
+++ b/comp/views/public.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+from artifacts import (
+    CanonicalRowArtifact,
+    ClaimArtifact,
+    LineageEvidenceArtifact,
+    PartialFrameArtifact,
+    RoleLineageArtifact,
+    error_codes_from_diagnostics,
+    warning_codes_from_diagnostics,
+)
+from comp.judgment import ProjectionSpec, project_public_row
+from runtime_env import RuntimeEnv
+
+DEFAULT_PUBLIC_PROJECTION = ProjectionSpec(
+    "canonical_row",
+    (
+        "site_id",
+        "entity_id",
+        "period",
+        "activity_type",
+        "raw_amount",
+        "raw_unit",
+        "standardized_amount",
+        "standardized_unit",
+        "scope_category",
+    ),
+)
+
+
+def materialize_public_rows(
+    frames: Iterable[PartialFrameArtifact],
+    claims_by_id: dict[str, ClaimArtifact],
+    env: RuntimeEnv,
+    *,
+    emit_only_committed: bool = True,
+    skip_empty_rows: bool = True,
+    include_shadow_as_contradiction: bool = True,
+) -> list[CanonicalRowArtifact]:
+    rows: list[CanonicalRowArtifact] = []
+    for frame in frames:
+        if emit_only_committed and frame.status != "committed":
+            continue
+        row = project_canonical_row(
+            frame=frame,
+            claims_by_id=claims_by_id,
+            env=env,
+            skip_empty_rows=skip_empty_rows,
+            include_shadow_as_contradiction=include_shadow_as_contradiction,
+        )
+        if row is not None:
+            rows.append(row)
+    return rows
+
+
+def project_canonical_row(
+    *,
+    frame: PartialFrameArtifact,
+    claims_by_id: dict[str, ClaimArtifact],
+    env: RuntimeEnv,
+    projection: ProjectionSpec = DEFAULT_PUBLIC_PROJECTION,
+    skip_empty_rows: bool = True,
+    include_shadow_as_contradiction: bool = True,
+) -> Optional[CanonicalRowArtifact]:
+    values = _extract_active_values(frame, claims_by_id)
+
+    site_id = _resolve_site_id(values.get("site"), env)
+    entity_id = _resolve_entity_id(site_id, env)
+    activity_type = _as_str(values.get("activity_type"))
+    period = _as_str(values.get("period"))
+    raw_unit = _as_str(values.get("raw_unit"))
+    raw_amount = _as_float(values.get("raw_amount"))
+
+    standardized_amount, standardized_unit = _normalize_amount_and_unit(
+        raw_amount=raw_amount,
+        raw_unit=raw_unit,
+        env=env,
+    )
+
+    scope_category = None
+    if activity_type and activity_type in env.activity_index:
+        scope_category = env.activity_index[activity_type].scope_category
+
+    field_values = {
+        "site_id": site_id,
+        "entity_id": entity_id,
+        "period": period,
+        "activity_type": activity_type,
+        "raw_amount": raw_amount,
+        "raw_unit": raw_unit,
+        "standardized_amount": standardized_amount,
+        "standardized_unit": standardized_unit,
+        "scope_category": scope_category,
+    }
+    projected = project_public_row(field_values, projection)
+
+    lineage = _build_lineage(frame, claims_by_id, include_shadow_as_contradiction=include_shadow_as_contradiction)
+    warning_codes = warning_codes_from_diagnostics(frame.diagnostics)
+    error_codes = error_codes_from_diagnostics(frame.diagnostics)
+
+    if skip_empty_rows:
+        all_core_empty = (
+            projected["site_id"] is None
+            and projected["period"] is None
+            and projected["activity_type"] is None
+            and projected["raw_amount"] is None
+            and projected["raw_unit"] is None
+        )
+        if all_core_empty:
+            return None
+
+    return CanonicalRowArtifact(
+        row_id=_row_id_from_frame(frame.frame_id),
+        frame_id=frame.frame_id,
+        parser_name=frame.parser_name,
+        frame_type=frame.frame_type,
+        status=frame.status,
+        site_id=projected["site_id"],
+        entity_id=projected["entity_id"],
+        period=projected["period"],
+        activity_type=projected["activity_type"],
+        raw_amount=projected["raw_amount"],
+        raw_unit=projected["raw_unit"],
+        standardized_amount=projected["standardized_amount"],
+        standardized_unit=projected["standardized_unit"],
+        scope_category=projected["scope_category"],
+        resolution_score=float(frame.runtime.resolution_score),
+        lineage=lineage,
+        source_fragment_ids=list(frame.fragment_ids),
+        warning_codes=warning_codes,
+        error_codes=error_codes,
+        metadata={
+            "projection_id": projection.projection_id,
+            "iteration_count": frame.runtime.iteration_count,
+            "stable_count": frame.runtime.stable_count,
+            "termination_reason": frame.runtime.termination_reason,
+            "repair_trace_len": len(frame.metadata.get("repair_trace", [])),
+            "selection_receipts": list(frame.metadata.get("selection_receipts", [])),
+        },
+    )
+
+
+def _extract_active_values(
+    frame: PartialFrameArtifact,
+    claims_by_id: dict[str, ClaimArtifact],
+) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for role_name, slot in frame.slots.items():
+        if not slot.active_claim_id:
+            continue
+        claim = claims_by_id.get(slot.active_claim_id)
+        if claim is None:
+            continue
+        out[role_name] = claim.value
+    return out
+
+
+def _build_lineage(
+    frame: PartialFrameArtifact,
+    claims_by_id: dict[str, ClaimArtifact],
+    *,
+    include_shadow_as_contradiction: bool,
+) -> dict[str, RoleLineageArtifact]:
+    lineage: dict[str, RoleLineageArtifact] = {}
+    for role_name, slot in frame.slots.items():
+        node = RoleLineageArtifact()
+        if slot.active_claim_id and slot.active_claim_id in claims_by_id:
+            active = claims_by_id[slot.active_claim_id]
+            evidence = _to_lineage_evidence(active)
+            if active.extraction_mode == "explicit":
+                node.direct.append(evidence)
+            elif active.extraction_mode == "inherited":
+                node.inherited.append(evidence)
+            elif active.extraction_mode == "backward_inferred":
+                node.backward_inferred.append(evidence)
+            else:
+                node.derived.append(evidence)
+        if include_shadow_as_contradiction:
+            for cid in [*slot.shadow_claim_ids, *slot.rejected_claim_ids]:
+                claim = claims_by_id.get(cid)
+                if claim is None:
+                    continue
+                node.contradicted_by.append(_to_lineage_evidence(claim))
+        lineage[role_name] = node
+    return lineage
+
+
+def _to_lineage_evidence(claim: ClaimArtifact) -> LineageEvidenceArtifact:
+    return LineageEvidenceArtifact(
+        claim_id=claim.claim_id,
+        fragment_id=claim.source_fragment_id or claim.fragment_id,
+        span=claim.span,
+        extraction_mode=claim.extraction_mode,
+        value=claim.value,
+        reason_codes=list(claim.reason_codes),
+        evidence_ids=list(claim.evidence_ids),
+        metadata=dict(claim.metadata),
+    )
+
+
+def _resolve_site_id(value: Any, env: RuntimeEnv) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, str) and value in env.site_records:
+        return value
+    key = str(value).strip().lower()
+    return env.site_alias_index.get(key)
+
+
+def _resolve_entity_id(site_id: Optional[str], env: RuntimeEnv) -> Optional[str]:
+    if site_id is None:
+        return None
+    rec = env.site_records.get(site_id)
+    if rec is None:
+        return None
+    return rec.entity_id
+
+
+def _normalize_amount_and_unit(
+    *,
+    raw_amount: Optional[float],
+    raw_unit: Optional[str],
+    env: RuntimeEnv,
+) -> tuple[Optional[float], Optional[str]]:
+    if raw_amount is None or raw_unit is None:
+        return None, None
+    spec = env.unit_index.get(raw_unit)
+    if spec is None or spec.normalize_to is None or spec.normalize_op is None or spec.normalize_factor is None:
+        return raw_amount, raw_unit
+    x = raw_amount
+    factor = float(spec.normalize_factor)
+    if spec.normalize_op == "*":
+        x = x * factor
+    elif spec.normalize_op == "/":
+        x = x / factor
+    elif spec.normalize_op == "+":
+        x = x + factor
+    elif spec.normalize_op == "-":
+        x = x - factor
+    return float(x), spec.normalize_to
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value).replace(",", "").strip())
+    except Exception:
+        return None
+
+
+def _as_str(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _row_id_from_frame(frame_id: str) -> str:
+    if frame_id.startswith("FRM-"):
+        return "ROW-" + frame_id[len("FRM-"):]
+    return f"ROW-{frame_id}"
+
+
+__all__ = [
+    "DEFAULT_PUBLIC_PROJECTION",
+    "project_canonical_row",
+    "materialize_public_rows",
+]

--- a/emit_pass.py
+++ b/emit_pass.py
@@ -2,18 +2,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Optional
 
-from artifacts import (
-    CanonicalRowArtifact,
-    ClaimArtifact,
-    CompileArtifacts,
-    LineageEvidenceArtifact,
-    PartialFrameArtifact,
-    RoleLineageArtifact,
-    error_codes_from_diagnostics,
-    warning_codes_from_diagnostics,
-)
+from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact
+from comp.views import materialize_public_rows, project_canonical_row
 from runtime_env import RuntimeEnv
 
 
@@ -23,6 +15,7 @@ class EmitPassConfig:
     emit은 committed frame만 대상으로 한다.
     governance에서 merged 여부를 다루므로 여기선 status 변경 안 함.
     """
+
     emit_only_committed: bool = True
     skip_empty_rows: bool = True
     include_shadow_as_contradiction: bool = True
@@ -39,31 +32,15 @@ class EmitPass:
         env: RuntimeEnv,
     ) -> CompileArtifacts:
         claims_by_id = {c.claim_id: c for c in artifacts.claims}
-
-        new_rows: list[CanonicalRowArtifact] = []
-
-        for frame in artifacts.frames:
-            if self.config.emit_only_committed and frame.status != "committed":
-                continue
-
-            row = self._emit_row(
-                frame=frame,
-                claims_by_id=claims_by_id,
-                env=env,
-            )
-
-            if row is None:
-                continue
-
-            new_rows.append(row)
-
-        # emit pass는 항상 rows를 재생성하는 게 안전하다
-        artifacts.rows = new_rows
+        artifacts.rows = materialize_public_rows(
+            artifacts.frames,
+            claims_by_id,
+            env,
+            emit_only_committed=self.config.emit_only_committed,
+            skip_empty_rows=self.config.skip_empty_rows,
+            include_shadow_as_contradiction=self.config.include_shadow_as_contradiction,
+        )
         return artifacts
-
-    # ------------------------------------------------------------------
-    # Core
-    # ------------------------------------------------------------------
 
     def _emit_row(
         self,
@@ -71,219 +48,11 @@ class EmitPass:
         frame: PartialFrameArtifact,
         claims_by_id: dict[str, ClaimArtifact],
         env: RuntimeEnv,
-    ) -> Optional[CanonicalRowArtifact]:
-        values = self._extract_active_values(frame, claims_by_id)
-
-        site_id = self._resolve_site_id(values.get("site"), env)
-        entity_id = self._resolve_entity_id(site_id, env)
-        activity_type = self._as_str(values.get("activity_type"))
-        period = self._as_str(values.get("period"))
-        raw_unit = self._as_str(values.get("raw_unit"))
-        raw_amount = self._as_float(values.get("raw_amount"))
-
-        standardized_amount, standardized_unit = self._normalize_amount_and_unit(
-            raw_amount=raw_amount,
-            raw_unit=raw_unit,
+    ):
+        return project_canonical_row(
+            frame=frame,
+            claims_by_id=claims_by_id,
             env=env,
+            skip_empty_rows=self.config.skip_empty_rows,
+            include_shadow_as_contradiction=self.config.include_shadow_as_contradiction,
         )
-
-        scope_category = None
-        if activity_type and activity_type in env.activity_index:
-            scope_category = env.activity_index[activity_type].scope_category
-
-        lineage = self._build_lineage(frame, claims_by_id)
-
-        warning_codes = warning_codes_from_diagnostics(frame.diagnostics)
-        error_codes = error_codes_from_diagnostics(frame.diagnostics)
-
-        if self.config.skip_empty_rows:
-            all_core_empty = (
-                site_id is None
-                and period is None
-                and activity_type is None
-                and raw_amount is None
-                and raw_unit is None
-            )
-            if all_core_empty:
-                return None
-
-        row = CanonicalRowArtifact(
-            row_id=self._row_id_from_frame(frame.frame_id),
-            frame_id=frame.frame_id,
-            parser_name=frame.parser_name,
-            frame_type=frame.frame_type,
-            status=frame.status,
-
-            site_id=site_id,
-            entity_id=entity_id,
-            period=period,
-            activity_type=activity_type,
-
-            raw_amount=raw_amount,
-            raw_unit=raw_unit,
-            standardized_amount=standardized_amount,
-            standardized_unit=standardized_unit,
-
-            scope_category=scope_category,
-            resolution_score=float(frame.runtime.resolution_score),
-            lineage=lineage,
-
-            source_fragment_ids=list(frame.fragment_ids),
-            warning_codes=warning_codes,
-            error_codes=error_codes,
-
-            metadata={
-                "iteration_count": frame.runtime.iteration_count,
-                "stable_count": frame.runtime.stable_count,
-                "termination_reason": frame.runtime.termination_reason,
-                "repair_trace_len": len(frame.metadata.get("repair_trace", [])),
-            },
-        )
-        return row
-
-    # ------------------------------------------------------------------
-    # Value extraction
-    # ------------------------------------------------------------------
-
-    def _extract_active_values(
-        self,
-        frame: PartialFrameArtifact,
-        claims_by_id: dict[str, ClaimArtifact],
-    ) -> dict[str, Any]:
-        out: dict[str, Any] = {}
-
-        for role_name, slot in frame.slots.items():
-            if not slot.active_claim_id:
-                continue
-            claim = claims_by_id.get(slot.active_claim_id)
-            if claim is None:
-                continue
-            out[role_name] = claim.value
-
-        return out
-
-    # ------------------------------------------------------------------
-    # Lineage
-    # ------------------------------------------------------------------
-
-    def _build_lineage(
-        self,
-        frame: PartialFrameArtifact,
-        claims_by_id: dict[str, ClaimArtifact],
-    ) -> dict[str, RoleLineageArtifact]:
-        lineage: dict[str, RoleLineageArtifact] = {}
-
-        for role_name, slot in frame.slots.items():
-            node = RoleLineageArtifact()
-
-            # active claim
-            if slot.active_claim_id and slot.active_claim_id in claims_by_id:
-                active = claims_by_id[slot.active_claim_id]
-                evidence = self._to_lineage_evidence(active)
-
-                if active.extraction_mode == "explicit":
-                    node.direct.append(evidence)
-                elif active.extraction_mode == "inherited":
-                    node.inherited.append(evidence)
-                elif active.extraction_mode == "backward_inferred":
-                    node.backward_inferred.append(evidence)
-                else:
-                    node.derived.append(evidence)
-
-            # shadow / rejected claims = contradicted_by 관점으로 남김
-            if self.config.include_shadow_as_contradiction:
-                for cid in [*slot.shadow_claim_ids, *slot.rejected_claim_ids]:
-                    claim = claims_by_id.get(cid)
-                    if claim is None:
-                        continue
-                    node.contradicted_by.append(self._to_lineage_evidence(claim))
-
-            lineage[role_name] = node
-
-        return lineage
-
-    def _to_lineage_evidence(self, claim: ClaimArtifact) -> LineageEvidenceArtifact:
-        return LineageEvidenceArtifact(
-            claim_id=claim.claim_id,
-            fragment_id=claim.source_fragment_id or claim.fragment_id,
-            span=claim.span,
-            extraction_mode=claim.extraction_mode,
-            value=claim.value,
-            reason_codes=list(claim.reason_codes),
-            evidence_ids=list(claim.evidence_ids),
-            metadata=dict(claim.metadata),
-        )
-
-    # ------------------------------------------------------------------
-    # Canonicalization helpers
-    # ------------------------------------------------------------------
-
-    def _resolve_site_id(self, value: Any, env: RuntimeEnv) -> Optional[str]:
-        if value in (None, ""):
-            return None
-
-        # 이미 site_id일 수 있음
-        if isinstance(value, str) and value in env.site_records:
-            return value
-
-        # alias lookup
-        key = str(value).strip().lower()
-        return env.site_alias_index.get(key)
-
-    def _resolve_entity_id(self, site_id: Optional[str], env: RuntimeEnv) -> Optional[str]:
-        if site_id is None:
-            return None
-        rec = env.site_records.get(site_id)
-        if rec is None:
-            return None
-        return rec.entity_id
-
-    def _normalize_amount_and_unit(
-        self,
-        *,
-        raw_amount: Optional[float],
-        raw_unit: Optional[str],
-        env: RuntimeEnv,
-    ) -> tuple[Optional[float], Optional[str]]:
-        if raw_amount is None or raw_unit is None:
-            return None, None
-
-        spec = env.unit_index.get(raw_unit)
-        if spec is None or spec.normalize_to is None or spec.normalize_op is None or spec.normalize_factor is None:
-            return raw_amount, raw_unit
-
-        x = raw_amount
-        factor = float(spec.normalize_factor)
-
-        if spec.normalize_op == "*":
-            x = x * factor
-        elif spec.normalize_op == "/":
-            x = x / factor
-        elif spec.normalize_op == "+":
-            x = x + factor
-        elif spec.normalize_op == "-":
-            x = x - factor
-
-        return float(x), spec.normalize_to
-
-    def _as_float(self, value: Any) -> Optional[float]:
-        if value in (None, ""):
-            return None
-        if isinstance(value, (int, float)):
-            return float(value)
-
-        try:
-            return float(str(value).replace(",", "").strip())
-        except Exception:
-            return None
-
-    def _as_str(self, value: Any) -> Optional[str]:
-        if value in (None, ""):
-            return None
-        return str(value)
-
-    def _row_id_from_frame(self, frame_id: str) -> str:
-        # e.g. FRM-0000001 -> ROW-0000001
-        if frame_id.startswith("FRM-"):
-            return "ROW-" + frame_id[len("FRM-"):]
-        return f"ROW-{frame_id}"

--- a/tests/test_public_view.py
+++ b/tests/test_public_view.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+
+from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
+from emit_pass import EmitPass
+from comp.views import DEFAULT_PUBLIC_PROJECTION, materialize_public_rows, project_canonical_row
+
+
+def _env():
+    return SimpleNamespace(
+        site_records={"SITE-1": SimpleNamespace(entity_id="ENT-1")},
+        site_alias_index={"hq": "SITE-1"},
+        activity_index={"electricity": SimpleNamespace(scope_category="Scope2")},
+        unit_index={
+            "kwh": SimpleNamespace(
+                normalize_to="kwh",
+                normalize_op="*",
+                normalize_factor=1.0,
+            )
+        },
+    )
+
+
+def _claims():
+    return {
+        "c-site": ClaimArtifact(
+            claim_id="c-site",
+            frame_id="FRM-1",
+            fragment_id="frag-1",
+            parser_name="parser-a",
+            role_name="site",
+            value="hq",
+            confidence=0.9,
+            extraction_mode="explicit",
+            candidate_state="active",
+        ),
+        "c-activity": ClaimArtifact(
+            claim_id="c-activity",
+            frame_id="FRM-1",
+            fragment_id="frag-1",
+            parser_name="parser-a",
+            role_name="activity_type",
+            value="electricity",
+            confidence=0.8,
+            extraction_mode="explicit",
+            candidate_state="active",
+        ),
+        "c-amount": ClaimArtifact(
+            claim_id="c-amount",
+            frame_id="FRM-1",
+            fragment_id="frag-1",
+            parser_name="parser-a",
+            role_name="raw_amount",
+            value=100.0,
+            confidence=0.7,
+            extraction_mode="explicit",
+            candidate_state="active",
+        ),
+        "c-unit": ClaimArtifact(
+            claim_id="c-unit",
+            frame_id="FRM-1",
+            fragment_id="frag-1",
+            parser_name="parser-a",
+            role_name="raw_unit",
+            value="kwh",
+            confidence=0.7,
+            extraction_mode="explicit",
+            candidate_state="active",
+        ),
+    }
+
+
+def _frame(status="committed"):
+    frame = PartialFrameArtifact(
+        frame_id="FRM-1",
+        parser_name="parser-a",
+        frame_type="ActivityFrame",
+        fragment_ids=["frag-1"],
+        status=status,
+        slots={
+            "site": RoleSlotArtifact(role_name="site", active_claim_id="c-site"),
+            "activity_type": RoleSlotArtifact(role_name="activity_type", active_claim_id="c-activity"),
+            "raw_amount": RoleSlotArtifact(role_name="raw_amount", active_claim_id="c-amount"),
+            "raw_unit": RoleSlotArtifact(role_name="raw_unit", active_claim_id="c-unit"),
+        },
+    )
+    frame.runtime.iteration_count = 3
+    frame.runtime.stable_count = 2
+    frame.runtime.termination_reason = "commit_condition_satisfied"
+    frame.metadata["selection_receipts"] = [{"bundle_id": "FRM-1:raw_amount", "winner_id": "c-amount"}]
+    return frame
+
+
+def test_project_canonical_row_keeps_projection_metadata():
+    row = project_canonical_row(
+        frame=_frame(),
+        claims_by_id=_claims(),
+        env=_env(),
+        projection=DEFAULT_PUBLIC_PROJECTION,
+    )
+
+    assert row is not None
+    assert row.row_id == "ROW-1"
+    assert row.site_id == "SITE-1"
+    assert row.entity_id == "ENT-1"
+    assert row.scope_category == "Scope2"
+    assert row.metadata["projection_id"] == "canonical_row"
+    assert row.metadata["selection_receipts"][0]["winner_id"] == "c-amount"
+
+
+def test_emit_pass_delegates_to_public_view_materializer():
+    committed = _frame(status="committed")
+    resolving = _frame(status="resolving")
+    resolving.frame_id = "FRM-2"
+
+    artifacts = CompileArtifacts(
+        claims=list(_claims().values()),
+        frames=[committed, resolving],
+    )
+
+    EmitPass().run(spec=None, artifacts=artifacts, env=_env())
+
+    assert len(artifacts.rows) == 1
+    assert artifacts.rows[0].frame_id == "FRM-1"
+
+    rows = materialize_public_rows(
+        [committed, resolving],
+        _claims(),
+        _env(),
+        emit_only_committed=True,
+    )
+    assert len(rows) == 1
+    assert rows[0].frame_id == "FRM-1"


### PR DESCRIPTION
## PR3

`emit_pass`가 직접 canonical row를 조립하던 로직을 `comp.views.public`으로 분리하는 PR입니다.

### 이번 PR에서 한 일
- `comp.views.public` 추가
- `DEFAULT_PUBLIC_PROJECTION`, `project_canonical_row`, `materialize_public_rows` 구현
- `comp.views.__init__` export 정리
- `emit_pass`를 얇은 wrapper로 축소
- public view 테스트 추가 (`tests/test_public_view.py`)

### 의도
이번 PR은 emit을 없애는 것이 아니라, **emit이 하던 public row 투영을 view/projection 층으로 옮기는 것**에 집중합니다.
즉 source of truth는 frame/claims 쪽에 두고, row는 projection 결과로 더 명확하게 다루기 시작합니다.

### 다음 단계
- draft/review/public view를 더 분리
- governance와 public projection의 경계 정리
- emit pass를 더 얇게 유지하면서 projection spec 연결 강화
