### PR TITLE
packaging: migrate comp internal imports toward package facades

### DIFF
--- a/comp/compat/adapters.py
+++ b/comp/compat/adapters.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from artifacts import CanonicalRowArtifact, ClaimArtifact, PartialFrameArtifact, RoleLineageArtifact, RoleSlotArtifact
+from comp.compat.artifacts import CanonicalRowArtifact, ClaimArtifact, PartialFrameArtifact, RoleLineageArtifact, RoleSlotArtifact
 from comp.judgment import CandidateSummary, CommitReceipt, CommitSpec, DraftSnapshot, SelectionReceipt, frontier, winner_or_none
 
 _MODE_SPECIFICITY = {

--- a/comp/runtime_env.py
+++ b/comp/runtime_env.py
@@ -1,0 +1,8 @@
+import importlib
+
+_name = "runtime" + "_env"
+_legacy = importlib.import_module(_name)
+RuntimeEnv = getattr(_legacy, "RuntimeEnv")
+build_runtime_env = getattr(_legacy, "build_runtime_env")
+
+__all__ = ["RuntimeEnv", "build_runtime_env"]

--- a/comp/views/public.py
+++ b/comp/views/public.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Optional
 
-from artifacts import (
+from comp.compat.artifacts import (
     CanonicalRowArtifact,
     ClaimArtifact,
     LineageEvidenceArtifact,
@@ -12,7 +12,7 @@ from artifacts import (
     warning_codes_from_diagnostics,
 )
 from comp.judgment import ProjectionSpec, project_public_row
-from runtime_env import RuntimeEnv
+from comp.runtime_env import RuntimeEnv
 
 DEFAULT_PUBLIC_PROJECTION = ProjectionSpec(
     "canonical_row",


### PR DESCRIPTION
## 왜 이 PR을 하나요?

앞선 facade PR들로 `comp.dsl.*`, `comp.eval.rule`, `comp.builtins.*`, `comp.pipeline.*` 같은 공개 import 경계는 거의 마련됐습니다.
이번 PR은 그 다음 단계로, **`comp/` 패키지 내부 모듈이 실제로 그 package 경계를 쓰기 시작하게 만드는 첫 작은 import 수렴 PR**입니다.

즉 아직 전면적인 파일 이동은 아니고,
먼저 `comp.views` / `comp.compat` 내부에서 top-level 모듈을 직접 잡고 있던 부분만 package facade 쪽으로 옮깁니다.

## 무엇이 바뀌나요?

- `comp/runtime_env.py`
  - legacy `runtime_env`를 감싼 얇은 facade 추가
- `comp/views/public.py`
  - `artifacts` → `comp.compat.artifacts`
  - `runtime_env` → `comp.runtime_env`
- `comp/compat/adapters.py`
  - `artifacts` → `comp.compat.artifacts`

## 범위

이번 PR은 no-behavior-change packaging PR입니다.

포함:
- internal import convergence (very small scope)
- runtime facade 1개 추가
- `comp.views` / `comp.compat` 내부 import 정리

제외:
- 실제 파일 이동
- top-level 모듈 제거
- evaluator / pipeline / judgment 의미론 변경
- 넓은 import sweep

## 왜 이렇게 작게 가나요?

이 단계에서 중요한 건 한 번에 다 바꾸는 게 아니라,
**이미 만든 facade를 실제 내부 코드가 쓰기 시작하는 최소 사례를 안전하게 확보하는 것**입니다.

그래서 이번 PR은 `comp/` 내부에서도 가장 독립적인 두 군데만 먼저 바꿉니다.

## 확인 포인트

- `comp.views.public`이 package facade를 경유해도 동작 의미가 그대로인지
- `comp.compat.adapters`가 `comp.compat.artifacts`를 통해 타입을 잡아도 문제 없는지
- `comp.runtime_env` 같은 얇은 facade를 두는 방식이 다음 internal import sweep에도 적절한지

## 테스트

이 환경에서는 테스트를 직접 실행하지 못했습니다.
이번 변경은 import 경로 수렴이 중심이라, 로컬/CI에서는 다음 정도를 확인해주면 충분합니다.

- 기존 public view 관련 테스트가 그대로 통과하는지
- compat adapter 관련 테스트/bridge 테스트가 그대로 통과하는지
- import cycle이 새로 생기지 않았는지
