### PR TITLE
import: guard package entrypoint eager imports

### DIFF
--- a/comp/__init__.py
+++ b/comp/__init__.py
@@ -1,16 +1,15 @@
-"""Top-level package entrypoint for the experimental comp package."""
+"""Top-level package entrypoint for the experimental comp package.
 
-from comp.runner import (
-    ESGPipelineRunner,
-    CompiledESGPipelineRunner,
-    PipelineResources,
-    PipelineRunResult,
-    compile_program_spec,
-    load_compiled_program_spec_from_dsl,
-    load_program_spec_from_dsl,
-)
+Keep the package import light: runner-facing symbols are resolved lazily so
+``import comp`` does not eagerly import the legacy runner bridge.
+"""
 
-__all__ = [
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_RUNNER_EXPORTS = {
     "ESGPipelineRunner",
     "CompiledESGPipelineRunner",
     "PipelineResources",
@@ -18,4 +17,18 @@ __all__ = [
     "compile_program_spec",
     "load_program_spec_from_dsl",
     "load_compiled_program_spec_from_dsl",
-]
+}
+
+__all__ = sorted(_RUNNER_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _RUNNER_EXPORTS:
+        value = getattr(import_module("comp.runner"), name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | _RUNNER_EXPORTS)

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 from comp import CompiledESGPipelineRunner, ESGPipelineRunner
 from comp.compat.artifacts import CompileArtifacts
 from comp.compat.compiled_spec import CompiledProgramSpec
@@ -11,3 +14,15 @@ def test_package_smoke_imports():
     assert CompiledProgramSpec is not None
     assert LexPass is not None
     assert ParsePass is not None
+
+
+def test_import_comp_does_not_eagerly_import_runner_bridge():
+    script = "\n".join(
+        [
+            "import sys",
+            "import comp",
+            "assert 'comp.runner' not in sys.modules",
+            "assert 'pipeline_runner' not in sys.modules",
+        ]
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
## Summary

- make top-level `comp` runner-facing exports lazy via `__getattr__`
- keep `from comp import ESGPipelineRunner` and related public symbols working
- add a smoke test that `import comp` alone does not eagerly import `comp.runner` or the legacy `pipeline_runner` bridge

## Linked Issue

Closes #63

## Changes

- Updates `comp/__init__.py` to avoid eager runner import at package import time.
- Updates `tests/test_package_smoke.py` with an import-time guard using a fresh Python subprocess.

## Tests

Not run in this environment.

Suggested:

```bash
pytest -q tests/test_package_smoke.py
pytest -q tests/test_runner_package_facades.py tests/test_pipeline_package_facades.py
pytest -q
```

## Notes

No relocation work.
No facade removal.
No runtime behavior changes intended.