### PR TITLE
packaging: add runner compat facades and package smoke tests

### DIFF
--- a/comp/compat/compiled_pipeline_runner.py
+++ b/comp/compat/compiled_pipeline_runner.py
@@ -1,0 +1,7 @@
+import importlib
+
+_legacy = importlib.import_module("compiled_pipeline_runner")
+
+CompiledESGPipelineRunner = getattr(_legacy, "CompiledESGPipelineRunner")
+
+__all__ = ["CompiledESGPipelineRunner"]

--- a/comp/compat/pipeline_runner.py
+++ b/comp/compat/pipeline_runner.py
@@ -1,0 +1,19 @@
+import importlib
+
+_legacy = importlib.import_module("pipeline_runner")
+
+ESGPipelineRunner = getattr(_legacy, "ESGPipelineRunner")
+PipelineResources = getattr(_legacy, "PipelineResources")
+PipelineRunResult = getattr(_legacy, "PipelineRunResult")
+compile_program_spec = getattr(_legacy, "compile_program_spec")
+load_compiled_program_spec_from_dsl = getattr(_legacy, "load_compiled_program_spec_from_dsl")
+load_program_spec_from_dsl = getattr(_legacy, "load_program_spec_from_dsl")
+
+__all__ = [
+    "ESGPipelineRunner",
+    "PipelineResources",
+    "PipelineRunResult",
+    "compile_program_spec",
+    "load_program_spec_from_dsl",
+    "load_compiled_program_spec_from_dsl",
+]

--- a/comp/runner.py
+++ b/comp/runner.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional
 
-from compiled_pipeline_runner import CompiledESGPipelineRunner as _LegacyCompiledRunner
-from pipeline_runner import (
+from comp.compat.compiled_pipeline_runner import CompiledESGPipelineRunner as _LegacyCompiledRunner
+from comp.compat.pipeline_runner import (
     ESGPipelineRunner as _LegacyRunner,
     PipelineResources,
     PipelineRunResult,

--- a/tests/test_runner_package_facades.py
+++ b/tests/test_runner_package_facades.py
@@ -1,0 +1,48 @@
+from compiled_pipeline_runner import CompiledESGPipelineRunner as LegacyCompiledRunner
+from pipeline_runner import (
+    ESGPipelineRunner as LegacyRunner,
+    PipelineResources as LegacyPipelineResources,
+    PipelineRunResult as LegacyPipelineRunResult,
+    compile_program_spec as legacy_compile_program_spec,
+    load_compiled_program_spec_from_dsl as legacy_load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl as legacy_load_program_spec_from_dsl,
+)
+
+from comp.compat.compiled_pipeline_runner import CompiledESGPipelineRunner as CompatCompiledRunner
+from comp.compat.pipeline_runner import (
+    ESGPipelineRunner as CompatRunner,
+    PipelineResources as CompatPipelineResources,
+    PipelineRunResult as CompatPipelineRunResult,
+    compile_program_spec as compat_compile_program_spec,
+    load_compiled_program_spec_from_dsl as compat_load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl as compat_load_program_spec_from_dsl,
+)
+from comp.runner import (
+    CompiledESGPipelineRunner,
+    ESGPipelineRunner,
+    PipelineResources,
+    PipelineRunResult,
+    compile_program_spec,
+    load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl,
+)
+
+
+def test_runner_compat_facades_match_legacy_exports():
+    assert CompatRunner is LegacyRunner
+    assert CompatCompiledRunner is LegacyCompiledRunner
+    assert CompatPipelineResources is LegacyPipelineResources
+    assert CompatPipelineRunResult is LegacyPipelineRunResult
+    assert compat_compile_program_spec is legacy_compile_program_spec
+    assert compat_load_program_spec_from_dsl is legacy_load_program_spec_from_dsl
+    assert compat_load_compiled_program_spec_from_dsl is legacy_load_compiled_program_spec_from_dsl
+
+
+def test_comp_runner_exports_use_compat_facades():
+    assert PipelineResources is CompatPipelineResources
+    assert PipelineRunResult is CompatPipelineRunResult
+    assert compile_program_spec is compat_compile_program_spec
+    assert load_program_spec_from_dsl is compat_load_program_spec_from_dsl
+    assert load_compiled_program_spec_from_dsl is compat_load_compiled_program_spec_from_dsl
+    assert issubclass(ESGPipelineRunner, CompatRunner)
+    assert issubclass(CompiledESGPipelineRunner, CompatCompiledRunner)


### PR DESCRIPTION
## Summary
- add `comp/compat/pipeline_runner.py` and `comp/compat/compiled_pipeline_runner.py`
- switch `comp/runner.py` to import through those compat facades
- add `tests/test_runner_package_facades.py` to lock facade/package exports

## Scope
This is a no-behavior-change packaging PR.
It only moves the `comp.runner` package entrypoint one step away from direct top-level runner imports.

## Notes
I could not run tests in this environment.
Please verify that `tests/test_runner_package_facades.py` passes and that the package entrypoint still works as expected.
