### PR TITLE
docs: declare legacy pipeline archive

### DIFF
--- a/legacy/archive/pipeline_legacy_20260518/README.md
+++ b/legacy/archive/pipeline_legacy_20260518/README.md
@@ -1,0 +1,116 @@
+# Legacy Pipeline Archive
+
+This directory is the archive target for the pre-cutover ESGDL pass pipeline.
+
+The archived pipeline is reference material. It is not the active authority
+boundary for the rebuild branch.
+
+---
+
+## Why This Exists
+
+The legacy pipeline remains useful history, but its core concepts must not
+become the new kernel:
+
+```text
+CompileArtifacts as shared mutable state
+row.status as commit truth
+GovernancePass mutating rows into public state
+merge_log and event_log as receipt substitutes
+pass-owned semantic authority
+legacy/package parity as success
+```
+
+The active rebuild direction is:
+
+```text
+CompilerTool
+-> CompileReport / ProofObligations
+-> Judgment Facts
+-> Governance Decision
+-> Receipt
+-> Projection
+```
+
+---
+
+## Archive Candidates
+
+Pipeline modules:
+
+```text
+artifacts.py
+lex_pass.py
+parse_pass.py
+scope_resolution_pass.py
+inference_pass.py
+semantic_pass.py
+repair_pass.py
+emit_pass.py
+governance_pass.py
+calculation_pass.py
+pipeline_runner.py
+compiled_pipeline_runner.py
+compiled_spec.py
+binder.py
+runtime_env.py
+rule_eval.py
+rule_ir.py
+source_eval.py
+source_ir.py
+lex_eval.py
+lex_ir.py
+esg_builtins.py
+rule_builtins.py
+esgdl.lark
+```
+
+Compatibility surfaces:
+
+```text
+comp.compat
+comp.pipeline
+legacy runner exports
+```
+
+Legacy-oriented tests:
+
+```text
+row.status / merge_log / event_log contract tests
+golden tests for legacy row-pipeline behavior
+compiled runner parity tests
+repair-stage smoke tests
+lex/source stage semantics tied to the legacy pass pipeline
+```
+
+---
+
+## Test Collection Policy
+
+Archived tests must not be collected by active pytest runs.
+
+When tests are copied here, store them as reference material using one of these
+forms:
+
+```text
+reference_tests/*.py.txt
+reference_tests/*.md
+explicit pytest collection exclusions
+```
+
+Do not let archived tests define the active pass/fail status of the rebuild.
+
+---
+
+## Non-Goals For This Declaration
+
+This declaration does not:
+
+```text
+move legacy files
+delete active files
+change pyproject packaging
+change runtime behavior
+implement CompilerTool
+create public projection
+```


### PR DESCRIPTION
## Summary

- Add `legacy/archive/pipeline_legacy_20260518/README.md` as the PR2 archive declaration.
- Document that the legacy pass pipeline is reference material, not the active authority boundary.
- Declare archive candidates, compatibility surfaces, legacy-oriented test categories, and archive test collection policy.

## Scope

This PR intentionally does not move legacy files, delete active files, change packaging, alter runtime behavior, implement CompilerTool, or create public projection.

## Validation

- `git diff --cached --check` passed before commit.
- `python -m pytest tests/test_package_smoke.py tests/test_judgment_core.py -q` passed: 6 passed.
- `python -m pytest -q` currently reports 20 failed, 20 passed from existing legacy pipeline tests. Failures are in legacy runner/parser/binder/e2e areas, primarily `Lowerer().lower(...)` receiving a Lark `Tree` and grammar/token expectations. This PR is docs-only and does not change those paths.