### PR TITLE
docs: add internal architecture map set

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,143 @@
+# Architecture
+
+## 한 줄 설명
+
+`comp`는 ESGDL 기반의 **실험적 evidence compiler**이다.
+
+이 레포는 raw fragment를 곧바로 정답 row로 바꾸는 도구라기보다,
+후보·근거·충돌·정책을 축적한 뒤 정당한 public row만 안전하게 승격하는 구조를 목표로 한다.
+
+---
+
+## 현재 구조
+
+현재 본류 실행 모델은 **stage pipeline**이다.
+
+```text
+LexPass
+→ ParsePass
+→ ScopeResolutionPass
+→ InferencePass
+→ SemanticPass
+→ RepairPass
+→ EmitPass
+→ GovernancePass
+→ CalculationPass
+```
+
+이 구조는 현재 레포의 주 실행 경로이며,
+실제 runner는 이 pass chain을 따라 `CompileArtifacts`를 갱신한다.
+
+핵심 산출물은 다음과 같다.
+
+- fragments
+- tokens
+- claims
+- frames
+- rows
+- calculations
+- diagnostics
+- merge_log
+- event_log
+- commit_log
+
+즉 현재 구조는 **하나의 artifact container를 단계별로 정제하는 staged compiler**로 이해하는 것이 가장 정확하다.
+
+---
+
+## 장기 구조
+
+장기적으로 `comp`는 단순 pass chain을 넘어
+**judgment-first architecture**로 이동하는 것을 목표로 한다.
+
+핵심 생각은 다음과 같다.
+
+1. row를 최상위 본체로 두지 않는다.
+2. candidate / evidence / hazard / provenance를 append-only judgment vocabulary로 다룬다.
+3. representative selection은 frontier 계산으로 설명한다.
+4. public row는 commit barrier를 통과한 projection만 허용한다.
+5. data와 spec을 같은 판정 어휘로 본다.
+
+즉 목표 구조는 대략 다음과 같다.
+
+```text
+raw input
+→ seed facts
+→ monotone transfer / fixpoint
+→ frontier / winner selection
+→ commit barrier
+→ public projection
+```
+
+---
+
+## 현재 레포의 실제 상태
+
+현재 레포는 “완전히 새 구조로 넘어간 상태”는 아니다.
+
+더 정확히는:
+
+- 공개 정체성은 README와 pyproject를 통해 정리되었다.
+- `comp.judgment`, `comp.views`, `comp.compat`가 실제 코드로 들어왔다.
+- 그러나 메인 러너와 주 pass 체인은 아직 기존 staged pipeline이 본류다.
+- 일부 `comp.pipeline.*` 모듈은 façade 또는 legacy wrapper 성격을 가진다.
+
+즉 현재 상태는 **legacy pipeline 위에 새 judgment vocabulary가 부분적으로 스며든 bridge 단계**로 보는 것이 맞다.
+
+---
+
+## 세 층으로 보는 현재 레포
+
+### 1. 현재 본류
+- `pipeline_runner.py`
+- 기존 pass chain
+- `CompileArtifacts`
+
+### 2. 새 의미층
+- `comp.judgment`
+- `comp.views`
+- `comp.compat`
+
+### 3. 이행 표면
+- `comp.pipeline.*`
+- 패키지 공개 surface
+- legacy와 새 구조를 동시에 연결하는 bridge
+
+---
+
+## 이 구조를 이렇게 두는 이유
+
+지금 레포는 두 가지 요구를 동시에 만족해야 한다.
+
+1. 현재 동작하는 staged pipeline을 유지해야 한다.
+2. 장기적으로 judgment-first 구조로 갈 수 있는 의미 축을 먼저 세워야 한다.
+
+한 번에 전면 재작성하면 현재 테스트, artifact 계약, existing flow가 무너질 수 있다.
+반대로 새 구조를 전혀 도입하지 않으면 emit / governance / selection을 더 이상 설명 가능하게 만들기 어렵다.
+
+따라서 지금 단계의 올바른 구조는:
+
+- 현재 파이프라인을 유지하되
+- selection / projection / commit vocabulary를 먼저 분리하고
+- 이후 점진적으로 본류를 judgment core 쪽으로 이동하는 것
+
+이다.
+
+---
+
+## 핵심 설계 원칙
+
+1. **row-first가 아니라 judgment-first**
+2. **append-only core**
+3. **draft와 public row의 분리**
+4. **emit은 source of truth가 아니라 projection**
+5. **selection / commit의 이유를 receipt로 남김**
+6. **spec과 data를 같은 판정 어휘로 설명**
+
+---
+
+## 다음 문서
+
+- 현재 실제 실행 흐름: `current-pipeline.md`
+- judgment core의 개념과 현재 연결점: `judgment-core.md`
+- 앞으로의 정리 순서: `migration-plan.md`

--- a/docs/current-pipeline.md
+++ b/docs/current-pipeline.md
@@ -1,0 +1,149 @@
+# Current Pipeline
+
+이 문서는 **현재 레포에서 실제로 실행되는 staged pipeline**만 설명한다.
+
+여기서는 장기 judgment 설계의 이상형을 섞지 않는다.
+지금 코드가 실제로 무엇을 하고 있는가만 적는다.
+
+---
+
+## 실행 순서
+
+현재 기본 실행 순서는 다음과 같다.
+
+```text
+LexPass
+→ ParsePass
+→ ScopeResolutionPass
+→ InferencePass
+→ SemanticPass
+→ RepairPass
+→ EmitPass
+→ GovernancePass
+→ CalculationPass
+```
+
+필요하면 `semantic_post`가 `RepairPass` 뒤에 추가될 수 있다.
+
+---
+
+## 실행 단위
+
+실행의 중심 객체는 `CompileArtifacts`다.
+
+이 객체는 다음 산출물을 단계별로 들고 간다.
+
+- fragments
+- tokens
+- claims
+- frames
+- rows
+- calculations
+- diagnostics
+- event_log
+- commit_log
+- merge_log
+
+즉 현재 구조의 핵심은
+**하나의 artifact container를 각 pass가 순차적으로 갱신하는 방식**이다.
+
+---
+
+## 단계별 역할
+
+### 1. LexPass
+입력 fragment에서 token occurrence를 만든다.
+
+결과:
+- `artifacts.tokens`
+
+### 2. ParsePass
+token과 parser rule을 바탕으로 claim / partial frame을 만든다.
+
+결과:
+- `artifacts.claims`
+- `artifacts.frames`
+
+### 3. ScopeResolutionPass
+context와 scope 규칙을 사용해 slot 후보를 좁히거나 상속/보완한다.
+
+결과:
+- frame 내부 slot 상태 보정
+- claim 상태 일부 조정
+
+### 4. InferencePass
+명시적으로 보이지 않는 값도 규칙에 따라 후보로 추가한다.
+
+결과:
+- claim 추가
+- inferred candidate 생성
+
+### 5. SemanticPass
+constraint / diagnostic / rule builtin 평가를 통해 warning/error를 쌓는다.
+
+결과:
+- frame diagnostics
+- artifact diagnostics
+
+### 6. RepairPass
+slot별 active/shadow/frozen/rejected를 재정렬하고,
+frame-level score / stability / commit 판정을 계산한다.
+
+결과:
+- slot lifecycle 정리
+- frame status 정리
+- frame runtime 값 갱신
+- selection receipt 저장
+
+### 7. EmitPass
+committed frame을 대상으로 canonical row를 materialize한다.
+
+중요:
+- 여기서는 row를 projection처럼 다루기 시작했지만,
+- 현재 구조상 row는 여전히 `artifacts.rows`에 materialize된다.
+
+### 8. GovernancePass
+row 단위 policy와 commit barrier를 보고 merge/hold/skip을 결정한다.
+
+결과:
+- `merge_log`
+- `event_log`
+- `commit_log`
+- row status 일부 변경
+
+### 9. CalculationPass
+merge 가능한 row를 기준으로 calculation을 수행한다.
+
+결과:
+- `artifacts.calculations`
+
+---
+
+## 현재 구조의 장점
+
+1. 실행 순서가 명확하다.
+2. artifact 기반이라 디버깅과 golden test가 쉽다.
+3. 단계별 책임을 나눠보기 쉽다.
+4. compiled runner parity 테스트를 붙이기 좋다.
+
+---
+
+## 현재 구조의 약점
+
+1. row가 비교적 이른 시점에 실체처럼 등장한다.
+2. selection / projection / governance가 stage 경계에 걸쳐 있다.
+3. emit / governance / calculation이 장기 구조 기준으로는 아직 완전히 분리되지 않았다.
+4. judgment-first 구조로 가기엔 현재 artifact mutation 중심 흐름이 강하다.
+
+---
+
+## 현재 문서의 범위 바깥
+
+이 문서에서는 다음을 자세히 다루지 않는다.
+
+- `Fact`, `JudgmentState`, `FixpointEngine`
+- frontier 기반 candidate selection
+- commit barrier의 장기 정식 모델
+- spec/data를 같은 judgment language로 다루는 구조
+
+그 내용은 `judgment-core.md`에서 다룬다.

--- a/docs/esgdl-reference.md
+++ b/docs/esgdl-reference.md
@@ -1,0 +1,296 @@
+# ESGDL Reference
+
+이 문서는 `comp`에서 사용하는 ESGDL의 **실용적 참조 문서**다.
+
+중요:
+이 문서는 grammar 전체를 그대로 옮긴 백과사전이 아니다.
+대신 “무엇을 선언하는 언어인가”를 빠르게 이해할 수 있게 정리한다.
+
+정확한 최종 기준은 언제나 실제 grammar / binder / lowering 코드다.
+이 문서는 그 구조를 이해하기 위한 안내 문서다.
+
+---
+
+## ESGDL이 하려는 일
+
+ESGDL은 단순한 입력 포맷이 아니다.
+
+이 DSL은 다음을 함께 다루려 한다.
+
+- 어떤 token을 추출할 것인가
+- 어떤 parser가 frame을 만들 것인가
+- 어떤 inherit / infer 규칙을 적용할 것인가
+- 어떤 resolver가 대표 후보를 정할 것인가
+- 어떤 governance가 public row 승격을 허용할 것인가
+
+즉 ESGDL은 raw를 row로 바꾸는 “문법”이라기보다
+**증거 기반 정제 파이프라인을 선언하는 언어**에 가깝다.
+
+---
+
+## ESGDL의 큰 블록
+
+ESGDL은 대체로 다음 선언 축을 가진다.
+
+### 1. 기초 도메인 선언
+예:
+- module
+- dimension
+- unit
+- activity
+- scope
+- context
+- frame
+
+이 블록들은 “무엇이 세계의 기초 객체인가”를 정한다.
+
+---
+
+### 2. 추출 선언
+예:
+- token
+- parser
+- build
+- bind
+- inherit
+- tag
+
+이 블록들은 raw/fragment에서
+무엇을 어떻게 claim / frame으로 끌어올릴지 정한다.
+
+---
+
+### 3. 의미 규칙 선언
+예:
+- infer
+- require
+- forbid
+- diagnostic
+
+이 블록들은
+어떤 조건이 후보를 강화하거나 약화시키는지,
+어떤 진단을 붙여야 하는지,
+무엇이 금지되어야 하는지를 정한다.
+
+---
+
+### 4. 후반 정책 선언
+예:
+- resolver
+- governance
+
+이 블록들은
+여러 후보 중 무엇을 대표로 볼지,
+어떤 경우 public row로 승격할지 정한다.
+
+---
+
+## 핵심 개념
+
+### token
+fragment에서 직접 찾을 수 있는 추출 단위다.
+
+예를 들면:
+- 숫자
+- 기간
+- 사이트 별칭
+- 활동명
+- 단위 기호
+
+token은 보통 parser의 재료가 된다.
+
+---
+
+### parser
+token과 source expression을 이용해 frame을 만든다.
+
+parser는 대체로:
+- 어떤 frame을 build할지
+- 어떤 source를 어떤 role에 bind할지
+- 무엇을 inherit/tag할지
+
+를 결정한다.
+
+즉 parser는 “문자열을 읽는 함수”가 아니라
+**frame 생성 규칙의 선언**이다.
+
+---
+
+### frame
+후보와 슬롯을 담는 중간 구조다.
+
+현재 구조 기준으로는
+frame이 row보다 먼저 존재하며,
+여러 candidate claim을 품은 상태로 repair/resolution 단계를 거친다.
+
+즉 frame은 아직 public row가 아니고,
+**정제 중인 구조화 상태**다.
+
+---
+
+### infer
+명시적으로 쓰이지 않은 값을 규칙으로 추가한다.
+
+예:
+- 어떤 조건이 만족되면 특정 role 값을 추론
+- 다른 slot 값을 근거로 유도된 claim 생성
+
+즉 infer는 “없는 것을 마음대로 채우는 것”이 아니라,
+**조건부로 후보를 더 생성하는 선언**이다.
+
+---
+
+### require / forbid / diagnostic
+이 블록들은 semantic 층의 핵심이다.
+
+- `require`
+  - 꼭 있어야 하는 조건을 선언
+
+- `forbid`
+  - 있으면 안 되는 조합이나 상태를 선언
+
+- `diagnostic`
+  - warning / error / info 같은 진단을 붙이는 규칙
+
+즉 이 블록들은 값 생성보다
+**판정과 제약**에 더 가깝다.
+
+---
+
+### resolver
+resolver는 frame 내부 후보들 중
+어떤 값을 대표로 볼지 정하는 정책 선언이다.
+
+현재 구조에서는 repair 단계와 깊게 연결되어 있다.
+
+resolver는 보통 다음을 다룬다.
+
+- candidate pool
+- score 관련 local
+- commit_condition
+- review_condition
+
+즉 resolver는 단순 정렬 규칙이 아니라
+**slot/frame 수준 selection 정책**이다.
+
+---
+
+### governance
+governance는 row를 바로 merge하는 코드라기보다
+**public 상태 승격 조건을 선언하는 정책**이다.
+
+보통 여기선:
+- emit 가능 여부
+- merge 조건
+- merge 금지 조건
+
+을 다룬다.
+
+즉 governance는 “row 생성”이 아니라
+**생성된 row를 밖으로 인정할 수 있는가**를 판단하는 층이다.
+
+---
+
+## 실행 흐름에서 ESGDL이 작동하는 위치
+
+ESGDL은 전체 pipeline의 여러 지점에 걸쳐 작동한다.
+
+### 초기
+- token 선언
+- parser 선언
+
+### 중간
+- inherit / infer
+- require / forbid / diagnostic
+
+### 후반
+- resolver
+- governance
+
+즉 ESGDL은 특정 한 pass만 위한 언어가 아니라
+**전체 staged compiler의 의미를 선언하는 언어**다.
+
+---
+
+## binder / compiled path와의 관계
+
+현재 레포는 ESGDL을 단순 AST로만 쓰지 않는다.
+
+장기적으로 중요한 점은:
+
+- syntax는 그대로 유지하되
+- binder가 host-aware하게 이름을 묶고
+- compiled spec이 실제 실행용 구조를 별도로 가진다는 점이다
+
+즉 ESGDL의 선언은 그대로 사람이 읽는 문법이지만,
+실제 실행은 점점 compiled form으로 이동하고 있다.
+
+이건 중요한 차이다.
+
+---
+
+## 자주 헷갈리는 점
+
+### 1. token = 최종 값이 아니다
+token은 추출 재료다.
+최종 public row 필드와 1:1로 같다고 보면 안 된다.
+
+### 2. frame = row가 아니다
+frame은 중간 상태다.
+여기엔 candidate, shadow, frozen, diagnostics가 남아 있을 수 있다.
+
+### 3. resolver = governance가 아니다
+resolver는 내부 대표 선택,
+governance는 public 승격 판단이다.
+
+### 4. infer = 무조건 자동 보정이 아니다
+infer는 조건부 후보 생성이다.
+semantic / governance를 건너뛰는 shortcut이 아니다.
+
+---
+
+## 지금 문서의 한계
+
+이 문서는 “ESGDL이 무엇을 선언하는가”를 설명하는 안내 문서다.
+
+다음은 의도적으로 자세히 쓰지 않는다.
+
+- 모든 grammar production 나열
+- 각 builtin의 전체 시그니처
+- binder의 모든 예외 메시지
+- 모든 lowering detail
+
+그건 문서가 아니라 코드와 가까운 영역이기 때문이다.
+
+---
+
+## 나중에 더 붙일 수 있는 것
+
+ESGDL이 더 안정화되면 이 문서에 다음을 추가할 수 있다.
+
+1. 최소 동작 예제 1개
+2. token / parser / infer / resolver / governance 예제 1개씩
+3. builtin reference
+4. common mistakes 섹션
+5. syntax → compiled spec 대응표
+
+하지만 첫 버전에서는
+문법 전체 나열보다 **개념적 지형도**를 먼저 두는 게 낫다.
+
+---
+
+## 요약
+
+ESGDL은 단순 parser용 미니 언어가 아니다.
+
+이 DSL은 다음을 함께 선언한다.
+
+- 추출
+- 조립
+- 추론
+- 진단
+- 대표 선택
+- public 승격 조건
+
+즉 ESGDL은 raw를 곧바로 row로 바꾸는 언어라기보다,
+**증거 기반 정제 파이프라인 전체를 선언하는 언어**로 보는 게 맞다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# docs
+
+`comp` 내부 구조 문서 모음입니다.
+
+이 디렉토리는 README보다 한 단계 깊은 **내부 지도**를 제공합니다.
+목표는 모듈별 백과사전을 만드는 것이 아니라, 현재 구조와 장기 구조, 그리고 그 사이의 이행 상태를 명확히 드러내는 것입니다.
+
+## 읽는 순서
+
+### 처음 보는 경우
+1. `../README.md`
+2. `architecture.md`
+3. `current-pipeline.md`
+
+### 현재 코드 흐름이 궁금한 경우
+1. `current-pipeline.md`
+2. `migration-plan.md`
+
+### 새 설계 방향이 궁금한 경우
+1. `architecture.md`
+2. `judgment-core.md`
+3. `migration-plan.md`
+
+## 문서 구성
+
+- `architecture.md`
+  - 레포 전체를 한 장으로 설명하는 중심 문서
+  - 현재 구조 / 장기 구조 / bridge 상태를 함께 설명
+
+- `current-pipeline.md`
+  - 현재 staged pipeline의 실제 실행 흐름과 artifact 계약 설명
+
+- `judgment-core.md`
+  - 장기적으로 밀고 있는 judgment-first 구조와 현재 코드 연결점 설명
+
+- `migration-plan.md`
+  - 패키지화, façade 제거, judgment core 흡수 등 이행 작업 추적 문서
+
+- `testing.md`
+  - 테스트가 무엇을 보호하는지 설명하는 문서
+
+- `esgdl-reference.md`
+  - ESGDL이 무엇을 선언하는 언어인지 설명하는 실용 참조 문서
+
+## 문서 원칙
+
+1. 현재 사실과 장기 방향을 섞어 쓰지 않는다.
+2. 구현되지 않은 미래 구조를 이미 완료된 것처럼 쓰지 않는다.
+3. bridge 상태를 숨기지 않는다.
+4. README는 바깥 설명, `docs/`는 내부 지도로 역할을 분리한다.

--- a/docs/judgment-core.md
+++ b/docs/judgment-core.md
@@ -1,0 +1,188 @@
+# Judgment Core
+
+이 문서는 `comp`의 장기 구조로서 **judgment-first architecture**를 설명한다.
+
+중요:
+이 문서는 완전히 미래의 이야기만 적는 문서가 아니다.
+현재 레포에 이미 들어온 judgment vocabulary와,
+그 vocabulary가 기존 pipeline에 어디까지 연결되었는지도 함께 적는다.
+
+---
+
+## 왜 judgment core가 필요한가
+
+현재 staged pipeline은 동작한다.
+하지만 다음 문제가 남는다.
+
+- 왜 이 candidate가 선택되었는가
+- 왜 이 row는 아직 public state가 아닌가
+- 왜 emit은 가능하지만 merge는 hold인가
+- data와 spec을 같은 판정 언어로 설명할 수 있는가
+
+이 문제를 풀려면 row보다 먼저
+**판정 가능한 사실들의 세계**를 세워야 한다.
+
+---
+
+## 핵심 생각
+
+`comp`의 장기 구조는 다음과 같이 요약할 수 있다.
+
+1. raw 입력은 seed fact로 올라간다.
+2. spec/DSL은 monotone transfer rule로 컴파일된다.
+3. core는 fixpoint engine 위에서 동작한다.
+4. candidate selection은 frontier 계산으로 처리한다.
+5. public row는 commit barrier를 통과한 projection만 허용한다.
+6. selection과 commit은 receipt를 남긴다.
+
+---
+
+## 현재 들어와 있는 judgment 객체
+
+현재 패키지에는 이미 다음 개념이 존재한다.
+
+### core
+- `SubjectRef`
+- `Fact`
+- `JudgmentState`
+- `FactTag`
+- `SubjectKind`
+
+### program
+- `TransferRule`
+- `BundleSpec`
+- `CommitSpec`
+- `ProjectionSpec`
+- `CompiledJudgmentProgram`
+
+### execution
+- `FixpointEngine`
+
+### selection
+- `CandidateSummary`
+- `dominates`
+- `frontier`
+- `winner_or_none`
+- `needs_review`
+
+### commit
+- `DraftSnapshot`
+- `committable`
+- `project_public_row`
+
+### receipts
+- `SelectionReceipt`
+- `CommitReceipt`
+
+즉 judgment core는 이미 “문서상의 목표”가 아니라
+**패키지 안에 실제 코드로 존재하는 상태**다.
+
+---
+
+## judgment vocabulary의 의미
+
+### Fact
+모든 중요한 상태를 먼저 fact로 떨어뜨린다.
+
+예:
+- candidate proposal
+- evidence 추가
+- hazard open
+- hazard discharge
+- provenance edge
+
+### JudgmentState
+append-only fact 집합과 subject version을 가진다.
+
+### TransferRule
+어떤 fact 변화가 들어왔을 때 새 fact를 더 생성하는 rule이다.
+
+### FixpointEngine
+더 이상 새 fact가 생기지 않을 때까지 monotone rule을 반복 적용한다.
+
+### CandidateSummary / frontier
+전체 후보를 다 저장한 뒤 하나를 즉시 지우는 구조가 아니라,
+요약된 candidate summary들 사이의 dominance 관계를 보고
+frontier를 계산한다.
+
+### DraftSnapshot / committable
+draft가 public state로 승격 가능한지 판단하는 barrier 표현이다.
+
+### ProjectionSpec / project_public_row
+public row를 source of truth로 보는 대신,
+판정 결과로부터 materialize되는 projection으로 본다.
+
+---
+
+## 현재 pipeline과의 실제 연결점
+
+judgment core는 아직 주 실행 모델을 대체하지 않았다.
+그러나 이미 몇 군데에 실제로 연결되어 있다.
+
+### 1. RepairPass ↔ selection receipt
+`RepairPass`는 slot repair 이후 selection receipt를 저장한다.
+이 receipt는 judgment 쪽 frontier/winner vocabulary와 연결되는 첫 bridge다.
+
+### 2. EmitPass ↔ views / projection
+`EmitPass`는 row 조립을 직접 다 하지 않고,
+`comp.views`의 public projection helper에 위임하기 시작했다.
+
+### 3. GovernancePass ↔ commit barrier
+`GovernancePass`는 row snapshot을 judgment-style `DraftSnapshot`으로 보고,
+`committable`을 통해 hold/merge 여부를 일부 설명한다.
+
+### 4. compat.adapters ↔ 기존 artifact 구조
+현재 row, slot, claim, lineage는 아직 legacy artifact 구조가 중심이다.
+`comp.compat.adapters`는 이 구조를 judgment vocabulary로 번역하는 bridge 역할을 한다.
+
+---
+
+## 현재 한계
+
+현재 judgment core는 아직 다음 단계까지는 가지 않았다.
+
+1. 메인 runner가 judgment program을 직접 실행하지 않는다.
+2. `CompiledJudgmentProgram`이 본류 DSL lowering 결과는 아니다.
+3. frontier가 repair loop 전체를 장악하지 않는다.
+4. public ledger가 artifact row를 완전히 대체하지 않았다.
+
+즉 지금 judgment core는
+**실행 본류를 대체한 코어라기보다, 장기 구조를 미리 세운 의미층 + adapter 층**이다.
+
+---
+
+## 목표 상태
+
+장기적으로는 다음에 가까워지는 것이 목표다.
+
+```text
+seed facts
+→ transfer rules
+→ fixpoint state
+→ frontier selection
+→ commit barrier
+→ public projection
+→ ledger / receipts
+```
+
+이 상태가 되면:
+
+- data와 spec을 같은 판단 언어로 설명할 수 있고
+- selection과 commit의 이유를 기록할 수 있고
+- emit을 source of truth가 아니라 projection으로 둘 수 있고
+- governance가 mutation보다 barrier/receipt 중심으로 설명 가능해진다
+
+---
+
+## 요약
+
+현재 judgment core는 아직 본류를 장악한 상태는 아니다.
+그러나 이미 다음 역할을 시작했다.
+
+- selection vocabulary 제공
+- commit vocabulary 제공
+- projection vocabulary 제공
+- legacy artifact를 새 판단 언어로 번역하는 bridge 제공
+
+즉 지금 레포에서 judgment core는
+**실험 메모가 아니라, 본류로 올라오기 시작한 의미 축**이다.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,0 +1,166 @@
+# Migration Plan
+
+이 문서는 `comp`의 구조 이행 작업을 추적한다.
+
+중요:
+이 문서는 추상 설계 문서가 아니다.
+PR 단위로 무엇이 이미 들어왔고, 무엇이 아직 façade/bridge 상태인지,
+그리고 다음에 무엇을 실제로 옮길지를 적는 문서다.
+
+---
+
+## 현재 상태 요약
+
+현재 레포는 다음 세 층이 공존한다.
+
+### 1. legacy 본류
+- top-level 모듈
+- staged pass 실행
+- `pipeline_runner.py` 중심 구조
+
+### 2. 새 공개 표면
+- `comp.*` 패키지
+- `README.md`
+- `pyproject.toml`
+
+### 3. bridge / adapter 층
+- `comp.compat`
+- `comp.views`
+- `comp.judgment`
+- 일부 `comp.pipeline.*` façade
+
+즉 현재 상태는 **정리 완료**가 아니라 **의도적 bridge 단계**다.
+
+---
+
+## 이미 들어온 것
+
+### 패키지 표면
+- `pyproject.toml`
+- `comp.dsl`
+- `comp.pipeline`
+- `comp.eval`
+- `comp.builtins`
+- `comp.compat`
+- `comp.judgment`
+- `comp.views`
+
+### 공개 정체성
+- 한국어 README
+- judgment-first 방향 명시
+- experimental 상태 명시
+
+### 새 구조의 실제 코드
+- `Fact`, `JudgmentState`
+- `FixpointEngine`
+- `frontier`
+- `committable`
+- public projection helpers
+- selection / commit adapter
+
+---
+
+## 아직 façade 또는 wrapper인 부분
+
+### `comp.pipeline.*`
+일부 모듈은 아직 실제 구현체가 아니라 legacy top-level 모듈 re-export다.
+
+예:
+- `comp.pipeline.repair`
+
+### `comp.compat.*`
+일부 호환 모듈은 실제 이행을 위한 thin wrapper다.
+
+예:
+- `comp.compat.artifacts`
+
+### main runner
+주 실행은 아직 top-level `pipeline_runner.py` 중심이다.
+
+즉 새 패키지가 생겼지만,
+본류 import 경로와 실제 구현체 이동은 아직 중간 단계다.
+
+---
+
+## 구조 debt
+
+현재 가장 중요한 debt는 다음 네 가지다.
+
+1. **루트 import 의존**
+   - 본류 실행이 아직 top-level 모듈 중심이다.
+
+2. **façade 잔존**
+   - `comp.pipeline.*` 일부가 공개 표면만 제공하고 실제 구현은 legacy에 남아 있다.
+
+3. **row 중심 mutation**
+   - emit / governance / commit이 아직 완전히 ledger/receipt 중심으로 넘어가지 않았다.
+
+4. **judgment core의 본류 미흡수**
+   - judgment vocabulary는 들어왔지만 main executor는 아직 stage pipeline이다.
+
+---
+
+## 다음 PR 우선순위
+
+### PR-A: import surface 정리
+목표:
+- 테스트와 문서 기준 import를 `comp.*`로 수렴
+- 새 package surface를 정식 경로로 확정
+
+완료 기준:
+- 새 코드 예제와 테스트에서 legacy import를 줄임
+
+---
+
+### PR-B: façade 제거
+목표:
+- `comp.pipeline.*` 내부에서 실제 구현체를 패키지 안으로 이동
+- thin re-export 감소
+
+완료 기준:
+- `importlib` re-export 모듈 축소
+- 실제 구현이 패키지 내부로 이동
+
+---
+
+### PR-C: emit / governance 경계 정리
+목표:
+- emit을 projection으로 더 명확히 분리
+- governance를 barrier / receipt 중심으로 더 정리
+
+완료 기준:
+- row mutation보다 receipt/log 중심 설명이 더 자연스러워짐
+
+---
+
+### PR-D: judgment core 흡수 시작
+목표:
+- 일부 규칙 또는 selection 흐름을 judgment program 관점으로 직접 표현
+- adapter 아닌 실제 본류 흡수 시작
+
+완료 기준:
+- judgment core가 설명용 보조층이 아니라 일부 실행 경로를 직접 담당
+
+---
+
+## 하지 말아야 할 것
+
+1. 한 번에 전면 재작성
+2. façade를 오래 방치한 채 패키지 이름만 늘리기
+3. README/문서만 새 구조를 말하고 본류 코드는 그대로 두기
+4. judgment core를 실제 실행 흡수 없이 “좋은 미래 설계”로만 방치하기
+
+---
+
+## 최종 목표
+
+장기적으로는 다음 상태를 목표로 한다.
+
+- 공개 import surface는 `comp.*`로 통일
+- legacy top-level 모듈 제거 또는 최소화
+- selection / commit / projection 책임 분리
+- judgment core가 본류 실행 모델 일부를 직접 담당
+- receipt / ledger 중심 설명 가능성 강화
+
+즉 목표는 단순히 “폴더 정리된 레포”가 아니라,
+**현재 pipeline과 장기 judgment 구조가 하나의 설명 체계로 수렴된 레포**다.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,171 @@
+# Testing
+
+이 문서는 `comp`의 테스트가 **무엇을 보호하는지** 설명한다.
+
+중요:
+여기서는 “pytest를 어떻게 실행하나”보다
+**각 테스트가 어떤 구조적 약속을 지키는가**를 중심으로 적는다.
+
+---
+
+## 테스트의 역할
+
+`comp`는 단순 함수 하나의 입력/출력만 보는 레포가 아니다.
+
+이 레포는 다음을 동시에 보존해야 한다.
+
+- artifact 계약
+- staged pipeline 결과 일관성
+- compiled path와 기존 path의 동치성
+- selection / repair / governance의 안정성
+- e2e 결과의 회귀 방지
+
+즉 테스트는 “값이 맞는가”만이 아니라
+**현재 구조가 깨졌는가**를 잡는 장치다.
+
+---
+
+## 테스트 층위
+
+현재 테스트는 크게 네 층으로 나눠 볼 수 있다.
+
+### 1. Artifact contract 테스트
+목적:
+- artifact 자료형과 helper의 계약이 깨지지 않는지 확인
+
+대표적으로 보는 것:
+- frame diagnostics가 `DiagnosticArtifact`인지
+- helper가 예상 타입 외 입력에 fail-fast 하는지
+- repair 이후 runtime 상태가 채워지는지
+- row error code가 frame diagnostics와 일치하는지
+
+이 층은 `artifacts.py`의 의미를 보호한다.
+
+즉:
+“지금 구조에서 artifact가 무엇을 약속하는가”를 지키는 테스트다.
+
+---
+
+### 2. Stage smoke / golden 테스트
+목적:
+- 특정 stage까지의 산출물이 기존 기대값과 같은지 확인
+
+예:
+- `RepairPass` 직후 snapshot이 golden과 같은지 비교
+
+이 층은
+특정 pass를 고쳤을 때 중간 산출물이 의도치 않게 바뀌는지 잡는다.
+
+즉:
+“현재 pipeline의 중간 상태”를 보호하는 테스트다.
+
+---
+
+### 3. Compiled runner parity 테스트
+목적:
+- compiled path가 기존 pipeline path와 같은 결과를 내는지 확인
+
+핵심 질문:
+- `CompiledProgramSpec`로 내려간 경로가
+  기존 spec 실행과 의미적으로 같은가
+
+이 층은 매우 중요하다.
+왜냐하면 이 레포는 binder / compiled path를 강화하고 있기 때문이다.
+
+즉:
+“새 실행 경로가 기존 경로를 깨지 않고 같은 의미를 유지하는가”를 보호한다.
+
+---
+
+### 4. End-to-end golden 테스트
+목적:
+- 실제 케이스 전체 실행 결과가 golden과 같은지 확인
+
+이 층은 다음을 함께 본다.
+
+- fragments
+- tokens
+- claims
+- frames
+- rows
+- calculations
+- diagnostics
+- merge decisions
+
+즉:
+“레포 전체가 지금 어떤 동작을 하는가”를 보호하는 가장 넓은 테스트다.
+
+---
+
+## 테스트가 보호하는 핵심 불변조건
+
+### 1. Artifact shape가 갑자기 바뀌지 않는다
+필드 이름, 타입, 의미가 조용히 깨지면 안 된다.
+
+### 2. Repair의 결과는 설명 가능해야 한다
+score, iteration, termination reason 같은 runtime 값이 비어 있으면 안 된다.
+
+### 3. Compiled path는 기존 path와 동치여야 한다
+compiled route를 강화하더라도 의미가 바뀌면 안 된다.
+
+### 4. Public row와 governance 결과는 회귀하면 안 된다
+row/error/merge/calculation 결과가 무심코 바뀌면 안 된다.
+
+---
+
+## 테스트를 읽을 때의 기준
+
+새 기능을 넣거나 구조를 바꿀 때는
+아래 순서로 테스트를 보는 게 좋다.
+
+### 구조만 바꾼 경우
+1. artifact contract
+2. stage smoke
+3. e2e golden
+
+### binder / compiled path를 건드린 경우
+1. compiled runner parity
+2. e2e golden
+
+### repair / selection / governance를 건드린 경우
+1. repair stage smoke
+2. artifact contract
+3. e2e golden
+
+---
+
+## 앞으로 더 필요해질 테스트
+
+현재 구조가 judgment-first 쪽으로 더 이동하면,
+다음 테스트가 더 중요해질 가능성이 크다.
+
+### 1. judgment core 단위 테스트
+- `Fact`
+- `JudgmentState`
+- `FixpointEngine`
+- `frontier`
+- `committable`
+
+### 2. receipt 테스트
+- selection receipt가 현재 slot 상태를 제대로 반영하는지
+- commit receipt가 barrier snapshot을 제대로 담는지
+
+### 3. projection 테스트
+- public projection이 source of truth를 왜곡하지 않는지
+- emit/view helper가 같은 입력에 대해 안정적으로 같은 결과를 내는지
+
+---
+
+## 문서의 결론
+
+`comp`의 테스트는 단순히 “정답 값 비교”가 아니다.
+
+이 레포에서 테스트는 다음을 보호한다.
+
+- 현재 staged pipeline의 의미
+- artifact 계약
+- compiled path의 동치성
+- judgment-first 구조로 가는 이행 과정의 안전성
+
+즉 테스트는 결과 검증 도구이면서 동시에
+**현재 아키텍처의 경계와 약속을 고정하는 장치**다.


### PR DESCRIPTION
## 요약
- `docs/` 첫 버전 7개 문서를 추가합니다.
- README보다 한 단계 깊은 내부 지도를 목표로 합니다.
- 현재 staged pipeline / 장기 judgment-first 구조 / bridge 상태를 분리해서 설명합니다.

## 추가된 문서
- `docs/index.md`
- `docs/architecture.md`
- `docs/current-pipeline.md`
- `docs/judgment-core.md`
- `docs/migration-plan.md`
- `docs/testing.md`
- `docs/esgdl-reference.md`

## 의도
이번 PR은 모듈별 백과사전을 만드는 것이 아니라,
현재 구조와 장기 구조, 그리고 그 사이의 이행 상태를 명확히 드러내는 문서 지도를 추가하는 데 목적이 있습니다.

## 비고
- 코드 실행 로직은 건드리지 않았습니다.
- 현재 본류가 staged pipeline이고 judgment core가 bridge 단계라는 점을 문서에 명시했습니다.
- façade / compat / migration debt도 숨기지 않고 기록했습니다.
