### PR TITLE
docs: establish active authority docs for rebuild

### DIFF
--- a/docs/architecture/authority-map.md
+++ b/docs/architecture/authority-map.md
@@ -1,0 +1,143 @@
+# Authority Map
+
+이 문서는 `comp` 재정렬의 active architecture policy입니다.
+
+목표는 파일 위치를 정리하는 것이 아니라, 각 개념이 어떤 권한을 갖는지 먼저 고정하는 것입니다. 앞으로의 구조 변경은 이 문서를 기준으로 판단합니다.
+
+---
+
+## 1. Authoritative state
+
+`comp`의 장기 source of truth는 다음 세 가지입니다.
+
+```text
+Evidence-backed Judgment
+Governance Decision
+Receipt Ledger
+```
+
+즉 public output은 직접 진실이 아닙니다. public output은 판정과 receipt에서 파생된 projection입니다.
+
+---
+
+## 2. Derived views
+
+다음은 authoritative state가 아니라 derived view입니다.
+
+```text
+Public row
+CSV / JSON output
+DataFrame view
+Report-facing projection
+```
+
+이들은 외부에 보여주기 위한 표현입니다. 이 표현이 commit 여부나 정당성을 스스로 소유하면 안 됩니다.
+
+---
+
+## 3. Legacy transport
+
+다음은 현재 실행 호환을 위해 남아 있을 수 있지만, 장기 source of truth가 아닙니다.
+
+```text
+CompileArtifacts
+PartialFrameArtifact runtime metadata
+CanonicalRowArtifact.status
+pipeline pass metadata
+legacy event_log / merge_log coupling
+```
+
+이 객체들은 legacy staged pipeline을 유지하기 위한 transport 또는 compatibility layer로만 취급합니다.
+
+---
+
+## 4. Authority rules
+
+### Evidence
+
+Evidence layer는 다음 질문만 소유합니다.
+
+```text
+이 값은 어디서 왔는가?
+어떤 source / span / claim / provenance가 연결되는가?
+어떤 충돌 또는 hazard가 있는가?
+```
+
+Evidence layer는 public 여부를 결정하지 않습니다.
+
+### Judgment
+
+Judgment layer는 다음 질문을 소유합니다.
+
+```text
+어떤 claim/fact가 선택 가능한가?
+왜 이 후보가 선택되었는가?
+어떤 derivation 또는 justification이 남는가?
+```
+
+Judgment layer는 row를 직접 만들지 않습니다.
+
+### Governance
+
+Governance layer는 다음 질문을 소유합니다.
+
+```text
+이 judgment를 public으로 내보내도 되는가?
+hold / commit / reject 중 무엇인가?
+어떤 reason code와 receipt가 남는가?
+```
+
+Governance layer는 row를 직접 mutate하지 않습니다. Governance의 출력은 decision과 receipt입니다.
+
+### Projection
+
+Projection layer는 다음 질문만 소유합니다.
+
+```text
+committed decision / receipt를 어떤 public representation으로 보여줄 것인가?
+```
+
+Projection layer는 commit 여부를 결정하지 않습니다.
+
+### App / pipeline orchestration
+
+App 또는 runner는 조립과 적용을 담당합니다.
+
+```text
+input loading
+pipeline sequencing
+legacy adapter invocation
+output writing
+integration behavior
+```
+
+App은 모든 조각을 알 수 있지만, core layer가 app orchestration을 알면 안 됩니다.
+
+---
+
+## 5. Import boundary
+
+장기적으로 다음 방향을 지향합니다.
+
+```text
+core authority layer -> legacy artifacts import 금지
+legacy pipeline -> core authority layer 호출 가능
+app/runner -> 모든 layer 조립 가능
+```
+
+즉 legacy가 core를 호출하는 것은 허용되지만, core가 legacy artifact에 의존하면 안 됩니다.
+
+---
+
+## 6. Migration rule
+
+앞으로 relocation PR은 다음 조건을 먼저 통과해야 합니다.
+
+```text
+1. 이 module이 어떤 authority를 소유하는지 명확한가?
+2. 그 authority가 장기 구조에서도 살아남는가?
+3. 아니라면 package-owned implementation으로 승격하지 않는가?
+4. 기존 behavior를 보존하기 전에, 보존할 가치가 있는 behavior인지 확인했는가?
+```
+
+이 조건을 통과하지 못하면 relocation이 아니라 legacy containment 또는 architecture correction이 먼저입니다.

--- a/docs/architecture/kill-list.md
+++ b/docs/architecture/kill-list.md
@@ -1,0 +1,156 @@
+# Kill List
+
+이 문서는 장기 구조에서 authoritative state로 살아남으면 안 되는 개념을 고정합니다.
+
+목표는 기존 코드를 즉시 삭제하는 것이 아닙니다. 목표는 어떤 개념이 더 이상 진실을 소유하면 안 되는지 먼저 명시하는 것입니다.
+
+---
+
+## 1. Must not survive as authoritative state
+
+다음 항목은 compatibility나 legacy transport로 잠시 남을 수 있지만, 장기 source of truth가 되면 안 됩니다.
+
+```text
+row.status as commit truth
+GovernancePass mutating rows directly
+CommitReceipt stored primarily in row metadata
+CompileArtifacts as kernel state
+pass-owned semantic authority
+indefinite compatibility wrappers
+legacy/package parity as architecture success criteria
+```
+
+---
+
+## 2. Row status as commit truth
+
+`CanonicalRowArtifact.status`는 projection 상태를 표시할 수는 있지만, commit의 진실이 되면 안 됩니다.
+
+Commit 여부는 governance decision과 receipt가 소유해야 합니다.
+
+```text
+Bad:
+  row.status == "merged" means this row is public truth
+
+Target:
+  decision.action == "commit"
+  receipt proves why the projection is allowed
+```
+
+---
+
+## 3. Governance mutating rows directly
+
+Governance는 판정자입니다. Governance가 row를 직접 바꾸면 decision과 apply가 섞입니다.
+
+```text
+Bad:
+  GovernancePass evaluates policy and mutates row.status
+
+Target:
+  governance.evaluate(...) -> CommitDecision
+  app.apply(decision, projection_state)
+```
+
+---
+
+## 4. Receipt as row metadata
+
+Receipt는 부속 metadata가 아니라 first-class output이어야 합니다.
+
+```text
+Bad:
+  row.metadata["commit_receipt"] = ...
+
+Target:
+  ReceiptLedger[receipt_id] = receipt
+  row.receipt_ref = receipt_id
+```
+
+Row는 receipt를 참조할 수 있지만, receipt의 primary home이 되면 안 됩니다.
+
+---
+
+## 5. CompileArtifacts as kernel state
+
+`CompileArtifacts`는 현재 staged pipeline을 이어가기 위한 legacy transport입니다.
+
+장기 kernel은 `CompileArtifacts`를 import하거나 내부 state로 삼으면 안 됩니다.
+
+```text
+Bad:
+  kernel function accepts CompileArtifacts
+
+Target:
+  kernel accepts evidence / judgment / decision inputs
+  legacy adapter translates CompileArtifacts into kernel inputs
+```
+
+---
+
+## 6. Pass-owned semantic authority
+
+Pipeline pass는 orchestration boundary일 수 있지만, semantic authority를 영구 소유하면 안 됩니다.
+
+```text
+RepairPass owns final selection semantics      -> no
+GovernancePass owns commit truth by mutation  -> no
+EmitPass owns public truth                    -> no
+```
+
+Target:
+
+```text
+selection -> judgment
+commit decision -> governance
+public representation -> projection
+pipeline pass -> orchestration/apply
+```
+
+---
+
+## 7. Indefinite compatibility wrappers
+
+Compatibility wrapper는 임시 bridge입니다.
+
+Wrapper가 남아야 한다면 다음이 필요합니다.
+
+```text
+why it exists
+what it preserves
+when it can die
+what must replace it
+```
+
+기한이나 제거 조건이 없는 wrapper는 architecture가 됩니다. 이 상태를 피해야 합니다.
+
+---
+
+## 8. Legacy/package parity as architecture success
+
+Package import와 legacy import가 같은 객체인지 확인하는 parity test는 relocation safety에는 유용합니다.
+
+하지만 그것은 architecture success criterion이 아닙니다.
+
+장기 구조에서는 다음 테스트가 더 중요합니다.
+
+```text
+core does not import legacy artifacts
+governance does not mutate rows
+public rows require receipt references
+row is projection, not commit authority
+compat adapters do not gain semantic authority
+```
+
+---
+
+## 9. Review rule
+
+새 PR은 다음 질문에 답해야 합니다.
+
+```text
+이 PR은 kill list 항목을 줄이는가?
+아니면 kill list 항목을 더 공식화하는가?
+```
+
+후자라면 migration이 아니라 architecture regression입니다.

--- a/docs/archive/2026-migration/README.md
+++ b/docs/archive/2026-migration/README.md
@@ -1,0 +1,71 @@
+# 2026 Migration Archive
+
+이 디렉토리는 이전 package migration / facade / compatibility 문서 흐름을 보존하기 위한 archive입니다.
+
+이 문서들은 삭제하지 않습니다. 다만 active architecture policy로 사용하지 않습니다.
+
+---
+
+## Status
+
+```text
+historical reference only
+not active implementation guidance
+not active architecture policy
+```
+
+---
+
+## Why archived?
+
+이전 migration 문서들은 다음 문제를 분석하는 데 가치가 있습니다.
+
+```text
+how package relocation proceeded
+how bridge state was defined
+how wrappers and facades were classified
+how no-behavior-change migration protected legacy behavior
+how architecture work was deferred into later tracks
+```
+
+그러나 rebuild 방향에서는 다음 원칙이 우선합니다.
+
+```text
+source of truth before relocation
+authority transfer before file movement
+legacy containment before package-owned promotion
+receipt/decision/projection before row mutation
+```
+
+---
+
+## Preserved source
+
+현재 main 상태는 다음 branch에 보존됩니다.
+
+```text
+legacy/current-migration-state-20260429
+```
+
+이 branch의 docs와 code는 과거 migration state의 증거물입니다.
+
+---
+
+## Active replacements
+
+새 active architecture policy는 다음 문서를 봅니다.
+
+```text
+docs/architecture/authority-map.md
+docs/architecture/kill-list.md
+```
+
+추가 active docs는 이 두 문서의 원칙을 따라 작성해야 합니다.
+
+---
+
+## Rule
+
+이 archive 안의 문서를 근거로 새 implementation 작업을 시작하면 안 됩니다.
+
+필요한 개념은 archive에서 직접 가져오지 말고, active architecture 문서로 재작성한 뒤 사용합니다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,35 +3,56 @@
 `comp` 내부 구조 문서 모음입니다.
 
 이 디렉토리는 README보다 한 단계 깊은 **내부 지도**를 제공합니다.
-목표는 모듈별 백과사전을 만드는 것이 아니라, 현재 구조와 장기 구조, 그리고 그 사이의 이행 상태를 명확히 드러내는 것입니다.
+다만 앞으로의 rebuild / architecture correction 작업은 먼저 active authority docs를 기준으로 판단합니다.
+
+---
+
+## Active architecture policy
+
+현재 active policy는 다음 문서를 우선합니다.
+
+1. `architecture/authority-map.md`
+2. `architecture/kill-list.md`
+
+이 두 문서는 파일 이동보다 먼저 다음 질문을 고정합니다.
+
+```text
+무엇이 source of truth인가?
+무엇이 derived projection인가?
+무엇이 legacy transport인가?
+무엇을 장기 구조에서 죽여야 하는가?
+```
+
+앞으로 relocation / wrapper / facade / pipeline 작업은 이 두 문서를 통과해야 합니다.
+
+---
+
+## Archived migration state
+
+이전 package migration / facade / compatibility 흐름은 보존하되 active architecture policy로 쓰지 않습니다.
+
+- 현재 main 기준 migration state 보존 branch:
+  - `legacy/current-migration-state-20260429`
+- archive 안내:
+  - `archive/2026-migration/README.md`
+
+Archive 문서는 증거물과 참고자료입니다. 새 구현 지침으로 직접 사용하지 않습니다.
+
+---
 
 ## 읽는 순서
 
-### 처음 보는 경우
-1. `../README.md`
-2. `architecture.md`
-3. `worked-example.md`
-4. `current-pipeline.md`
+### 새 구조를 다시 잡는 경우
+1. `architecture/authority-map.md`
+2. `architecture/kill-list.md`
+3. `judgment-core.md`
+4. `emit-governance-boundary.md`
+5. `views-ledger.md`
 
 ### 현재 코드 흐름이 궁금한 경우
 1. `current-pipeline.md`
 2. `emit-governance-boundary.md`
 3. `worked-example.md`
-4. `migration-plan.md`
-5. `migration-checklist.md`
-
-### 새 설계 방향이 궁금한 경우
-1. `architecture.md`
-2. `worked-example.md`
-3. `judgment-core.md`
-4. `emit-governance-boundary.md`
-5. `migration-plan.md`
-
-### 미래 설계 압력을 탐색하고 싶은 경우
-1. `design-probes/index.md`
-2. `design-probes/_template.md`
-3. `migration-checklist.md`
-4. `architecture.md`
 
 ### 판정 언어와 의미론이 궁금한 경우
 1. `worked-example.md`
@@ -44,26 +65,29 @@
 2. `spec-pipeline.md`
 3. `worked-example.md`
 
-### 목표 실행 모델과 view 구조가 궁금한 경우
-1. `worked-example.md`
-2. `execution-model.md`
-3. `views-ledger.md`
-4. `emit-governance-boundary.md`
-5. `migration-plan.md`
-
-### 이행 작업을 issue로 나누고 싶은 경우
-1. `migration-checklist.md`
-2. `issue-plan.md`
+### 과거 migration / compatibility 상태를 확인하는 경우
+1. `archive/2026-migration/README.md`
+2. `migration-checklist.md`
 3. `migration-plan.md`
+4. `facade-inventory.md`
+5. `facade-thinness.md`
+6. `compatibility-policy.md`
 
-### façade / wrapper 상태가 궁금한 경우
-1. `facade-inventory.md`
-2. `facade-thinness.md`
-3. `compatibility-policy.md`
-4. `migration-checklist.md`
-5. `migration-plan.md`
+주의: 위 migration / compatibility 문서는 historical reference입니다. active architecture policy로 쓰지 않습니다.
+
+---
 
 ## 문서 구성
+
+### Active policy
+
+- `architecture/authority-map.md`
+  - source of truth, derived projection, legacy transport, layer별 권한을 고정하는 active policy
+
+- `architecture/kill-list.md`
+  - 장기 구조에서 authoritative state로 살아남으면 안 되는 개념을 고정하는 문서
+
+### Core explanation
 
 - `architecture.md`
   - 레포 전체를 한 장으로 설명하는 중심 문서
@@ -96,11 +120,13 @@
 - `views-ledger.md`
   - 무엇이 authoritative state이고 무엇이 projection/view인지 설명
 
+### Historical / migration references
+
 - `migration-plan.md`
-  - 패키지화, façade 제거, judgment core 흡수 등 이행 작업 추적 문서
+  - 패키지화, façade 제거, judgment core 흡수 등 과거 이행 작업 추적 문서
 
 - `migration-checklist.md`
-  - PR 단위 완료 조건과 현재 진행 상태를 추적하는 실행 체크리스트
+  - PR 단위 완료 조건과 진행 상태를 추적하던 실행 체크리스트
 
 - `issue-plan.md`
   - migration checklist를 실제 GitHub Issue 작업 단위로 내리는 운영 문서와 초기 issue 초안
@@ -114,11 +140,18 @@
 - `compatibility-policy.md`
   - top-level wrapper / compat wrapper의 유지, deprecation, removal gate를 정리하는 정책 문서
 
+- `archive/2026-migration/README.md`
+  - 이전 migration state를 active policy와 분리하기 위한 archive 안내 문서
+
+### Exploration
+
 - `design-probes/index.md`
   - 미래 아키텍처 방향을 구현 대기열이 아니라 관찰 가능한 설계 가설로 관리하는 운영 문서
 
 - `design-probes/_template.md`
   - Design Probe 작성 템플릿. promotion / retirement criteria, disconfirming evidence, guardrail을 포함한다.
+
+### Other references
 
 - `testing.md`
   - 테스트가 무엇을 보호하는지 설명하는 문서
@@ -126,11 +159,15 @@
 - `esgdl-reference.md`
   - ESGDL이 무엇을 선언하는 언어인지 설명하는 실용 참조 문서
 
+---
+
 ## 문서 원칙
 
-1. 현재 사실과 장기 방향을 섞어 쓰지 않는다.
-2. 구현되지 않은 미래 구조를 이미 완료된 것처럼 쓰지 않는다.
-3. bridge 상태를 숨기지 않는다.
-4. README는 바깥 설명, `docs/`는 내부 지도로 역할을 분리한다.
-5. judgment vocabulary와 formal semantics는 별도 문서에서 다루고, 현재 코드 흐름 문서와 섞지 않는다.
-6. Design Probe는 구현 대기열이 아니라 미래 설계 압력 관찰판으로 유지한다.
+1. active policy와 historical reference를 섞지 않는다.
+2. 현재 사실과 장기 방향을 섞어 쓰지 않는다.
+3. 구현되지 않은 미래 구조를 이미 완료된 것처럼 쓰지 않는다.
+4. bridge 상태를 숨기지 않되, bridge를 active target으로 승격하지 않는다.
+5. README는 바깥 설명, `docs/`는 내부 지도로 역할을 분리한다.
+6. judgment vocabulary와 formal semantics는 별도 문서에서 다루고, 현재 코드 흐름 문서와 섞지 않는다.
+7. Design Probe는 구현 대기열이 아니라 미래 설계 압력 관찰판으로 유지한다.
+8. relocation 작업은 active authority docs를 먼저 통과해야 한다.


### PR DESCRIPTION
## Summary

- add `docs/architecture/authority-map.md`
- add `docs/architecture/kill-list.md`
- add `docs/archive/2026-migration/README.md`
- update `docs/index.md` to separate active policy docs from historical migration references

## Preservation

Current main is preserved at:

```text
legacy/current-migration-state-20260429
```

## Tests

Docs-only review.

## Notes

No code changes.
No runtime behavior changes.
No relocation work.
