### PR TITLE
packaging: add DSL facades and normalize rule evaluator package export

### DIFF
--- a/comp/dsl/__init__.py
+++ b/comp/dsl/__init__.py
@@ -1,9 +1,9 @@
 """DSL-facing package exports for ESGDL."""
 
-from ast_builder import ASTBuilder
-from binder import Binder, BindingError
-from lowering import Lowerer
-from spec_nodes import ProgramSpec
+from comp.dsl.ast_builder import ASTBuilder
+from comp.dsl.binder import Binder, BindingError
+from comp.dsl.lowering import Lowerer
+from comp.dsl.spec_nodes import ProgramSpec
 
 __all__ = [
     "ASTBuilder",

--- a/comp/dsl/ast_builder.py
+++ b/comp/dsl/ast_builder.py
@@ -1,0 +1,5 @@
+"""Package facade for the legacy ast_builder module."""
+
+from ast_builder import ASTBuilder
+
+__all__ = ["ASTBuilder"]

--- a/comp/dsl/ast_nodes.py
+++ b/comp/dsl/ast_nodes.py
@@ -1,0 +1,3 @@
+"""Package facade for the legacy ast_nodes module."""
+
+from ast_nodes import *

--- a/comp/dsl/binder.py
+++ b/comp/dsl/binder.py
@@ -1,0 +1,1 @@
+from binder import *

--- a/comp/dsl/lowering.py
+++ b/comp/dsl/lowering.py
@@ -1,0 +1,1 @@
+from lowering import *

--- a/comp/dsl/spec_nodes.py
+++ b/comp/dsl/spec_nodes.py
@@ -1,0 +1,3 @@
+"""Package facade for the legacy spec_nodes module."""
+
+from spec_nodes import *

--- a/comp/eval/__init__.py
+++ b/comp/eval/__init__.py
@@ -3,7 +3,7 @@
 from compiled_expr_eval import CompiledExprEvaluator
 from expr_eval import ExprEvaluator
 from lex_eval import LexEvaluator
-from rule_eval import RuleEvaluator
+from comp.eval.rule import RuleEvaluator
 from source_eval import SourceEvaluator
 
 __all__ = [

--- a/comp/eval/rule.py
+++ b/comp/eval/rule.py
@@ -1,0 +1,1 @@
+from rule_eval import *

--- a/tests/test_package_module_facades.py
+++ b/tests/test_package_module_facades.py
@@ -1,0 +1,24 @@
+from ast_builder import ASTBuilder as LegacyASTBuilder
+from binder import Binder as LegacyBinder
+from rule_eval import RuleEvaluator as LegacyRuleEvaluator
+
+from comp.dsl import ASTBuilder, Binder
+from comp.dsl.ast_builder import ASTBuilder as PackageASTBuilder
+from comp.dsl.binder import Binder as PackageBinder
+from comp.eval import RuleEvaluator
+from comp.eval.rule import RuleEvaluator as PackageRuleEvaluator
+
+
+def test_dsl_package_exports_match_legacy_objects():
+    assert ASTBuilder is LegacyASTBuilder
+    assert Binder is LegacyBinder
+
+
+def test_dsl_module_facades_match_legacy_objects():
+    assert PackageASTBuilder is LegacyASTBuilder
+    assert PackageBinder is LegacyBinder
+
+
+def test_eval_rule_facade_matches_legacy_object():
+    assert RuleEvaluator is LegacyRuleEvaluator
+    assert PackageRuleEvaluator is LegacyRuleEvaluator


### PR DESCRIPTION
## 왜 이 PR을 하나요?

`comp/` 패키지 골격은 이미 들어와 있지만, 실제 모듈 단위 import 경계는 아직 많이 top-level 파일에 기대고 있습니다.
이번 PR은 그중에서 **가장 위험이 낮은 범위부터** 시작해서, DSL 쪽과 rule evaluator 쪽에 패키지 façade를 추가하는 작업입니다.

즉 아직 파일을 실제로 옮기지는 않지만, 앞으로는 아래 같은 import 경로를 점진적으로 공식 경계로 삼을 수 있게 만듭니다.

- `comp.dsl.ast_builder`
- `comp.dsl.binder`
- `comp.dsl.spec_nodes`
- `comp.dsl.lowering`
- `comp.eval.rule`

## 무엇이 바뀌나요?

### DSL façade 추가
- `comp/dsl/ast_builder.py`
- `comp/dsl/ast_nodes.py`
- `comp/dsl/binder.py`
- `comp/dsl/lowering.py`
- `comp/dsl/spec_nodes.py`

이 파일들은 현재 legacy top-level 모듈을 그대로 re-export하는 얇은 façade입니다.

### 패키지 export 정리
- `comp/dsl/__init__.py`
  - 이제 façade 모듈을 바라보도록 변경
- `comp/eval/__init__.py`
  - `RuleEvaluator` export를 `comp.eval.rule` façade를 통해 내보내도록 변경

### eval façade 추가
- `comp/eval/rule.py`

### 테스트 추가
- `tests/test_package_module_facades.py`
  - 새 package import가 기존 legacy 객체와 동일한 객체를 가리키는지 smoke check

## 범위

이번 PR은 **패키지 경계 정리의 첫 단계**입니다.

포함:
- DSL façade
- rule evaluator façade
- 관련 package export 정리
- import smoke test

제외:
- 실제 파일 이동
- pipeline pass façade 전체 추가
- builtins façade 전체 추가
- 의미론 변경

즉 이번 PR은 no-behavior-change packaging PR입니다.

## 확인 포인트

- `comp.dsl.*` 경로가 안정적인 공개 import 경계로 쓰기 시작해도 되는지
- `RuleEvaluator` 공개 경로를 `comp.eval.rule` 쪽으로 한 발 옮기는 게 자연스러운지
- 실제 코드 이동 전에 이런 얇은 façade 단계를 거치는 방향이 맞는지

## 테스트

이 환경에서는 테스트를 직접 실행하지 못했습니다.
로컬/CI에서는 다음 정도만 확인해주면 충분합니다.

- `tests/test_package_module_facades.py` 수집/통과
- 기존 import 경로와 새 package façade 경로가 동시에 살아있는지
- package export가 깨지지 않았는지
