### PR TITLE
rebuild: cut top-level package surface to judgment core

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,29 @@ Read these first:
 docs/architecture/authority-map.md
 docs/architecture/kill-list.md
 docs/architecture/llm-orchestrated-compiler-tool-loop.md
+docs/architecture/active-surface-cutover.md
 ```
 
-These documents define what may own authority in the rebuild branch, and how LLM-driven interpretation loops should treat the compiler as an obligation-producing tool rather than a public truth authority.
+These documents define what may own authority in the rebuild branch, how LLM-driven interpretation loops should treat the compiler as an obligation-producing tool rather than a public truth authority, and which package surface is active during the cutover.
+
+---
+
+## Active package surface
+
+The top-level `comp` package intentionally exposes the judgment-core surface only.
+
+```python
+from comp import Fact, JudgmentState, SubjectRef
+from comp import SelectionReceipt, CommitReceipt
+```
+
+Legacy pipeline runners remain importable from `comp.runner` while they are kept for compatibility, but they are no longer the active top-level contract.
+
+```python
+from comp.runner import ESGPipelineRunner
+```
+
+This compatibility surface is an archive candidate, not the rebuild target.
 
 ---
 

--- a/comp/__init__.py
+++ b/comp/__init__.py
@@ -1,21 +1,62 @@
-"""Top-level package entrypoint for the experimental comp package."""
+"""Active package surface for the comp rebuild branch.
 
-from comp.runner import (
-    ESGPipelineRunner,
-    CompiledESGPipelineRunner,
-    PipelineResources,
-    PipelineRunResult,
-    compile_program_spec,
-    load_compiled_program_spec_from_dsl,
-    load_program_spec_from_dsl,
+The top-level package intentionally exposes the judgment-core surface only.
+Legacy pipeline runners remain importable from ``comp.runner`` while they are
+kept for compatibility, but they are no longer the active top-level contract.
+"""
+
+from comp.judgment import (
+    BundleSpec,
+    CandidateSummary,
+    CommitReceipt,
+    CommitSpec,
+    CompiledJudgmentProgram,
+    DraftSnapshot,
+    Fact,
+    FactTag,
+    FixpointEngine,
+    JudgmentState,
+    ProjectionSpec,
+    SelectionReceipt,
+    SubjectKind,
+    SubjectRef,
+    TransferEmitter,
+    TransferRule,
+    blocking_hazards_clear,
+    committable,
+    dominates,
+    frontier,
+    needs_review,
+    project_public_row,
+    prov_enough,
+    resolved_required_bundles,
+    winner_or_none,
 )
 
 __all__ = [
-    "ESGPipelineRunner",
-    "CompiledESGPipelineRunner",
-    "PipelineResources",
-    "PipelineRunResult",
-    "compile_program_spec",
-    "load_program_spec_from_dsl",
-    "load_compiled_program_spec_from_dsl",
+    "SubjectKind",
+    "FactTag",
+    "SubjectRef",
+    "Fact",
+    "JudgmentState",
+    "TransferEmitter",
+    "TransferRule",
+    "BundleSpec",
+    "CommitSpec",
+    "ProjectionSpec",
+    "CompiledJudgmentProgram",
+    "FixpointEngine",
+    "CandidateSummary",
+    "dominates",
+    "frontier",
+    "winner_or_none",
+    "needs_review",
+    "DraftSnapshot",
+    "resolved_required_bundles",
+    "blocking_hazards_clear",
+    "prov_enough",
+    "committable",
+    "project_public_row",
+    "SelectionReceipt",
+    "CommitReceipt",
 ]

--- a/docs/architecture/active-surface-cutover.md
+++ b/docs/architecture/active-surface-cutover.md
@@ -1,0 +1,213 @@
+# Active Surface Cutover Plan
+
+이 문서는 rebuild branch에서 **active package surface**를 legacy pipeline에서 judgment/compiler-tool loop 중심으로 전환하는 첫 번째 cutover 기준을 정의한다.
+
+이 문서의 목적은 legacy 파일을 즉시 삭제하는 것이 아니다. 목적은 다음을 명확히 하는 것이다.
+
+```text
+무엇이 현재 active surface인가?
+무엇이 legacy/archive 후보인가?
+어떤 import path가 새 아키텍처의 public contract인가?
+```
+
+---
+
+## 1. 결론
+
+`comp` top-level package는 더 이상 legacy runner facade를 대표하지 않는다.
+
+기존 top-level surface는 다음을 노출했다.
+
+```text
+ESGPipelineRunner
+CompiledESGPipelineRunner
+PipelineResources
+PipelineRunResult
+compile_program_spec
+load_program_spec_from_dsl
+load_compiled_program_spec_from_dsl
+```
+
+이들은 legacy pass pipeline을 실행하기 위한 surface다.
+
+rebuild branch의 active direction은 다음이다.
+
+```text
+Evidence-backed Judgment
+Compiler Tool Report / Obligations
+Governance Decision
+Receipt Ledger
+Projection Boundary
+```
+
+따라서 top-level `comp`는 legacy runner가 아니라 **judgment core와 이후 compiler-tool loop의 진입면**을 대표해야 한다.
+
+---
+
+## 2. PR1 범위
+
+PR1은 작은 cutover다.
+
+```text
+1. top-level `comp`에서 legacy runner export를 제거한다.
+2. top-level `comp`는 judgment-core exports만 노출한다.
+3. README에 active package surface를 명시한다.
+4. package smoke test를 새 active surface 기준으로 바꾼다.
+```
+
+PR1에서 하지 않는 것:
+
+```text
+legacy 파일 삭제
+legacy pipeline 이동
+pyproject.py-modules 제거
+GovernancePass 수정
+row.status 의미 변경
+LLM API 연결
+CompilerTool 구현
+```
+
+---
+
+## 3. Active surface
+
+PR1 이후 active top-level surface는 judgment core다.
+
+```text
+Fact
+FactTag
+SubjectRef
+SubjectKind
+JudgmentState
+FixpointEngine
+CandidateSummary
+frontier
+winner_or_none
+needs_review
+DraftSnapshot
+CommitSpec
+ProjectionSpec
+CompiledJudgmentProgram
+TransferRule
+SelectionReceipt
+CommitReceipt
+committable
+project_public_row
+```
+
+이 surface는 새 architecture의 최소 기반이다.
+
+```text
+LLM Agent
+→ InterpretationHypothesis
+→ Compiler Tool
+→ CompileReport / Obligations
+→ Judgment Facts
+→ Governance Decision
+→ Receipt
+→ Projection
+```
+
+PR1은 아직 `InterpretationHypothesis`나 `CompileReport`를 추가하지 않는다. 그 작업은 다음 PR의 대상이다.
+
+---
+
+## 4. Legacy/archive 후보
+
+다음은 active surface가 아니라 archive 후보로 본다.
+
+```text
+CompileArtifacts
+LexPass
+ParsePass
+ScopeResolutionPass
+InferencePass
+SemanticPass
+RepairPass
+EmitPass
+GovernancePass
+CalculationPass
+ESGPipelineRunner
+CompiledESGPipelineRunner
+legacy event_log / merge_log 중심 tests
+```
+
+이들은 바로 삭제하지 않는다. 하지만 장기 authority boundary로 승격하지 않는다.
+
+이 판단은 `docs/architecture/kill-list.md`의 다음 항목들과 연결된다.
+
+```text
+row.status as commit truth
+GovernancePass as direct row mutator
+CompileArtifacts as kernel state
+pass-owned semantic authority
+legacy/package parity as architecture success
+```
+
+---
+
+## 5. Import policy
+
+새 코드에서는 다음을 선호한다.
+
+```python
+from comp import Fact, JudgmentState, SubjectRef
+from comp.judgment import SelectionReceipt, CommitReceipt
+```
+
+legacy runner가 필요한 과거 테스트나 archive reference에서는 명시적으로 legacy path를 사용한다.
+
+```python
+from comp.runner import ESGPipelineRunner
+```
+
+다만 `comp.runner` 자체도 장기 active API가 아니다. 이후 PR에서 legacy archive로 이동하거나 compatibility-only surface로 낮춘다.
+
+---
+
+## 6. 다음 PR
+
+PR2는 다음 중 하나로 간다.
+
+```text
+A. legacy pipeline archive 이동
+B. CompilerTool / CompileReport 최소 slice 추가
+```
+
+권장 순서는 다음이다.
+
+```text
+PR1: active top-level surface cutover
+PR2: CompilerTool report contract
+PR3: legacy pipeline archive move
+PR4: report → judgment facts adapter
+```
+
+PR2에서 만들어야 할 최소 모델은 다음이다.
+
+```text
+InterpretationHypothesis
+ClaimHypothesis
+EvidenceWitness
+CompileReport
+CheckedClaim
+FailedClaim
+UnknownClaim
+UncheckedArea
+ProofObligation
+Hazard
+```
+
+---
+
+## 7. Success criteria
+
+PR1은 다음을 만족하면 된다.
+
+```text
+`from comp import Fact, JudgmentState, SubjectRef`가 가능하다.
+`from comp import ESGPipelineRunner`는 더 이상 active contract가 아니다.
+package smoke test가 judgment-core surface 기준으로 갱신된다.
+legacy runner 파일은 아직 존재하지만 top-level active API에서는 내려간다.
+README가 active surface 기준을 설명한다.
+```

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,13 +1,25 @@
-from comp import CompiledESGPipelineRunner, ESGPipelineRunner
-from comp.compat.artifacts import CompileArtifacts
-from comp.compat.compiled_spec import CompiledProgramSpec
-from comp.pipeline import LexPass, ParsePass
+import comp
+from comp import (
+    CommitReceipt,
+    Fact,
+    FixpointEngine,
+    JudgmentState,
+    SelectionReceipt,
+    SubjectRef,
+)
 
 
-def test_package_smoke_imports():
-    assert ESGPipelineRunner is not None
-    assert CompiledESGPipelineRunner is not None
-    assert CompileArtifacts is not None
-    assert CompiledProgramSpec is not None
-    assert LexPass is not None
-    assert ParsePass is not None
+def test_top_level_package_exposes_active_judgment_surface():
+    assert Fact is not None
+    assert JudgmentState is not None
+    assert SubjectRef is not None
+    assert FixpointEngine is not None
+    assert SelectionReceipt is not None
+    assert CommitReceipt is not None
+
+
+def test_top_level_package_no_longer_exports_legacy_runner_surface():
+    assert not hasattr(comp, "ESGPipelineRunner")
+    assert not hasattr(comp, "CompiledESGPipelineRunner")
+    assert not hasattr(comp, "PipelineResources")
+    assert not hasattr(comp, "PipelineRunResult")


### PR DESCRIPTION
## Summary

PR1 for the rebuild cutover.

This narrows the active top-level `comp` package surface away from the legacy pipeline runner facade and toward the judgment-core surface.

The PR intentionally does **not** move or delete legacy pipeline files yet. That is left for a later archive PR.

## Changes

- Add `docs/architecture/active-surface-cutover.md`
- Update `README.md` with the active package surface policy
- Change `comp/__init__.py` to export judgment-core symbols instead of legacy runners
- Update `tests/test_package_smoke.py` to assert the new active surface
- Merge current `main` after PR0 so the PR1 branch includes `docs/architecture/legacy-archive-cutover-plan.md` from #110 without duplicating PR0 work

## New top-level active surface

```python
from comp import Fact, JudgmentState, SubjectRef
from comp import SelectionReceipt, CommitReceipt
```

Legacy runner compatibility remains explicit for now:

```python
from comp.runner import ESGPipelineRunner
```

But it is no longer the active top-level contract.

## Non-goals

- No legacy file deletion
- No legacy file archive move yet
- No pyproject `py-modules` cleanup yet
- No GovernancePass / row.status changes
- No CompilerTool implementation yet
- No LLM API integration

## Validation

- `python -m pytest tests/test_package_smoke.py tests/test_judgment_core.py -q` -> 6 passed
- `git diff --check HEAD` -> passed
- `python -m pytest -q` was also run and still fails in the legacy pipeline suite: 20 failed, 20 passed. The failures are in existing legacy DSL/pipeline tests (`Lowerer().lower(...)` receiving a Lark `Tree`, plus legacy parser/runner related failures), not in the PR1 package-surface tests.