### PR TITLE
docs: add bounded design probe lane

### DIFF
--- a/docs/design-probes/_template.md
+++ b/docs/design-probes/_template.md
@@ -1,0 +1,219 @@
+# Design Probe: <name>
+
+## Status
+
+```text
+watching | active | promoted | retired | parked
+```
+
+Current status: `watching`
+
+---
+
+## Problem Pressure
+
+현재 migration / architecture 작업에서 반복해서 드러나는 압력을 적는다.
+
+예:
+
+```text
+- 같은 책임이 여러 pass에 반복된다.
+- current fact와 target semantics를 문서에서 계속 분리하기 어렵다.
+- wrapper / facade / adapter 경계가 반복해서 흐려진다.
+- row / receipt / log / ledger 의미가 PR마다 다시 충돌한다.
+```
+
+---
+
+## Current Fact
+
+현재 코드는 실제로 무엇을 하는가?
+
+주의:
+
+```text
+현재 구현 사실과 미래 candidate direction을 섞지 않는다.
+구현되지 않은 target semantics를 이미 완료된 것처럼 쓰지 않는다.
+```
+
+---
+
+## Candidate Direction
+
+미래에 고려할 수 있는 방향을 적는다.
+
+주의:
+
+```text
+확정 표현을 피한다.
+이 방향으로 간다는 선언이 아니라, 검토할 후보로 적는다.
+```
+
+---
+
+## MAPE-K Loop
+
+### Monitor
+
+어떤 signal을 관찰할 것인가?
+
+예:
+
+```text
+- 관련 PR에서 반복되는 책임 경계 혼동
+- 같은 종류의 test fixture 중복
+- 같은 bug / regression 재발
+- docs에서 current fact와 target semantics 충돌
+```
+
+### Analyze
+
+signal을 어떤 기준으로 구조 압력이라고 판단할 것인가?
+
+예:
+
+```text
+- 1회성 작업 실수가 아니라 2회 이상 반복되는가?
+- 같은 책임이 3개 이상 파일에 분산되는가?
+- migration PR에서 architecture 설명이 계속 필요해지는가?
+```
+
+### Plan
+
+이 probe가 어떤 후속 행동으로 이어질 수 있는가?
+
+예:
+
+```text
+- characterization test 추가
+- docs boundary 정리
+- architecture issue 생성
+- implementation issue 후보 분할
+```
+
+### Execute
+
+지금 허용되는 실행 범위를 적는다.
+
+기본값:
+
+```text
+- docs 갱신 허용
+- issue comment 허용
+- characterization test 후보 제안 허용
+- runtime behavior 변경 금지
+- schema 변경 금지
+- relocation PR과 혼합 금지
+```
+
+### Knowledge
+
+관련 문서, issue, PR, tests를 적는다.
+
+---
+
+## Promotion Criteria
+
+이 probe를 architecture issue 또는 implementation issue로 승격할 조건을 적는다.
+
+### Hard Triggers
+
+가능하면 수치화한다.
+
+예:
+
+```text
+- 같은 책임 중복이 3개 이상 파일에서 발견된다.
+- 같은 boundary bug가 2회 이상 발생한다.
+- 같은 종류의 test fixture 중복이 3회 이상 반복된다.
+- 측정 가능한 성능 저하 또는 pass 비용 증가가 관찰된다.
+```
+
+### Architectural Triggers
+
+수치화하기 어렵지만 반복되는 구조 압력을 적는다.
+
+예:
+
+```text
+- 현재 구조로는 책임 경계를 설명하기 어려운 PR이 반복된다.
+- current fact와 target semantics를 계속 분리하기 어려워진다.
+- compatibility wrapper가 사실상 behavior를 품기 시작한다.
+- row / receipt / log / ledger 의미가 코드에서 반복적으로 충돌한다.
+```
+
+### Required Before Promotion
+
+승격 전 필수 조건을 적는다.
+
+```text
+- 최소 2개 이상의 대안을 비교한다.
+- 구현하지 않을 범위를 명시한다.
+- migration PR과 섞이지 않는 작은 implementation issue로 쪼갤 수 있어야 한다.
+- disconfirming evidence를 검토한다.
+```
+
+---
+
+## Retirement Criteria
+
+이 probe를 폐기할 조건을 적는다.
+
+예:
+
+```text
+- 관련 migration 이후 문제가 반복되지 않는다.
+- current docs / compatibility policy만으로 충분히 설명 가능하다.
+- candidate direction이 현재 model보다 명확한 이득을 만들지 못한다.
+- 더 작은 docs / test / policy 작업으로 압력이 해소된다.
+```
+
+---
+
+## Disconfirming Evidence
+
+이 probe가 틀렸거나 약하다고 볼 수 있는 증거를 적는다.
+
+예:
+
+```text
+- migration이 끝난 뒤 문제 signal이 사라진다.
+- 현재 artifact model이 더 단순하고 충분하다.
+- proposed direction이 testability를 낮춘다.
+- proposed direction이 compatibility cost를 과도하게 키운다.
+```
+
+---
+
+## Guardrails
+
+이 probe가 현재 migration 작업을 오염시키지 않도록 막는 규칙을 적는다.
+
+기본값:
+
+```text
+- 이 probe는 exploration-only다.
+- 이 probe만으로 runtime behavior를 바꾸지 않는다.
+- implementation은 별도 architecture / implementation issue가 필요하다.
+- migration PR 안에 이 probe의 target design을 끼워 넣지 않는다.
+- 현재 구현 사실을 target semantics처럼 문서화하지 않는다.
+```
+
+---
+
+## Related Migration Work
+
+관련 migration issue / PR / docs를 적는다.
+
+---
+
+## Probe Log
+
+### YYYY-MM-DD
+
+```text
+Observation:
+Hypothesis:
+Decision:
+Next watch:
+```

--- a/docs/design-probes/index.md
+++ b/docs/design-probes/index.md
@@ -1,0 +1,175 @@
+# Design Probes
+
+이 디렉토리는 아직 구현하지 않을 미래 아키텍처 방향을 안전하게 탐색하기 위한 공간이다.
+
+중요:
+
+```text
+Design Probe는 implementation backlog가 아니다.
+Design Probe는 현재 migration PR에 섞을 설계 변경도 아니다.
+Design Probe는 반복해서 드러나는 설계 압력을 관찰하고, 승격/폐기 조건을 갖춘 가설로 보관하는 문서다.
+```
+
+---
+
+## 목적
+
+현재 migration issue는 의도적으로 실행 중심이다.
+
+```text
+implementation 이동
+compatibility wrapper 유지
+package / legacy parity 확인
+behavior change 금지
+```
+
+이 방식은 안전하지만, 장기 설계 압력이 작업 중에 사라지거나 임시 대화에 묻힐 수 있다.
+
+Design Probe lane은 그 중간층이다.
+
+```text
+미래 설계를 코드로 선점하지 않는다.
+하지만 미래 설계 압력을 잊지도 않는다.
+```
+
+---
+
+## 운영 모델
+
+Design Probe는 bounded recursive design loop로 운영한다.
+
+```text
+Monitor
+  PR / issue / test / docs 충돌 / 반복되는 코드 냄새를 관찰한다.
+
+Analyze
+  이 signal이 일회성 문제인지 구조 압력인지 판단한다.
+
+Plan
+  probe 갱신, architecture issue 후보, characterization test 후보를 만든다.
+
+Execute
+  기본적으로 docs / issue / test characterization까지만 허용한다.
+  runtime behavior 변경은 별도 architecture/implementation issue 없이는 금지한다.
+
+Knowledge
+  docs/design-probes, migration-checklist, issue comments, PR notes를 공유 기억으로 둔다.
+```
+
+---
+
+## 상태
+
+각 probe는 다음 상태 중 하나를 가진다.
+
+```text
+watching
+  관찰 중이지만 아직 강한 가설은 아니다.
+
+active
+  반복 signal이 있어 적극 추적한다.
+
+promoted
+  별도 architecture 또는 implementation issue로 승격되었다.
+
+retired
+  가설이 약해졌거나 더 작은 작업으로 해소되어 폐기되었다.
+
+parked
+  당장은 증거가 부족해 보류한다.
+```
+
+---
+
+## 승격 원칙
+
+Design Probe는 다음 조건 없이 구현 이슈로 승격하지 않는다.
+
+```text
+- hard trigger 또는 architectural trigger가 명시되어야 한다.
+- 최소 2개 이상의 대안 또는 tradeoff가 비교되어야 한다.
+- 구현하지 않을 범위가 명시되어야 한다.
+- migration PR과 섞이지 않는 작은 implementation issue로 쪼갤 수 있어야 한다.
+- disconfirming evidence를 검토해야 한다.
+```
+
+---
+
+## 폐기 원칙
+
+모든 probe가 구현으로 승격될 필요는 없다.
+
+다음 경우 probe는 retired 될 수 있다.
+
+```text
+- migration 이후 문제가 더 이상 반복되지 않는다.
+- current docs / compatibility policy만으로 충분히 설명 가능하다.
+- candidate direction이 현재 model보다 명확한 이득을 만들지 못한다.
+- 더 작은 test / docs / policy 작업으로 압력이 해소된다.
+```
+
+---
+
+## 금지
+
+Design Probe PR에서는 다음을 하지 않는다.
+
+```text
+- runtime refactor
+- pass behavior change
+- artifact schema change
+- judgment core absorption
+- public ledger implementation
+- wrapper removal
+- migration PR 안에 architecture refactor 섞기
+```
+
+---
+
+## 작성법
+
+새 probe는 `_template.md`를 복사해 작성한다.
+
+최소한 다음을 포함해야 한다.
+
+```text
+Problem Pressure
+Current Fact
+Candidate Direction
+MAPE-K Loop
+Promotion Criteria
+Retirement Criteria
+Disconfirming Evidence
+Guardrails
+Probe Log
+```
+
+---
+
+## Migration checklist와의 관계
+
+활성 probe는 `docs/migration-checklist.md` 하단의 `Active Design Probes` 섹션에도 링크한다.
+
+다만 그 섹션은 구현 대기열이 아니다.
+
+```text
+Migration checklist의 Now / Next / Later
+  실제 실행 작업 큐
+
+Active Design Probes
+  미래 설계 압력 관찰판
+```
+
+---
+
+## 초기 후보 예시
+
+아래는 바로 구현할 작업이 아니라, 필요할 때 별도 issue로 열 수 있는 후보 예시다.
+
+| Probe candidate | Pressure it would watch |
+|---|---|
+| StageState runtime direction | `CompileArtifacts` mutation 중심 흐름이 pass 간 상태 중복을 만들 때 |
+| Projection-first public row model | row가 source-of-truth인지 projection인지 혼동이 반복될 때 |
+| Receipt / ledger boundary | `merge_log`, `event_log`, `commit_log`, receipt, explanation view가 섞일 때 |
+| Judgment runtime absorption | `RepairPass` / `GovernancePass` 책임 일부가 judgment core와 반복적으로 겹칠 때 |
+| Scheduler / hazard scoreboard | full pass scan과 diagnostic/hazard state가 반복해서 비효율 또는 중복을 만들 때 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,12 @@
 4. `emit-governance-boundary.md`
 5. `migration-plan.md`
 
+### 미래 설계 압력을 탐색하고 싶은 경우
+1. `design-probes/index.md`
+2. `design-probes/_template.md`
+3. `migration-checklist.md`
+4. `architecture.md`
+
 ### 판정 언어와 의미론이 궁금한 경우
 1. `worked-example.md`
 2. `judgment-language.md`
@@ -104,6 +110,12 @@
 - `facade-thinness.md`
   - façade / wrapper / bridge가 허용하는 얇은 역할과 금지되는 behavior를 정리하는 규칙 문서
 
+- `design-probes/index.md`
+  - 미래 아키텍처 방향을 구현 대기열이 아니라 관찰 가능한 설계 가설로 관리하는 운영 문서
+
+- `design-probes/_template.md`
+  - Design Probe 작성 템플릿. promotion / retirement criteria, disconfirming evidence, guardrail을 포함한다.
+
 - `testing.md`
   - 테스트가 무엇을 보호하는지 설명하는 문서
 
@@ -117,3 +129,4 @@
 3. bridge 상태를 숨기지 않는다.
 4. README는 바깥 설명, `docs/`는 내부 지도로 역할을 분리한다.
 5. judgment vocabulary와 formal semantics는 별도 문서에서 다루고, 현재 코드 흐름 문서와 섞지 않는다.
+6. Design Probe는 구현 대기열이 아니라 미래 설계 압력 관찰판으로 유지한다.

--- a/docs/migration-checklist.md
+++ b/docs/migration-checklist.md
@@ -133,6 +133,28 @@
 
 ---
 
+## Active Design Probes
+
+이 섹션은 구현 대기열이 아니다.
+
+Design Probe는 현재 migration 작업 중 반복해서 드러나는 미래 설계 압력을 추적하는 관찰판이다. 실제 구현은 별도 architecture / implementation issue로 승격된 뒤에만 진행한다.
+
+| Probe | Status | Related migration work | Promotion trigger |
+|---|---|---|---|
+| `docs/design-probes/index.md` | lane-definition | #85 | 개별 probe issue가 생성될 때 이 표에 추가한다. |
+
+운영 기준:
+
+```text
+Migration checklist의 Now / Next / Later
+  실제 실행 작업 큐
+
+Active Design Probes
+  미래 설계 압력 관찰판
+```
+
+---
+
 ## 2) 트랙별 완료 조건 (Acceptance Criteria)
 
 ### A-track (import convergence)
@@ -228,6 +250,13 @@
 ---
 
 ## 6) 진행 로그
+
+### 2026-04-27
+
+- `docs/design-probes/` lane을 추가했다.
+- Design Probe를 구현 대기열이 아니라 미래 설계 압력 관찰판으로 정의했다.
+- 각 probe가 promotion criteria, retirement criteria, disconfirming evidence, guardrail을 갖도록 템플릿을 추가했다.
+- `Active Design Probes` 섹션을 추가해 migration checklist에서 probe 가시성을 유지하도록 했다.
 
 ### 2026-04-24
 


### PR DESCRIPTION
## Summary

- add `docs/design-probes/index.md` as an exploration-only lane for future architecture pressure
- add `docs/design-probes/_template.md` with MAPE-K, promotion criteria, retirement criteria, disconfirming evidence, guardrails, and probe log sections
- link the design probe lane from `docs/index.md`
- expose `Active Design Probes` in `docs/migration-checklist.md` without treating probes as implementation backlog

## Linked Issue

Closes #85

## Changes

- Defines Design Probes as bounded recursive design loops rather than implementation issues.
- Separates current fact, candidate direction, promotion criteria, retirement criteria, and disconfirming evidence.
- Keeps probes visible from the migration checklist while explicitly separating them from `Now / Next / Later` execution queues.

## Tests

Docs-only review. No runtime tests run.

## Notes

- No code changes.
- No runtime behavior changes.
- No schema changes.
- No wrapper removal.
- No judgment core absorption.
- This PR intentionally does not add a concrete StageState / ledger / projection probe yet; it only adds the operating lane and template.