### PR TITLE
packaging: relocate runner-adjacent implementation into package

### DIFF
--- a/comp/compat/compiled_pipeline_runner.py
+++ b/comp/compat/compiled_pipeline_runner.py
@@ -1,7 +1,3 @@
-import importlib
-
-_legacy = importlib.import_module("compiled_pipeline_runner")
-
-CompiledESGPipelineRunner = getattr(_legacy, "CompiledESGPipelineRunner")
+from comp.compiled_pipeline_runner import CompiledESGPipelineRunner
 
 __all__ = ["CompiledESGPipelineRunner"]

--- a/comp/compat/pipeline_runner.py
+++ b/comp/compat/pipeline_runner.py
@@ -1,13 +1,11 @@
-import importlib
-
-_legacy = importlib.import_module("pipeline_runner")
-
-ESGPipelineRunner = getattr(_legacy, "ESGPipelineRunner")
-PipelineResources = getattr(_legacy, "PipelineResources")
-PipelineRunResult = getattr(_legacy, "PipelineRunResult")
-compile_program_spec = getattr(_legacy, "compile_program_spec")
-load_compiled_program_spec_from_dsl = getattr(_legacy, "load_compiled_program_spec_from_dsl")
-load_program_spec_from_dsl = getattr(_legacy, "load_program_spec_from_dsl")
+from comp.pipeline_runner import (
+    ESGPipelineRunner,
+    PipelineResources,
+    PipelineRunResult,
+    compile_program_spec,
+    load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl,
+)
 
 __all__ = [
     "ESGPipelineRunner",

--- a/comp/compiled_pipeline_runner.py
+++ b/comp/compiled_pipeline_runner.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from comp.dsl.compiled_spec import CompiledProgramSpec
+from comp.pipeline_runner import ESGPipelineRunner, load_compiled_program_spec_from_dsl
+
+
+class CompiledESGPipelineRunner(ESGPipelineRunner):
+    def load_spec(
+        self,
+        *,
+        dsl_path: str | Path | None = None,
+        dsl_text: str | None = None,
+    ) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(
+            grammar_path=self.grammar_path,
+            dsl_path=dsl_path,
+            dsl_text=dsl_text,
+        )
+
+
+__all__ = ["CompiledESGPipelineRunner"]

--- a/comp/pipeline_runner.py
+++ b/comp/pipeline_runner.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Protocol, Sequence
+
+from binder import Binder
+from comp.artifacts import CompileArtifacts
+from comp.builtins.esg import register_default_builtins
+from comp.dsl.compiled_spec import CompiledProgramSpec
+from comp.dsl.spec_nodes import ProgramSpec
+from comp.pipeline.calculation import CalculationPass
+from comp.pipeline.emit import EmitPass
+from comp.pipeline.governance import GovernancePass
+from comp.pipeline.infer import InferencePass
+from comp.pipeline.lex import LexPass
+from comp.pipeline.parsing import ParsePass
+from comp.pipeline.repair import RepairPass
+from comp.pipeline.scope import ScopeResolutionPass
+from comp.pipeline.semantic import SemanticPass, SemanticPassConfig
+from comp.runtime_env import RuntimeEnv, SiteRecord, build_runtime_env
+
+
+class Fragmentizer(Protocol):
+    def __call__(self, documents: Sequence[Any]) -> list[Any]:
+        ...
+
+
+class CompilerPass(Protocol):
+    def run(self, spec: ProgramSpec | CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        ...
+
+
+@dataclass
+class PipelineResources:
+    site_records: Sequence[SiteRecord] = field(default_factory=list)
+    factor_rows: Sequence[dict[str, Any]] = field(default_factory=list)
+    policy_flags: dict[str, Any] = field(default_factory=dict)
+    activity_aliases: dict[str, list[str]] = field(default_factory=dict)
+    unit_aliases: dict[str, list[str]] = field(default_factory=dict)
+    llm_fallback: Optional[Any] = None
+    llm_budget: int = 0
+
+
+@dataclass
+class PipelineRunResult:
+    spec: ProgramSpec | CompiledProgramSpec
+    env: RuntimeEnv
+    artifacts: CompileArtifacts
+
+    def summary(self) -> dict[str, Any]:
+        frame_status_counts: dict[str, int] = {}
+        for f in self.artifacts.frames:
+            frame_status_counts[f.status] = frame_status_counts.get(f.status, 0) + 1
+
+        row_status_counts: dict[str, int] = {}
+        for r in self.artifacts.rows:
+            row_status_counts[r.status] = row_status_counts.get(r.status, 0) + 1
+
+        calc_status_counts: dict[str, int] = {}
+        for c in self.artifacts.calculations:
+            calc_status_counts[c.calculation_status] = calc_status_counts.get(c.calculation_status, 0) + 1
+
+        return {
+            "module_name": self.spec.module_name,
+            "fragments": len(self.artifacts.fragments),
+            "tokens": len(self.artifacts.tokens),
+            "claims": len(self.artifacts.claims),
+            "frames": len(self.artifacts.frames),
+            "rows": len(self.artifacts.rows),
+            "calculations": len(self.artifacts.calculations),
+            "frame_status_counts": frame_status_counts,
+            "row_status_counts": row_status_counts,
+            "calculation_status_counts": calc_status_counts,
+            "merge_decisions": len(self.artifacts.merge_log),
+            "events": len(self.artifacts.event_log),
+            "diagnostics": len(self.artifacts.diagnostics),
+            "llm_budget_remaining": self.env.llm_budget_remaining,
+        }
+
+
+def load_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> ProgramSpec:
+    if dsl_text is None and dsl_path is None:
+        raise ValueError("one of dsl_text or dsl_path must be provided")
+    grammar = Path(grammar_path).read_text(encoding="utf-8")
+    source = dsl_text if dsl_text is not None else Path(dsl_path).read_text(encoding="utf-8")
+    from lark import Lark
+    from ast_builder import ASTBuilder
+    from lowering import Lowerer
+
+    parser = Lark(grammar, parser="lalr", lexer="contextual", start="start")
+    tree = parser.parse(source)
+    return Lowerer().lower(ASTBuilder().transform(tree))
+
+
+def compile_program_spec(program_spec: ProgramSpec) -> CompiledProgramSpec:
+    return Binder().bind(program_spec)
+
+
+def load_compiled_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
+    return compile_program_spec(load_program_spec_from_dsl(grammar_path=grammar_path, dsl_path=dsl_path, dsl_text=dsl_text))
+
+
+def build_default_passes(*, include_post_repair_semantic: bool = False) -> list[CompilerPass]:
+    passes: list[CompilerPass] = [
+        LexPass(),
+        ParsePass(),
+        ScopeResolutionPass(),
+        InferencePass(),
+        SemanticPass(config=SemanticPassConfig(phase_label="semantic_pre")),
+        RepairPass(),
+    ]
+    if include_post_repair_semantic:
+        passes.append(SemanticPass(config=SemanticPassConfig(phase_label="semantic_post")))
+    passes.extend([EmitPass(), GovernancePass(), CalculationPass()])
+    return passes
+
+
+class ESGPipelineRunner:
+    def __init__(self, *, grammar_path: str | Path = "esgdl.lark", passes: Optional[list[CompilerPass]] = None, fragmentizer: Optional[Fragmentizer] = None) -> None:
+        self.grammar_path = Path(grammar_path)
+        self.fragmentizer = fragmentizer
+        self.passes = passes or build_default_passes()
+
+    def load_spec(self, *, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(grammar_path=self.grammar_path, dsl_path=dsl_path, dsl_text=dsl_text)
+
+    def build_env(self, *, spec: ProgramSpec | CompiledProgramSpec, resources: Optional[PipelineResources] = None) -> RuntimeEnv:
+        resources = resources or PipelineResources()
+        syntax_spec = spec.syntax if isinstance(spec, CompiledProgramSpec) else spec
+        env = build_runtime_env(spec=syntax_spec, site_records=list(resources.site_records), factor_rows=list(resources.factor_rows), policy_flags=dict(resources.policy_flags), activity_aliases=dict(resources.activity_aliases), unit_aliases=dict(resources.unit_aliases), llm_fallback=resources.llm_fallback, llm_budget=resources.llm_budget)
+        register_default_builtins(env)
+        return env
+
+    def prepare_fragments(self, *, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None) -> list[Any]:
+        if fragments is not None:
+            return fragments
+        if documents is None:
+            raise ValueError("one of fragments or documents must be provided")
+        if self.fragmentizer is None:
+            raise ValueError("documents were provided but no fragmentizer is configured. Either pass pre-built fragments or inject a fragmentizer callable.")
+        return self.fragmentizer(documents)
+
+    def run(self, *, spec: Optional[ProgramSpec | CompiledProgramSpec] = None, dsl_path: str | Path | None = None, dsl_text: str | None = None, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None, resources: Optional[PipelineResources] = None) -> PipelineRunResult:
+        if spec is None:
+            spec = self.load_spec(dsl_path=dsl_path, dsl_text=dsl_text)
+        elif not isinstance(spec, CompiledProgramSpec):
+            spec = compile_program_spec(spec)
+
+        env = self.build_env(spec=spec, resources=resources)
+        prepared_fragments = self.prepare_fragments(fragments=fragments, documents=documents)
+        artifacts = CompileArtifacts(fragments=prepared_fragments)
+        for p in self.passes:
+            artifacts = p.run(spec, artifacts, env)
+        return PipelineRunResult(spec=spec, env=env, artifacts=artifacts)
+
+
+__all__ = [
+    "Fragmentizer",
+    "CompilerPass",
+    "PipelineResources",
+    "PipelineRunResult",
+    "load_program_spec_from_dsl",
+    "compile_program_spec",
+    "load_compiled_program_spec_from_dsl",
+    "build_default_passes",
+    "ESGPipelineRunner",
+]

--- a/comp/runner.py
+++ b/comp/runner.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional
 
-from comp.compat.compiled_pipeline_runner import CompiledESGPipelineRunner as _LegacyCompiledRunner
-from comp.compat.pipeline_runner import (
-    ESGPipelineRunner as _LegacyRunner,
+from comp.compiled_pipeline_runner import CompiledESGPipelineRunner as _PackageCompiledRunner
+from comp.pipeline_runner import (
+    ESGPipelineRunner as _PackageRunner,
     PipelineResources,
     PipelineRunResult,
     compile_program_spec,
@@ -16,7 +16,7 @@ from comp.compat.pipeline_runner import (
 _DEFAULT_GRAMMAR_PATH = Path(__file__).resolve().parent / "dsl" / "esgdl.lark"
 
 
-class ESGPipelineRunner(_LegacyRunner):
+class ESGPipelineRunner(_PackageRunner):
     def __init__(
         self,
         *,
@@ -31,7 +31,7 @@ class ESGPipelineRunner(_LegacyRunner):
         )
 
 
-class CompiledESGPipelineRunner(_LegacyCompiledRunner):
+class CompiledESGPipelineRunner(_PackageCompiledRunner):
     def __init__(
         self,
         *,

--- a/compiled_pipeline_runner.py
+++ b/compiled_pipeline_runner.py
@@ -1,20 +1,3 @@
-from __future__ import annotations
+from comp.compiled_pipeline_runner import CompiledESGPipelineRunner
 
-from pathlib import Path
-
-from comp.dsl.compiled_spec import CompiledProgramSpec
-from pipeline_runner import ESGPipelineRunner, load_compiled_program_spec_from_dsl
-
-
-class CompiledESGPipelineRunner(ESGPipelineRunner):
-    def load_spec(
-        self,
-        *,
-        dsl_path: str | Path | None = None,
-        dsl_text: str | None = None,
-    ) -> CompiledProgramSpec:
-        return load_compiled_program_spec_from_dsl(
-            grammar_path=self.grammar_path,
-            dsl_path=dsl_path,
-            dsl_text=dsl_text,
-        )
+__all__ = ["CompiledESGPipelineRunner"]

--- a/docs/facade-inventory.md
+++ b/docs/facade-inventory.md
@@ -66,10 +66,12 @@ legacy artifact shape와 target judgment vocabulary 사이를 번역하는 modul
 
 | Module | Current role | Notes | Later action |
 |---|---|---|---|
-| `comp.__init__` | Public API facade | `comp.runner`의 runner API를 top-level package에서 노출한다. | eager import 부담은 A2에서 점검 |
-| `comp.runner` | Public API facade / temporary runner facade | legacy runner class를 상속하고 package grammar path 기본값을 주입한다. | runner relocation 후 실제 package runner surface로 재분류 |
+| `comp.__init__` | Public API facade | runner-facing symbols를 lazy export한다. | 유지하되 eager import는 계속 감시 |
+| `comp.runner` | Public API facade | package runner implementation 위에 package-local default grammar path를 주입한다. | 유지 |
+| `comp.pipeline_runner` | Actual implementation | staged runner implementation을 package가 소유한다. | 유지 |
+| `comp.compiled_pipeline_runner` | Actual implementation | compiled runner implementation을 package가 소유한다. | 유지 |
 
-`comp.runner`는 단순 re-export보다 조금 두껍다. 현재는 기본 grammar path를 package 내부로 잡아 주는 public convenience layer 역할을 한다. 하지만 실제 runner implementation은 아직 legacy runner 쪽에 있으므로, runner relocation 전까지는 temporary runner facade로도 봐야 한다.
+`comp.runner`는 단순 re-export보다 조금 두껍다. 현재는 기본 grammar path를 package 내부로 잡아 주는 public convenience layer 역할을 한다. 실제 runner implementation은 `comp.pipeline_runner` / `comp.compiled_pipeline_runner`가 소유한다.
 
 ---
 
@@ -99,8 +101,8 @@ legacy artifact shape와 target judgment vocabulary 사이를 번역하는 modul
 
 | Module | Current role | Notes | Later action |
 |---|---|---|---|
-| `comp.compat.pipeline_runner` | Temporary migration bridge | top-level `pipeline_runner`를 importlib로 참조한다. | runner relocation 후 package implementation re-export로 축소 |
-| `comp.compat.compiled_pipeline_runner` | Temporary migration bridge | top-level `compiled_pipeline_runner`를 importlib로 참조한다. | runner relocation 후 package implementation re-export로 축소 |
+| `comp.compat.pipeline_runner` | Legacy compatibility wrapper | `comp.pipeline_runner` package implementation을 re-export한다. | compatibility 방침 정리 후 제거/축소 검토 |
+| `comp.compat.compiled_pipeline_runner` | Legacy compatibility wrapper | `comp.compiled_pipeline_runner` package implementation을 re-export한다. | compatibility 방침 정리 후 제거/축소 검토 |
 | `comp.compat.artifacts` | Legacy compatibility wrapper | 이미 `comp.artifacts` package implementation을 re-export한다. | top-level compatibility 방침이 정리될 때까지 유지 |
 | `comp.compat.adapters` | Bridge adapter | legacy artifact object를 judgment receipt / frontier / commit vocabulary로 번역한다. | judgment core absorption 이후 축소 또는 재배치 후보 |
 
@@ -141,8 +143,10 @@ legacy artifact shape와 target judgment vocabulary 사이를 번역하는 modul
 |---|---|---|---|
 | `runtime_env.py` | Legacy compatibility wrapper | `comp.runtime_env` | compatibility policy 이후 제거/축소 검토 |
 | `artifacts.py` | Legacy compatibility wrapper | `comp.artifacts` | compatibility policy 이후 제거/축소 검토 |
+| `pipeline_runner.py` | Legacy compatibility wrapper | `comp.pipeline_runner` | compatibility policy 이후 제거/축소 검토 |
+| `compiled_pipeline_runner.py` | Legacy compatibility wrapper | `comp.compiled_pipeline_runner` | compatibility policy 이후 제거/축소 검토 |
 
-이 둘은 더 이상 top-level implementation으로 보면 안 된다. 현재는 legacy import path 보존을 위한 wrapper다.
+이 파일들은 더 이상 top-level implementation으로 보면 안 된다. 현재는 legacy import path 보존을 위한 wrapper다.
 
 ---
 
@@ -150,8 +154,6 @@ legacy artifact shape와 target judgment vocabulary 사이를 번역하는 modul
 
 | Module family | Current role | Notes | Later action |
 |---|---|---|---|
-| `pipeline_runner.py` | Legacy implementation | main staged runner implementation | PR-R3에서 package-owned implementation으로 이동 |
-| `compiled_pipeline_runner.py` | Legacy implementation | compiled runner implementation | PR-R3에서 package-owned implementation으로 이동 |
 | `*_pass.py` modules | Legacy pass implementation | current staged pipeline pass bodies | pass relocation 또는 architecture cleanup에서 점진 이동 |
 
 이 영역은 아직 public package surface와 implementation owner가 분리되어 있다. 즉 `comp.pipeline.*`가 존재한다고 해서 pass implementation까지 package로 이동한 것은 아니다.
@@ -165,8 +167,9 @@ legacy artifact shape와 target judgment vocabulary 사이를 번역하는 modul
 | Candidate | Remove only after |
 |---|---|
 | `comp.pipeline.*` importlib bridges | 해당 pass implementation이 package path로 이동하고 parity tests가 생긴 뒤 |
-| `comp.compat.pipeline_runner` / `compiled_pipeline_runner` legacy bridges | runner implementation이 package path로 이동한 뒤 |
+| `comp.compat.pipeline_runner` / `compiled_pipeline_runner` wrappers | compatibility / deprecation policy가 정리된 뒤 |
 | top-level `runtime_env.py` / `artifacts.py` wrappers | compatibility / deprecation policy가 정리된 뒤 |
+| top-level `pipeline_runner.py` / `compiled_pipeline_runner.py` wrappers | compatibility / deprecation policy가 정리된 뒤 |
 | old top-level evaluator / DSL / IR wrappers | package path가 충분히 안정되고 downstream compatibility 방침이 정리된 뒤 |
 | `comp.compat.adapters` | judgment core가 더 많은 실행 경로를 직접 담당하고 legacy artifact translation 경계가 줄어든 뒤 |
 
@@ -176,9 +179,9 @@ legacy artifact shape와 target judgment vocabulary 사이를 번역하는 modul
 
 ### 4.1 Eager import risk
 
-`comp.__init__` imports `comp.runner`, and `comp.runner` imports compat runner bridges. That means top-level `import comp` may pull runner-adjacent legacy paths earlier than desired.
+`comp.__init__` lazily resolves runner-facing symbols so plain `import comp` should not eagerly import runner implementation.
 
-This should be audited under A-track eager import / cycle work.
+This should continue to be audited under A-track eager import / cycle work.
 
 ### 4.2 Bridge invisibility risk
 

--- a/docs/facade-thinness.md
+++ b/docs/facade-thinness.md
@@ -153,7 +153,7 @@ __all__ = ["EmitPass"]
 - 내부 implementation owner가 명확하다.
 - default가 바뀌면 테스트나 PR 본문에서 명시한다.
 
-`comp.runner`는 현재 이 범주와 temporary runner facade 사이에 있다. package grammar path 기본값을 주입하지만, 실제 runner implementation은 아직 legacy runner에 있다. 따라서 runner relocation 전까지는 public convenience facade이면서 temporary runner facade로 취급한다.
+`comp.runner`는 이 범주에 해당한다. 기본 grammar path를 package 내부로 잡아 주는 public convenience layer이고, 실제 runner behavior는 `comp.pipeline_runner` / `comp.compiled_pipeline_runner`가 소유한다.
 
 ---
 
@@ -203,7 +203,7 @@ class CompileArtifacts(CompileArtifacts):
 
 - `comp.pipeline.emit` wrapper 안에서 public projection semantics를 새로 구현
 - `comp.pipeline.governance` wrapper 안에서 commit barrier 판단을 바꿈
-- `comp.compat.pipeline_runner`에서 pass order를 바꿈
+- compatibility wrapper에서 pass order를 바꿈
 
 architecture work는 별도 issue / PR로 분리한다.
 
@@ -340,11 +340,11 @@ Wrapper / facade 관련 PR은 다음을 확인한다.
 
 현재 inventory 기준으로 적용하면 다음과 같다.
 
-- `comp.eval.*` and `comp.builtins.*`
+- `comp.eval.*`, `comp.builtins.*`, `comp.pipeline_runner`, and `comp.compiled_pipeline_runner`
   - package-owned implementation 영역이다.
   - 새 code는 이 경로를 기준으로 써야 한다.
 
-- `runtime_env.py` and `artifacts.py`
+- `runtime_env.py`, `artifacts.py`, `pipeline_runner.py`, and `compiled_pipeline_runner.py`
   - legacy compatibility wrapper다.
   - package implementation을 re-export해야 하며 behavior를 추가하면 안 된다.
 
@@ -354,12 +354,12 @@ Wrapper / facade 관련 PR은 다음을 확인한다.
   - package-owned implementation처럼 설명하면 안 된다.
 
 - `comp.compat.pipeline_runner` and `comp.compat.compiled_pipeline_runner`
-  - runner relocation 전 temporary migration bridge다.
-  - runner behavior를 추가하면 안 된다.
+  - legacy compatibility wrapper다.
+  - package runner implementation을 re-export해야 하며 runner behavior를 추가하면 안 된다.
 
 - `comp.runner`
-  - public convenience facade이지만, 실제 runner implementation은 아직 legacy에 있다.
-  - runner relocation 후 재분류가 필요하다.
+  - public convenience facade다.
+  - package-owned runner implementation 위에 default grammar path를 주입한다.
 
 - `comp.compat.adapters`
   - explicit bridge adapter다.
@@ -374,7 +374,6 @@ Wrapper / facade 관련 PR은 다음을 확인한다.
 다음 follow-up은 별도 issue / PR로 나눈다.
 
 - eager import / cycle audit
-- runner-adjacent relocation
 - pass implementation relocation
 - compatibility wrapper deprecation policy
 - adapter boundary tests

--- a/docs/migration-checklist.md
+++ b/docs/migration-checklist.md
@@ -63,6 +63,11 @@
   - top-level `artifacts.py`는 compatibility wrapper로 축소
   - `comp.compat.artifacts`는 package implementation을 참조
   - artifact identity / parity smoke test 추가
+- [x] **PR-R3: relocate runner-adjacent modules**
+  - `comp.pipeline_runner` / `comp.compiled_pipeline_runner`가 실제 runner implementation을 소유
+  - top-level `pipeline_runner.py` / `compiled_pipeline_runner.py`는 compatibility wrapper로 축소
+  - `comp.compat.pipeline_runner` / `comp.compat.compiled_pipeline_runner`는 package implementation을 참조
+  - runner wrapper / package parity test 갱신
 
 #### B-track: façade 축소 기준 수립
 - [x] **PR-B0: facade inventory / thinness audit**
@@ -79,9 +84,8 @@
 현재 레포는 정리 완료 상태가 아니라 **의도적 bridge 단계**다.
 
 - [ ] top-level legacy 모듈이 아직 배포 표면에 남아 있다.
-- [ ] `runtime_env.py` / `artifacts.py`는 아직 top-level compatibility wrapper로 남아 있다.
-- [ ] `pipeline_runner.py`는 아직 main runner implementation이다.
-- [ ] 일부 `comp.pipeline.*` / `comp.compat.*` 모듈은 여전히 thin wrapper 또는 legacy bridge다.
+- [ ] `runtime_env.py` / `artifacts.py` / `pipeline_runner.py` / `compiled_pipeline_runner.py`는 아직 top-level compatibility wrapper로 남아 있다.
+- [ ] 일부 `comp.pipeline.*` 모듈은 여전히 thin wrapper 또는 legacy bridge다.
 - [ ] `pyproject.toml`의 `py-modules`에는 legacy top-level 모듈들이 아직 포함되어 있다.
 
 ---
@@ -109,12 +113,6 @@
 
 ### Next (다음)
 
-#### R-track: runner-adjacent relocation
-- [ ] **PR-R3: relocate runner-adjacent modules**
-  - `pipeline_runner.py` / `compiled_pipeline_runner.py` 주변을 package implementation으로 이동
-  - top-level runner는 compatibility wrapper로 축소
-  - package runner와 legacy runner의 parity 유지
-
 #### Architecture track (초기)
 - [ ] **PR-C1: emit/governance boundary 정리 시작**
   - emit projection 경계와 governance barrier 경계 분리
@@ -123,6 +121,11 @@
 ---
 
 ### Later (후속)
+
+#### R-track: pass implementation relocation
+- [ ] **PR-R4: relocate pass implementation modules**
+  - `*_pass.py` implementation을 package-owned modules로 점진 이동
+  - `comp.pipeline.*` temporary bridges를 package implementation re-export로 재분류
 
 #### Architecture track (본격)
 - [ ] **PR-D: judgment core 본류 흡수**
@@ -241,6 +244,7 @@
   - `compiled_spec` relocation 완료
   - `runtime_env` relocation 완료
   - `artifacts` relocation 완료
+  - runner-adjacent relocation 완료
   - façade inventory / thinness audit 완료
   - façade thinness rule 문서화 완료
   - `comp.eval.compiled_expr` / `comp.eval.lex` / `comp.eval.source_module` / `comp.dsl.compiled_spec`의 package DSL import 정합성 확인
@@ -249,13 +253,15 @@
   - `compiled_spec`는 완료된 `PR-R2a`로 이동
   - `runtime_env`는 완료된 `PR-R2b`로 이동
   - `artifacts`는 완료된 `PR-R2c`로 이동
+- `comp.pipeline_runner` / `comp.compiled_pipeline_runner`가 runner implementation을 소유하도록 이동했다.
+- top-level runner files와 `comp.compat.*runner`는 package implementation wrapper로 축소했다.
 - `docs/facade-inventory.md`를 추가해 wrapper / bridge / facade 상태를 분류했다.
 - `docs/facade-thinness.md`를 추가해 wrapper 허용/금지 규칙을 정리했다.
 - 다음 액션을 다음 순서로 재정렬했다.
   1. runtime/artifact 이동 후 package/compat import 정리
   2. eager import / cycle 점검
-  3. runner-adjacent relocation
-  4. emit/governance boundary 정리
+  3. emit/governance boundary 정리
+  4. pass implementation relocation
 
 ### 2026-04-23
 

--- a/pipeline_runner.py
+++ b/pipeline_runner.py
@@ -1,155 +1,23 @@
-from __future__ import annotations
+from comp.pipeline_runner import (
+    CompilerPass,
+    ESGPipelineRunner,
+    Fragmentizer,
+    PipelineResources,
+    PipelineRunResult,
+    build_default_passes,
+    compile_program_spec,
+    load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl,
+)
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Optional, Protocol, Sequence
-
-from binder import Binder
-from calculation_pass import CalculationPass
-from comp.artifacts import CompileArtifacts
-from comp.builtins.esg import register_default_builtins
-from comp.dsl.compiled_spec import CompiledProgramSpec
-from comp.dsl.spec_nodes import ProgramSpec
-from comp.runtime_env import RuntimeEnv, SiteRecord, build_runtime_env
-from emit_pass import EmitPass
-from governance_pass import GovernancePass
-from inference_pass import InferencePass
-from lex_pass import LexPass
-from parse_pass import ParsePass
-from repair_pass import RepairPass
-from scope_resolution_pass import ScopeResolutionPass
-from semantic_pass import SemanticPass, SemanticPassConfig
-
-
-class Fragmentizer(Protocol):
-    def __call__(self, documents: Sequence[Any]) -> list[Any]:
-        ...
-
-
-class CompilerPass(Protocol):
-    def run(self, spec: ProgramSpec | CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
-        ...
-
-
-@dataclass
-class PipelineResources:
-    site_records: Sequence[SiteRecord] = field(default_factory=list)
-    factor_rows: Sequence[dict[str, Any]] = field(default_factory=list)
-    policy_flags: dict[str, Any] = field(default_factory=dict)
-    activity_aliases: dict[str, list[str]] = field(default_factory=dict)
-    unit_aliases: dict[str, list[str]] = field(default_factory=dict)
-    llm_fallback: Optional[Any] = None
-    llm_budget: int = 0
-
-
-@dataclass
-class PipelineRunResult:
-    spec: ProgramSpec | CompiledProgramSpec
-    env: RuntimeEnv
-    artifacts: CompileArtifacts
-
-    def summary(self) -> dict[str, Any]:
-        frame_status_counts: dict[str, int] = {}
-        for f in self.artifacts.frames:
-            frame_status_counts[f.status] = frame_status_counts.get(f.status, 0) + 1
-
-        row_status_counts: dict[str, int] = {}
-        for r in self.artifacts.rows:
-            row_status_counts[r.status] = row_status_counts.get(r.status, 0) + 1
-
-        calc_status_counts: dict[str, int] = {}
-        for c in self.artifacts.calculations:
-            calc_status_counts[c.calculation_status] = calc_status_counts.get(c.calculation_status, 0) + 1
-
-        return {
-            "module_name": self.spec.module_name,
-            "fragments": len(self.artifacts.fragments),
-            "tokens": len(self.artifacts.tokens),
-            "claims": len(self.artifacts.claims),
-            "frames": len(self.artifacts.frames),
-            "rows": len(self.artifacts.rows),
-            "calculations": len(self.artifacts.calculations),
-            "frame_status_counts": frame_status_counts,
-            "row_status_counts": row_status_counts,
-            "calculation_status_counts": calc_status_counts,
-            "merge_decisions": len(self.artifacts.merge_log),
-            "events": len(self.artifacts.event_log),
-            "diagnostics": len(self.artifacts.diagnostics),
-            "llm_budget_remaining": self.env.llm_budget_remaining,
-        }
-
-
-def load_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> ProgramSpec:
-    if dsl_text is None and dsl_path is None:
-        raise ValueError("one of dsl_text or dsl_path must be provided")
-    grammar = Path(grammar_path).read_text(encoding="utf-8")
-    source = dsl_text if dsl_text is not None else Path(dsl_path).read_text(encoding="utf-8")
-    from lark import Lark
-    from ast_builder import ASTBuilder
-    from lowering import Lowerer
-
-    parser = Lark(grammar, parser="lalr", lexer="contextual", start="start")
-    tree = parser.parse(source)
-    return Lowerer().lower(ASTBuilder().transform(tree))
-
-
-def compile_program_spec(program_spec: ProgramSpec) -> CompiledProgramSpec:
-    return Binder().bind(program_spec)
-
-
-def load_compiled_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
-    return compile_program_spec(load_program_spec_from_dsl(grammar_path=grammar_path, dsl_path=dsl_path, dsl_text=dsl_text))
-
-
-def build_default_passes(*, include_post_repair_semantic: bool = False) -> list[CompilerPass]:
-    passes: list[CompilerPass] = [
-        LexPass(),
-        ParsePass(),
-        ScopeResolutionPass(),
-        InferencePass(),
-        SemanticPass(config=SemanticPassConfig(phase_label="semantic_pre")),
-        RepairPass(),
-    ]
-    if include_post_repair_semantic:
-        passes.append(SemanticPass(config=SemanticPassConfig(phase_label="semantic_post")))
-    passes.extend([EmitPass(), GovernancePass(), CalculationPass()])
-    return passes
-
-
-class ESGPipelineRunner:
-    def __init__(self, *, grammar_path: str | Path = "esgdl.lark", passes: Optional[list[CompilerPass]] = None, fragmentizer: Optional[Fragmentizer] = None) -> None:
-        self.grammar_path = Path(grammar_path)
-        self.fragmentizer = fragmentizer
-        self.passes = passes or build_default_passes()
-
-    def load_spec(self, *, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
-        return load_compiled_program_spec_from_dsl(grammar_path=self.grammar_path, dsl_path=dsl_path, dsl_text=dsl_text)
-
-    def build_env(self, *, spec: ProgramSpec | CompiledProgramSpec, resources: Optional[PipelineResources] = None) -> RuntimeEnv:
-        resources = resources or PipelineResources()
-        syntax_spec = spec.syntax if isinstance(spec, CompiledProgramSpec) else spec
-        env = build_runtime_env(spec=syntax_spec, site_records=list(resources.site_records), factor_rows=list(resources.factor_rows), policy_flags=dict(resources.policy_flags), activity_aliases=dict(resources.activity_aliases), unit_aliases=dict(resources.unit_aliases), llm_fallback=resources.llm_fallback, llm_budget=resources.llm_budget)
-        register_default_builtins(env)
-        return env
-
-    def prepare_fragments(self, *, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None) -> list[Any]:
-        if fragments is not None:
-            return fragments
-        if documents is None:
-            raise ValueError("one of fragments or documents must be provided")
-        if self.fragmentizer is None:
-            raise ValueError("documents were provided but no fragmentizer is configured. Either pass pre-built fragments or inject a fragmentizer callable.")
-        return self.fragmentizer(documents)
-
-    def run(self, *, spec: Optional[ProgramSpec | CompiledProgramSpec] = None, dsl_path: str | Path | None = None, dsl_text: str | None = None, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None, resources: Optional[PipelineResources] = None) -> PipelineRunResult:
-        if spec is None:
-            spec = self.load_spec(dsl_path=dsl_path, dsl_text=dsl_text)
-        elif not isinstance(spec, CompiledProgramSpec):
-            spec = compile_program_spec(spec)
-
-        env = self.build_env(spec=spec, resources=resources)
-        prepared_fragments = self.prepare_fragments(fragments=fragments, documents=documents)
-        artifacts = CompileArtifacts(fragments=prepared_fragments)
-        for p in self.passes:
-            artifacts = p.run(spec, artifacts, env)
-        return PipelineRunResult(spec=spec, env=env, artifacts=artifacts)
+__all__ = [
+    "Fragmentizer",
+    "CompilerPass",
+    "PipelineResources",
+    "PipelineRunResult",
+    "load_program_spec_from_dsl",
+    "compile_program_spec",
+    "load_compiled_program_spec_from_dsl",
+    "build_default_passes",
+    "ESGPipelineRunner",
+]

--- a/tests/test_runner_package_facades.py
+++ b/tests/test_runner_package_facades.py
@@ -8,6 +8,7 @@ from pipeline_runner import (
     load_program_spec_from_dsl as legacy_load_program_spec_from_dsl,
 )
 
+from comp.compiled_pipeline_runner import CompiledESGPipelineRunner as PackageCompiledRunner
 from comp.compat.compiled_pipeline_runner import CompiledESGPipelineRunner as CompatCompiledRunner
 from comp.compat.pipeline_runner import (
     ESGPipelineRunner as CompatRunner,
@@ -16,6 +17,14 @@ from comp.compat.pipeline_runner import (
     compile_program_spec as compat_compile_program_spec,
     load_compiled_program_spec_from_dsl as compat_load_compiled_program_spec_from_dsl,
     load_program_spec_from_dsl as compat_load_program_spec_from_dsl,
+)
+from comp.pipeline_runner import (
+    ESGPipelineRunner as PackageRunner,
+    PipelineResources as PackagePipelineResources,
+    PipelineRunResult as PackagePipelineRunResult,
+    compile_program_spec as package_compile_program_spec,
+    load_compiled_program_spec_from_dsl as package_load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl as package_load_program_spec_from_dsl,
 )
 from comp.runner import (
     CompiledESGPipelineRunner,
@@ -28,21 +37,31 @@ from comp.runner import (
 )
 
 
-def test_runner_compat_facades_match_legacy_exports():
-    assert CompatRunner is LegacyRunner
-    assert CompatCompiledRunner is LegacyCompiledRunner
-    assert CompatPipelineResources is LegacyPipelineResources
-    assert CompatPipelineRunResult is LegacyPipelineRunResult
-    assert compat_compile_program_spec is legacy_compile_program_spec
-    assert compat_load_program_spec_from_dsl is legacy_load_program_spec_from_dsl
-    assert compat_load_compiled_program_spec_from_dsl is legacy_load_compiled_program_spec_from_dsl
+def test_top_level_runner_wrappers_match_package_exports():
+    assert LegacyRunner is PackageRunner
+    assert LegacyCompiledRunner is PackageCompiledRunner
+    assert LegacyPipelineResources is PackagePipelineResources
+    assert LegacyPipelineRunResult is PackagePipelineRunResult
+    assert legacy_compile_program_spec is package_compile_program_spec
+    assert legacy_load_program_spec_from_dsl is package_load_program_spec_from_dsl
+    assert legacy_load_compiled_program_spec_from_dsl is package_load_compiled_program_spec_from_dsl
 
 
-def test_comp_runner_exports_use_compat_facades():
-    assert PipelineResources is CompatPipelineResources
-    assert PipelineRunResult is CompatPipelineRunResult
-    assert compile_program_spec is compat_compile_program_spec
-    assert load_program_spec_from_dsl is compat_load_program_spec_from_dsl
-    assert load_compiled_program_spec_from_dsl is compat_load_compiled_program_spec_from_dsl
-    assert issubclass(ESGPipelineRunner, CompatRunner)
-    assert issubclass(CompiledESGPipelineRunner, CompatCompiledRunner)
+def test_runner_compat_facades_match_package_exports():
+    assert CompatRunner is PackageRunner
+    assert CompatCompiledRunner is PackageCompiledRunner
+    assert CompatPipelineResources is PackagePipelineResources
+    assert CompatPipelineRunResult is PackagePipelineRunResult
+    assert compat_compile_program_spec is package_compile_program_spec
+    assert compat_load_program_spec_from_dsl is package_load_program_spec_from_dsl
+    assert compat_load_compiled_program_spec_from_dsl is package_load_compiled_program_spec_from_dsl
+
+
+def test_comp_runner_exports_use_package_implementation():
+    assert PipelineResources is PackagePipelineResources
+    assert PipelineRunResult is PackagePipelineRunResult
+    assert compile_program_spec is package_compile_program_spec
+    assert load_program_spec_from_dsl is package_load_program_spec_from_dsl
+    assert load_compiled_program_spec_from_dsl is package_load_compiled_program_spec_from_dsl
+    assert issubclass(ESGPipelineRunner, PackageRunner)
+    assert issubclass(CompiledESGPipelineRunner, PackageCompiledRunner)


### PR DESCRIPTION
## Summary

- move runner implementation into `comp.pipeline_runner`
- move compiled runner implementation into `comp.compiled_pipeline_runner`
- reduce top-level `pipeline_runner.py` and `compiled_pipeline_runner.py` to compatibility wrappers
- point `comp.compat.*runner` wrappers at package-owned implementations
- update runner façade tests and migration/facade docs

## Linked Issue

Closes #64

## Changes

- Adds package-owned runner implementation modules:
  - `comp/pipeline_runner.py`
  - `comp/compiled_pipeline_runner.py`
- Converts legacy top-level runner modules into thin wrappers.
- Updates `comp.runner` to subclass package-owned runner implementations while keeping package-local default grammar path behavior.
- Updates runner parity tests so legacy, compat, and package paths all resolve to the package implementation.
- Updates `docs/facade-inventory.md`, `docs/facade-thinness.md`, and `docs/migration-checklist.md` to reflect the new runner ownership.

## Tests

Not run in this environment.

Recommended:

```bash
pytest -q tests/test_package_smoke.py
pytest -q tests/test_runner_package_facades.py tests/test_pipeline_package_facades.py
pytest -q tests/test_default_runner_compiled_rule_path.py
pytest -q
```

## Notes

No intended behavior change.
No pass-order change.
No emit/governance architecture change.
No wrapper removal beyond reducing top-level runner modules to compatibility wrappers.