### PR TITLE
docs: fix artifact contract test command

### DIFF
--- a/docs/migration-checklist.md
+++ b/docs/migration-checklist.md
@@ -224,7 +224,7 @@
 ### runtime / artifacts relocation
 - `pytest -q tests/test_runtime_env_package_location.py`
 - `pytest -q tests/test_artifacts_package_location.py`
-- `pytest -q tests/test_artifact_contracts.py`
+- `pytest -q tests/test_artifact_contract.py`
 
 ### compiled path / governance safety
 - `pytest -q tests/test_default_runner_compiled_rule_path.py`


### PR DESCRIPTION
## Summary

- fix the runtime/artifacts relocation verification command in `docs/migration-checklist.md`
- correct `tests/test_artifact_contracts.py` to the actual file name `tests/test_artifact_contract.py`

## Linked PR

Follow-up from #61

## Changes

- Docs-only typo fix in the verification command list.

## Tests

Docs-only update. No tests run.

## Notes

No code changes.
No behavior changes.