### PR TITLE
packaging: add builtins facades on top of package facade branch

### DIFF
--- a/comp/builtins/__init__.py
+++ b/comp/builtins/__init__.py
@@ -1,7 +1,7 @@
 """Builtin registries and helpers."""
 
-from esg_builtins import register_default_builtins
-from rule_builtins import get_default_rule_builtin_registry
+from comp.builtins.esg import register_default_builtins
+from comp.builtins.rule import get_default_rule_builtin_registry
 
 __all__ = [
     "register_default_builtins",

--- a/comp/builtins/esg.py
+++ b/comp/builtins/esg.py
@@ -1,0 +1,1 @@
+from esg_builtins import *

--- a/comp/builtins/rule.py
+++ b/comp/builtins/rule.py
@@ -1,0 +1,1 @@
+from rule_builtins import *


### PR DESCRIPTION
## 왜 이 PR을 하나요?

`packaging/package-module-facades` 브랜치에서 DSL / eval.rule façade를 먼저 깔아둔 뒤, 그 위에 **builtins 공개 경계도 같은 방식으로 정리**하려고 이 후속 PR을 쌓았습니다.

즉 이 PR은 `main`으로 바로 가는 큰 구조 변경이 아니라, 이전 façade PR 위에 얹는 작은 stacked PR입니다.

## 무엇이 바뀌나요?

- `comp/builtins/esg.py`
  - legacy `esg_builtins` re-export façade 추가
- `comp/builtins/rule.py`
  - legacy `rule_builtins` re-export façade 추가
- `comp/builtins/__init__.py`
  - 이제 top-level 모듈이 아니라 façade 모듈을 통해 export 하도록 변경

## 범위

이번 PR은 no-behavior-change packaging PR입니다.

포함:
- builtins façade 추가
- package export 경로 정리

제외:
- pipeline façade 전체 추가
- 실제 파일 이동
- 의미론 변경
- builtins 구현 변경

## 왜 stacked PR로 가나요?

이전 PR(#18)이 먼저 `comp.dsl.*` / `comp.eval.rule` 같은 공개 import 경계를 깔아두고 있기 때문에, 그 위에서 `comp.builtins.*`도 같은 방식으로 정리하는 게 scope가 더 작고 리뷰하기 쉽습니다.

## 확인 포인트

- `comp.builtins.*` 경로를 공개 import 경계로 삼아도 자연스러운지
- builtins export가 façade를 경유해도 의미론 변화가 없는지
- 이 정도 크기의 stacked PR이 다음 pipeline façade 작업 전 단계로 적절한지

## 테스트

이 환경에서는 테스트를 직접 실행하지 못했습니다.
이번 변경은 façade 추가와 export 경로 정리가 중심이라, 로컬/CI에서는 builtins import가 깨지지 않는지만 확인해주면 충분합니다.
