### PR TITLE
chore: converge post-relocation imports on package paths

### DIFF
--- a/calculation_pass.py
+++ b/calculation_pass.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from itertools import count
 from typing import Any, Optional
 
-from artifacts import CalculationArtifact, CanonicalRowArtifact, CompileArtifacts
-from runtime_env import RuntimeEnv
+from comp.artifacts import CalculationArtifact, CanonicalRowArtifact, CompileArtifacts
+from comp.runtime_env import RuntimeEnv
 
 
 @dataclass

--- a/compiled_pipeline_runner.py
+++ b/compiled_pipeline_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from compiled_spec import CompiledProgramSpec
+from comp.dsl.compiled_spec import CompiledProgramSpec
 from pipeline_runner import ESGPipelineRunner, load_compiled_program_spec_from_dsl
 
 

--- a/emit_pass.py
+++ b/emit_pass.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact
+from comp.artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact
+from comp.runtime_env import RuntimeEnv
 from comp.views import materialize_public_rows, project_canonical_row
-from runtime_env import RuntimeEnv
 
 
 @dataclass

--- a/governance_pass.py
+++ b/governance_pass.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from itertools import count
 
-from artifacts import CanonicalRowArtifact, CompileArtifacts, GovernanceDecisionArtifact
+from comp.artifacts import CanonicalRowArtifact, CompileArtifacts, GovernanceDecisionArtifact
 from comp.compat.adapters import build_commit_receipt, commit_spec_from_row, draft_snapshot_from_row
+from comp.dsl.compiled_spec import CompiledGovernancePolicy, CompiledProgramSpec
+from comp.eval.expr import EvalContext
+from comp.eval.rule import RuleEvaluator
 from comp.judgment import committable
-from compiled_spec import CompiledGovernancePolicy, CompiledProgramSpec
-from expr_eval import EvalContext
-from rule_eval import RuleEvaluator
-from runtime_env import RuntimeEnv
+from comp.runtime_env import RuntimeEnv
 
 
 @dataclass

--- a/inference_pass.py
+++ b/inference_pass.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from itertools import count
 from typing import Any
 
-from artifacts import (
+from comp.artifacts import (
     ClaimArtifact,
     CompileArtifacts,
     DiagnosticArtifact,
@@ -13,10 +13,10 @@ from artifacts import (
     error_codes_from_diagnostics,
     warning_codes_from_diagnostics,
 )
-from compiled_spec import CompiledProgramSpec
-from expr_eval import EvalContext
-from rule_eval import RuleEvaluator
-from runtime_env import RuntimeEnv, ScopePath
+from comp.dsl.compiled_spec import CompiledProgramSpec
+from comp.eval.expr import EvalContext
+from comp.eval.rule import RuleEvaluator
+from comp.runtime_env import RuntimeEnv, ScopePath
 
 
 @dataclass

--- a/lex_pass.py
+++ b/lex_pass.py
@@ -5,10 +5,10 @@ from dataclasses import dataclass
 from itertools import count
 from typing import Any, Optional
 
-from artifacts import CompileArtifacts, TokenOccurrence
-from compiled_spec import CompiledProgramSpec
-from lex_eval import LexEvaluator
-from runtime_env import LexCandidate, RuntimeEnv
+from comp.artifacts import CompileArtifacts, TokenOccurrence
+from comp.dsl.compiled_spec import CompiledProgramSpec
+from comp.eval.lex import LexEvaluator
+from comp.runtime_env import LexCandidate, RuntimeEnv
 
 
 @dataclass
@@ -194,7 +194,7 @@ class LexPass:
         return out
 
     def _build_eval_context(self, fragment: Any, env: RuntimeEnv):
-        from expr_eval import EvalContext
+        from comp.eval.expr import EvalContext
 
         metadata = getattr(fragment, "metadata", {}) or {}
 

--- a/parse_pass.py
+++ b/parse_pass.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from itertools import count
 from typing import Any, Optional
 
-from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact, TokenOccurrence
-from compiled_spec import CompiledBindAction, CompiledParserInheritAction, CompiledProgramSpec, CompiledTagAction
-from rule_eval import RuleEvaluator
-from runtime_env import RuntimeEnv
-from source_eval import SourceEvaluator
+from comp.artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact, TokenOccurrence
+from comp.dsl.compiled_spec import CompiledBindAction, CompiledParserInheritAction, CompiledProgramSpec, CompiledTagAction
+from comp.eval.rule import RuleEvaluator
+from comp.eval.source_module import SourceEvaluator
+from comp.runtime_env import RuntimeEnv
 
 
 class ParsePass:
@@ -100,7 +100,7 @@ class ParsePass:
         claims_out.extend(claims)
 
     def _build_eval_context(self, fragment: Any, env: RuntimeEnv, frame: PartialFrameArtifact):
-        from expr_eval import EvalContext
+        from comp.eval.expr import EvalContext
         metadata = getattr(fragment, "metadata", {}) or {}
         row = metadata.get("row", {}) if isinstance(metadata, dict) else {}
         row_label = metadata.get("row_label") if isinstance(metadata, dict) else None

--- a/pipeline_runner.py
+++ b/pipeline_runner.py
@@ -4,21 +4,21 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, Protocol, Sequence
 
-from artifacts import CompileArtifacts
 from binder import Binder
-from esg_builtins import register_default_builtins
 from calculation_pass import CalculationPass
-from compiled_spec import CompiledProgramSpec
+from comp.artifacts import CompileArtifacts
+from comp.builtins.esg import register_default_builtins
+from comp.dsl.compiled_spec import CompiledProgramSpec
+from comp.dsl.spec_nodes import ProgramSpec
+from comp.runtime_env import RuntimeEnv, SiteRecord, build_runtime_env
 from emit_pass import EmitPass
 from governance_pass import GovernancePass
 from inference_pass import InferencePass
 from lex_pass import LexPass
 from parse_pass import ParsePass
 from repair_pass import RepairPass
-from runtime_env import RuntimeEnv, SiteRecord, build_runtime_env
 from scope_resolution_pass import ScopeResolutionPass
 from semantic_pass import SemanticPass, SemanticPassConfig
-from spec_nodes import ProgramSpec
 
 
 class Fragmentizer(Protocol):

--- a/repair_pass.py
+++ b/repair_pass.py
@@ -4,7 +4,7 @@ from dataclasses import asdict, dataclass
 from itertools import count
 from typing import Any, Optional
 
-from artifacts import (
+from comp.artifacts import (
     ClaimArtifact,
     CompileArtifacts,
     PartialFrameArtifact,
@@ -12,10 +12,10 @@ from artifacts import (
     diagnostic_codes,
 )
 from comp.compat.adapters import build_slot_selection_receipt
-from compiled_spec import CompiledProgramSpec, CompiledResolverPolicy
-from expr_eval import EvalContext
-from rule_eval import RuleEvaluator
-from runtime_env import RuntimeEnv
+from comp.dsl.compiled_spec import CompiledProgramSpec, CompiledResolverPolicy
+from comp.eval.expr import EvalContext
+from comp.eval.rule import RuleEvaluator
+from comp.runtime_env import RuntimeEnv
 
 
 @dataclass

--- a/scope_resolution_pass.py
+++ b/scope_resolution_pass.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass
 from itertools import count
 from typing import Any, Optional
 
-from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
-from compiled_spec import CompiledProgramSpec
-from rule_eval import RuleEvaluator
-from runtime_env import RuntimeEnv, ScopePath
-from source_eval import SourceEvaluator
-from spec_nodes import ContextPolicy
+from comp.artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
+from comp.dsl.compiled_spec import CompiledProgramSpec
+from comp.dsl.spec_nodes import ContextPolicy
+from comp.eval.rule import RuleEvaluator
+from comp.eval.source_module import SourceEvaluator
+from comp.runtime_env import RuntimeEnv, ScopePath
 
 
 YEAR_ONLY_RE = re.compile(r"^20\d{2}$")
@@ -196,5 +196,5 @@ class ScopeResolutionPass:
         return getattr(frag, "scope_path", tuple())
 
     def _make_eval_context(self, *, env: RuntimeEnv, scope_path: ScopePath, frame: PartialFrameArtifact, claims_by_id: dict[str, ClaimArtifact]):
-        from expr_eval import EvalContext
+        from comp.eval.expr import EvalContext
         return EvalContext(env=env, text="", scope_path=scope_path, frame=frame, claims_by_id=claims_by_id, local_vars={"frame_type": frame.frame_type, "status": frame.status})

--- a/semantic_pass.py
+++ b/semantic_pass.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass
 from itertools import count
 from typing import Any
 
-from artifacts import CompileArtifacts, DiagnosticArtifact, PartialFrameArtifact
-from compiled_spec import CompiledProgramSpec
-from expr_eval import EvalContext
-from rule_eval import RuleEvaluator
-from runtime_env import RuntimeEnv
+from comp.artifacts import CompileArtifacts, DiagnosticArtifact, PartialFrameArtifact
+from comp.dsl.compiled_spec import CompiledProgramSpec
+from comp.eval.expr import EvalContext
+from comp.eval.rule import RuleEvaluator
+from comp.runtime_env import RuntimeEnv
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- converge runner/pass imports onto relocated `comp.*` package paths after `runtime_env` and `artifacts` relocation
- update runner-adjacent files to import relocated contracts from `comp.artifacts`, `comp.runtime_env`, `comp.dsl.*`, `comp.eval.*`, and `comp.builtins.*`
- keep top-level pass/runner implementations in place; this PR does not relocate runner modules

## Linked Issue

Closes #56

## Changes

- Updates import paths in:
  - `pipeline_runner.py`
  - `compiled_pipeline_runner.py`
  - `lex_pass.py`
  - `parse_pass.py`
  - `scope_resolution_pass.py`
  - `inference_pass.py`
  - `semantic_pass.py`
  - `repair_pass.py`
  - `emit_pass.py`
  - `governance_pass.py`
  - `calculation_pass.py`

## Tests

Not run in this environment. Local clone failed because the execution environment could not resolve `github.com`.

Suggested verification:

```bash
pytest -q tests/test_package_smoke.py
pytest -q tests/test_runner_package_facades.py tests/test_pipeline_package_facades.py
pytest -q
```

## Notes

- No behavior change intended.
- No runner relocation included.
- No facade removal included.
- No emit/governance architecture refactor included.
- The branch is based on the prior main commit and may need a trivial update if GitHub reports it behind the current base.
