### PR TITLE
docs: add judgment semantics design guides

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,8 +136,26 @@ raw input
 
 ---
 
+## 이 문서가 다루지 않는 것
+
+다음 내용은 이 문서에서 요약만 하고,
+별도 문서에서 더 자세히 다룬다.
+
+- 공통 판정 어휘와 judgeable subject
+- 하나의 judgment core / fixpoint / frontier shell 관점의 의미론
+- ESGDL/spec의 parse → bind → lower → validate 경로
+- staged pass를 장기 runtime engine으로 재배치하는 방식
+- authoritative state / receipt log / public ledger / view의 구분
+
+---
+
 ## 다음 문서
 
 - 현재 실제 실행 흐름: `current-pipeline.md`
 - judgment core의 개념과 현재 연결점: `judgment-core.md`
+- 공통 판정 언어: `judgment-language.md`
+- 코어 의미론: `core-semantics.md`
+- spec 컴파일 경로: `spec-pipeline.md`
+- 목표 실행 모델: `execution-model.md`
+- view / ledger 구분: `views-ledger.md`
 - 앞으로의 정리 순서: `migration-plan.md`

--- a/docs/core-semantics.md
+++ b/docs/core-semantics.md
@@ -1,0 +1,269 @@
+# Core Semantics
+
+이 문서는 `comp`의 장기 구조를 **하나의 코어 의미론**으로 설명합니다.
+
+중요:
+이 문서는 현재 `pipeline_runner.py`가 실제로 어떻게 돈다는 설명을 대체하지 않습니다.
+현재 실행 흐름은 `current-pipeline.md`가 설명합니다.
+
+여기서는 그 위에서,
+왜 `comp`를 여러 패스와 여러 저장소의 집합으로만 보지 않고
+**하나의 judgment core + 얇은 selection/commit shell** 로 보려 하는지를 설명합니다.
+
+---
+
+## 왜 “하나의 코어”가 필요한가
+
+`comp`의 관심사는 단순 변환이 아닙니다.
+
+이 레포는 다음을 함께 설명해야 합니다.
+
+- 어떤 candidate가 생겼는가
+- 무엇이 그것을 지지하는가
+- 어떤 hazard가 열려 있는가
+- 어떤 provenance가 붙어 있는가
+- 왜 이 상태는 아직 public이 아닌가
+- 왜 이 representative가 선택되었는가
+
+이걸 각각 다른 subsystem, 다른 저장소, 다른 pass로만 밀어내면
+아키텍처가 쉽게 커집니다.
+
+그래서 장기적으로는,
+후보/근거/hazard/provenance를 **하나의 판정 우주** 안에서 다루고,
+selection과 commit만 얇은 껍질로 남기는 쪽이 자연스럽습니다.
+
+---
+
+## 하나의 judgment state
+
+장기 구조에서 중심 state는 row 테이블이 아니라
+**판정 사실들의 상태**입니다.
+
+직관적으로는 다음 좌표를 함께 가진 상태로 볼 수 있습니다.
+
+- candidate 관련 사실
+- evidence 관련 사실
+- hazard 관련 사실
+- provenance 관련 사실
+
+즉 “support store”, “hazard store”, “review store”를 다 독립 본체로 두기보다,
+**하나의 judgment state의 다른 좌표**로 보는 쪽이 더 단순합니다.
+
+현재 레포의 `Fact`, `JudgmentState`는 이 방향을 가리키는 core vocabulary입니다.
+
+---
+
+## seed fact와 compiled operator
+
+장기적으로는 data와 spec이 같은 코어에서 만납니다.
+
+### data는 seed fact
+
+raw input은 바로 public row가 되는 것이 아니라,
+먼저 seed fact로 올라갑니다.
+
+예:
+- token proposal
+- parser output claim
+- source-linked evidence
+- 초기 hazard
+
+### spec은 compiled operator
+
+DSL/spec는 그대로 실행되는 것이 아니라,
+judgment state 위에서 작동하는 rule/operator로 내려옵니다.
+
+즉 spec은 대략 다음 역할을 합니다.
+
+- 어떤 fact가 새 fact를 유도하는가
+- 어떤 bundle/selection 규칙이 적용되는가
+- 어떤 barrier가 commit을 막는가
+- 어떤 projection이 public view를 정의하는가
+
+그래서 data와 spec은 각각
+
+- `seed`
+- `compiled operator`
+
+로 하나의 코어에서 만나는 구조가 됩니다.
+
+---
+
+## least fixpoint 관점
+
+이 구조를 가장 짧게 말하면,
+실행은 “패스를 한 번씩 지나간다”보다
+**고정점을 푼다**에 더 가깝습니다.
+
+직관적으로는 다음과 같이 생각할 수 있습니다.
+
+`x* = μX.(i_d ⊔ F_θ(X))`
+
+여기서
+
+- `i_d`
+  - data가 올린 seed fact
+- `F_θ`
+  - spec/DSL이 컴파일된 operator
+- `⊔`
+  - 현재 상태와 새 사실을 합치는 누적 연산
+- `μ`
+  - 더 이상 새 사실이 생기지 않을 때까지 반복 적용한 최소 고정점
+
+중요한 점은,
+이 관점에선 중심이 pass 순서가 아니라
+**새 판단 사실이 더 생기느냐 아니냐** 입니다.
+
+---
+
+## monotone core
+
+코어에서는 가능한 한 모노토닉하게 움직이는 것이 좋습니다.
+
+즉 이미 알게 된 사실을 함부로 지우기보다,
+새 fact를 append하는 방향으로 가는 것입니다.
+
+예를 들면:
+
+- proposal 추가
+- evidence 추가
+- provenance edge 추가
+- hazard open
+- hazard discharge를 기록하는 새 사실 추가
+
+이렇게 하면 코어는 “무엇을 알게 되었는가”를 누적하는 쪽에 집중할 수 있습니다.
+
+현재 judgment vocabulary가 append-only 성격을 강하게 가지는 이유도 여기에 있습니다.
+
+---
+
+## thin non-monotonic shell
+
+selection과 commit은 코어와 똑같이 다룰 수 없는 부분이 있습니다.
+
+예:
+- 대표 후보를 하나로 정해야 한다
+- review로 보낼지 결정해야 한다
+- public row를 열지 막을지 판단해야 한다
+
+이 부분까지 전부 코어 mutation으로 섞어 버리면 구조가 다시 커집니다.
+
+그래서 장기적으로는 이 부분을
+**얇은 비모노토닉 껍질**로 남기는 것이 좋습니다.
+
+### frontier / representative
+
+candidate 전체를 바로 지워 버리기보다,
+candidate summary 사이의 dominance를 보고 frontier를 계산합니다.
+
+이 관점에선:
+
+- 단일 winner가 있으면 자동 선택 가능
+- frontier가 여러 개면 review가 필요할 수 있음
+- 탈락 후보는 “삭제”보다 residue/비대표 상태로 남김
+
+현재 `CandidateSummary`, `frontier`, `winner_or_none`은 이 방향의 초기 형태입니다.
+
+### commit barrier
+
+public state는 단순 row 생성과 다릅니다.
+
+장기적으로 public row는 다음 같은 조건을 통과해야 합니다.
+
+- 현재 선택이 fresh한가
+- blocking hazard가 남아 있지 않은가
+- provenance가 충분한가
+- policy가 merge를 허용하는가
+
+현재 `DraftSnapshot`, `CommitSpec`, `committable()`은 이 barrier vocabulary를 이미 제공합니다.
+
+---
+
+## public row는 partial projection
+
+장기 구조에서 public row는 source of truth가 아닙니다.
+
+source of truth에 더 가까운 것은 judgment state와 receipt log입니다.
+public row는 그 상태에서 commit barrier를 통과한 결과를
+밖으로 내보내는 **projection** 입니다.
+
+이 관점이 중요한 이유는 다음과 같습니다.
+
+1. emit이 본체 mutation이 아니라 materialization이 된다.
+2. draft/review/public/explanation을 같은 코어의 다른 view로 다룰 수 있다.
+3. 왜 merge는 hold인데 row는 보일 수 있는지 설명하기 쉬워진다.
+
+현재 `ProjectionSpec`과 `comp.views.public` helper는 이 방향의 초기 구현입니다.
+
+---
+
+## incremental / delta 관점
+
+장기적으로는 dirty-driven recomputation도
+이 코어 의미론 위에서 설명하는 것이 좋습니다.
+
+즉 “어디를 다시 돌릴 것인가”를 ad-hoc하게 관리하기보다,
+변화량이 judgment state에 어떤 새 사실을 추가하는지,
+그리고 어떤 bundle/frontier/commit barrier가 영향을 받는지로 설명하는 쪽이 더 자연스럽습니다.
+
+이 문서에서 중요한 점은 특정 알고리즘을 고정하는 것이 아니라,
+incremental 실행도 결국
+**동일한 judgment state 위의 증분 고정점 계산**으로 본다는 점입니다.
+
+---
+
+## 현재 레포와의 연결점
+
+현재 레포는 아직 이 의미론을 본류 실행 모델로 쓰지 않습니다.
+
+대신 다음처럼 부분적으로 연결되어 있습니다.
+
+- `current-pipeline.md`
+  - 실제 본류는 staged pass chain
+- `RepairPass`
+  - selection 관련 상태와 receipt를 계산하는 bridge
+- `comp.views.public`
+  - public projection helper 제공
+- `GovernancePass`
+  - barrier/receipt vocabulary 일부 사용
+- `comp.compat.adapters`
+  - legacy artifact를 judgment vocabulary로 번역
+
+즉 지금 레포는 완전한 fixpoint runtime은 아니지만,
+이 문서가 설명하는 코어 의미론을 향해 vocabulary와 helper를 미리 세운 상태입니다.
+
+---
+
+## 이 문서가 고정하는 것과 고정하지 않는 것
+
+### 이 문서가 고정하는 것
+
+- `comp`의 장기 설명 중심은 row-first가 아니라 judgment-first 라는 점
+- data와 spec이 같은 코어에서 만난다는 점
+- selection/commit은 얇은 shell로 남겨야 한다는 점
+- public row는 projection이라는 점
+
+### 이 문서가 아직 고정하지 않는 것
+
+- 최종 lattice 좌표의 정확한 분해
+- obligation/review lifecycle의 정식 규칙
+- delta runtime의 구체 알고리즘
+- 모든 rule family의 최종 lowering 형식
+
+즉 이 문서는 구현 세부를 잠그는 문서가 아니라,
+**장기 구조를 설명하는 최소 의미론**을 고정하는 문서입니다.
+
+---
+
+## 요약
+
+`comp`를 장기적으로 가장 간단하게 설명하면 이렇습니다.
+
+- data는 seed fact를 올리고
+- spec은 compiled operator로 내려오고
+- core는 judgment state 위에서 고정점을 향해 fact를 누적하고
+- selection과 commit은 얇은 shell로 남고
+- public row는 barrier를 통과한 projection으로만 나타난다
+
+즉 `comp`의 장기 본체는 pass 묶음이 아니라,
+**하나의 judgment core semantics** 입니다.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,0 +1,237 @@
+# Execution Model
+
+이 문서는 `comp`의 **목표 실행 모델**을 설명합니다.
+
+중요:
+현재 실제로 돌아가는 pass chain은 `current-pipeline.md`가 설명합니다.
+이 문서는 그 문서를 덮어쓰지 않습니다.
+
+여기서는 다음을 다룹니다.
+
+- 왜 장기적으로 pass 목록만으로는 구조를 설명하기 어려운가
+- 목표 실행 모델에서 어떤 엔진 경계가 중요한가
+- 현재 pass를 그 목표 모델에 어떻게 대응시킬 수 있는가
+- migration 과정에서 무엇을 섞지 말아야 하는가
+
+---
+
+## 왜 execution model 문서가 따로 필요한가
+
+현재 레포는 staged pipeline으로 동작합니다.
+그 자체는 지금 단계에서 맞는 구조입니다.
+
+하지만 장기적으로 `comp`를 설명할 때,
+pass 이름만 계속 늘어놓는 방식에는 한계가 있습니다.
+
+왜냐하면 `comp`의 중요한 질문은 다음이기 때문입니다.
+
+- 후보와 근거는 어디서 누적되는가
+- 대표선출은 어디서 일어나는가
+- public 승격은 어디서 막히거나 허용되는가
+- emit/view는 core mutation인가 projection인가
+
+즉 장기적으로는
+“무슨 pass가 몇 번째에 돈다”보다
+**어떤 엔진이 어떤 책임을 가진다**가 더 중요해집니다.
+
+---
+
+## 목표 실행 모델의 큰 그림
+
+장기적으로는 다음 실행 모델이 더 자연스럽습니다.
+
+```text
+frontend
+→ saturation
+→ arbitration
+→ commit
+→ post-commit / views
+```
+
+여기서 핵심은 세 엔진입니다.
+
+- `saturation`
+- `arbitration`
+- `commit`
+
+frontend와 post-commit/view는 중요하지만,
+핵심 판단 구조는 저 세 엔진이 나눠 갖는 편이 좋습니다.
+
+---
+
+## 1. frontend
+
+frontend는 raw input를 judgment world로 올리는 앞단입니다.
+
+대표적으로는 다음 일을 합니다.
+
+- fragment 준비
+- token 추출
+- parser 적용
+- 초기 claim/frame 생성
+
+즉 frontend의 역할은 아직 최종 판단을 내리는 것이 아니라,
+**판정 가능한 seed를 만드는 것** 입니다.
+
+---
+
+## 2. saturation
+
+`saturation`은 가능한 한 모노토닉하게 fact를 누적하는 엔진입니다.
+
+대표적으로는 다음 역할을 맡습니다.
+
+- proposal 추가
+- evidence 추가
+- provenance 확장
+- infer rule 적용
+- semantic constraint/diagnostic 반영
+- hazard open / discharge 관련 사실 누적
+
+직관적으로는,
+“새 사실을 계속 더해 보고 더 이상 추가될 것이 없을 때까지 간다”는 쪽에 가깝습니다.
+
+장기적으로는 이 엔진이 judgment state를 고정점 쪽으로 밀어가는 본체가 됩니다.
+
+---
+
+## 3. arbitration
+
+`arbitration`은 후보를 대표선출 관점에서 정리하는 엔진입니다.
+
+여기서는 다음 질문을 다룹니다.
+
+- 어떤 후보들이 같은 bundle에서 경쟁하는가
+- dominance/frontier 기준으로 보면 최대 후보는 누구인가
+- single winner인가, review가 필요한가
+- residue/shadow/rejected 상태는 어떻게 설명되는가
+- stale recheck가 필요한가
+
+즉 arbitration은 “사실을 더 쌓는” 엔진이라기보다,
+**누적된 판단 세계를 보고 대표선출 상태를 정리하는 엔진** 입니다.
+
+현재 레포에선 이 역할이 상당 부분 `RepairPass`에 섞여 있습니다.
+
+---
+
+## 4. commit
+
+`commit`은 draft를 public state로 승격시킬지 판단하는 엔진입니다.
+
+중심 질문은 다음과 같습니다.
+
+- 현재 선택이 fresh한가
+- blocking hazard가 남아 있는가
+- provenance가 충분한가
+- policy가 merge를 허용하는가
+- public ledger에 append할 수 있는가
+
+즉 commit은 row를 “만드는” 단계라기보다,
+**이미 형성된 draft를 public state로 인정할 수 있는지 검사하는 barrier 단계** 입니다.
+
+현재 레포에선 `GovernancePass`가 이 역할의 일부를 맡고 있습니다.
+
+---
+
+## 5. post-commit / views
+
+public state 이후에는 두 가지가 갈립니다.
+
+### post-commit
+
+- calculation
+- external apply/effect
+- downstream derivation
+
+### views
+
+- draft view
+- review view
+- public export view
+- explanation view
+
+중요:
+이 둘은 core judgment mutation과 분리되어야 합니다.
+특히 emit/public row materialization은 장기적으로 view 쪽에 더 가깝습니다.
+
+---
+
+## 현재 pass와 목표 엔진의 대응
+
+현재 레포를 목표 실행 모델에 대응시키면 대략 다음과 같이 볼 수 있습니다.
+
+### `LexPass`, `ParsePass`
+- frontend
+- raw를 token/claim/frame seed로 올리는 역할
+
+### `ScopeResolutionPass`, `InferencePass`, `SemanticPass`
+- saturation 쪽에 가까움
+- 후보/근거/diagnostic/hazard 관련 상태를 누적
+
+### `RepairPass`
+- arbitration + control이 섞인 상태
+- selection, freeze/reject, stability, receipt가 한 곳에 뭉쳐 있음
+
+### `EmitPass`
+- 장기적으로는 view/materialization으로 더 내려갈 부분이 큼
+- 현재는 row를 materialize하는 bridge 역할
+
+### `GovernancePass`
+- commit barrier 쪽에 가까움
+- hold/merge 판단과 commit receipt를 다룸
+
+### `CalculationPass`
+- post-commit 쪽에 가까움
+- committed/mergeable 상태 이후의 계산을 맡음
+
+즉 현재 pipeline은 완전히 잘못된 구조가 아니라,
+장기적으로는 다른 엔진 경계로 다시 묶여야 하는 **1세대 분해**라고 보는 것이 맞습니다.
+
+---
+
+## migration에서 지켜야 할 것
+
+execution model을 바꾼다고 해서,
+한 번에 본류를 뒤집는 것은 좋지 않습니다.
+
+특히 다음을 섞지 않는 것이 중요합니다.
+
+1. packaging 이동과 의미 변경
+2. façade 제거와 selection semantics 변경
+3. runtime 재배치와 golden/parity 붕괴
+
+즉 장기 execution model은 먼저 문서와 vocabulary로 세우고,
+실제 본류 이동은 adapter와 parity를 유지하면서 점진적으로 하는 편이 맞습니다.
+
+---
+
+## 현재 레포의 위치
+
+현재 레포는 아직 목표 execution model을 직접 실행하지 않습니다.
+
+더 정확히는:
+
+- 본류는 staged pipeline이다
+- 일부 judgment vocabulary는 이미 들어와 있다
+- selection/commit/projection helper도 부분적으로 들어와 있다
+- 그러나 메인 러너가 `saturation → arbitration → commit`을 직접 돌리는 구조는 아니다
+
+즉 지금은 목표 execution model로 가기 위한 bridge 단계입니다.
+
+---
+
+## 요약
+
+장기적으로 `comp`를 가장 자연스럽게 설명하는 실행 모델은:
+
+- frontend
+- saturation
+- arbitration
+- commit
+- post-commit / views
+
+의 구조입니다.
+
+이 관점에서 보면,
+현재 pass chain은 버려야 할 것이 아니라
+**앞으로 다른 엔진 경계로 재정렬될 1세대 구현** 입니다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,25 @@
 ### 현재 코드 흐름이 궁금한 경우
 1. `current-pipeline.md`
 2. `migration-plan.md`
+3. `migration-checklist.md`
 
 ### 새 설계 방향이 궁금한 경우
 1. `architecture.md`
 2. `judgment-core.md`
+3. `migration-plan.md`
+
+### 판정 언어와 의미론이 궁금한 경우
+1. `judgment-language.md`
+2. `core-semantics.md`
+3. `judgment-core.md`
+
+### spec 컴파일 경로가 궁금한 경우
+1. `esgdl-reference.md`
+2. `spec-pipeline.md`
+
+### 목표 실행 모델과 view 구조가 궁금한 경우
+1. `execution-model.md`
+2. `views-ledger.md`
 3. `migration-plan.md`
 
 ## 문서 구성
@@ -33,8 +48,26 @@
 - `judgment-core.md`
   - 장기적으로 밀고 있는 judgment-first 구조와 현재 코드 연결점 설명
 
+- `judgment-language.md`
+  - data와 spec이 공유해야 할 공통 판정 어휘와 judgeable subject 설명
+
+- `core-semantics.md`
+  - 하나의 judgment core, fixpoint, frontier, commit shell 관점의 장기 의미론 설명
+
+- `spec-pipeline.md`
+  - ESGDL/spec가 parse → bind → lower → validate를 거쳐 실행 구조로 내려오는 경로 설명
+
+- `execution-model.md`
+  - staged pass를 장기적으로 어떤 runtime engine 경계로 재배치할지 설명
+
+- `views-ledger.md`
+  - 무엇이 authoritative state이고 무엇이 projection/view인지 설명
+
 - `migration-plan.md`
   - 패키지화, façade 제거, judgment core 흡수 등 이행 작업 추적 문서
+
+- `migration-checklist.md`
+  - PR 단위 완료 조건과 현재 진행 상태를 추적하는 실행 체크리스트
 
 - `testing.md`
   - 테스트가 무엇을 보호하는지 설명하는 문서
@@ -48,3 +81,4 @@
 2. 구현되지 않은 미래 구조를 이미 완료된 것처럼 쓰지 않는다.
 3. bridge 상태를 숨기지 않는다.
 4. README는 바깥 설명, `docs/`는 내부 지도로 역할을 분리한다.
+5. judgment vocabulary와 formal semantics는 별도 문서에서 다루고, 현재 코드 흐름 문서와 섞지 않는다.

--- a/docs/judgment-core.md
+++ b/docs/judgment-core.md
@@ -7,6 +7,15 @@
 현재 레포에 이미 들어온 judgment vocabulary와,
 그 vocabulary가 기존 pipeline에 어디까지 연결되었는지도 함께 적는다.
 
+또한 이 문서는 다음을 전부 대신하지 않는다.
+
+- 공통 판정 언어 전체: `judgment-language.md`
+- 코어 의미론 전체: `core-semantics.md`
+- 목표 실행 모델 전체: `execution-model.md`
+
+즉 이 문서의 중심은
+**현재 레포에 judgment core가 어디까지 들어와 있는가** 이다.
+
 ---
 
 ## 왜 judgment core가 필요한가
@@ -106,7 +115,7 @@ append-only fact 집합과 subject version을 가진다.
 frontier를 계산한다.
 
 ### DraftSnapshot / committable
-draft가 public state로 승격 가능한지 판단하는 barrier 표현이다.
+ draft가 public state로 승격 가능한지 판단하는 barrier 표현이다.
 
 ### ProjectionSpec / project_public_row
 public row를 source of truth로 보는 대신,
@@ -151,26 +160,13 @@ judgment core는 아직 주 실행 모델을 대체하지 않았다.
 
 ---
 
-## 목표 상태
+## 같이 읽을 문서
 
-장기적으로는 다음에 가까워지는 것이 목표다.
-
-```text
-seed facts
-→ transfer rules
-→ fixpoint state
-→ frontier selection
-→ commit barrier
-→ public projection
-→ ledger / receipts
-```
-
-이 상태가 되면:
-
-- data와 spec을 같은 판단 언어로 설명할 수 있고
-- selection과 commit의 이유를 기록할 수 있고
-- emit을 source of truth가 아니라 projection으로 둘 수 있고
-- governance가 mutation보다 barrier/receipt 중심으로 설명 가능해진다
+- 공통 판정 언어: `judgment-language.md`
+- 코어 의미론: `core-semantics.md`
+- 목표 실행 모델: `execution-model.md`
+- view / ledger 구분: `views-ledger.md`
+- 앞으로의 정리 순서: `migration-plan.md`
 
 ---
 

--- a/docs/judgment-language.md
+++ b/docs/judgment-language.md
@@ -1,0 +1,259 @@
+# Judgment Language
+
+이 문서는 `comp`가 장기적으로 공유하려는 **공통 판정 언어**를 설명합니다.
+
+중요:
+이 문서는 “현재 코드에 이미 전부 구현된 것”만 적는 문서가 아닙니다.
+반대로 완전히 공중에 떠 있는 미래 설계만 적는 문서도 아닙니다.
+
+여기서는 다음을 함께 다룹니다.
+
+- 현재 레포에 이미 들어온 judgment vocabulary
+- 앞으로 spec과 data가 같이 공유해야 할 판정 어휘
+- 무엇이 judgeable object인가에 대한 기준
+
+---
+
+## 왜 이 문서가 필요한가
+
+`comp`가 하려는 일은 단순히 row를 만드는 것이 아닙니다.
+
+이 레포는 다음 둘을 함께 다뤄야 합니다.
+
+1. **결과물 쪽 대상**
+   - claim
+   - bundle
+   - draft
+   - public row
+
+2. **생성 틀 쪽 대상**
+   - transfer rule
+   - selection policy
+   - commit policy
+   - projection/schema
+   - compiled program
+
+즉 `comp`는 data만 심사하는 시스템이 아니라,
+**데이터와 생성 틀을 같이 심사하는 시스템**이어야 합니다.
+
+그러려면 둘이 같은 언어를 공유해야 합니다.
+여기서 말하는 “같은 언어”는 같은 문법 파일을 쓴다는 뜻이 아니라,
+**같은 판정 어휘와 같은 판정 기록 구조를 공유한다**는 뜻입니다.
+
+---
+
+## judgeable subject
+
+이 문서에서 subject는 “판정의 대상”을 뜻합니다.
+
+### data-side subject
+
+현재와 장기 구조를 함께 보면, data 쪽 subject는 대체로 다음과 같습니다.
+
+- `claim`
+  - 개별 후보 주장
+- `bundle`
+  - 함께 경쟁하거나 함께 묶어야 하는 후보 집합
+- `draft`
+  - 아직 public state가 되지 않은 중간 상태
+- `public_row`
+  - commit barrier를 통과한 공개 상태
+
+현재 레포는 frame/slot/row 중심 artifact를 많이 사용하므로,
+당분간은 frame/slot 구조가 bundle/draft vocabulary의 bridge 역할을 합니다.
+
+### spec-side subject
+
+장기적으로 spec도 data와 같은 언어로 다뤄야 합니다.
+
+대표적으로는 다음이 subject가 됩니다.
+
+- `transfer_rule`
+- `selection_policy`
+- `commit_policy`
+- `projection`
+- `compiled_program`
+
+즉 rule이나 policy도 “그냥 코드 조각”이 아니라,
+**판정 가능한 객체**로 취급해야 합니다.
+
+---
+
+## 공통 predicate vocabulary
+
+predicate 이름이 현재 코드와 미래 구조에서 완전히 1:1로 같을 필요는 없습니다.
+하지만 다음 판정 어휘는 공통 코어로 유지하는 것이 좋습니다.
+
+### `well_formed`
+구조적으로 성립하는가.
+
+- data 쪽: claim/draft/row가 필요한 모양을 갖췄는가
+- spec 쪽: rule/policy/projection이 허용된 구조를 따르는가
+
+### `supported`
+충분한 근거를 갖는가.
+
+- data 쪽: candidate가 evidence/provenance를 갖는가
+- spec 쪽: rule이 정당한 입력/출력 계약 위에 서 있는가
+
+### `conflicted`
+서로 배타적인 상태가 동시에 열려 있는가.
+
+### `unsafe`
+현재 상태로는 통과시키면 안 되는가.
+
+- data 쪽: hazard가 해소되지 않았는가
+- spec 쪽: provenance 없는 shortcut이나 unsafe projection을 허용하는가
+
+### `stale`
+현재 선택이나 상태가 최신 판단과 어긋나는가.
+
+### `fresh`
+현재 선택이나 상태가 최신 판단을 반영하는가.
+
+### `admissible`
+경쟁 후보 중 대표 후보가 될 자격이 있는가.
+
+### `requires_review`
+자동으로 단일 결론을 내리기보다 검토로 넘겨야 하는가.
+
+### `committable`
+public state로 승격시킬 수 있는가.
+
+중요한 점은,
+이 어휘가 data에만 붙는 것이 아니라 spec에도 붙어야 한다는 것입니다.
+
+---
+
+## 판정 사실의 종류
+
+공통 판정 언어는 단순 predicate 이름만으로 끝나지 않습니다.
+그 predicate가 왜 성립했는지를 기록하는 fact 구조가 필요합니다.
+
+### evidence fact
+어떤 값을 지지하는 근거를 기록합니다.
+
+예:
+- source fragment에서 직접 추출됨
+- infer rule에 의해 생성됨
+- 다른 slot/value를 근거로 도출됨
+
+### hazard fact
+commit이나 대표선출을 막는 위험 신호를 기록합니다.
+
+예:
+- unresolved conflict
+- missing required field
+- insufficient provenance
+- merge policy block
+
+### provenance fact
+현재 상태가 무엇에서 왔는지 기록합니다.
+
+예:
+- fragment → claim
+- claim → bundle summary
+- draft → public row
+- rule/policy → decision path
+
+### obligation fact
+지금 당장 merge하지 말고 review/repair/approval을 요구하는 상태를 기록합니다.
+
+### receipt
+판정의 이유를 남기는 append-only 기록입니다.
+
+- `SelectionReceipt`
+- `CommitReceipt`
+
+### explanation record
+판정 결과를 사람이 읽을 수 있게 다시 투영한 설명 기록입니다.
+
+중요:
+설명은 source of truth가 아닙니다.
+설명은 fact와 receipt를 읽기 좋게 다시 표현한 **view** 입니다.
+
+---
+
+## 같은 언어를 data와 spec에 적용하는 방식
+
+### data validation
+
+data 쪽에서는 보통 다음 질문을 합니다.
+
+- 이 candidate는 `supported`한가
+- 이 draft는 `well_formed`한가
+- 이 winner는 `admissible`한가
+- 이 row는 `committable`한가
+- 이 상태는 `stale`한가
+
+### spec validation
+
+spec 쪽에서는 보통 다음 질문을 합니다.
+
+- 이 rule은 `well_formed`한가
+- 이 selection policy는 `admissible`하지 않은 대표를 허용하는가
+- 이 commit policy는 `unsafe`한 row를 막는가
+- 이 projection은 provenance 손실을 허용하는가
+- 이 compiled program은 `committable`하지 않은 상태를 통과시키는가
+
+즉 validator가 둘인 것이 아니라,
+**같은 judgment vocabulary를 서로 다른 subject에 적용하는 것**이 중요합니다.
+
+---
+
+## 현재 레포의 연결점
+
+현재 레포에는 이미 다음 judgment vocabulary가 들어와 있습니다.
+
+- `SubjectRef`
+- `Fact`
+- `JudgmentState`
+- `TransferRule`
+- `CommitSpec`
+- `ProjectionSpec`
+- `SelectionReceipt`
+- `CommitReceipt`
+
+또한 다음 bridge도 이미 존재합니다.
+
+- `comp.compat.adapters`
+  - legacy artifact를 judgment vocabulary로 번역
+- `comp.views.public`
+  - projection helper 제공
+- `GovernancePass`
+  - `DraftSnapshot`과 `committable()`을 사용해 barrier를 평가
+
+즉 이 문서의 내용은 전부 미래 상상만이 아니라,
+이미 들어온 코드와 앞으로 강화할 방향을 함께 설명합니다.
+
+---
+
+## 아직 고정되지 않은 것
+
+현재 레포에서 아직 완전히 고정되지 않은 부분도 있습니다.
+
+1. predicate 집합의 최종 이름과 범위
+2. obligation lifecycle의 정식 모델
+3. explanation record의 표준 스키마
+4. spec-side subject 전체를 같은 엔진에서 직접 심사하는 경로
+
+즉 지금 단계에서는 공통 판정 언어의 방향은 잡혔지만,
+완전한 canonical schema가 확정된 것은 아닙니다.
+
+---
+
+## 요약
+
+`comp`는 row만 만드는 시스템으로 보면 설명이 부족합니다.
+
+이 레포가 장기적으로 목표로 하는 것은:
+
+- data와 spec을 함께 judgeable object로 보고
+- 같은 predicate vocabulary를 공유하고
+- evidence / hazard / provenance / receipt를 같은 언어로 남기고
+- selection과 commit의 이유를 같은 언어로 설명하는 구조
+
+입니다.
+
+즉 `comp`의 중심 언어는 최종 row schema만이 아니라,
+**판정 가능한 세계 전체를 설명하는 judgment language** 입니다.

--- a/docs/spec-pipeline.md
+++ b/docs/spec-pipeline.md
@@ -1,0 +1,240 @@
+# Spec Pipeline
+
+이 문서는 ESGDL/spec가 어떻게 **실행 가능한 판단 구조**로 내려오는지를 설명합니다.
+
+중요:
+이 문서는 grammar reference가 아닙니다.
+문법 자체의 큰 블록은 `esgdl-reference.md`가 설명합니다.
+
+여기서는 다음 질문에 답합니다.
+
+- DSL은 어떤 중간 표현을 거치는가
+- binder는 무엇을 고정하는가
+- lowering 결과는 어떤 실행용 구조인가
+- spec validation은 왜 필요한가
+- 현재 레포는 어디까지 왔는가
+
+---
+
+## 왜 data pipeline과 별도로 spec pipeline이 필요한가
+
+현재 `comp`를 보기 쉬운 방식은 “raw가 stages를 지나 row가 된다”입니다.
+하지만 장기 구조에서는 그것만으로 설명이 부족합니다.
+
+왜냐하면 `comp`는 data만 처리하는 시스템이 아니라,
+**어떤 rule/policy/projection으로 처리할 것인지까지 심사해야 하는 시스템**이기 때문입니다.
+
+즉 data pipeline만 있는 것이 아니라,
+그 data를 다루는 틀을 만들어 내는 **spec pipeline**도 따로 있어야 합니다.
+
+---
+
+## 입력과 출력
+
+### 입력
+
+입력은 ESGDL/spec 선언입니다.
+
+대표적으로는 다음 선언이 포함됩니다.
+
+- token
+- parser
+- build/bind/inherit/tag
+- infer
+- require/forbid/diagnostic
+- resolver
+- governance
+
+### 출력
+
+출력은 단순 syntax tree가 아니라,
+실행용 의미가 정리된 compiled form 입니다.
+
+장기적으로는 이 출력이
+**`CompiledJudgmentProgram`에 가까운 형태**가 되어야 합니다.
+
+즉 결과물은 “문법을 읽은 트리”가 아니라,
+다음 정보를 가진 실행 구조여야 합니다.
+
+- 어떤 subject가 judgeable한가
+- 어떤 transfer rule이 fact를 생성하는가
+- 어떤 selection 정책이 frontier/winner를 판정하는가
+- 어떤 commit barrier가 public 승격을 막는가
+- 어떤 projection이 public view를 정의하는가
+
+---
+
+## 단계 1: syntax parse
+
+제일 앞단은 syntax를 읽는 단계입니다.
+
+여기서 하는 일은:
+
+- grammar로 source를 파싱
+- AST/ProgramSpec 수준 구조를 생성
+- 선언 블록의 계층과 기본 형태를 잡기
+
+이 단계의 목적은 “실행”이 아니라,
+**무엇이 선언되었는가를 구조적으로 복원하는 것**입니다.
+
+중요:
+이 단계만으로는 아직 rule이 합법한지,
+어떤 host에서 어떤 이름을 참조하는지가 확정되지 않습니다.
+
+---
+
+## 단계 2: binding
+
+binding은 spec pipeline에서 매우 중요한 단계입니다.
+
+이 단계에서 고정해야 하는 것은 단순 이름 치환이 아닙니다.
+
+### binder가 하는 일
+
+- 이름이 무엇을 가리키는지 확정
+- 선언 위치와 사용 위치를 연결
+- host별로 허용된 참조만 통과시킴
+- lexical/source/rule/governance 계열의 의미 범주를 구분
+- 불법 참조나 잘못된 builtin 사용을 조기에 차단
+
+즉 binder는 단순 convenience layer가 아니라,
+**spec가 어떤 판단 세계에서 합법한가를 고정하는 관문** 입니다.
+
+현재 레포의 binder는 이 host-aware binding 방향을 이미 강하게 반영합니다.
+
+---
+
+## 단계 3: lowering
+
+binding이 끝난 spec는 실행용 구조로 내려와야 합니다.
+
+장기적으로 lowering이 만들고 싶은 것은,
+syntax가 아니라 다음과 같은 judgment-oriented program입니다.
+
+- `TransferRule`
+- `BundleSpec`
+- `CommitSpec`
+- `ProjectionSpec`
+- `CompiledJudgmentProgram`
+
+직관적으로는 이렇습니다.
+
+### transfer rule
+어떤 fact 변화가 새 fact를 유도하는가.
+
+### bundle / selection spec
+어떤 후보들이 같이 비교되는가.
+어떤 조건이 frontier/winner/review로 이어지는가.
+
+### commit spec
+어떤 hazard/provenance/freshness 조건이 public 승격을 막는가.
+
+### projection spec
+판정 결과를 바깥에서 어떤 field/view로 materialize할 것인가.
+
+즉 lowering의 결과는 “예쁜 AST”가 아니라,
+**runtime이 직접 사용할 수 있는 판정 프로그램** 입니다.
+
+---
+
+## 단계 4: spec validation
+
+장기적으로 spec도 data와 같은 judgment language로 심사해야 합니다.
+
+즉 validation은 단순 schema check가 아닙니다.
+
+예:
+
+- 이 rule은 `well_formed`한가
+- 이 selection policy는 admissible하지 않은 winner를 허용하는가
+- 이 commit policy는 unsafe한 상태를 막는가
+- 이 projection은 provenance 손실을 과도하게 일으키는가
+
+이 질문은 data validation과 전혀 별개의 세계가 아닙니다.
+핵심 predicate vocabulary는 공유되어야 합니다.
+
+즉 spec pipeline의 마지막은 “컴파일 끝”이 아니라,
+**컴파일된 틀 자체가 판정 가능한가를 본다** 에 가깝습니다.
+
+---
+
+## 현재 레포의 실제 상태
+
+현재 레포는 이미 compiled path를 가지고 있습니다.
+
+예를 들면:
+
+- syntax spec를 읽는다
+- binder가 이름과 builtin 사용을 고정한다
+- compiled spec를 만든다
+- governance/rule evaluation은 compiled form을 읽는다
+
+다만 아직 이 경로가 전부
+`CompiledJudgmentProgram`이라는 이름과 형식으로 정리된 것은 아닙니다.
+
+현재 상태를 더 정확히 말하면:
+
+- compiled path는 이미 존재한다
+- binder도 이미 중요한 역할을 한다
+- 그러나 spec lowering 결과가 judgment-native vocabulary 하나로 완전히 통합된 상태는 아니다
+- 일부는 아직 legacy artifact / compiled spec / pass 구조와 bridge 관계에 있다
+
+즉 지금은 **spec pipeline이 이미 시작되었지만, 아직 judgment-first 용어로 완전히 재서술되지는 않은 상태** 입니다.
+
+---
+
+## `esgdl-reference.md`와의 역할 차이
+
+두 문서는 역할이 다릅니다.
+
+### `esgdl-reference.md`
+
+- ESGDL이 무엇을 선언하는가
+- token/parser/infer/resolver/governance가 무슨 뜻인가
+- 언어의 개념적 지형도
+
+### `spec-pipeline.md`
+
+- 그 선언이 어떤 단계를 거쳐 실행 구조로 내려오는가
+- binder가 무엇을 막고 무엇을 허용하는가
+- lowering 결과가 어떤 실행 의미를 갖는가
+- spec validation이 왜 필요한가
+
+즉 전자는 **언어 설명**, 후자는 **컴파일 경로 설명** 입니다.
+
+---
+
+## 아직 문서가 잠그지 않는 것
+
+이 문서는 다음까지 고정하지는 않습니다.
+
+- 모든 builtin의 전체 시그니처
+- binder error의 전체 목록
+- lowering IR의 최종 필드 스키마
+- `CompiledJudgmentProgram`의 최종 직렬화 포맷
+
+그건 현재 레포가 아직 bridge 단계이기 때문입니다.
+
+대신 이 문서는 다음을 고정합니다.
+
+- spec에도 독립적인 pipeline이 필요하다는 점
+- binder가 핵심 관문이라는 점
+- lowering의 목표는 judgment-oriented executable form 이라는 점
+- spec validation이 data validation과 다른 우주가 아니라는 점
+
+---
+
+## 요약
+
+`comp`에서 ESGDL/spec는 단순 설정 파일이 아닙니다.
+
+spec pipeline은 다음 흐름을 가집니다.
+
+- syntax parse
+- host-aware binding
+- judgment-oriented lowering
+- spec validation
+
+그리고 장기적으로 그 출력은,
+pass chain을 그냥 채우는 설정 값이 아니라
+**runtime이 직접 실행할 판정 프로그램**에 가까워져야 합니다.

--- a/docs/views-ledger.md
+++ b/docs/views-ledger.md
@@ -1,0 +1,223 @@
+# Views and Ledger
+
+이 문서는 `comp`에서 **무엇이 본체 상태이고 무엇이 view/projection인가**를 설명합니다.
+
+중요:
+이 문서는 단순 UI 문서가 아닙니다.
+여기서의 view는 화면을 뜻하는 것이 아니라,
+판정 상태를 바깥에서 읽기 좋은 형태로 **다시 materialize한 표현**을 뜻합니다.
+
+---
+
+## 왜 이 문서가 필요한가
+
+`comp`를 row 중심으로만 보면,
+다음이 쉽게 흐려집니다.
+
+- row가 source of truth인가
+- draft와 public row는 어떻게 다른가
+- emit은 state mutation인가 export인가
+- selection/commit의 이유는 어디에 남는가
+- review/explanation은 본체 상태인가 파생 view인가
+
+장기 구조에서는 이 질문을 분명히 갈라야 합니다.
+
+핵심 기준은 이겁니다.
+
+> **본체는 judgment state와 receipt/log 쪽에 더 가깝고,**
+> **draft/review/public/explanation은 그 상태를 보는 view에 가깝다.**
+
+---
+
+## authoritative state
+
+장기적으로 authoritative state에 가까운 것은 다음 셋입니다.
+
+### 1. JudgmentState / FactStore
+
+가장 중심이 되는 것은 판정 사실들의 상태입니다.
+
+여기에는 대체로 다음이 포함됩니다.
+
+- candidate 관련 사실
+- evidence 관련 사실
+- hazard 관련 사실
+- provenance 관련 사실
+
+즉 public row보다 먼저,
+**무엇이 판정되었는가**가 본체입니다.
+
+### 2. ReceiptLog
+
+selection과 commit의 이유는 append-only 기록으로 남아야 합니다.
+
+대표적으로는:
+
+- `SelectionReceipt`
+- `CommitReceipt`
+
+이 로그가 있어야
+“왜 이 후보가 선택되었는가”,
+“왜 지금 commit이 hold 되었는가”를 다시 설명할 수 있습니다.
+
+### 3. PublicLedger
+
+public row는 아무 row나 임시로 찍어 두는 캐시가 아니라,
+commit barrier를 통과한 결과를 바깥으로 append하는 공개 기록에 가깝습니다.
+
+즉 public 쪽의 핵심은 “현재 row 스냅샷”보다
+**정당한 공개 상태의 누적 기록** 입니다.
+
+---
+
+## derived view
+
+다음 것들은 장기적으로 authoritative state 그 자체라기보다,
+그 상태를 다시 읽기 좋게 표현한 derived view에 가깝습니다.
+
+### DraftView
+
+아직 public commit 되지 않은 상태를 본 view입니다.
+
+예:
+- 현재 active candidate
+- 열린 hazard
+- unresolved bundle
+- provenance 상태
+
+### ReviewView
+
+자동 단일 결론보다 검토가 필요한 상태를 강조한 view입니다.
+
+예:
+- frontier가 여러 개인 bundle
+- stale selection
+- commit blocked draft
+
+### PublicExport
+
+외부 시스템이나 다운스트림 계산이 읽기 쉬운 public projection입니다.
+
+예:
+- canonical row export
+- merge 대상 row snapshot
+
+### ExplanationView
+
+판정 사실과 receipt를 사람이 읽기 좋게 정리한 설명 view입니다.
+
+예:
+- 왜 winner가 바뀌었는가
+- 왜 merge가 hold 되었는가
+- 어떤 evidence와 hazard가 현재 상태를 만들었는가
+
+중요:
+설명 문자열이 본체가 아니라,
+설명은 fact/receipt를 읽기 쉽게 다시 만든 **파생 결과** 입니다.
+
+---
+
+## emit은 mutation보다 materialization에 가깝다
+
+장기 구조에서 emit을 별도 source-of-truth pass로 두면,
+다음이 쉽게 섞입니다.
+
+- 현재 판단 상태
+- 외부에 보여 주기 위한 field projection
+- merge 가능한지 여부
+
+그래서 장기적으로 emit은
+state 본체를 만드는 단계라기보다,
+**판정 결과를 특정 schema/view로 materialize하는 단계**로 보는 것이 더 자연스럽습니다.
+
+이 관점이 있으면 다음 구분이 쉬워집니다.
+
+- row가 보인다고 바로 merge 상태는 아니다
+- draft view가 존재한다고 public ledger에 append된 것은 아니다
+- explanation이 있다고 source of truth가 바뀌는 것은 아니다
+
+---
+
+## append-only와 재계산의 경계
+
+장기적으로는 모든 것을 append-only로 둘 필요는 없습니다.
+
+구분은 이렇게 잡는 편이 좋습니다.
+
+### append-only로 남길 것
+
+- judgment fact의 누적 상태
+- selection/commit receipt
+- public ledger 기록
+
+### 재계산 가능한 것
+
+- draft view
+- review view
+- explanation view
+- public export snapshot
+
+즉 “다 저장한다”가 아니라,
+**무엇을 authoritative하게 남기고 무엇을 projection으로 다시 만들지**를 분리해야 합니다.
+
+---
+
+## 현재 레포의 실제 연결점
+
+현재 레포는 아직 이 모델을 완전히 구현하지는 않았습니다.
+
+하지만 다음 연결점은 이미 있습니다.
+
+### `comp.views.public`
+
+public row materialization helper를 제공하며,
+projection 관점을 코드로 옮기기 시작한 부분입니다.
+
+### `EmitPass`
+
+아직 `artifacts.rows`를 채우지만,
+장기적으로는 view/materialization 계층으로 더 내려갈 수 있는 위치에 있습니다.
+
+### `SelectionReceipt` / `CommitReceipt`
+
+selection과 commit의 이유를 별도 기록으로 남기기 시작한 vocabulary입니다.
+
+### `GovernancePass`
+
+merge/hold 결정과 commit receipt append를 통해,
+barrier와 public append 개념을 일부 반영합니다.
+
+즉 지금 레포는 row를 아직 물리적으로 materialize하지만,
+동시에 row를 projection으로 다시 보려는 vocabulary도 함께 도입한 상태입니다.
+
+---
+
+## 목표 상태
+
+장기적으로는 대략 다음 그림이 자연스럽습니다.
+
+- core: JudgmentState / FactStore
+- append-only logs: ReceiptLog / PublicLedger
+- derived views: DraftView / ReviewView / PublicExport / ExplanationView
+
+이 구조가 되면,
+row와 explanation과 review 화면이 서로 독립 저장소가 아니라
+**같은 판정 세계를 보는 다른 창문**이 됩니다.
+
+---
+
+## 요약
+
+`comp`에서 중요한 것은 row를 많이 만드는 것이 아닙니다.
+
+더 중요한 것은:
+
+- 무엇이 authoritative state인가
+- 무엇이 append-only 기록인가
+- 무엇이 projection/view인가
+
+를 분리하는 것입니다.
+
+장기적으로 `comp`는
+**judgment state + receipt/public ledger를 본체로 두고,**
+**draft/review/public/explanation을 그 위의 view로 두는 구조**를 지향합니다.


### PR DESCRIPTION
## Summary
- add new docs for judgment language, core semantics, spec pipeline, execution model, and views/ledger
- expand `docs/index.md` so the new semantics docs and migration checklist are discoverable
- tighten `architecture.md` and `judgment-core.md` so they point to the new docs instead of trying to hold every layer at once

## Why
The existing docs already explained the current pipeline, bridge state, and migration work well.
What was still missing was the formal/document-level layer for:
- shared judgment vocabulary across data and spec
- one-core / fixpoint / frontier / commit-shell semantics
- spec compilation path
- target execution model
- authoritative state vs. derived view separation

## Notes
- this PR keeps the current docs style: current fact vs long-term target are separated
- no code/runtime behavior changes
- this is documentation-only and intended to reduce overlap between the existing docs while filling the semantics gap