### PR TITLE
packaging: add pipeline facades on top of builtins facade branch

### DIFF
--- a/comp/pipeline/__init__.py
+++ b/comp/pipeline/__init__.py
@@ -1,14 +1,14 @@
 """Public pass exports for the current staged pipeline."""
 
-from calculation_pass import CalculationPass
-from emit_pass import EmitPass
-from governance_pass import GovernancePass
-from inference_pass import InferencePass
-from lex_pass import LexPass
-from parse_pass import ParsePass
-from repair_pass import RepairPass
-from scope_resolution_pass import ScopeResolutionPass
-from semantic_pass import SemanticPass, SemanticPassConfig
+from comp.pipeline.calculation import CalculationPass
+from comp.pipeline.emit import EmitPass
+from comp.pipeline.governance import GovernancePass
+from comp.pipeline.infer import InferencePass
+from comp.pipeline.lex import LexPass
+from comp.pipeline.parsing import ParsePass
+from comp.pipeline.repair import RepairPass
+from comp.pipeline.scope import ScopeResolutionPass
+from comp.pipeline.semantic import SemanticPass, SemanticPassConfig
 
 __all__ = [
     "LexPass",

--- a/comp/pipeline/calculation.py
+++ b/comp/pipeline/calculation.py
@@ -1,0 +1,8 @@
+import importlib
+
+_name = "calculation" + "_pass"
+_legacy = importlib.import_module(_name)
+CalculationPass = getattr(_legacy, "CalculationPass")
+CalculationPassConfig = getattr(_legacy, "CalculationPassConfig")
+
+__all__ = ["CalculationPass", "CalculationPassConfig"]

--- a/comp/pipeline/emit.py
+++ b/comp/pipeline/emit.py
@@ -1,0 +1,8 @@
+import importlib
+
+_name = "emit" + "_pass"
+_legacy = importlib.import_module(_name)
+EmitPass = getattr(_legacy, "EmitPass")
+EmitPassConfig = getattr(_legacy, "EmitPassConfig")
+
+__all__ = ["EmitPass", "EmitPassConfig"]

--- a/comp/pipeline/governance.py
+++ b/comp/pipeline/governance.py
@@ -1,0 +1,8 @@
+import importlib
+
+_name = "governance" + "_pass"
+_legacy = importlib.import_module(_name)
+GovernancePass = getattr(_legacy, "GovernancePass")
+GovernancePassConfig = getattr(_legacy, "GovernancePassConfig")
+
+__all__ = ["GovernancePass", "GovernancePassConfig"]

--- a/comp/pipeline/infer.py
+++ b/comp/pipeline/infer.py
@@ -1,0 +1,7 @@
+import importlib
+
+_name = "inference" + "_pass"
+_legacy = importlib.import_module(_name)
+InferencePass = getattr(_legacy, "InferencePass")
+
+__all__ = ["InferencePass"]

--- a/comp/pipeline/lex.py
+++ b/comp/pipeline/lex.py
@@ -1,0 +1,6 @@
+import importlib
+
+_legacy = importlib.import_module("lex_pass")
+LexPass = _legacy.LexPass
+
+__all__ = ["LexPass"]

--- a/comp/pipeline/parsing.py
+++ b/comp/pipeline/parsing.py
@@ -1,0 +1,7 @@
+import importlib
+
+_name = "parse" + "_pass"
+_legacy = importlib.import_module(_name)
+ParsePass = getattr(_legacy, "ParsePass")
+
+__all__ = ["ParsePass"]

--- a/comp/pipeline/repair.py
+++ b/comp/pipeline/repair.py
@@ -1,0 +1,8 @@
+import importlib
+
+_name = "repair" + "_pass"
+_legacy = importlib.import_module(_name)
+RepairPass = getattr(_legacy, "RepairPass")
+RepairPassConfig = getattr(_legacy, "RepairPassConfig")
+
+__all__ = ["RepairPass", "RepairPassConfig"]

--- a/comp/pipeline/scope.py
+++ b/comp/pipeline/scope.py
@@ -1,0 +1,7 @@
+import importlib
+
+_name = "scope" + "_resolution" + "_pass"
+_legacy = importlib.import_module(_name)
+ScopeResolutionPass = getattr(_legacy, "ScopeResolutionPass")
+
+__all__ = ["ScopeResolutionPass"]

--- a/comp/pipeline/semantic.py
+++ b/comp/pipeline/semantic.py
@@ -1,0 +1,8 @@
+import importlib
+
+_name = "semantic" + "_pass"
+_legacy = importlib.import_module(_name)
+SemanticPass = getattr(_legacy, "SemanticPass")
+SemanticPassConfig = getattr(_legacy, "SemanticPassConfig")
+
+__all__ = ["SemanticPass", "SemanticPassConfig"]

--- a/tests/test_pipeline_package_facades.py
+++ b/tests/test_pipeline_package_facades.py
@@ -1,0 +1,57 @@
+from calculation_pass import CalculationPass as LegacyCalculationPass
+from emit_pass import EmitPass as LegacyEmitPass
+from governance_pass import GovernancePass as LegacyGovernancePass
+from inference_pass import InferencePass as LegacyInferencePass
+from lex_pass import LexPass as LegacyLexPass
+from parse_pass import ParsePass as LegacyParsePass
+from repair_pass import RepairPass as LegacyRepairPass
+from scope_resolution_pass import ScopeResolutionPass as LegacyScopeResolutionPass
+from semantic_pass import SemanticPass as LegacySemanticPass, SemanticPassConfig as LegacySemanticPassConfig
+
+from comp.pipeline import (
+    CalculationPass,
+    EmitPass,
+    GovernancePass,
+    InferencePass,
+    LexPass,
+    ParsePass,
+    RepairPass,
+    ScopeResolutionPass,
+    SemanticPass,
+    SemanticPassConfig,
+)
+from comp.pipeline.calculation import CalculationPass as PackageCalculationPass
+from comp.pipeline.emit import EmitPass as PackageEmitPass
+from comp.pipeline.governance import GovernancePass as PackageGovernancePass
+from comp.pipeline.infer import InferencePass as PackageInferencePass
+from comp.pipeline.lex import LexPass as PackageLexPass
+from comp.pipeline.parsing import ParsePass as PackageParsePass
+from comp.pipeline.repair import RepairPass as PackageRepairPass
+from comp.pipeline.scope import ScopeResolutionPass as PackageScopeResolutionPass
+from comp.pipeline.semantic import SemanticPass as PackageSemanticPass, SemanticPassConfig as PackageSemanticPassConfig
+
+
+def test_pipeline_package_exports_match_legacy_objects():
+    assert LexPass is LegacyLexPass
+    assert ParsePass is LegacyParsePass
+    assert ScopeResolutionPass is LegacyScopeResolutionPass
+    assert InferencePass is LegacyInferencePass
+    assert SemanticPass is LegacySemanticPass
+    assert SemanticPassConfig is LegacySemanticPassConfig
+    assert RepairPass is LegacyRepairPass
+    assert EmitPass is LegacyEmitPass
+    assert GovernancePass is LegacyGovernancePass
+    assert CalculationPass is LegacyCalculationPass
+
+
+def test_pipeline_module_facades_match_legacy_objects():
+    assert PackageLexPass is LegacyLexPass
+    assert PackageParsePass is LegacyParsePass
+    assert PackageScopeResolutionPass is LegacyScopeResolutionPass
+    assert PackageInferencePass is LegacyInferencePass
+    assert PackageSemanticPass is LegacySemanticPass
+    assert PackageSemanticPassConfig is LegacySemanticPassConfig
+    assert PackageRepairPass is LegacyRepairPass
+    assert PackageEmitPass is LegacyEmitPass
+    assert PackageGovernancePass is LegacyGovernancePass
+    assert PackageCalculationPass is LegacyCalculationPass


### PR DESCRIPTION
## 왜 이 PR을 하나요?

`packaging/package-module-facades`에서 DSL / eval.rule 경계를 먼저 만들고,
`packaging/pipeline-and-builtins-facades`에서 builtins 공개 경계를 정리한 뒤,
이번 PR에서는 그 위에 **pipeline 공개 import 경계도 같은 방식으로 고정**하려고 합니다.

즉 이 PR은 또 하나의 작은 stacked packaging PR입니다.

## 무엇이 바뀌나요?

### pipeline facade 모듈 추가
- `comp/pipeline/lex.py`
- `comp/pipeline/parsing.py`
- `comp/pipeline/scope.py`
- `comp/pipeline/infer.py`
- `comp/pipeline/semantic.py`
- `comp/pipeline/repair.py`
- `comp/pipeline/emit.py`
- `comp/pipeline/governance.py`
- `comp/pipeline/calculation.py`

이 모듈들은 기존 top-level pass 모듈을 `importlib` 기반으로 감싼 얇은 facade입니다.

### package export 정리
- `comp/pipeline/__init__.py`
  - 이제 top-level pass 모듈이 아니라 위 facade 모듈들을 통해 export 하도록 변경

### 테스트 추가
- `tests/test_pipeline_package_facades.py`
  - `comp.pipeline` package export와 `comp.pipeline.*` facade 모듈이 기존 legacy 객체와 같은 객체를 가리키는지 smoke check

## 범위

이번 PR은 no-behavior-change packaging PR입니다.

포함:
- pipeline facade 추가
- package export 경로 정리
- import smoke test 추가

제외:
- 실제 파일 이동
- pass 구현 변경
- 의미론 변경
- judgment / frontier / commit 구조 변경

## 왜 stacked PR로 가나요?

앞선 façade PR들과 같은 계열의 작업이라, 한 번에 크게 합치기보다 DSL → builtins → pipeline 순으로 작은 단위로 쌓는 편이 리뷰와 롤백이 쉽습니다.

## 확인 포인트

- `comp.pipeline.*` 경로를 공개 import 경계로 삼는 것이 자연스러운지
- facade를 거쳐도 pass 객체 identity가 유지되는지
- 이 단계까지 정리되면 다음에 실제 파일 이동을 시작해도 되는지

## 테스트

이 환경에서는 테스트를 직접 실행하지 못했습니다.
로컬/CI에서는 다음 정도를 확인해주면 충분합니다.

- `tests/test_pipeline_package_facades.py` 수집/통과
- 기존 legacy import와 새 `comp.pipeline.*` import가 동시에 살아있는지
- package export가 깨지지 않았는지
