### PR TITLE
archive: copy legacy pipeline snapshot

### DIFF
--- a/legacy/archive/pipeline_legacy_20260518/README.md
+++ b/legacy/archive/pipeline_legacy_20260518/README.md
@@ -85,6 +85,31 @@ lex/source stage semantics tied to the legacy pass pipeline
 
 ---
 
+## Current Snapshot Layout
+
+The PR3 archive copy keeps original active files in place and adds this
+reference snapshot:
+
+```text
+dsl/
+modules/
+package_surfaces/
+reference_tests/
+```
+
+`modules/` contains the top-level legacy pipeline implementation and supporting
+DSL compiler/runtime modules.
+
+`dsl/` contains the root legacy grammar snapshot.
+
+`package_surfaces/` contains compatibility package facades that preserve legacy
+runner, DSL, evaluator, builtin, compat, and pass-export surfaces.
+
+`reference_tests/` contains legacy-oriented tests and fixtures as reference
+material, not active test authority.
+
+---
+
 ## Test Collection Policy
 
 Archived tests must not be collected by active pytest runs.
@@ -102,12 +127,11 @@ Do not let archived tests define the active pass/fail status of the rebuild.
 
 ---
 
-## Non-Goals For This Declaration
+## Non-Goals For This Archive Snapshot
 
-This declaration does not:
+This archive snapshot does not:
 
 ```text
-move legacy files
 delete active files
 change pyproject packaging
 change runtime behavior

--- a/legacy/archive/pipeline_legacy_20260518/dsl/esgdl.lark
+++ b/legacy/archive/pipeline_legacy_20260518/dsl/esgdl.lark
@@ -1,0 +1,188 @@
+start: program
+
+program: statement*
+
+?statement: module_decl
+          | import_decl
+          | dimension_decl
+          | unit_decl
+          | activity_decl
+          | scope_decl
+          | context_decl
+          | frame_decl
+          | token_decl
+          | fallback_token_decl
+          | parser_decl
+          | inherit_rule
+          | infer_rule
+          | require_rule
+          | forbid_rule
+          | diagnostic_rule
+          | resolver_decl
+          | governance_decl
+
+module_decl: "module" qname                         -> module_decl
+import_decl: "import" qname                         -> import_decl
+
+dimension_decl: "dimension" IDENT                   -> dimension_decl
+
+unit_decl: "unit" IDENT ":" IDENT normalize_clause? -> unit_decl
+normalize_clause: "normalize" "(" IDENT "," NORM_OP NUMBER ")" -> normalize_clause
+
+activity_decl: "activity" IDENT ":" IDENT "->" IDENT -> activity_decl
+
+scope_decl: "scope" scope_chain                     -> scope_decl
+scope_chain: IDENT (">" IDENT)+
+
+context_decl: "context" IDENT "{" context_stmt* "}" -> context_decl
+?context_stmt: precedence_stmt
+             | refine_stmt
+             | ttl_stmt
+             | supports_stmt
+
+precedence_stmt: "precedence" precedence_chain      -> precedence_stmt
+precedence_chain: IDENT (">" IDENT)+
+
+refine_stmt: "refine" IDENT "over" IDENT            -> refine_stmt
+
+ttl_stmt: "ttl" ttl_chain                           -> ttl_stmt
+ttl_chain: IDENT ("|" IDENT)+
+
+supports_stmt: "supports" supports_chain            -> supports_stmt
+supports_chain: IDENT ("," IDENT)*
+
+frame_decl: "frame" IDENT "{" field_decl* "}"       -> frame_decl
+field_decl: IDENT ":" type_ref optional_marker?     -> field_decl
+optional_marker: "?"
+type_ref: IDENT generic_arg?                        -> type_ref
+generic_arg: "<" IDENT ">"
+
+token_decl: "token" IDENT ":=" token_expr           -> token_decl
+fallback_token_decl: "fallback" "token" IDENT ":=" token_expr -> fallback_token_decl
+
+token_expr: source_expr
+
+parser_decl: "parser" IDENT "on" selector_chain "{" parser_stmt* "}" -> parser_decl
+selector_chain: IDENT ("|" IDENT)*
+
+?parser_stmt: build_stmt
+            | bind_stmt
+            | parser_inherit_stmt
+            | tag_stmt
+
+build_stmt: "build" IDENT                           -> build_stmt
+bind_stmt: "bind" IDENT optional_marker? "from" source_expr -> bind_stmt
+parser_inherit_stmt: "inherit" IDENT "from" source_expr ("when" bool_expr)? -> parser_inherit_stmt
+tag_stmt: "tag" IDENT "from" source_expr            -> tag_stmt
+
+inherit_rule: "inherit" IDENT "from" source_expr "when" bool_expr -> inherit_rule
+
+infer_rule: "infer" IDENT INFER_OP expr infer_weight? "when" bool_expr -> infer_rule
+infer_weight: "weight" NUMBER
+
+require_rule: "require" bool_expr                   -> require_rule
+forbid_rule: "forbid" bool_expr ("for" "frame" IDENT)? -> forbid_rule
+
+diagnostic_rule: DIAG_LEVEL IDENT "when" bool_expr -> diagnostic_rule
+
+resolver_decl: "resolver" IDENT "{" resolver_stmt* "}" -> resolver_decl
+?resolver_stmt: assign_stmt
+              | candidate_pool_block
+              | commit_stmt
+              | review_stmt
+              | reject_stmt
+
+assign_stmt: IDENT "=" expr                         -> assign_stmt
+
+candidate_pool_block: "candidate_pool" "{" assign_stmt* "}" -> candidate_pool_block
+
+commit_stmt: "commit" "when" bool_expr             -> commit_stmt
+review_stmt: "review" "when" bool_expr             -> review_stmt
+reject_stmt: "reject" "otherwise"                  -> reject_stmt
+
+governance_decl: "governance" IDENT "{" governance_stmt* "}" -> governance_decl
+?governance_stmt: emit_stmt
+                | merge_stmt
+                | forbid_merge_stmt
+
+emit_stmt: "emit" "row" "when" bool_expr           -> emit_stmt
+merge_stmt: "merge" "when" bool_expr               -> merge_stmt
+forbid_merge_stmt: "forbid" "merge" "when" bool_expr -> forbid_merge_stmt
+
+
+// -----------------------------
+// Expressions
+// -----------------------------
+
+?source_expr: source_atom ("|" source_atom)*        -> source_expr
+
+?source_atom: function_call
+            | column_ref
+            | context_ref
+            | row_label_ref
+            | qname
+            | literal
+
+?expr: function_call
+     | column_ref
+     | context_ref
+     | row_label_ref
+     | set_literal
+     | qname
+     | literal
+
+?bool_expr: bool_or
+
+?bool_or: bool_or "or" bool_and                     -> bool_or
+        | bool_and
+
+?bool_and: bool_and "and" bool_not                  -> bool_and
+         | bool_not
+
+?bool_not: "not" bool_not                           -> bool_not
+         | comparison
+         | predicate
+         | "(" bool_expr ")"                        -> grouped_bool
+
+?comparison: expr COMP_OP expr                      -> comparison
+           | expr "in" set_literal                  -> in_expr
+           | expr "matches" expr                    -> matches_expr
+
+?predicate: function_call                           -> bool_call
+          | qname                                   -> bool_ref
+
+function_call: qname "(" [arg_list] ")"            -> function_call
+arg_list: expr ("," expr)*
+
+set_literal: "{" [expr ("," expr)*] "}"            -> set_literal
+
+column_ref: "column" "(" STRING ")"                -> column_ref
+context_ref: "context" "." IDENT                   -> context_ref
+row_label_ref: "row_label" "(" STRING ")"          -> row_label_ref
+
+qname: IDENT ("." IDENT)*                          -> qname
+
+literal: STRING                                    -> string_lit
+       | NUMBER                                    -> number_lit
+       | BOOL                                      -> bool_lit
+
+
+// -----------------------------
+// Tokens
+// -----------------------------
+
+BOOL: "true" | "false"
+COMP_OP: "==" | "!=" | ">=" | "<=" | ">" | "<"
+NORM_OP: "*" | "/" | "+" | "-"
+INFER_OP: "=" | "~"
+DIAG_LEVEL: "error" | "warning"
+
+IDENT: /[A-Za-z_][A-Za-z0-9_]*/
+NUMBER: /-?[0-9]+(\.[0-9]+)?/
+
+%import common.ESCAPED_STRING -> STRING
+%import common.WS
+
+%ignore WS
+%ignore /\/\/[^\n]*/
+%ignore /\#[^\n]*/

--- a/legacy/archive/pipeline_legacy_20260518/modules/artifacts.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/artifacts.py
@@ -1,0 +1,257 @@
+# artifacts.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Optional
+
+
+@dataclass
+class CalculationArtifact:
+    calculation_id: str
+    row_id: str
+    frame_id: str
+
+    row_status_at_calc: str
+    calculation_status: str           # success | failed | excluded
+
+    activity_type: Optional[str] = None
+
+    standardized_amount: Optional[float] = None
+    standardized_unit: Optional[str] = None
+
+    factor_id: Optional[str] = None
+    applied_factor: Optional[float] = None
+    factor_unit: Optional[str] = None
+
+    co2e_kg: Optional[float] = None
+    scope_category: Optional[str] = None
+
+    exclusion_reason: Optional[str] = None
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    calculated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class GovernanceDecisionArtifact:
+    decision_id: str
+    row_id: str
+    frame_id: str
+
+    from_status: str
+    to_status: str
+
+    action: str              # hold | merge | skip
+    actor: str               # system | human_reviewer | policy_engine
+    reason_codes: list[str] = field(default_factory=list)
+    matched_rule_keys: list[str] = field(default_factory=list)
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class DiagnosticArtifact:
+    diagnostic_id: str
+
+    severity: str                 # error | warning | info
+    code: str
+    message: str
+
+    scope_kind: str               # frame | claim | row
+    scope_id: str
+
+    frame_id: Optional[str] = None
+    claim_id: Optional[str] = None
+    fragment_id: Optional[str] = None
+    span: Optional[tuple[int, int]] = None
+
+    rule_kind: Optional[str] = None   # require | forbid | diagnostic | inference
+    source_key: Optional[str] = None  # e.g. require:3, warning:AggregateRow
+    phase: Optional[str] = None       # semantic_pre / semantic_post / inference
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class TokenOccurrence:
+    token_id: str
+    token_name: str
+    fragment_id: str
+
+    value: Any
+    start: Optional[int] = None
+    end: Optional[int] = None
+    confidence: float = 0.0
+
+    source_channel: str = "primary"   # primary | fallback
+    used_llm: bool = False
+    rank: int = 0
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class ClaimArtifact:
+    claim_id: str
+    frame_id: str
+    fragment_id: str
+    parser_name: str
+
+    role_name: str
+    value: Any
+    normalized_value: Any = None
+
+    extraction_mode: str = "explicit"   # explicit | inherited | backward_inferred | derived
+    confidence: float = 0.0
+
+    candidate_state: str = "shadow"     # active | shadow | frozen | rejected
+    status: str = "resolving"
+
+    source_token_id: Optional[str] = None
+    source_fragment_id: Optional[str] = None
+    span: Optional[tuple[int, int]] = None
+
+    reason_codes: list[str] = field(default_factory=list)
+    evidence_ids: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class RoleSlotArtifact:
+    role_name: str
+
+    active_claim_id: Optional[str] = None
+    shadow_claim_ids: list[str] = field(default_factory=list)
+    frozen_claim_ids: list[str] = field(default_factory=list)
+    rejected_claim_ids: list[str] = field(default_factory=list)
+
+    resolved_value: Any = None
+    confidence: float = 0.0
+
+    missing_tag: Optional[str] = None   # missing_waiting_context / missing_parser_failed ...
+    reason_codes: list[str] = field(default_factory=list)
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FrameRuntimeState:
+    resolution_score: float = 0.0
+    iteration_count: int = 0
+    stable_count: int = 0
+    termination_reason: Optional[str] = None
+
+
+@dataclass
+class PartialFrameArtifact:
+    frame_id: str
+    parser_name: str
+    frame_type: str
+
+    fragment_ids: list[str] = field(default_factory=list)
+    slots: dict[str, RoleSlotArtifact] = field(default_factory=dict)
+
+    diagnostics: list[DiagnosticArtifact] = field(default_factory=list)
+    status: str = "resolving"
+    runtime: FrameRuntimeState = field(default_factory=FrameRuntimeState)
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class CompileArtifacts:
+    fragments: list[Any] = field(default_factory=list)
+    tokens: list[TokenOccurrence] = field(default_factory=list)
+    claims: list[ClaimArtifact] = field(default_factory=list)
+    frames: list[PartialFrameArtifact] = field(default_factory=list)
+    rows: list[CanonicalRowArtifact] = field(default_factory=list)
+    calculations: list[CalculationArtifact] = field(default_factory=list)
+
+    diagnostics: list[DiagnosticArtifact] = field(default_factory=list)
+    event_log: list[Any] = field(default_factory=list)
+    commit_log: list[Any] = field(default_factory=list)
+    merge_log: list[GovernanceDecisionArtifact] = field(default_factory=list)
+
+
+def diagnostic_codes(
+    diagnostics: list[DiagnosticArtifact],
+    *,
+    severity: str,
+) -> list[str]:
+    codes: set[str] = set()
+    for diag in diagnostics:
+        if not isinstance(diag, DiagnosticArtifact):
+            raise TypeError("diagnostics must contain DiagnosticArtifact only")
+        if diag.severity == severity and diag.code:
+            codes.add(diag.code)
+    return sorted(codes)
+
+
+def warning_codes_from_diagnostics(diagnostics: list[DiagnosticArtifact]) -> list[str]:
+    return diagnostic_codes(diagnostics, severity="warning")
+
+
+def error_codes_from_diagnostics(diagnostics: list[DiagnosticArtifact]) -> list[str]:
+    return diagnostic_codes(diagnostics, severity="error")
+
+
+@dataclass
+class LineageEvidenceArtifact:
+    claim_id: str
+    fragment_id: Optional[str] = None
+    span: Optional[tuple[int, int]] = None
+    extraction_mode: str = "explicit"
+
+    value: Any = None
+    reason_codes: list[str] = field(default_factory=list)
+    evidence_ids: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RoleLineageArtifact:
+    direct: list[LineageEvidenceArtifact] = field(default_factory=list)
+    inherited: list[LineageEvidenceArtifact] = field(default_factory=list)
+    backward_inferred: list[LineageEvidenceArtifact] = field(default_factory=list)
+    derived: list[LineageEvidenceArtifact] = field(default_factory=list)
+    contradicted_by: list[LineageEvidenceArtifact] = field(default_factory=list)
+
+
+@dataclass
+class CanonicalRowArtifact:
+    row_id: str
+    frame_id: str
+    parser_name: str
+    frame_type: str
+
+    status: str = "committed"
+
+    site_id: Optional[str] = None
+    entity_id: Optional[str] = None
+    period: Optional[str] = None
+    activity_type: Optional[str] = None
+
+    raw_amount: Optional[float] = None
+    raw_unit: Optional[str] = None
+
+    standardized_amount: Optional[float] = None
+    standardized_unit: Optional[str] = None
+
+    scope_category: Optional[str] = None
+    resolution_score: float = 0.0
+
+    lineage: dict[str, RoleLineageArtifact] = field(default_factory=dict)
+
+    source_fragment_ids: list[str] = field(default_factory=list)
+    warning_codes: list[str] = field(default_factory=list)
+    error_codes: list[str] = field(default_factory=list)
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/legacy/archive/pipeline_legacy_20260518/modules/ast_builder.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/ast_builder.py
@@ -1,0 +1,392 @@
+# ast_builder.py
+from __future__ import annotations
+
+import ast
+from lark import Transformer, Token
+
+from ast_nodes import (
+    ActivityDecl,
+    AlternationExpr,
+    AssignStmt,
+    BinaryExpr,
+    BindStmt,
+    BuildStmt,
+    CandidatePoolBlock,
+    ColumnRefExpr,
+    CommitStmt,
+    ContextDecl,
+    ContextRefExpr,
+    DiagnosticRule,
+    DimensionDecl,
+    EmitStmt,
+    FallbackTokenDecl,
+    FieldDecl,
+    ForbidMergeStmt,
+    ForbidRule,
+    FrameDecl,
+    FunctionCallExpr,
+    GovernanceDecl,
+    ImportDecl,
+    InheritRule,
+    InferRule,
+    LiteralExpr,
+    MergeStmt,
+    ModuleDecl,
+    NameExpr,
+    NormalizeClause,
+    ParserDecl,
+    ParserInheritStmt,
+    PrecedenceStmt,
+    Program,
+    RefineStmt,
+    RejectStmt,
+    RequireRule,
+    ResolverDecl,
+    ReviewStmt,
+    RowLabelRefExpr,
+    ScopeDecl,
+    SetExpr,
+    SupportsStmt,
+    TagStmt,
+    TokenDecl,
+    TtlStmt,
+    TypeRef,
+    UnaryExpr,
+    UnitDecl,
+)
+
+
+class ASTBuilder(Transformer):
+    """
+    Lark parse tree -> AST dataclasses
+    """
+
+    # -----------------------------
+    # Tokens
+    # -----------------------------
+    def IDENT(self, tok: Token):
+        return str(tok)
+
+    def NUMBER(self, tok: Token):
+        text = str(tok)
+        return float(text) if "." in text else int(text)
+
+    def STRING(self, tok: Token):
+        return ast.literal_eval(str(tok))
+
+    def BOOL(self, tok: Token):
+        return str(tok) == "true"
+
+    def NORM_OP(self, tok: Token):
+        return str(tok)
+
+    def INFER_OP(self, tok: Token):
+        return str(tok)
+
+    def DIAG_LEVEL(self, tok: Token):
+        return str(tok)
+
+    def COMP_OP(self, tok: Token):
+        return str(tok)
+
+    # -----------------------------
+    # Program
+    # -----------------------------
+    def program(self, items):
+        return Program(statements=list(items))
+
+    # -----------------------------
+    # Top-level declarations
+    # -----------------------------
+    def module_decl(self, items):
+        return ModuleDecl(name=items[0])
+
+    def import_decl(self, items):
+        return ImportDecl(name=items[0])
+
+    def dimension_decl(self, items):
+        return DimensionDecl(name=items[0])
+
+    def normalize_clause(self, items):
+        target_unit, op, factor = items
+        return NormalizeClause(
+            target_unit=target_unit,
+            op=op,
+            factor=float(factor),
+        )
+
+    def unit_decl(self, items):
+        name = items[0]
+        dimension = items[1]
+        normalize = items[2] if len(items) > 2 else None
+        return UnitDecl(name=name, dimension=dimension, normalize=normalize)
+
+    def activity_decl(self, items):
+        return ActivityDecl(
+            name=items[0],
+            dimension=items[1],
+            scope_category=items[2],
+        )
+
+    def scope_chain(self, items):
+        return list(items)
+
+    def scope_decl(self, items):
+        return ScopeDecl(chain=items[0])
+
+    # -----------------------------
+    # Context
+    # -----------------------------
+    def precedence_chain(self, items):
+        return list(items)
+
+    def precedence_stmt(self, items):
+        return PrecedenceStmt(chain=items[0])
+
+    def refine_stmt(self, items):
+        return RefineStmt(specific=items[0], broad=items[1])
+
+    def ttl_chain(self, items):
+        return list(items)
+
+    def ttl_stmt(self, items):
+        return TtlStmt(values=items[0])
+
+    def supports_chain(self, items):
+        return list(items)
+
+    def supports_stmt(self, items):
+        return SupportsStmt(values=items[0])
+
+    def context_decl(self, items):
+        role_name = items[0]
+        stmts = items[1:]
+        return ContextDecl(role_name=role_name, statements=stmts)
+
+    # -----------------------------
+    # Frame
+    # -----------------------------
+    def generic_arg(self, items):
+        return items[0]
+
+    def type_ref(self, items):
+        name = items[0]
+        generic = items[1] if len(items) > 1 else None
+        return TypeRef(name=name, generic=generic)
+
+    def optional_marker(self, _items):
+        return True
+
+    def field_decl(self, items):
+        name = items[0]
+        type_ref = items[1]
+        optional = bool(items[2]) if len(items) > 2 else False
+        return FieldDecl(name=name, type_ref=type_ref, optional=optional)
+
+    def frame_decl(self, items):
+        name = items[0]
+        fields = items[1:]
+        return FrameDecl(name=name, fields=fields)
+
+    # -----------------------------
+    # Token declarations
+    # -----------------------------
+    def token_decl(self, items):
+        return TokenDecl(name=items[0], expr=items[1])
+
+    def fallback_token_decl(self, items):
+        return FallbackTokenDecl(name=items[0], expr=items[1])
+
+    # -----------------------------
+    # Parser declarations
+    # -----------------------------
+    def selector_chain(self, items):
+        return list(items)
+
+    def build_stmt(self, items):
+        return BuildStmt(frame_name=items[0])
+
+    def bind_stmt(self, items):
+        role_name = items[0]
+        if len(items) == 3:
+            return BindStmt(role_name=role_name, optional=True, source_expr=items[2])
+        return BindStmt(role_name=role_name, optional=False, source_expr=items[1])
+
+    def parser_inherit_stmt(self, items):
+        role_name = items[0]
+        source_expr = items[1]
+        condition = items[2] if len(items) > 2 else None
+        return ParserInheritStmt(
+            role_name=role_name,
+            source_expr=source_expr,
+            condition=condition,
+        )
+
+    def tag_stmt(self, items):
+        return TagStmt(role_name=items[0], source_expr=items[1])
+
+    def parser_decl(self, items):
+        name = items[0]
+        selectors = items[1]
+        actions = items[2:]
+        return ParserDecl(name=name, source_selectors=selectors, actions=actions)
+
+    # -----------------------------
+    # Rules
+    # -----------------------------
+    def inherit_rule(self, items):
+        return InheritRule(
+            role_name=items[0],
+            source_expr=items[1],
+            condition=items[2],
+        )
+
+    def infer_weight(self, items):
+        return float(items[0])
+
+    def infer_rule(self, items):
+        target_name = items[0]
+        op = items[1]
+        value_expr = items[2]
+        if len(items) == 4:
+            weight = None
+            condition = items[3]
+        else:
+            weight = float(items[3])
+            condition = items[4]
+        return InferRule(
+            target_name=target_name,
+            op=op,
+            value_expr=value_expr,
+            weight=weight,
+            condition=condition,
+        )
+
+    def require_rule(self, items):
+        return RequireRule(condition=items[0])
+
+    def forbid_rule(self, items):
+        condition = items[0]
+        frame_name = items[1] if len(items) > 1 else None
+        return ForbidRule(condition=condition, frame_name=frame_name)
+
+    def diagnostic_rule(self, items):
+        return DiagnosticRule(
+            level=items[0],
+            code=items[1],
+            condition=items[2],
+        )
+
+    # -----------------------------
+    # Resolver
+    # -----------------------------
+    def assign_stmt(self, items):
+        return AssignStmt(name=items[0], value=items[1])
+
+    def candidate_pool_block(self, items):
+        return CandidatePoolBlock(assigns=list(items))
+
+    def commit_stmt(self, items):
+        return CommitStmt(condition=items[0])
+
+    def review_stmt(self, items):
+        return ReviewStmt(condition=items[0])
+
+    def reject_stmt(self, _items):
+        return RejectStmt()
+
+    def resolver_decl(self, items):
+        frame_name = items[0]
+        stmts = items[1:]
+        return ResolverDecl(frame_name=frame_name, statements=stmts)
+
+    # -----------------------------
+    # Governance
+    # -----------------------------
+    def emit_stmt(self, items):
+        return EmitStmt(condition=items[0])
+
+    def merge_stmt(self, items):
+        return MergeStmt(condition=items[0])
+
+    def forbid_merge_stmt(self, items):
+        return ForbidMergeStmt(condition=items[0])
+
+    def governance_decl(self, items):
+        frame_name = items[0]
+        stmts = items[1:]
+        return GovernanceDecl(frame_name=frame_name, statements=stmts)
+
+    # -----------------------------
+    # Expressions
+    # -----------------------------
+    def qname(self, items):
+        return ".".join(items)
+
+    def string_lit(self, items):
+        return LiteralExpr(value=items[0])
+
+    def number_lit(self, items):
+        return LiteralExpr(value=items[0])
+
+    def bool_lit(self, items):
+        return LiteralExpr(value=items[0])
+
+    def function_call(self, items):
+        name = items[0]
+        args = items[1] if len(items) > 1 else []
+        return FunctionCallExpr(name=name, args=args)
+
+    def arg_list(self, items):
+        return list(items)
+
+    def set_literal(self, items):
+        return SetExpr(items=list(items))
+
+    def column_ref(self, items):
+        return ColumnRefExpr(column_name=items[0])
+
+    def context_ref(self, items):
+        return ContextRefExpr(role_name=items[0])
+
+    def row_label_ref(self, items):
+        return RowLabelRefExpr(label=items[0])
+
+    def source_expr(self, items):
+        if len(items) == 1:
+            return items[0]
+        return AlternationExpr(options=list(items))
+
+    def bool_or(self, items):
+        if len(items) == 1:
+            return items[0]
+        return BinaryExpr(left=items[0], op="or", right=items[1])
+
+    def bool_and(self, items):
+        if len(items) == 1:
+            return items[0]
+        return BinaryExpr(left=items[0], op="and", right=items[1])
+
+    def bool_not(self, items):
+        return UnaryExpr(op="not", operand=items[0])
+
+    def grouped_bool(self, items):
+        return items[0]
+
+    def comparison(self, items):
+        return BinaryExpr(left=items[0], op=items[1], right=items[2])
+
+    def in_expr(self, items):
+        return BinaryExpr(left=items[0], op="in", right=items[1])
+
+    def matches_expr(self, items):
+        return BinaryExpr(left=items[0], op="matches", right=items[1])
+
+    def bool_call(self, items):
+        return items[0]
+
+    def bool_ref(self, items):
+        return NameExpr(name=items[0])
+
+    def literal(self, items):
+        return items[0]

--- a/legacy/archive/pipeline_legacy_20260518/modules/ast_nodes.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/ast_nodes.py
@@ -1,0 +1,354 @@
+# ast_nodes.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+# -----------------------------
+# Base
+# -----------------------------
+
+class ASTNode:
+    pass
+
+
+class Expr(ASTNode):
+    pass
+
+
+class Statement(ASTNode):
+    pass
+
+
+class ParserAction(ASTNode):
+    pass
+
+
+class ResolverStmt(ASTNode):
+    pass
+
+
+class GovernanceStmt(ASTNode):
+    pass
+
+
+# -----------------------------
+# Program
+# -----------------------------
+
+@dataclass
+class Program(ASTNode):
+    statements: list[Statement] = field(default_factory=list)
+
+
+# -----------------------------
+# Expressions
+# -----------------------------
+
+@dataclass
+class NameExpr(Expr):
+    name: str
+
+
+@dataclass
+class LiteralExpr(Expr):
+    value: Any
+
+
+@dataclass
+class FunctionCallExpr(Expr):
+    name: str
+    args: list[Expr] = field(default_factory=list)
+
+
+@dataclass
+class SetExpr(Expr):
+    items: list[Expr] = field(default_factory=list)
+
+
+@dataclass
+class ColumnRefExpr(Expr):
+    column_name: str
+
+
+@dataclass
+class ContextRefExpr(Expr):
+    role_name: str
+
+
+@dataclass
+class RowLabelRefExpr(Expr):
+    label: str
+
+
+@dataclass
+class AlternationExpr(Expr):
+    options: list[Expr] = field(default_factory=list)
+
+
+@dataclass
+class UnaryExpr(Expr):
+    op: str
+    operand: Expr
+
+
+@dataclass
+class BinaryExpr(Expr):
+    left: Expr
+    op: str
+    right: Expr
+
+
+# -----------------------------
+# Top-level declarations
+# -----------------------------
+
+@dataclass
+class ModuleDecl(Statement):
+    name: str
+
+
+@dataclass
+class ImportDecl(Statement):
+    name: str
+
+
+@dataclass
+class DimensionDecl(Statement):
+    name: str
+
+
+@dataclass
+class NormalizeClause(ASTNode):
+    target_unit: str
+    op: str
+    factor: float
+
+
+@dataclass
+class UnitDecl(Statement):
+    name: str
+    dimension: str
+    normalize: Optional[NormalizeClause] = None
+
+
+@dataclass
+class ActivityDecl(Statement):
+    name: str
+    dimension: str
+    scope_category: str
+
+
+@dataclass
+class ScopeDecl(Statement):
+    chain: list[str]
+
+
+# -----------------------------
+# Context
+# -----------------------------
+
+class ContextStmt(ASTNode):
+    pass
+
+
+@dataclass
+class PrecedenceStmt(ContextStmt):
+    chain: list[str]
+
+
+@dataclass
+class RefineStmt(ContextStmt):
+    specific: str
+    broad: str
+
+
+@dataclass
+class TtlStmt(ContextStmt):
+    values: list[str]
+
+
+@dataclass
+class SupportsStmt(ContextStmt):
+    values: list[str]
+
+
+@dataclass
+class ContextDecl(Statement):
+    role_name: str
+    statements: list[ContextStmt] = field(default_factory=list)
+
+
+# -----------------------------
+# Frame
+# -----------------------------
+
+@dataclass
+class TypeRef(ASTNode):
+    name: str
+    generic: Optional[str] = None
+
+
+@dataclass
+class FieldDecl(ASTNode):
+    name: str
+    type_ref: TypeRef
+    optional: bool = False
+
+
+@dataclass
+class FrameDecl(Statement):
+    name: str
+    fields: list[FieldDecl] = field(default_factory=list)
+
+
+# -----------------------------
+# Token declarations
+# -----------------------------
+
+@dataclass
+class TokenDecl(Statement):
+    name: str
+    expr: Expr
+
+
+@dataclass
+class FallbackTokenDecl(Statement):
+    name: str
+    expr: Expr
+
+
+# -----------------------------
+# Parser declarations
+# -----------------------------
+
+@dataclass
+class BuildStmt(ParserAction):
+    frame_name: str
+
+
+@dataclass
+class BindStmt(ParserAction):
+    role_name: str
+    source_expr: Expr
+    optional: bool = False
+
+
+@dataclass
+class ParserInheritStmt(ParserAction):
+    role_name: str
+    source_expr: Expr
+    condition: Optional[Expr] = None
+
+
+@dataclass
+class TagStmt(ParserAction):
+    role_name: str
+    source_expr: Expr
+
+
+@dataclass
+class ParserDecl(Statement):
+    name: str
+    source_selectors: list[str]
+    actions: list[ParserAction] = field(default_factory=list)
+
+
+# -----------------------------
+# Rules
+# -----------------------------
+
+@dataclass
+class InheritRule(Statement):
+    role_name: str
+    source_expr: Expr
+    condition: Expr
+
+
+@dataclass
+class InferRule(Statement):
+    target_name: str
+    op: str          # "=" or "~"
+    value_expr: Expr
+    condition: Expr
+    weight: Optional[float] = None
+
+
+@dataclass
+class RequireRule(Statement):
+    condition: Expr
+
+
+@dataclass
+class ForbidRule(Statement):
+    condition: Expr
+    frame_name: Optional[str] = None
+
+
+@dataclass
+class DiagnosticRule(Statement):
+    level: str       # error / warning
+    code: str
+    condition: Expr
+
+
+# -----------------------------
+# Resolver
+# -----------------------------
+
+@dataclass
+class AssignStmt(ResolverStmt):
+    name: str
+    value: Expr
+
+
+@dataclass
+class CandidatePoolBlock(ResolverStmt):
+    assigns: list[AssignStmt] = field(default_factory=list)
+
+
+@dataclass
+class CommitStmt(ResolverStmt):
+    condition: Expr
+
+
+@dataclass
+class ReviewStmt(ResolverStmt):
+    condition: Expr
+
+
+@dataclass
+class RejectStmt(ResolverStmt):
+    pass
+
+
+@dataclass
+class ResolverDecl(Statement):
+    frame_name: str
+    statements: list[ResolverStmt] = field(default_factory=list)
+
+
+# -----------------------------
+# Governance
+# -----------------------------
+
+@dataclass
+class EmitStmt(GovernanceStmt):
+    condition: Expr
+
+
+@dataclass
+class MergeStmt(GovernanceStmt):
+    condition: Expr
+
+
+@dataclass
+class ForbidMergeStmt(GovernanceStmt):
+    condition: Expr
+
+
+@dataclass
+class GovernanceDecl(Statement):
+    frame_name: str
+    statements: list[GovernanceStmt] = field(default_factory=list)

--- a/legacy/archive/pipeline_legacy_20260518/modules/binder.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/binder.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from ast_nodes import AlternationExpr, BinaryExpr, BindStmt, BuildStmt, ColumnRefExpr, ContextRefExpr, Expr, FunctionCallExpr, LiteralExpr, NameExpr, ParserInheritStmt, RowLabelRefExpr, SetExpr, TagStmt, UnaryExpr
+from compiled_spec import CompiledBindAction, CompiledConstraintSpec, CompiledDiagnosticSpec, CompiledGovernancePolicy, CompiledInheritSpec, CompiledInferSpec, CompiledParserInheritAction, CompiledParserSpec, CompiledProgramSpec, CompiledResolverPolicy, CompiledTagAction, CompiledTokenSpec
+from lex_ir import LexBuiltinCall, LexColumnRef, LexContextRef, LexExpr, LexLiteral, LexRowLabelMatch, LexSetExpr, LexSymbolConst, LexUnion
+from rule_ir import ContextValueRef, FrameSlotRef, HasApproval, HasDiagnostic, LocalVarRef, PolicyRef, RowFieldRef, RuleBinary, RuleBuiltinCall, RuleCoalesce, RuleExpr, RuleLiteral, RuleSetExpr, RuleUnary, SymbolConst
+from source_ir import SourceBuiltinCall, SourceColumnRef, SourceContextRef, SourceExpr, SourceFirstOf, SourceLiteral, SourceRowLabelMatch, SourceSetExpr, SourceSymbolConst, SourceTokenRef
+from spec_nodes import ProgramSpec
+
+
+class BindingError(ValueError):
+    pass
+
+
+@dataclass
+class BindingWarning:
+    code: str
+    message: str
+
+
+@dataclass
+class BindingReport:
+    warnings: list[BindingWarning] = field(default_factory=list)
+
+    def messages(self) -> list[str]:
+        return [warning.message for warning in self.warnings]
+
+
+@dataclass
+class BindingHost:
+    kind: str
+    frame_name: str | None = None
+    local_vars: set[str] = field(default_factory=set)
+    frame_slots: set[str] = field(default_factory=set)
+    row_field_aliases: dict[str, str] = field(default_factory=dict)
+
+
+class Binder:
+    RULE_BUILTINS = {"dimension", "compatible", "valid", "valid_period", "missing", "origin", "evidence"}
+    FRAME_ONLY_RULE_BUILTINS = {"missing", "origin", "evidence"}
+    LEXICAL_BUILTINS = {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number", "one_of", "llm.fuzzy_lex"}
+    TOKEN_BUILTINS = set(LEXICAL_BUILTINS)
+    SOURCE_BUILTINS = set(LEXICAL_BUILTINS)
+    KNOWN_BUILTINS = RULE_BUILTINS | LEXICAL_BUILTINS
+    SYMBOL_ALLOWLIST = {"committed", "merged", "review_required", "rejected", "resolving"}
+    GOVERNANCE_ROW_FIELDS = {"row_id": "row_id", "frame_id": "frame_id", "frame_type": "frame_type", "status": "status", "score": "resolution_score", "resolution_score": "resolution_score", "site_id": "site_id", "entity_id": "entity_id", "period": "period", "activity_type": "activity_type", "raw_amount": "raw_amount", "raw_unit": "raw_unit", "standardized_amount": "standardized_amount", "standardized_unit": "standardized_unit", "scope_category": "scope_category", "parser_name": "parser_name"}
+    FRAME_RULE_LOCALS = {"frame_type", "status"}
+    RESOLVER_LOCALS = {"score", "stable", "status", "iteration", "no_improve_count"}
+
+    def bind(self, spec: ProgramSpec) -> CompiledProgramSpec:
+        report = BindingReport()
+        return CompiledProgramSpec(
+            syntax=spec,
+            compiled_tokens={name: self._bind_token_spec(spec, token_spec) for name, token_spec in spec.tokens.items()},
+            compiled_parsers={name: self._bind_parser_spec(spec, parser_spec) for name, parser_spec in spec.parsers.items()},
+            compiled_inherit_rules=[CompiledInheritSpec(syntax=rule, source_ir=self._bind_source_expr(rule.source_expr, spec=spec, allow_token_ref=False), condition_ir=self._bind_expr(rule.condition, host=self._frame_rule_host(spec, None), spec=spec)) for rule in spec.inherit_rules],
+            compiled_constraints=[CompiledConstraintSpec(syntax=constraint, condition_ir=self._bind_expr(constraint.condition, host=self._frame_rule_host(spec, constraint.frame_name), spec=spec)) for constraint in spec.constraints],
+            compiled_diagnostics=[CompiledDiagnosticSpec(syntax=diagnostic, condition_ir=self._bind_expr(diagnostic.condition, host=self._frame_rule_host(spec, None), spec=spec)) for diagnostic in spec.diagnostics],
+            compiled_infer_rules=[CompiledInferSpec(syntax=rule, value_ir=self._bind_expr(rule.value_expr, host=self._frame_rule_host(spec, None), spec=spec), condition_ir=self._bind_expr(rule.condition, host=self._frame_rule_host(spec, None), spec=spec)) for rule in spec.infer_rules],
+            compiled_resolvers={frame_name: self._bind_resolver_policy(spec, frame_name, policy) for frame_name, policy in spec.resolvers.items()},
+            compiled_governances={frame_name: self._bind_governance_policy(spec, frame_name, policy) for frame_name, policy in spec.governances.items()},
+            binding_warnings=report.messages(),
+        )
+
+    def _bind_token_spec(self, spec: ProgramSpec, token_spec) -> CompiledTokenSpec:
+        return CompiledTokenSpec(syntax=token_spec, primary_ir=self._bind_token_expr(token_spec.primary_expr, spec=spec) if token_spec.primary_expr is not None else None, fallback_ir=self._bind_token_expr(token_spec.fallback_expr, spec=spec) if token_spec.fallback_expr is not None else None)
+
+    def _bind_parser_spec(self, spec: ProgramSpec, parser_spec) -> CompiledParserSpec:
+        host = self._frame_rule_host(spec, parser_spec.build_frame)
+        actions = []
+        for action in parser_spec.actions:
+            if isinstance(action, BuildStmt):
+                continue
+            if isinstance(action, BindStmt):
+                actions.append(CompiledBindAction(syntax=action, source_ir=self._bind_source_expr(action.source_expr, spec=spec, allow_token_ref=True)))
+                continue
+            if isinstance(action, ParserInheritStmt):
+                actions.append(CompiledParserInheritAction(syntax=action, source_ir=self._bind_source_expr(action.source_expr, spec=spec, allow_token_ref=True), condition_ir=self._bind_expr(action.condition, host=host, spec=spec) if action.condition is not None else None))
+                continue
+            if isinstance(action, TagStmt):
+                actions.append(CompiledTagAction(syntax=action, source_ir=self._bind_source_expr(action.source_expr, spec=spec, allow_token_ref=True)))
+                continue
+            raise BindingError(f"unsupported parser action for binding: {type(action).__name__}")
+        return CompiledParserSpec(syntax=parser_spec, actions=actions)
+
+    def _bind_resolver_policy(self, spec: ProgramSpec, frame_name: str, policy) -> CompiledResolverPolicy:
+        host = self._resolver_host(spec, frame_name)
+        return CompiledResolverPolicy(syntax=policy, assigns_ir={name: self._bind_expr(expr, host=host, spec=spec) for name, expr in policy.assigns.items()}, candidate_pool_assigns_ir={name: self._bind_expr(expr, host=host, spec=spec) for name, expr in policy.candidate_pool_assigns.items()}, commit_condition_ir=self._bind_expr(policy.commit_condition, host=host, spec=spec) if policy.commit_condition is not None else None, review_condition_ir=self._bind_expr(policy.review_condition, host=host, spec=spec) if policy.review_condition is not None else None)
+
+    def _bind_governance_policy(self, spec: ProgramSpec, frame_name: str, policy) -> CompiledGovernancePolicy:
+        host = self._governance_host(frame_name)
+        return CompiledGovernancePolicy(syntax=policy, emit_condition_ir=self._bind_expr(policy.emit_condition, host=host, spec=spec) if policy.emit_condition is not None else None, merge_conditions_ir=[self._bind_expr(expr, host=host, spec=spec) for expr in policy.merge_conditions], forbid_merge_conditions_ir=[self._bind_expr(expr, host=host, spec=spec) for expr in policy.forbid_merge_conditions])
+
+    def _frame_rule_host(self, spec: ProgramSpec, frame_name: str | None) -> BindingHost:
+        return BindingHost(kind="frame_rule", frame_name=frame_name, local_vars=set(self.FRAME_RULE_LOCALS), frame_slots=self._frame_slots(spec, frame_name))
+
+    def _resolver_host(self, spec: ProgramSpec, frame_name: str) -> BindingHost:
+        return BindingHost(kind="resolver", frame_name=frame_name, local_vars=set(self.RESOLVER_LOCALS), frame_slots=self._frame_slots(spec, frame_name))
+
+    def _governance_host(self, frame_name: str) -> BindingHost:
+        return BindingHost(kind="governance", frame_name=frame_name, row_field_aliases=dict(self.GOVERNANCE_ROW_FIELDS))
+
+    def _frame_slots(self, spec: ProgramSpec, frame_name: str | None) -> set[str]:
+        frame_names: Iterable[str] = spec.frames.keys() if frame_name is None else [frame_name]
+        names: set[str] = set()
+        for target_frame_name in frame_names:
+            frame_spec = spec.frames.get(target_frame_name)
+            if frame_spec is not None:
+                names.update(field.name for field in frame_spec.fields)
+            for parser in spec.parsers.values():
+                if parser.build_frame != target_frame_name:
+                    continue
+                for action in parser.actions:
+                    role_name = getattr(action, "role_name", None)
+                    if role_name:
+                        names.add(role_name)
+        names.update(rule.target_name for rule in spec.infer_rules if rule.target_name)
+        return names
+
+    def _declared_symbol_names(self, spec: ProgramSpec) -> set[str]:
+        return set(spec.frames.keys()) | set(spec.activities.keys()) | set(spec.units.keys()) | set(spec.dimensions.keys())
+
+    def _is_symbol_const_name(self, name: str, spec: ProgramSpec) -> bool:
+        return name in self._declared_symbol_names(spec) or name in self.SYMBOL_ALLOWLIST
+
+    def _bind_expr(self, expr: Expr, *, host: BindingHost, spec: ProgramSpec) -> RuleExpr:
+        if isinstance(expr, LiteralExpr):
+            return RuleLiteral(value=expr.value)
+        if isinstance(expr, NameExpr):
+            return self._bind_name(expr.name, host=host, spec=spec)
+        if isinstance(expr, FunctionCallExpr):
+            return self._bind_call(expr, host=host, spec=spec)
+        if isinstance(expr, SetExpr):
+            return RuleSetExpr(items=[self._bind_expr(item, host=host, spec=spec) for item in expr.items])
+        if isinstance(expr, ContextRefExpr):
+            return ContextValueRef(role_name=expr.role_name)
+        if isinstance(expr, AlternationExpr):
+            return RuleCoalesce(options=[self._bind_expr(option, host=host, spec=spec) for option in expr.options])
+        if isinstance(expr, UnaryExpr):
+            return RuleUnary(op=expr.op, operand=self._bind_expr(expr.operand, host=host, spec=spec))
+        if isinstance(expr, BinaryExpr):
+            return RuleBinary(left=self._bind_expr(expr.left, host=host, spec=spec), op=expr.op, right=self._bind_expr(expr.right, host=host, spec=spec))
+        if isinstance(expr, ColumnRefExpr):
+            raise BindingError(f"column(...) is not allowed in rule host {host.kind}")
+        if isinstance(expr, RowLabelRefExpr):
+            raise BindingError(f"row_label(...) is not allowed in rule host {host.kind}")
+        raise BindingError(f"unsupported rule expression: {type(expr).__name__}")
+
+    def _bind_name(self, name: str, *, host: BindingHost, spec: ProgramSpec) -> RuleExpr:
+        if name.startswith("policy."):
+            key = name.split(".", 1)[1]
+            if not key:
+                raise BindingError("policy reference must include a key")
+            return PolicyRef(key=key)
+        if name.startswith("warning."):
+            code = name.split(".", 1)[1]
+            if not code:
+                raise BindingError("warning reference must include a code")
+            return HasDiagnostic(severity="warning", code=code)
+        if name.startswith("error."):
+            code = name.split(".", 1)[1]
+            if not code:
+                raise BindingError("error reference must include a code")
+            return HasDiagnostic(severity="error", code=code)
+        if name.startswith("approval."):
+            key = name.split(".", 1)[1]
+            if not key:
+                raise BindingError("approval reference must include a key")
+            return HasApproval(key=key)
+        if name in host.local_vars:
+            return LocalVarRef(name=name)
+        if name in host.row_field_aliases:
+            return RowFieldRef(field_name=host.row_field_aliases[name])
+        if name in host.frame_slots:
+            return FrameSlotRef(role_name=name)
+        if self._is_symbol_const_name(name, spec):
+            return SymbolConst(name=name)
+        raise BindingError(f"unable to bind name '{name}' in host {host.kind}" + (f" for frame {host.frame_name}" if host.frame_name else ""))
+
+    def _bind_call(self, expr: FunctionCallExpr, *, host: BindingHost, spec: ProgramSpec) -> RuleBuiltinCall:
+        if expr.name in self.LEXICAL_BUILTINS:
+            raise BindingError(f"lexical builtin '{expr.name}' is not allowed in rule host {host.kind}")
+        if expr.name not in self.RULE_BUILTINS:
+            raise BindingError(f"unknown rule builtin: {expr.name}")
+        if expr.name in self.FRAME_ONLY_RULE_BUILTINS and host.kind not in {"frame_rule", "resolver"}:
+            raise BindingError(f"frame-only rule builtin '{expr.name}' is not allowed in rule host {host.kind}")
+        return RuleBuiltinCall(name=expr.name, args=[self._bind_expr(arg, host=host, spec=spec) for arg in expr.args])
+
+    def _bind_token_expr(self, expr: Expr, *, spec: ProgramSpec) -> LexExpr:
+        if isinstance(expr, LiteralExpr):
+            return LexLiteral(value=expr.value)
+        if isinstance(expr, NameExpr):
+            if not self._is_symbol_const_name(expr.name, spec):
+                raise BindingError(f"unable to bind bare name '{expr.name}' in token host; use a quoted literal or declared symbol")
+            return LexSymbolConst(name=expr.name)
+        if isinstance(expr, FunctionCallExpr):
+            if expr.name not in self.TOKEN_BUILTINS:
+                if expr.name in self.KNOWN_BUILTINS:
+                    raise BindingError(f"builtin '{expr.name}' is not allowed in token host")
+                raise BindingError(f"unknown builtin in token expression: {expr.name}")
+            return LexBuiltinCall(name=expr.name, args=[self._bind_token_value_expr(arg, spec=spec) for arg in expr.args])
+        if isinstance(expr, SetExpr):
+            return LexSetExpr(items=[self._bind_token_value_expr(item, spec=spec) for item in expr.items])
+        if isinstance(expr, ColumnRefExpr):
+            return LexColumnRef(column_name=expr.column_name)
+        if isinstance(expr, ContextRefExpr):
+            return LexContextRef(role_name=expr.role_name)
+        if isinstance(expr, RowLabelRefExpr):
+            return LexRowLabelMatch(label=expr.label)
+        if isinstance(expr, AlternationExpr):
+            return LexUnion(options=[self._bind_token_expr(option, spec=spec) for option in expr.options])
+        if isinstance(expr, (UnaryExpr, BinaryExpr)):
+            raise BindingError(f"boolean/comparison expression is not allowed in token host: {type(expr).__name__}")
+        raise BindingError(f"unsupported token expression: {type(expr).__name__}")
+
+    def _bind_token_value_expr(self, expr: Expr, *, spec: ProgramSpec) -> LexExpr:
+        if isinstance(expr, AlternationExpr):
+            raise BindingError("alternation is not allowed inside token builtin arguments")
+        return self._bind_token_expr(expr, spec=spec)
+
+    def _bind_source_expr(self, expr: Expr, *, spec: ProgramSpec, allow_token_ref: bool) -> SourceExpr:
+        if isinstance(expr, LiteralExpr):
+            return SourceLiteral(value=expr.value)
+        if isinstance(expr, NameExpr):
+            if allow_token_ref and expr.name in spec.tokens:
+                return SourceTokenRef(token_name=expr.name)
+            if self._is_symbol_const_name(expr.name, spec):
+                return SourceSymbolConst(name=expr.name)
+            raise BindingError(f"unable to bind bare name '{expr.name}' in source host; use a declared token, quoted literal, or declared symbol")
+        if isinstance(expr, FunctionCallExpr):
+            if expr.name not in self.SOURCE_BUILTINS:
+                if expr.name in self.KNOWN_BUILTINS:
+                    raise BindingError(f"builtin '{expr.name}' is not allowed in source host")
+                raise BindingError(f"unknown builtin in source expression: {expr.name}")
+            return SourceBuiltinCall(name=expr.name, args=[self._bind_source_value_expr(arg, spec=spec) for arg in expr.args])
+        if isinstance(expr, SetExpr):
+            return SourceSetExpr(items=[self._bind_source_value_expr(item, spec=spec) for item in expr.items])
+        if isinstance(expr, ColumnRefExpr):
+            return SourceColumnRef(column_name=expr.column_name)
+        if isinstance(expr, ContextRefExpr):
+            return SourceContextRef(role_name=expr.role_name)
+        if isinstance(expr, RowLabelRefExpr):
+            return SourceRowLabelMatch(label=expr.label)
+        if isinstance(expr, AlternationExpr):
+            return SourceFirstOf(options=[self._bind_source_expr(option, spec=spec, allow_token_ref=allow_token_ref) for option in expr.options])
+        if isinstance(expr, (UnaryExpr, BinaryExpr)):
+            raise BindingError(f"boolean/comparison expression is not allowed in source host: {type(expr).__name__}")
+        raise BindingError(f"unsupported source expression: {type(expr).__name__}")
+
+    def _bind_source_value_expr(self, expr: Expr, *, spec: ProgramSpec) -> SourceExpr:
+        if isinstance(expr, AlternationExpr):
+            raise BindingError("alternation is not allowed inside source builtin arguments")
+        return self._bind_source_expr(expr, spec=spec, allow_token_ref=False)

--- a/legacy/archive/pipeline_legacy_20260518/modules/calculation_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/calculation_pass.py
@@ -1,0 +1,282 @@
+# calculation_pass.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+from typing import Any, Optional
+
+from artifacts import CalculationArtifact, CanonicalRowArtifact, CompileArtifacts
+from runtime_env import RuntimeEnv
+
+
+@dataclass
+class CalculationPassConfig:
+    """
+    기본 원칙:
+    - merged row만 계산
+    - ActivityObservation만 계산
+    - standardized_amount/unit 우선 사용
+    - 필요하면 raw_amount/raw_unit fallback 허용
+    """
+    calculate_only_merged: bool = True
+    supported_frame_types: tuple[str, ...] = ("ActivityObservation",)
+    allow_raw_fallback: bool = True
+
+    # governance가 막아줬겠지만 마지막 safety belt
+    exclude_rows_with_errors: bool = True
+    exclude_rows_with_aggregate_warning: bool = True
+
+    emit_events: bool = True
+    replace_existing_calculations: bool = True
+
+
+class CalculationPass:
+    def __init__(self, config: Optional[CalculationPassConfig] = None) -> None:
+        self.config = config or CalculationPassConfig()
+        self._calc_seq = count(1)
+
+    def run(
+        self,
+        spec,
+        artifacts: CompileArtifacts,
+        env: RuntimeEnv,
+    ) -> CompileArtifacts:
+        results: list[CalculationArtifact] = []
+
+        for row in artifacts.rows:
+            result = self._calculate_row(row=row, env=env)
+            if result is None:
+                continue
+
+            results.append(result)
+
+            # row metadata에 간단 trace 남김
+            row.metadata.setdefault("calculation_trace", []).append(
+                {
+                    "calculation_id": result.calculation_id,
+                    "status": result.calculation_status,
+                    "reason": result.exclusion_reason,
+                    "factor_id": result.factor_id,
+                    "co2e_kg": result.co2e_kg,
+                }
+            )
+
+            if self.config.emit_events:
+                artifacts.event_log.append(
+                    {
+                        "event_id": f"EVT-CALC-{result.calculation_id}",
+                        "record_id": row.row_id,
+                        "event_type": (
+                            "CALCULATED"
+                            if result.calculation_status == "success"
+                            else "CALCULATION_EXCLUDED"
+                            if result.calculation_status == "excluded"
+                            else "CALCULATION_FAILED"
+                        ),
+                        "from_status": row.status,
+                        "to_status": row.status,
+                        "actor": "calculation_engine",
+                        "reason_codes": [result.exclusion_reason] if result.exclusion_reason else [],
+                        "created_at": result.calculated_at.isoformat() + "Z",
+                    }
+                )
+
+        if self.config.replace_existing_calculations:
+            artifacts.calculations = results
+        else:
+            artifacts.calculations.extend(results)
+
+        return artifacts
+
+    # ------------------------------------------------------------------
+    # Core
+    # ------------------------------------------------------------------
+
+    def _calculate_row(
+        self,
+        *,
+        row: CanonicalRowArtifact,
+        env: RuntimeEnv,
+    ) -> Optional[CalculationArtifact]:
+        # 1) merged row만
+        if self.config.calculate_only_merged and row.status != "merged":
+            return None
+
+        # 2) frame type gate
+        if row.frame_type not in self.config.supported_frame_types:
+            return self._excluded(
+                row=row,
+                reason="unsupported_frame_type",
+                metadata={"supported_frame_types": list(self.config.supported_frame_types)},
+            )
+
+        # 3) aggregate warning이 있으면 마지막 safety belt
+        if self.config.exclude_rows_with_aggregate_warning and "AggregateRow" in set(row.warning_codes):
+            return self._excluded(
+                row=row,
+                reason="aggregate_row_excluded",
+            )
+
+        # 4) error diagnostics 있으면 계산 금지
+        if self.config.exclude_rows_with_errors and row.error_codes:
+            return self._excluded(
+                row=row,
+                reason="row_has_error_diagnostics",
+                metadata={"error_codes": list(row.error_codes)},
+            )
+
+        # 5) 입력값 선택
+        amount, unit, used_raw_fallback = self._pick_amount_unit(row)
+
+        if row.activity_type in (None, ""):
+            return self._failed(
+                row=row,
+                reason="missing_activity_type",
+                amount=amount,
+                unit=unit,
+            )
+
+        if amount is None or unit is None:
+            return self._failed(
+                row=row,
+                reason="missing_amount_or_unit",
+                amount=amount,
+                unit=unit,
+            )
+
+        # 6) factor lookup
+        factor = env.factor_index.get((row.activity_type, unit))
+
+        # standardized lookup 실패 시 raw fallback 재시도
+        if factor is None and not used_raw_fallback and self.config.allow_raw_fallback:
+            if row.raw_amount is not None and row.raw_unit not in (None, ""):
+                amount = float(row.raw_amount)
+                unit = str(row.raw_unit)
+                used_raw_fallback = True
+                factor = env.factor_index.get((row.activity_type, unit))
+
+        if factor is None:
+            return self._failed(
+                row=row,
+                reason="factor_not_found",
+                amount=amount,
+                unit=unit,
+                metadata={
+                    "factor_lookup_key": [row.activity_type, unit],
+                    "used_raw_fallback": used_raw_fallback,
+                },
+            )
+
+        # 7) factor 적용
+        try:
+            applied_factor = float(factor["emission_factor"])
+        except Exception:
+            return self._failed(
+                row=row,
+                reason="invalid_factor_value",
+                amount=amount,
+                unit=unit,
+                metadata={"factor_row": dict(factor)},
+            )
+
+        co2e_kg = float(amount) * applied_factor
+
+        return CalculationArtifact(
+            calculation_id=f"CAL-{next(self._calc_seq):07d}",
+            row_id=row.row_id,
+            frame_id=row.frame_id,
+
+            row_status_at_calc=row.status,
+            calculation_status="success",
+
+            activity_type=row.activity_type,
+
+            standardized_amount=float(amount),
+            standardized_unit=str(unit),
+
+            factor_id=factor.get("factor_id"),
+            applied_factor=applied_factor,
+            factor_unit=factor.get("factor_unit"),
+
+            co2e_kg=round(co2e_kg, 6),
+            scope_category=row.scope_category,
+
+            metadata={
+                "used_raw_fallback": used_raw_fallback,
+                "source_row_status": row.status,
+                "factor_lookup_key": [row.activity_type, unit],
+                "warning_codes": list(row.warning_codes),
+                "error_codes": list(row.error_codes),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Amount / unit selection
+    # ------------------------------------------------------------------
+
+    def _pick_amount_unit(
+        self,
+        row: CanonicalRowArtifact,
+    ) -> tuple[Optional[float], Optional[str], bool]:
+        # standardized 우선
+        if row.standardized_amount is not None and row.standardized_unit not in (None, ""):
+            return float(row.standardized_amount), str(row.standardized_unit), False
+
+        # raw fallback
+        if self.config.allow_raw_fallback:
+            if row.raw_amount is not None and row.raw_unit not in (None, ""):
+                return float(row.raw_amount), str(row.raw_unit), True
+
+        return None, None, False
+
+    # ------------------------------------------------------------------
+    # Result constructors
+    # ------------------------------------------------------------------
+
+    def _excluded(
+        self,
+        *,
+        row: CanonicalRowArtifact,
+        reason: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> CalculationArtifact:
+        return CalculationArtifact(
+            calculation_id=f"CAL-{next(self._calc_seq):07d}",
+            row_id=row.row_id,
+            frame_id=row.frame_id,
+
+            row_status_at_calc=row.status,
+            calculation_status="excluded",
+
+            activity_type=row.activity_type,
+            scope_category=row.scope_category,
+
+            exclusion_reason=reason,
+            metadata=metadata or {},
+        )
+
+    def _failed(
+        self,
+        *,
+        row: CanonicalRowArtifact,
+        reason: str,
+        amount: Optional[float],
+        unit: Optional[str],
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> CalculationArtifact:
+        return CalculationArtifact(
+            calculation_id=f"CAL-{next(self._calc_seq):07d}",
+            row_id=row.row_id,
+            frame_id=row.frame_id,
+
+            row_status_at_calc=row.status,
+            calculation_status="failed",
+
+            activity_type=row.activity_type,
+            standardized_amount=amount,
+            standardized_unit=unit,
+            scope_category=row.scope_category,
+
+            exclusion_reason=reason,
+            metadata=metadata or {},
+        )

--- a/legacy/archive/pipeline_legacy_20260518/modules/compiled_expr_eval.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/compiled_expr_eval.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from types import SimpleNamespace
+
+from expr_eval import ExprEvaluator
+from rule_ir import RuleExpr
+from rule_eval import RuleEvaluator
+
+
+class CompiledExprEvaluator(ExprEvaluator):
+    def __init__(self, *, rule_evaluator: RuleEvaluator | None = None) -> None:
+        super().__init__()
+        self.rule_evaluator = RuleEvaluator() if rule_evaluator is None else rule_evaluator
+
+    def eval(self, expr, ctx):
+        if isinstance(expr, RuleExpr):
+            return self.rule_evaluator.eval(expr, self._ctx(ctx))
+        return super().eval(expr, ctx)
+
+    def eval_bool(self, expr, ctx):
+        if isinstance(expr, RuleExpr):
+            return self.rule_evaluator.eval_bool(expr, self._ctx(ctx))
+        return super().eval_bool(expr, ctx)
+
+    def _ctx(self, ctx):
+        row = getattr(ctx, "row", None)
+        if row in (None, {}):
+            row = getattr(ctx, "local_vars", {})
+        return SimpleNamespace(
+            env=ctx.env,
+            text=getattr(ctx, "text", ""),
+            scope_path=getattr(ctx, "scope_path", tuple()),
+            column_key=getattr(ctx, "column_key", None),
+            row=row,
+            frame=getattr(ctx, "frame", None),
+            claims_by_id=getattr(ctx, "claims_by_id", {}),
+            local_vars=getattr(ctx, "local_vars", {}),
+            warning_codes=set(getattr(ctx, "warning_codes", set()) or set()),
+            error_codes=set(getattr(ctx, "error_codes", set()) or set()),
+            approvals=getattr(ctx, "approvals", {}),
+        )

--- a/legacy/archive/pipeline_legacy_20260518/modules/compiled_pipeline_runner.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/compiled_pipeline_runner.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from compiled_spec import CompiledProgramSpec
+from pipeline_runner import ESGPipelineRunner, load_compiled_program_spec_from_dsl
+
+
+class CompiledESGPipelineRunner(ESGPipelineRunner):
+    def load_spec(
+        self,
+        *,
+        dsl_path: str | Path | None = None,
+        dsl_text: str | None = None,
+    ) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(
+            grammar_path=self.grammar_path,
+            dsl_path=dsl_path,
+            dsl_text=dsl_text,
+        )

--- a/legacy/archive/pipeline_legacy_20260518/modules/compiled_spec.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/compiled_spec.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ast_nodes import BindStmt, ParserInheritStmt, TagStmt
+from lex_ir import LexExpr
+from rule_ir import RuleExpr
+from source_ir import SourceExpr
+from spec_nodes import (
+    ConstraintSpec,
+    DiagnosticSpec,
+    GovernancePolicy,
+    InferSpec,
+    InheritSpec,
+    ParserSpec,
+    ProgramSpec,
+    ResolverPolicy,
+    TokenSpec,
+)
+
+
+@dataclass
+class CompiledTokenSpec:
+    syntax: TokenSpec
+    primary_ir: LexExpr | None = None
+    fallback_ir: LexExpr | None = None
+
+
+@dataclass
+class CompiledInheritSpec:
+    syntax: InheritSpec
+    source_ir: SourceExpr
+    condition_ir: RuleExpr
+
+
+@dataclass
+class CompiledConstraintSpec:
+    syntax: ConstraintSpec
+    condition_ir: RuleExpr
+
+
+@dataclass
+class CompiledDiagnosticSpec:
+    syntax: DiagnosticSpec
+    condition_ir: RuleExpr
+
+
+@dataclass
+class CompiledInferSpec:
+    syntax: InferSpec
+    value_ir: RuleExpr
+    condition_ir: RuleExpr
+
+
+@dataclass
+class CompiledBindAction:
+    syntax: BindStmt
+    source_ir: SourceExpr
+
+
+@dataclass
+class CompiledParserInheritAction:
+    syntax: ParserInheritStmt
+    source_ir: SourceExpr
+    condition_ir: RuleExpr | None = None
+
+
+@dataclass
+class CompiledTagAction:
+    syntax: TagStmt
+    source_ir: SourceExpr
+
+
+CompiledParserAction = CompiledBindAction | CompiledParserInheritAction | CompiledTagAction
+
+
+@dataclass
+class CompiledParserSpec:
+    syntax: ParserSpec
+    actions: list[CompiledParserAction] = field(default_factory=list)
+
+
+@dataclass
+class CompiledResolverPolicy:
+    syntax: ResolverPolicy
+    assigns_ir: dict[str, RuleExpr] = field(default_factory=dict)
+    candidate_pool_assigns_ir: dict[str, RuleExpr] = field(default_factory=dict)
+    commit_condition_ir: RuleExpr | None = None
+    review_condition_ir: RuleExpr | None = None
+
+
+@dataclass
+class CompiledGovernancePolicy:
+    syntax: GovernancePolicy
+    emit_condition_ir: RuleExpr | None = None
+    merge_conditions_ir: list[RuleExpr] = field(default_factory=list)
+    forbid_merge_conditions_ir: list[RuleExpr] = field(default_factory=list)
+
+
+@dataclass
+class CompiledProgramSpec:
+    syntax: ProgramSpec
+
+    compiled_tokens: dict[str, CompiledTokenSpec] = field(default_factory=dict)
+    compiled_parsers: dict[str, CompiledParserSpec] = field(default_factory=dict)
+    compiled_inherit_rules: list[CompiledInheritSpec] = field(default_factory=list)
+
+    compiled_constraints: list[CompiledConstraintSpec] = field(default_factory=list)
+    compiled_diagnostics: list[CompiledDiagnosticSpec] = field(default_factory=list)
+    compiled_infer_rules: list[CompiledInferSpec] = field(default_factory=list)
+    compiled_resolvers: dict[str, CompiledResolverPolicy] = field(default_factory=dict)
+    compiled_governances: dict[str, CompiledGovernancePolicy] = field(default_factory=dict)
+
+    binding_warnings: list[str] = field(default_factory=list)
+
+    def __getattr__(self, name: str):
+        return getattr(self.syntax, name)

--- a/legacy/archive/pipeline_legacy_20260518/modules/emit_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/emit_pass.py
@@ -1,0 +1,289 @@
+# emit_pass.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from artifacts import (
+    CanonicalRowArtifact,
+    ClaimArtifact,
+    CompileArtifacts,
+    LineageEvidenceArtifact,
+    PartialFrameArtifact,
+    RoleLineageArtifact,
+    error_codes_from_diagnostics,
+    warning_codes_from_diagnostics,
+)
+from runtime_env import RuntimeEnv
+
+
+@dataclass
+class EmitPassConfig:
+    """
+    emit은 committed frame만 대상으로 한다.
+    governance에서 merged 여부를 다루므로 여기선 status 변경 안 함.
+    """
+    emit_only_committed: bool = True
+    skip_empty_rows: bool = True
+    include_shadow_as_contradiction: bool = True
+
+
+class EmitPass:
+    def __init__(self, config: Optional[EmitPassConfig] = None) -> None:
+        self.config = config or EmitPassConfig()
+
+    def run(
+        self,
+        spec,
+        artifacts: CompileArtifacts,
+        env: RuntimeEnv,
+    ) -> CompileArtifacts:
+        claims_by_id = {c.claim_id: c for c in artifacts.claims}
+
+        new_rows: list[CanonicalRowArtifact] = []
+
+        for frame in artifacts.frames:
+            if self.config.emit_only_committed and frame.status != "committed":
+                continue
+
+            row = self._emit_row(
+                frame=frame,
+                claims_by_id=claims_by_id,
+                env=env,
+            )
+
+            if row is None:
+                continue
+
+            new_rows.append(row)
+
+        # emit pass는 항상 rows를 재생성하는 게 안전하다
+        artifacts.rows = new_rows
+        return artifacts
+
+    # ------------------------------------------------------------------
+    # Core
+    # ------------------------------------------------------------------
+
+    def _emit_row(
+        self,
+        *,
+        frame: PartialFrameArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+        env: RuntimeEnv,
+    ) -> Optional[CanonicalRowArtifact]:
+        values = self._extract_active_values(frame, claims_by_id)
+
+        site_id = self._resolve_site_id(values.get("site"), env)
+        entity_id = self._resolve_entity_id(site_id, env)
+        activity_type = self._as_str(values.get("activity_type"))
+        period = self._as_str(values.get("period"))
+        raw_unit = self._as_str(values.get("raw_unit"))
+        raw_amount = self._as_float(values.get("raw_amount"))
+
+        standardized_amount, standardized_unit = self._normalize_amount_and_unit(
+            raw_amount=raw_amount,
+            raw_unit=raw_unit,
+            env=env,
+        )
+
+        scope_category = None
+        if activity_type and activity_type in env.activity_index:
+            scope_category = env.activity_index[activity_type].scope_category
+
+        lineage = self._build_lineage(frame, claims_by_id)
+
+        warning_codes = warning_codes_from_diagnostics(frame.diagnostics)
+        error_codes = error_codes_from_diagnostics(frame.diagnostics)
+
+        if self.config.skip_empty_rows:
+            all_core_empty = (
+                site_id is None
+                and period is None
+                and activity_type is None
+                and raw_amount is None
+                and raw_unit is None
+            )
+            if all_core_empty:
+                return None
+
+        row = CanonicalRowArtifact(
+            row_id=self._row_id_from_frame(frame.frame_id),
+            frame_id=frame.frame_id,
+            parser_name=frame.parser_name,
+            frame_type=frame.frame_type,
+            status=frame.status,
+
+            site_id=site_id,
+            entity_id=entity_id,
+            period=period,
+            activity_type=activity_type,
+
+            raw_amount=raw_amount,
+            raw_unit=raw_unit,
+            standardized_amount=standardized_amount,
+            standardized_unit=standardized_unit,
+
+            scope_category=scope_category,
+            resolution_score=float(frame.runtime.resolution_score),
+            lineage=lineage,
+
+            source_fragment_ids=list(frame.fragment_ids),
+            warning_codes=warning_codes,
+            error_codes=error_codes,
+
+            metadata={
+                "iteration_count": frame.runtime.iteration_count,
+                "stable_count": frame.runtime.stable_count,
+                "termination_reason": frame.runtime.termination_reason,
+                "repair_trace_len": len(frame.metadata.get("repair_trace", [])),
+            },
+        )
+        return row
+
+    # ------------------------------------------------------------------
+    # Value extraction
+    # ------------------------------------------------------------------
+
+    def _extract_active_values(
+        self,
+        frame: PartialFrameArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+    ) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+
+        for role_name, slot in frame.slots.items():
+            if not slot.active_claim_id:
+                continue
+            claim = claims_by_id.get(slot.active_claim_id)
+            if claim is None:
+                continue
+            out[role_name] = claim.value
+
+        return out
+
+    # ------------------------------------------------------------------
+    # Lineage
+    # ------------------------------------------------------------------
+
+    def _build_lineage(
+        self,
+        frame: PartialFrameArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+    ) -> dict[str, RoleLineageArtifact]:
+        lineage: dict[str, RoleLineageArtifact] = {}
+
+        for role_name, slot in frame.slots.items():
+            node = RoleLineageArtifact()
+
+            # active claim
+            if slot.active_claim_id and slot.active_claim_id in claims_by_id:
+                active = claims_by_id[slot.active_claim_id]
+                evidence = self._to_lineage_evidence(active)
+
+                if active.extraction_mode == "explicit":
+                    node.direct.append(evidence)
+                elif active.extraction_mode == "inherited":
+                    node.inherited.append(evidence)
+                elif active.extraction_mode == "backward_inferred":
+                    node.backward_inferred.append(evidence)
+                else:
+                    node.derived.append(evidence)
+
+            # shadow / rejected claims = contradicted_by 관점으로 남김
+            if self.config.include_shadow_as_contradiction:
+                for cid in [*slot.shadow_claim_ids, *slot.rejected_claim_ids]:
+                    claim = claims_by_id.get(cid)
+                    if claim is None:
+                        continue
+                    node.contradicted_by.append(self._to_lineage_evidence(claim))
+
+            lineage[role_name] = node
+
+        return lineage
+
+    def _to_lineage_evidence(self, claim: ClaimArtifact) -> LineageEvidenceArtifact:
+        return LineageEvidenceArtifact(
+            claim_id=claim.claim_id,
+            fragment_id=claim.source_fragment_id or claim.fragment_id,
+            span=claim.span,
+            extraction_mode=claim.extraction_mode,
+            value=claim.value,
+            reason_codes=list(claim.reason_codes),
+            evidence_ids=list(claim.evidence_ids),
+            metadata=dict(claim.metadata),
+        )
+
+    # ------------------------------------------------------------------
+    # Canonicalization helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_site_id(self, value: Any, env: RuntimeEnv) -> Optional[str]:
+        if value in (None, ""):
+            return None
+
+        # 이미 site_id일 수 있음
+        if isinstance(value, str) and value in env.site_records:
+            return value
+
+        # alias lookup
+        key = str(value).strip().lower()
+        return env.site_alias_index.get(key)
+
+    def _resolve_entity_id(self, site_id: Optional[str], env: RuntimeEnv) -> Optional[str]:
+        if site_id is None:
+            return None
+        rec = env.site_records.get(site_id)
+        if rec is None:
+            return None
+        return rec.entity_id
+
+    def _normalize_amount_and_unit(
+        self,
+        *,
+        raw_amount: Optional[float],
+        raw_unit: Optional[str],
+        env: RuntimeEnv,
+    ) -> tuple[Optional[float], Optional[str]]:
+        if raw_amount is None or raw_unit is None:
+            return None, None
+
+        spec = env.unit_index.get(raw_unit)
+        if spec is None or spec.normalize_to is None or spec.normalize_op is None or spec.normalize_factor is None:
+            return raw_amount, raw_unit
+
+        x = raw_amount
+        factor = float(spec.normalize_factor)
+
+        if spec.normalize_op == "*":
+            x = x * factor
+        elif spec.normalize_op == "/":
+            x = x / factor
+        elif spec.normalize_op == "+":
+            x = x + factor
+        elif spec.normalize_op == "-":
+            x = x - factor
+
+        return float(x), spec.normalize_to
+
+    def _as_float(self, value: Any) -> Optional[float]:
+        if value in (None, ""):
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        try:
+            return float(str(value).replace(",", "").strip())
+        except Exception:
+            return None
+
+    def _as_str(self, value: Any) -> Optional[str]:
+        if value in (None, ""):
+            return None
+        return str(value)
+
+    def _row_id_from_frame(self, frame_id: str) -> str:
+        # e.g. FRM-0000001 -> ROW-0000001
+        if frame_id.startswith("FRM-"):
+            return "ROW-" + frame_id[len("FRM-"):]
+        return f"ROW-{frame_id}"

--- a/legacy/archive/pipeline_legacy_20260518/modules/esg_builtins.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/esg_builtins.py
@@ -1,0 +1,335 @@
+# esg_builtins.py
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, Optional
+
+from runtime_env import LexCandidate
+
+if TYPE_CHECKING:
+    from runtime_env import RuntimeEnv
+
+
+# ---------------------------------
+# Regexes
+# ---------------------------------
+
+YEAR_MONTH_1 = re.compile(r"(?P<year>20\d{2})[-/](?P<month>0?[1-9]|1[0-2])")
+YEAR_MONTH_2 = re.compile(r"(?P<year>20\d{2})\s*년\s*(?P<month>0?[1-9]|1[0-2])\s*월")
+YEAR_ONLY = re.compile(r"(?P<year>20\d{2})")
+NUMBER_RE = re.compile(r"-?\d{1,3}(?:,\d{3})*(?:\.\d+)?|-?\d+(?:\.\d+)?")
+
+
+# ---------------------------------
+# Lexical builtins
+# ---------------------------------
+
+def site_alias(text: str, env: RuntimeEnv) -> list[LexCandidate]:
+    hits: list[LexCandidate] = []
+    for alias, site_id in sorted(env.site_alias_index.items(), key=lambda x: len(x[0]), reverse=True):
+        for m in re.finditer(re.escape(alias), text.lower()):
+            hits.append(
+                LexCandidate(
+                    value=site_id,
+                    start=m.start(),
+                    end=m.end(),
+                    confidence=0.92,
+                    metadata={"surface": text[m.start():m.end()], "site_id": site_id},
+                )
+            )
+    return _dedupe_hits(hits)
+
+
+def activity_alias(text: str, env: RuntimeEnv) -> list[LexCandidate]:
+    hits: list[LexCandidate] = []
+    for alias, canonical in sorted(env.activity_alias_index.items(), key=lambda x: len(x[0]), reverse=True):
+        for m in re.finditer(re.escape(alias), text.lower()):
+            hits.append(
+                LexCandidate(
+                    value=canonical,
+                    start=m.start(),
+                    end=m.end(),
+                    confidence=0.92,
+                    metadata={"surface": text[m.start():m.end()], "activity_type": canonical},
+                )
+            )
+    return _dedupe_hits(hits)
+
+
+def unit_symbol(text: str, env: RuntimeEnv) -> list[LexCandidate]:
+    hits: list[LexCandidate] = []
+    for alias, canonical in sorted(env.unit_alias_index.items(), key=lambda x: len(x[0]), reverse=True):
+        for m in re.finditer(re.escape(alias), text.lower()):
+            hits.append(
+                LexCandidate(
+                    value=canonical,
+                    start=m.start(),
+                    end=m.end(),
+                    confidence=0.95,
+                    metadata={"surface": text[m.start():m.end()], "raw_unit": canonical},
+                )
+            )
+    return _dedupe_hits(hits)
+
+
+def period_expr(text: str, env: RuntimeEnv | None = None) -> list[LexCandidate]:
+    hits: list[LexCandidate] = []
+
+    for pat in (YEAR_MONTH_1, YEAR_MONTH_2):
+        for m in pat.finditer(text):
+            year = int(m.group("year"))
+            month = int(m.group("month"))
+            hits.append(
+                LexCandidate(
+                    value=f"{year:04d}-{month:02d}",
+                    start=m.start(),
+                    end=m.end(),
+                    confidence=0.97,
+                    metadata={"kind": "year_month"},
+                )
+            )
+
+    # 연-월을 못 찾은 경우에만 연도 토큰을 쓰는 편이 안전하다
+    if not hits:
+        for m in YEAR_ONLY.finditer(text):
+            hits.append(
+                LexCandidate(
+                    value=f"{int(m.group('year')):04d}",
+                    start=m.start(),
+                    end=m.end(),
+                    confidence=0.75,
+                    metadata={"kind": "year"},
+                )
+            )
+
+    return _dedupe_hits(hits)
+
+
+def number(text: str, env: RuntimeEnv | None = None) -> list[LexCandidate]:
+    hits: list[LexCandidate] = []
+    for m in NUMBER_RE.finditer(text):
+        raw = m.group(0).replace(",", "")
+        value = float(raw) if "." in raw else int(raw)
+        hits.append(
+            LexCandidate(
+                value=value,
+                start=m.start(),
+                end=m.end(),
+                confidence=0.96,
+                metadata={"surface": m.group(0)},
+            )
+        )
+    return hits
+
+
+def one_of(text: str, *choices: str, env: RuntimeEnv | None = None) -> list[LexCandidate]:
+    hits: list[LexCandidate] = []
+    lower_text = text.lower()
+
+    for choice in choices:
+        lower_choice = choice.lower()
+        for m in re.finditer(re.escape(lower_choice), lower_text):
+            hits.append(
+                LexCandidate(
+                    value=choice,
+                    start=m.start(),
+                    end=m.end(),
+                    confidence=0.90,
+                    metadata={"surface": text[m.start():m.end()]},
+                )
+            )
+    return _dedupe_hits(hits)
+
+
+def fuzzy_lex(role_name: str, text: str, env: RuntimeEnv) -> list[LexCandidate]:
+    if not env.can_call_llm():
+        return []
+
+    if not env.consume_llm_budget(1):
+        return []
+
+    out = env.llm_fallback(role_name, text)
+    return out or []
+
+
+# ---------------------------------
+# Semantic / evaluation builtins
+# ---------------------------------
+
+def dimension(raw_unit: str, env: RuntimeEnv) -> Optional[str]:
+    spec = env.unit_index.get(raw_unit)
+    return None if spec is None else spec.dimension
+
+
+def compatible(activity_type: str, raw_unit: str, env: RuntimeEnv) -> bool:
+    act = env.activity_index.get(activity_type)
+    unit = env.unit_index.get(raw_unit)
+
+    if act is None or unit is None:
+        return False
+
+    return act.dimension == unit.dimension
+
+
+def valid(value: Any, env: RuntimeEnv | None = None) -> bool:
+    """
+    MVP용 generic valid.
+    period에 주로 쓰일 걸 가정하고, 숫자/단위/문자열도 느슨하게 허용.
+    """
+    if value is None:
+        return False
+
+    if isinstance(value, (int, float)):
+        return True
+
+    if isinstance(value, str):
+        if YEAR_MONTH_1.fullmatch(value) or YEAR_ONLY.fullmatch(value):
+            return True
+        if env is not None and value in env.unit_index:
+            return True
+        if value.strip():
+            return True
+
+    return False
+
+
+def valid_period(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    return bool(YEAR_MONTH_1.fullmatch(value) or YEAR_ONLY.fullmatch(value))
+
+
+def missing(role_name: str, frame: Any) -> bool:
+    """
+    frame.bindings 또는 frame.slots 를 느슨하게 지원한다.
+    """
+    # typed frame 스타일
+    bindings = getattr(frame, "bindings", None)
+    if isinstance(bindings, dict):
+        return role_name not in bindings or bindings[role_name] is None
+
+    # frame.slots 스타일
+    slot = _lookup_slot(frame, role_name)
+    if slot is None:
+        return True
+
+    active_claim_id = getattr(slot, "active_claim_id", None)
+    resolved_value = getattr(slot, "resolved_value", None)
+    missing_tag = getattr(slot, "missing_tag", None)
+
+    if active_claim_id is None and resolved_value in (None, ""):
+        return True
+
+    if missing_tag is not None and resolved_value in (None, ""):
+        return True
+
+    return False
+
+
+def origin(role_name: str, frame: Any, claims_by_id: dict[str, Any] | None = None) -> Optional[str]:
+    """
+    active claim의 extraction_mode를 리턴한다.
+    """
+    if claims_by_id is None:
+        return None
+
+    slot = _lookup_slot(frame, role_name)
+    if slot is None:
+        return None
+
+    claim_id = getattr(slot, "active_claim_id", None)
+    if claim_id is None:
+        return None
+
+    claim = claims_by_id.get(claim_id)
+    if claim is None:
+        return None
+
+    return getattr(claim, "extraction_mode", None)
+
+
+def evidence(kind: str, frame: Any, claims_by_id: dict[str, Any] | None = None) -> int:
+    """
+    MVP: active claim들에 달린 evidence_ids 중 kind prefix가 맞는 것 카운트.
+    """
+    if claims_by_id is None:
+        return 0
+
+    total = 0
+    slots = getattr(frame, "slots", None)
+    if not isinstance(slots, dict):
+        return total
+
+    for slot in slots.values():
+        claim_id = getattr(slot, "active_claim_id", None)
+        if claim_id is None:
+            continue
+
+        claim = claims_by_id.get(claim_id)
+        if claim is None:
+            continue
+
+        for ev_id in getattr(claim, "evidence_ids", []):
+            if str(ev_id).startswith(f"{kind}:"):
+                total += 1
+
+    return total
+
+
+def register_default_builtins(env: RuntimeEnv) -> None:
+    env.builtin_registry.update(
+        {
+            # lexical
+            "site_alias": site_alias,
+            "activity_alias": activity_alias,
+            "unit_symbol": unit_symbol,
+            "period_expr": period_expr,
+            "number": number,
+            "one_of": one_of,
+            "llm.fuzzy_lex": fuzzy_lex,
+
+            # semantic
+            "dimension": dimension,
+            "compatible": compatible,
+            "valid": valid,
+            "valid_period": valid_period,
+            "missing": missing,
+            "origin": origin,
+            "evidence": evidence,
+        }
+    )
+
+
+# ---------------------------------
+# Internal helpers
+# ---------------------------------
+
+def _dedupe_hits(hits: list[LexCandidate]) -> list[LexCandidate]:
+    seen: set[tuple[Any, int | None, int | None]] = set()
+    out: list[LexCandidate] = []
+
+    for h in hits:
+        key = (h.value, h.start, h.end)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(h)
+
+    out.sort(key=lambda x: (x.start if x.start is not None else 10**9, -(x.end or 0)))
+    return out
+
+
+def _lookup_slot(frame: Any, role_name: str) -> Any | None:
+    slots = getattr(frame, "slots", None)
+    if not isinstance(slots, dict):
+        return None
+
+    if role_name in slots:
+        return slots[role_name]
+
+    for k, v in slots.items():
+        key_str = getattr(k, "value", k)
+        if key_str == role_name:
+            return v
+
+    return None

--- a/legacy/archive/pipeline_legacy_20260518/modules/expr_eval.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/expr_eval.py
@@ -1,0 +1,347 @@
+# expr_eval.py
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ast_nodes import (
+    AlternationExpr,
+    BinaryExpr,
+    ColumnRefExpr,
+    ContextRefExpr,
+    Expr,
+    FunctionCallExpr,
+    LiteralExpr,
+    NameExpr,
+    RowLabelRefExpr,
+    SetExpr,
+    UnaryExpr,
+)
+from runtime_env import RuntimeEnv, ScopePath
+
+
+class EvalError(ValueError):
+    pass
+
+
+@dataclass
+class EvalContext:
+    """
+    Expression evaluation context.
+
+    - text: 현재 fragment 원문
+    - scope_path: 현재 평가 대상 scope
+    - row: 현재 table row dict (tabular parser에서 사용)
+    - row_label: row 첫 컬럼 라벨 등
+    - column_key: 현재 컬럼 context 해석용
+    - frame: 현재 frame or typed frame
+    - claims_by_id: origin()/evidence() 같은 함수에서 사용
+    - local_vars: score, stable, status 같은 resolver 변수
+    - warning_codes / error_codes: governance/diagnostic 표현식에서 사용
+    - approvals: approval.human_reviewer 같은 외부 승인 상태
+    """
+    env: RuntimeEnv
+
+    text: str = ""
+    scope_path: ScopePath = field(default_factory=tuple)
+
+    row: dict[str, Any] = field(default_factory=dict)
+    row_label: Optional[str] = None
+    column_key: Optional[str] = None
+
+    frame: Any = None
+    claims_by_id: dict[str, Any] = field(default_factory=dict)
+
+    local_vars: dict[str, Any] = field(default_factory=dict)
+    warning_codes: set[str] = field(default_factory=set)
+    error_codes: set[str] = field(default_factory=set)
+    approvals: dict[str, bool] = field(default_factory=dict)
+
+
+class ExprEvaluator:
+    """
+    ESGDL expression evaluator.
+
+    원칙:
+    - bare identifier는 local var / frame role / policy / warning/error flag 순으로 해석
+    - 못 찾으면 "문자 상수"처럼 그대로 둔다
+      (예: committed, pair, EmissionObservation)
+    - AlternationExpr는 source 선택 표현식으로 보고 "첫 번째 present 값"을 리턴
+    """
+
+    def eval(self, expr: Expr | Any, ctx: EvalContext) -> Any:
+        if isinstance(expr, Expr):
+            return self._eval_expr(expr, ctx)
+
+        # lowering 이전/중간 단계에서 plain 값이 들어와도 견딜 수 있게
+        if isinstance(expr, (str, int, float, bool)):
+            return expr
+
+        return expr
+
+    def eval_bool(self, expr: Expr | Any, ctx: EvalContext) -> bool:
+        value = self.eval(expr, ctx)
+        return self._truthy(value)
+
+    def eval_source(self, expr: Expr | Any, ctx: EvalContext) -> Any:
+        """
+        parser bind/inherit/tag 에서 source expression 평가.
+        현재는 eval과 동일하지만, 추후 source-specific coercion 포인트로 분리.
+        """
+        return self.eval(expr, ctx)
+
+    # ------------------------------------------------------------------
+    # Core expression dispatcher
+    # ------------------------------------------------------------------
+
+    def _eval_expr(self, expr: Expr, ctx: EvalContext) -> Any:
+        if isinstance(expr, LiteralExpr):
+            return expr.value
+
+        if isinstance(expr, NameExpr):
+            return self._resolve_name(expr.name, ctx)
+
+        if isinstance(expr, FunctionCallExpr):
+            return self._call_function(expr, ctx)
+
+        if isinstance(expr, SetExpr):
+            return [self.eval(item, ctx) for item in expr.items]
+
+        if isinstance(expr, ColumnRefExpr):
+            return ctx.row.get(expr.column_name)
+
+        if isinstance(expr, ContextRefExpr):
+            res = ctx.env.context_store.resolve_best(
+                expr.role_name,
+                ctx.scope_path,
+                column_key=ctx.column_key,
+            )
+            return None if res.chosen is None else res.chosen.value
+
+        if isinstance(expr, RowLabelRefExpr):
+            if ctx.row_label is None:
+                return None
+            if expr.label in ctx.row_label:
+                return expr.label
+            return None
+
+        if isinstance(expr, AlternationExpr):
+            for option in expr.options:
+                value = self.eval(option, ctx)
+                if self._present(value):
+                    return value
+            return None
+
+        if isinstance(expr, UnaryExpr):
+            if expr.op == "not":
+                return not self.eval_bool(expr.operand, ctx)
+            raise EvalError(f"unsupported unary op: {expr.op}")
+
+        if isinstance(expr, BinaryExpr):
+            return self._eval_binary(expr, ctx)
+
+        raise EvalError(f"unsupported Expr type: {type(expr).__name__}")
+
+    # ------------------------------------------------------------------
+    # Name resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_name(self, name: str, ctx: EvalContext) -> Any:
+        # 1) local vars: score, stable, status, aggregation ...
+        if name in ctx.local_vars:
+            return ctx.local_vars[name]
+
+        # 2) frame role value
+        frame_value = self._frame_value(ctx.frame, name)
+        if frame_value is not None:
+            return frame_value
+
+        # 3) policy flags: policy.auto_merge
+        if name.startswith("policy."):
+            key = name.split(".", 1)[1]
+            return ctx.env.policy_flags.get(key)
+
+        # 4) diagnostic flags: warning.AggregateRow / error.InvalidPeriod
+        if name.startswith("warning."):
+            code = name.split(".", 1)[1]
+            return code in ctx.warning_codes
+
+        if name.startswith("error."):
+            code = name.split(".", 1)[1]
+            return code in ctx.error_codes
+
+        # 5) approvals: approval.human_reviewer
+        if name.startswith("approval."):
+            key = name.split(".", 1)[1]
+            return bool(ctx.approvals.get(key, False))
+
+        # 6) fallback: bare identifier를 문자열 상수처럼 취급
+        #    예: committed, pair, EmissionObservation
+        return name
+
+    def _frame_value(self, frame: Any, role_name: str) -> Any:
+        if frame is None:
+            return None
+
+        # typed frame style: frame.bindings[role_name]
+        bindings = getattr(frame, "bindings", None)
+        if isinstance(bindings, dict) and role_name in bindings:
+            binding = bindings[role_name]
+            # binding 자체가 scalar거나, Claim-like object일 수 있음
+            if hasattr(binding, "value"):
+                return getattr(binding, "value")
+            return binding
+
+        # partial frame style: frame.slots[role_name]
+        slots = getattr(frame, "slots", None)
+        if isinstance(slots, dict):
+            # key가 Enum일 수도 있어서 문자열 비교 둘 다 지원
+            if role_name in slots:
+                slot = slots[role_name]
+                resolved_value = getattr(slot, "resolved_value", None)
+                if resolved_value not in (None, ""):
+                    return resolved_value
+
+            for k, slot in slots.items():
+                key_str = getattr(k, "value", k)
+                if key_str == role_name:
+                    resolved_value = getattr(slot, "resolved_value", None)
+                    if resolved_value not in (None, ""):
+                        return resolved_value
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Binary operators
+    # ------------------------------------------------------------------
+
+    def _eval_binary(self, expr: BinaryExpr, ctx: EvalContext) -> Any:
+        left = self.eval(expr.left, ctx)
+        right = self.eval(expr.right, ctx)
+        op = expr.op
+
+        if op == "or":
+            return self._truthy(left) or self._truthy(right)
+
+        if op == "and":
+            return self._truthy(left) and self._truthy(right)
+
+        if op == "==":
+            return left == right
+
+        if op == "!=":
+            return left != right
+
+        if op == ">=":
+            return left >= right
+
+        if op == "<=":
+            return left <= right
+
+        if op == ">":
+            return left > right
+
+        if op == "<":
+            return left < right
+
+        if op == "in":
+            if right is None:
+                return False
+            return left in right
+
+        if op == "matches":
+            return re.search(str(right), str(left or "")) is not None
+
+        raise EvalError(f"unsupported binary op: {op}")
+
+    # ------------------------------------------------------------------
+    # Builtins / function calls
+    # ------------------------------------------------------------------
+
+    def _call_function(self, expr: FunctionCallExpr, ctx: EvalContext) -> Any:
+        name = expr.name
+
+        # special cases: DSL에서 bare identifier를 role/label로 쓰는 함수들
+        if name == "missing":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(role_name, ctx.frame)
+
+        if name == "origin":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(role_name, ctx.frame, ctx.claims_by_id)
+
+        if name == "evidence":
+            kind = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            fn = self._lookup_builtin(name, ctx)
+            return fn(kind, ctx.frame, ctx.claims_by_id)
+
+        # lexical builtins: 현재 text를 첫 인자로 받는다
+        if name in {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number"}:
+            fn = self._lookup_builtin(name, ctx)
+            return fn(ctx.text, ctx.env)
+
+        if name == "one_of":
+            fn = self._lookup_builtin(name, ctx)
+            choices = [self.eval(arg, ctx) for arg in expr.args]
+            return fn(ctx.text, *choices, env=ctx.env)
+
+        if name == "llm.fuzzy_lex":
+            fn = self._lookup_builtin(name, ctx)
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            return fn(role_name, ctx.text, ctx.env)
+
+        # generic semantic builtins
+        fn = self._lookup_builtin(name, ctx)
+        args = [self.eval(arg, ctx) for arg in expr.args]
+
+        # 표준 라이브러리 함수들이 env/frame/claims를 필요로 할 수 있으므로
+        # 안전하게 몇 가지 호출 패턴을 순서대로 시도
+        for pattern in (
+            lambda: fn(*args, env=ctx.env, frame=ctx.frame, claims_by_id=ctx.claims_by_id),
+            lambda: fn(*args, env=ctx.env, frame=ctx.frame),
+            lambda: fn(*args, env=ctx.env),
+            lambda: fn(*args),
+        ):
+            try:
+                return pattern()
+            except TypeError:
+                continue
+
+        raise EvalError(f"builtin call failed: {name}")
+
+    def _lookup_builtin(self, name: str, ctx: EvalContext):
+        fn = ctx.env.builtin_registry.get(name)
+        if fn is None:
+            raise EvalError(f"unknown builtin: {name}")
+        return fn
+
+    def _raw_identifier(self, args: list[Expr], index: int, ctx: EvalContext) -> str:
+        if index >= len(args):
+            raise EvalError("missing function arg")
+
+        arg = args[index]
+
+        if isinstance(arg, NameExpr):
+            return arg.name
+
+        value = self.eval(arg, ctx)
+        return str(value)
+
+    # ------------------------------------------------------------------
+    # Truthiness helpers
+    # ------------------------------------------------------------------
+
+    def _present(self, value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return value != ""
+        if isinstance(value, (list, tuple, set, dict)):
+            return len(value) > 0
+        return bool(value)
+
+    def _truthy(self, value: Any) -> bool:
+        return self._present(value)

--- a/legacy/archive/pipeline_legacy_20260518/modules/governance_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/governance_pass.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+
+from artifacts import CanonicalRowArtifact, CompileArtifacts, GovernanceDecisionArtifact
+from compiled_spec import CompiledGovernancePolicy, CompiledProgramSpec
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv
+
+
+@dataclass
+class GovernancePassConfig:
+    block_on_any_error: bool = True
+    enforce_emit_condition: bool = True
+    skip_non_committed_rows: bool = True
+
+
+class GovernancePass:
+    def __init__(self, evaluator: RuleEvaluator | None = None, config: GovernancePassConfig | None = None) -> None:
+        self.evaluator = evaluator or RuleEvaluator()
+        self.config = config or GovernancePassConfig()
+        self._decision_seq = count(1)
+
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("GovernancePass requires CompiledProgramSpec")
+
+        decisions: list[GovernanceDecisionArtifact] = []
+        for row in artifacts.rows:
+            if self.config.skip_non_committed_rows and row.status != "committed":
+                decisions.append(self._decision(row=row, from_status=row.status, to_status=row.status, action="skip", actor="policy_engine", reason_codes=["row_not_committed"], matched_rule_keys=[]))
+                continue
+
+            policy = spec.compiled_governances.get(row.frame_type)
+            if policy is None:
+                decisions.append(self._decision(row=row, from_status=row.status, to_status=row.status, action="hold", actor="policy_engine", reason_codes=["no_governance_policy"], matched_rule_keys=[]))
+                continue
+
+            decisions.append(self._apply_policy(row=row, policy=policy, env=env))
+
+        artifacts.merge_log.extend(decisions)
+        for d in decisions:
+            artifacts.event_log.append({
+                "event_id": f"EVT-GOV-{d.decision_id}",
+                "record_id": d.row_id,
+                "event_type": "MERGED" if d.action == "merge" else "MERGE_HELD" if d.action == "hold" else "SKIPPED",
+                "from_status": d.from_status,
+                "to_status": d.to_status,
+                "actor": d.actor,
+                "reason_codes": list(d.reason_codes),
+                "matched_rule_keys": list(d.matched_rule_keys),
+                "created_at": d.created_at.isoformat() + "Z",
+            })
+        return artifacts
+
+    def _apply_policy(self, *, row: CanonicalRowArtifact, policy: CompiledGovernancePolicy, env: RuntimeEnv) -> GovernanceDecisionArtifact:
+        ctx = self._build_eval_context(row, env)
+        from_status = row.status
+
+        if self.config.enforce_emit_condition and policy.emit_condition_ir is not None:
+            if not self._safe_eval_bool(policy.emit_condition_ir, ctx):
+                return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["emit_condition_not_satisfied"], matched_rule_keys=["emit_condition"])
+
+        if self.config.block_on_any_error and row.error_codes:
+            return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["row_has_error_diagnostics", *row.error_codes], matched_rule_keys=[])
+
+        matched_forbid = [f"forbid_merge:{idx}" for idx, expr in enumerate(policy.forbid_merge_conditions_ir, start=1) if self._safe_eval_bool(expr, ctx)]
+        if matched_forbid:
+            return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["forbid_merge_matched"], matched_rule_keys=matched_forbid)
+
+        matched_merge = [f"merge:{idx}" for idx, expr in enumerate(policy.merge_conditions_ir, start=1) if self._safe_eval_bool(expr, ctx)]
+        if matched_merge:
+            row.status = "merged"
+            actor = self._pick_actor(ctx)
+            row.metadata.setdefault("governance_trace", []).append({"action": "merge", "matched_rule_keys": matched_merge, "actor": actor})
+            return self._decision(row=row, from_status=from_status, to_status="merged", action="merge", actor=actor, reason_codes=["merge_condition_satisfied"], matched_rule_keys=matched_merge)
+
+        row.metadata.setdefault("governance_trace", []).append({"action": "hold", "reason": "no_merge_rule_matched"})
+        return self._decision(row=row, from_status=from_status, to_status=from_status, action="hold", actor="policy_engine", reason_codes=["no_merge_rule_matched"], matched_rule_keys=[])
+
+    def _build_eval_context(self, row: CanonicalRowArtifact, env: RuntimeEnv) -> EvalContext:
+        approvals = {}
+        if isinstance(env.policy_flags.get("approvals"), dict):
+            approvals.update(env.policy_flags["approvals"])
+        if isinstance(row.metadata.get("approvals"), dict):
+            approvals.update(row.metadata["approvals"])
+
+        return EvalContext(
+            env=env,
+            text="",
+            scope_path=tuple(),
+            row=row,
+            frame=None,
+            claims_by_id={},
+            local_vars={
+                "row_id": row.row_id,
+                "frame_id": row.frame_id,
+                "frame_type": row.frame_type,
+                "status": row.status,
+                "score": row.resolution_score,
+                "resolution_score": row.resolution_score,
+                "site_id": row.site_id,
+                "entity_id": row.entity_id,
+                "period": row.period,
+                "activity_type": row.activity_type,
+                "raw_amount": row.raw_amount,
+                "raw_unit": row.raw_unit,
+                "standardized_amount": row.standardized_amount,
+                "standardized_unit": row.standardized_unit,
+                "scope_category": row.scope_category,
+                "parser_name": row.parser_name,
+            },
+            warning_codes=set(row.warning_codes),
+            error_codes=set(row.error_codes),
+            approvals=approvals,
+        )
+
+    def _safe_eval_bool(self, expr, ctx: EvalContext) -> bool:
+        try:
+            return self.evaluator.eval_bool(expr, ctx)
+        except Exception:
+            return False
+
+    def _decision(self, *, row: CanonicalRowArtifact, from_status: str, to_status: str, action: str, actor: str, reason_codes: list[str], matched_rule_keys: list[str]) -> GovernanceDecisionArtifact:
+        return GovernanceDecisionArtifact(
+            decision_id=f"GOV-{next(self._decision_seq):07d}",
+            row_id=row.row_id,
+            frame_id=row.frame_id,
+            from_status=from_status,
+            to_status=to_status,
+            action=action,
+            actor=actor,
+            reason_codes=list(reason_codes),
+            matched_rule_keys=list(matched_rule_keys),
+            metadata={"frame_type": row.frame_type, "warning_codes": list(row.warning_codes), "error_codes": list(row.error_codes)},
+        )
+
+    def _pick_actor(self, ctx: EvalContext) -> str:
+        if ctx.approvals.get("human_reviewer"):
+            return "human_reviewer"
+        if ctx.env.policy_flags.get("auto_merge", False):
+            return "system"
+        return "policy_engine"

--- a/legacy/archive/pipeline_legacy_20260518/modules/inference_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/inference_pass.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+from typing import Any
+
+from artifacts import (
+    ClaimArtifact,
+    CompileArtifacts,
+    DiagnosticArtifact,
+    PartialFrameArtifact,
+    RoleSlotArtifact,
+    error_codes_from_diagnostics,
+    warning_codes_from_diagnostics,
+)
+from compiled_spec import CompiledProgramSpec
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv, ScopePath
+
+
+@dataclass
+class InferencePassConfig:
+    strong_replace_margin: float = 0.05
+    weak_infer_promotes_when_empty: bool = True
+    strong_infer_can_replace_non_explicit: bool = True
+
+
+class InferencePass:
+    def __init__(self, evaluator: RuleEvaluator | None = None, config: InferencePassConfig | None = None) -> None:
+        self.evaluator = evaluator or RuleEvaluator()
+        self.config = config or InferencePassConfig()
+        self._claim_seq = count(1)
+        self._diag_seq = count(1)
+
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("InferencePass requires CompiledProgramSpec")
+
+        claims_by_id = {c.claim_id: c for c in artifacts.claims}
+        fragments_by_id = {getattr(f, "fragment_id", f"FRG-{i:06d}"): f for i, f in enumerate(artifacts.fragments, start=1)}
+        new_claims: list[ClaimArtifact] = []
+
+        for frame in artifacts.frames:
+            ctx = EvalContext(
+                env=env,
+                text="",
+                scope_path=self._frame_scope(frame, fragments_by_id),
+                frame=frame,
+                claims_by_id=claims_by_id,
+                local_vars={"frame_type": frame.frame_type, "status": frame.status},
+                warning_codes=self._frame_warning_codes(frame),
+                error_codes=self._frame_error_codes(frame),
+            )
+
+            for compiled_rule in spec.compiled_infer_rules:
+                rule = compiled_rule.syntax
+                if not self.evaluator.eval_bool(compiled_rule.condition_ir, ctx):
+                    continue
+
+                inferred_values = self._normalize_values(self.evaluator.eval(compiled_rule.value_ir, ctx))
+                if not inferred_values:
+                    continue
+
+                if rule.target_name == "frame_type":
+                    changed = self._apply_frame_type_inference(frame=frame, rule=rule, inferred_values=inferred_values)
+                    if changed:
+                        ctx.local_vars["frame_type"] = frame.frame_type
+                    continue
+
+                created_or_updated = self._apply_role_inference(
+                    frame=frame,
+                    rule=rule,
+                    inferred_values=inferred_values,
+                    claims_by_id=claims_by_id,
+                )
+                for claim in created_or_updated:
+                    if claim.claim_id not in claims_by_id:
+                        claims_by_id[claim.claim_id] = claim
+                        new_claims.append(claim)
+                ctx.frame = frame
+
+        artifacts.claims.extend(new_claims)
+        return artifacts
+
+    def _apply_frame_type_inference(self, *, frame: PartialFrameArtifact, rule, inferred_values: list[Any]) -> bool:
+        if rule.op != "=":
+            return False
+        new_type = str(inferred_values[0]).strip()
+        if not new_type or frame.frame_type == new_type:
+            return False
+
+        frame.frame_type = new_type
+        frame.diagnostics.append(
+            DiagnosticArtifact(
+                diagnostic_id=f"DGN-INF-{next(self._diag_seq):07d}",
+                severity="info",
+                code="FrameTypeInferred",
+                message=f"frame_type inferred as {new_type}",
+                scope_kind="frame",
+                scope_id=frame.frame_id,
+                frame_id=frame.frame_id,
+                fragment_id=frame.fragment_ids[0] if frame.fragment_ids else None,
+                rule_kind="inference",
+                source_key=f"infer:{rule.target_name}",
+                phase="inference",
+                metadata={"rule_target": rule.target_name},
+            )
+        )
+        return True
+
+    def _apply_role_inference(self, *, frame: PartialFrameArtifact, rule, inferred_values: list[Any], claims_by_id: dict[str, ClaimArtifact]) -> list[ClaimArtifact]:
+        slot = frame.slots.get(rule.target_name)
+        if slot is None:
+            slot = RoleSlotArtifact(role_name=rule.target_name)
+            frame.slots[rule.target_name] = slot
+
+        created: list[ClaimArtifact] = []
+        for idx, value in enumerate(inferred_values, start=1):
+            if value in (None, ""):
+                continue
+
+            existing = self._find_existing_claim_with_same_value(slot=slot, value=value, claims_by_id=claims_by_id)
+            if existing is not None:
+                self._boost_existing_claim(existing, rule)
+                continue
+
+            new_claim = ClaimArtifact(
+                claim_id=f"CLM-{next(self._claim_seq):07d}",
+                frame_id=frame.frame_id,
+                fragment_id=frame.fragment_ids[0] if frame.fragment_ids else "FRG-UNKNOWN",
+                parser_name=frame.parser_name,
+                role_name=rule.target_name,
+                value=value,
+                extraction_mode="backward_inferred",
+                confidence=self._infer_confidence(rule, rank=idx),
+                candidate_state="shadow",
+                status="resolving",
+                source_fragment_id=frame.fragment_ids[0] if frame.fragment_ids else None,
+                span=None,
+                reason_codes=[f"inferred_by_rule:{rule.target_name}", f"infer_op:{rule.op}"],
+                evidence_ids=[f"pair:infer:{rule.target_name}:{rule.op}:{value}"],
+                metadata={"inference_weight": rule.weight, "inference_op": rule.op},
+            )
+
+            promoted = self._maybe_promote_to_active(slot=slot, new_claim=new_claim, claims_by_id=claims_by_id, op=rule.op)
+            if not promoted:
+                new_claim.candidate_state = "shadow"
+                slot.shadow_claim_ids.append(new_claim.claim_id)
+            else:
+                slot.missing_tag = None
+            created.append(new_claim)
+
+        return created
+
+    def _maybe_promote_to_active(self, *, slot: RoleSlotArtifact, new_claim: ClaimArtifact, claims_by_id: dict[str, ClaimArtifact], op: str) -> bool:
+        active_claim = claims_by_id.get(slot.active_claim_id) if slot.active_claim_id is not None else None
+        if active_claim is None:
+            if op == "=" or (op == "~" and self.config.weak_infer_promotes_when_empty):
+                self._promote(slot, new_claim, claims_by_id)
+                return True
+            return False
+
+        if op != "=" or not self.config.strong_infer_can_replace_non_explicit or active_claim.extraction_mode == "explicit":
+            return False
+        return self._promote_if_stronger(slot, active_claim, new_claim, claims_by_id)
+
+    def _promote_if_stronger(self, slot, active_claim, new_claim, claims_by_id) -> bool:
+        active_conf = float(active_claim.confidence)
+        new_conf = float(new_claim.confidence)
+        if new_conf >= active_conf + self.config.strong_replace_margin:
+            self._promote(slot, new_claim, claims_by_id)
+            return True
+        return False
+
+    def _promote(self, slot: RoleSlotArtifact, new_claim: ClaimArtifact, claims_by_id: dict[str, ClaimArtifact]) -> None:
+        old_active_id = slot.active_claim_id
+        if old_active_id is not None:
+            old_active = claims_by_id.get(old_active_id)
+            if old_active is not None:
+                old_active.candidate_state = "shadow"
+            if old_active_id not in slot.shadow_claim_ids:
+                slot.shadow_claim_ids.append(old_active_id)
+        new_claim.candidate_state = "active"
+        slot.active_claim_id = new_claim.claim_id
+        slot.resolved_value = new_claim.value
+        slot.confidence = new_claim.confidence
+
+    def _find_existing_claim_with_same_value(self, *, slot: RoleSlotArtifact, value: Any, claims_by_id: dict[str, ClaimArtifact]) -> ClaimArtifact | None:
+        ids = ([slot.active_claim_id] if slot.active_claim_id else []) + list(slot.shadow_claim_ids)
+        for cid in ids:
+            claim = claims_by_id.get(cid)
+            if claim is not None and claim.value == value:
+                return claim
+        return None
+
+    def _boost_existing_claim(self, claim: ClaimArtifact, rule) -> None:
+        new_conf = self._infer_confidence(rule, rank=1)
+        if new_conf > claim.confidence:
+            claim.confidence = new_conf
+        tag = f"inferred_by_rule:{rule.target_name}"
+        if tag not in claim.reason_codes:
+            claim.reason_codes.append(tag)
+        ev = f"pair:infer:{rule.target_name}:{rule.op}:{claim.value}"
+        if ev not in claim.evidence_ids:
+            claim.evidence_ids.append(ev)
+
+    def _infer_confidence(self, rule, rank: int) -> float:
+        base = rule.weight if rule.weight is not None else (0.90 if rule.op == "=" else 0.70)
+        penalty = (rank - 1) * 0.05
+        return max(0.0, min(1.0, float(base) - penalty))
+
+    def _normalize_values(self, value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple, set)):
+            out: list[Any] = []
+            for item in value:
+                out.extend(self._normalize_values(item))
+            return out
+        return [value]
+
+    def _frame_scope(self, frame: PartialFrameArtifact, fragments_by_id: dict[str, Any]) -> ScopePath:
+        if not frame.fragment_ids:
+            return tuple()
+        frag = fragments_by_id.get(frame.fragment_ids[0])
+        if frag is None:
+            return tuple()
+        return getattr(frag, "scope_path", tuple())
+
+    def _frame_warning_codes(self, frame: PartialFrameArtifact) -> set[str]:
+        return set(warning_codes_from_diagnostics(frame.diagnostics))
+
+    def _frame_error_codes(self, frame: PartialFrameArtifact) -> set[str]:
+        return set(error_codes_from_diagnostics(frame.diagnostics))

--- a/legacy/archive/pipeline_legacy_20260518/modules/lex_eval.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/lex_eval.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Any
+
+from expr_eval import EvalContext
+from lex_ir import (
+    LexBuiltinCall,
+    LexColumnRef,
+    LexContextRef,
+    LexExpr,
+    LexLiteral,
+    LexRowLabelMatch,
+    LexSetExpr,
+    LexSymbolConst,
+    LexUnion,
+)
+from runtime_env import LexCandidate
+
+
+class LexEvalError(ValueError):
+    pass
+
+
+class LexEvaluator:
+    ALLOWED_BUILTINS = {
+        "site_alias",
+        "activity_alias",
+        "unit_symbol",
+        "period_expr",
+        "number",
+        "one_of",
+        "llm.fuzzy_lex",
+    }
+
+    def resolve(self, expr: LexExpr | None, ctx: EvalContext) -> list[LexCandidate]:
+        if expr is None:
+            return []
+
+        if isinstance(expr, LexUnion):
+            hits: list[LexCandidate] = []
+            for option in expr.options:
+                hits.extend(self.resolve(option, ctx))
+            return self._merge_hits(hits)
+
+        value = self.eval_value(expr, ctx)
+        return self._coerce_to_candidates(value)
+
+    def eval_value(self, expr: LexExpr | Any, ctx: EvalContext) -> Any:
+        if not isinstance(expr, LexExpr):
+            return expr
+
+        if isinstance(expr, LexLiteral):
+            return expr.value
+
+        if isinstance(expr, LexSymbolConst):
+            return expr.name
+
+        if isinstance(expr, LexSetExpr):
+            return [self.eval_value(item, ctx) for item in expr.items]
+
+        if isinstance(expr, LexBuiltinCall):
+            return self._call(expr, ctx)
+
+        if isinstance(expr, LexColumnRef):
+            return ctx.row.get(expr.column_name)
+
+        if isinstance(expr, LexContextRef):
+            res = ctx.env.context_store.resolve_best(
+                expr.role_name,
+                ctx.scope_path,
+                column_key=ctx.column_key,
+            )
+            return None if res.chosen is None else res.chosen.value
+
+        if isinstance(expr, LexRowLabelMatch):
+            if ctx.row_label is None:
+                return None
+            return expr.label if expr.label in ctx.row_label else None
+
+        raise LexEvalError(f"unsupported LexExpr type: {type(expr).__name__}")
+
+    def _call(self, expr: LexBuiltinCall, ctx: EvalContext) -> Any:
+        name = expr.name
+        if name not in self.ALLOWED_BUILTINS:
+            raise LexEvalError(f"builtin '{name}' is not allowed in LexEvaluator")
+
+        fn = self._lookup_builtin(name, ctx)
+
+        if name in {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number"}:
+            return fn(ctx.text, ctx.env)
+
+        if name == "one_of":
+            choices = [self.eval_value(arg, ctx) for arg in expr.args]
+            return fn(ctx.text, *choices, env=ctx.env)
+
+        if name == "llm.fuzzy_lex":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx)
+            return fn(role_name, ctx.text, ctx.env)
+
+        args = [self.eval_value(arg, ctx) for arg in expr.args]
+        for pattern in (
+            lambda: fn(*args, env=ctx.env),
+            lambda: fn(*args),
+        ):
+            try:
+                return pattern()
+            except TypeError:
+                continue
+
+        raise LexEvalError(f"builtin call failed: {name}")
+
+    def _lookup_builtin(self, name: str, ctx: EvalContext):
+        fn = ctx.env.builtin_registry.get(name)
+        if fn is None:
+            raise LexEvalError(f"unknown builtin: {name}")
+        return fn
+
+    def _raw_identifier(self, args: list[LexExpr], index: int, ctx: EvalContext) -> str:
+        if index >= len(args):
+            raise LexEvalError("missing function arg")
+        value = self.eval_value(args[index], ctx)
+        return str(value)
+
+    def _coerce_to_candidates(self, value: Any) -> list[LexCandidate]:
+        if value is None:
+            return []
+
+        if isinstance(value, LexCandidate):
+            return [value]
+
+        if isinstance(value, list):
+            out: list[LexCandidate] = []
+            for item in value:
+                out.extend(self._coerce_to_candidates(item))
+            return out
+
+        if isinstance(value, tuple) and len(value) == 3:
+            return [
+                LexCandidate(
+                    value=value[0],
+                    start=value[1],
+                    end=value[2],
+                    confidence=0.80,
+                )
+            ]
+
+        return [
+            LexCandidate(
+                value=value,
+                start=None,
+                end=None,
+                confidence=0.50,
+            )
+        ]
+
+    def _merge_hits(self, hits: list[LexCandidate]) -> list[LexCandidate]:
+        by_key: dict[tuple[Any, int | None, int | None], LexCandidate] = {}
+        for hit in hits:
+            key = (hit.value, hit.start, hit.end)
+            prev = by_key.get(key)
+            if prev is None or hit.confidence > prev.confidence:
+                by_key[key] = hit
+        return list(by_key.values())

--- a/legacy/archive/pipeline_legacy_20260518/modules/lex_ir.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/lex_ir.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class LexExpr:
+    pass
+
+
+@dataclass
+class LexLiteral(LexExpr):
+    value: Any
+
+
+@dataclass
+class LexSymbolConst(LexExpr):
+    name: str
+
+
+@dataclass
+class LexSetExpr(LexExpr):
+    items: list[LexExpr] = field(default_factory=list)
+
+
+@dataclass
+class LexBuiltinCall(LexExpr):
+    name: str
+    args: list[LexExpr] = field(default_factory=list)
+
+
+@dataclass
+class LexColumnRef(LexExpr):
+    column_name: str
+
+
+@dataclass
+class LexContextRef(LexExpr):
+    role_name: str
+
+
+@dataclass
+class LexRowLabelMatch(LexExpr):
+    label: str
+
+
+@dataclass
+class LexUnion(LexExpr):
+    options: list[LexExpr] = field(default_factory=list)

--- a/legacy/archive/pipeline_legacy_20260518/modules/lex_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/lex_pass.py
@@ -1,0 +1,215 @@
+# lex_pass.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+from typing import Any, Optional
+
+from artifacts import CompileArtifacts, TokenOccurrence
+from compiled_spec import CompiledProgramSpec
+from lex_eval import LexEvaluator
+from runtime_env import LexCandidate, RuntimeEnv
+
+
+@dataclass
+class LexPassConfig:
+    min_primary_confidence: float = 0.80
+    ambiguity_delta: float = 0.05
+    max_hits_per_token_per_fragment: int = 8
+    fallback_confidence_multiplier: float = 0.90
+
+
+class LexPass:
+    """
+    fragment -> token occurrences
+
+    설계 원칙:
+    1) deterministic(primary) lexer 먼저
+    2) 필요할 때만 fallback lexer(LLM) 호출
+    3) token declaration의 alternation은 union semantics
+    4) 이 단계에서는 role-claim으로 확정하지 않고 token occurrence만 뽑음
+    """
+
+    def __init__(
+        self,
+        evaluator: Optional[LexEvaluator] = None,
+        config: Optional[LexPassConfig] = None,
+    ) -> None:
+        self.evaluator = evaluator or LexEvaluator()
+        self.config = config or LexPassConfig()
+        self._seq = count(1)
+
+    def run(
+        self,
+        spec: CompiledProgramSpec,
+        artifacts: CompileArtifacts,
+        env: RuntimeEnv,
+    ) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("LexPass requires CompiledProgramSpec")
+
+        out_tokens: list[TokenOccurrence] = []
+
+        for fragment in artifacts.fragments:
+            ctx = self._build_eval_context(fragment, env)
+
+            for token_spec in spec.compiled_tokens.values():
+                token_hits = self._lex_one_token(token_spec, ctx)
+                out_tokens.extend(
+                    self._to_occurrences(
+                        token_name=token_spec.syntax.name,
+                        fragment=fragment,
+                        hits=token_hits,
+                    )
+                )
+
+        artifacts.tokens.extend(out_tokens)
+        return artifacts
+
+    def _lex_one_token(
+        self,
+        token_spec,
+        ctx,
+    ) -> list[LexCandidate]:
+        primary_hits = self.evaluator.resolve(token_spec.primary_ir, ctx)
+        primary_hits = self._postprocess_hits(primary_hits, source_channel="primary")
+
+        fallback_hits: list[LexCandidate] = []
+        if token_spec.fallback_ir is not None and self._should_use_fallback(primary_hits):
+            fallback_hits = self.evaluator.resolve(token_spec.fallback_ir, ctx)
+            fallback_hits = self._postprocess_hits(fallback_hits, source_channel="fallback")
+
+        merged = self._merge_hits(primary_hits, fallback_hits)
+        merged.sort(
+            key=lambda h: (
+                -float(h.confidence),
+                h.start if h.start is not None else 10**9,
+                -((h.end or 0) - (h.start or 0)),
+            )
+        )
+        return merged[: self.config.max_hits_per_token_per_fragment]
+
+    def _postprocess_hits(
+        self,
+        hits: list[LexCandidate],
+        *,
+        source_channel: str,
+    ) -> list[LexCandidate]:
+        out: list[LexCandidate] = []
+
+        for h in hits:
+            conf = float(h.confidence)
+
+            if source_channel == "fallback":
+                conf *= self.config.fallback_confidence_multiplier
+
+            meta = dict(h.metadata)
+            meta["source_channel"] = source_channel
+
+            out.append(
+                LexCandidate(
+                    value=h.value,
+                    start=h.start,
+                    end=h.end,
+                    confidence=conf,
+                    metadata=meta,
+                )
+            )
+
+        return out
+
+    def _merge_hits(
+        self,
+        primary_hits: list[LexCandidate],
+        fallback_hits: list[LexCandidate],
+    ) -> list[LexCandidate]:
+        by_key: dict[tuple[Any, Optional[int], Optional[int]], LexCandidate] = {}
+
+        for h in [*primary_hits, *fallback_hits]:
+            key = (h.value, h.start, h.end)
+            prev = by_key.get(key)
+            if prev is None or h.confidence > prev.confidence:
+                by_key[key] = h
+
+        return list(by_key.values())
+
+    def _should_use_fallback(self, primary_hits: list[LexCandidate]) -> bool:
+        if not primary_hits:
+            return True
+
+        best = primary_hits[0]
+        if best.confidence < self.config.min_primary_confidence:
+            return True
+
+        if len(primary_hits) >= 2:
+            gap = abs(primary_hits[0].confidence - primary_hits[1].confidence)
+            if gap < self.config.ambiguity_delta:
+                return True
+
+        return False
+
+    def _to_occurrences(
+        self,
+        *,
+        token_name: str,
+        fragment: Any,
+        hits: list[LexCandidate],
+    ) -> list[TokenOccurrence]:
+        out: list[TokenOccurrence] = []
+
+        fragment_id = getattr(fragment, "fragment_id", "FRG-UNKNOWN")
+        text = getattr(fragment, "text", "")
+
+        for rank, hit in enumerate(hits, start=1):
+            used_llm = hit.metadata.get("source_channel") == "fallback"
+
+            surface = None
+            if (
+                hit.start is not None
+                and hit.end is not None
+                and 0 <= hit.start < hit.end <= len(text)
+            ):
+                surface = text[hit.start:hit.end]
+
+            metadata = dict(hit.metadata)
+            if surface is not None:
+                metadata.setdefault("surface", surface)
+
+            out.append(
+                TokenOccurrence(
+                    token_id=f"TOK-{next(self._seq):07d}",
+                    token_name=token_name,
+                    fragment_id=fragment_id,
+                    value=hit.value,
+                    start=hit.start,
+                    end=hit.end,
+                    confidence=hit.confidence,
+                    source_channel=hit.metadata.get("source_channel", "primary"),
+                    used_llm=used_llm,
+                    rank=rank,
+                    metadata=metadata,
+                )
+            )
+
+        return out
+
+    def _build_eval_context(self, fragment: Any, env: RuntimeEnv):
+        from expr_eval import EvalContext
+
+        metadata = getattr(fragment, "metadata", {}) or {}
+
+        row = metadata.get("row", {}) if isinstance(metadata, dict) else {}
+        row_label = metadata.get("row_label") if isinstance(metadata, dict) else None
+        column_key = metadata.get("column_key") if isinstance(metadata, dict) else None
+
+        return EvalContext(
+            env=env,
+            text=getattr(fragment, "text", ""),
+            scope_path=getattr(fragment, "scope_path", tuple()),
+            row=row,
+            row_label=row_label,
+            column_key=column_key,
+            frame=None,
+            claims_by_id={},
+            local_vars={},
+        )

--- a/legacy/archive/pipeline_legacy_20260518/modules/lowering.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/lowering.py
@@ -1,0 +1,578 @@
+# lowering.py
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from ast_nodes import (
+    Program,
+    Expr,
+    NameExpr,
+    LiteralExpr,
+    FunctionCallExpr,
+    SetExpr,
+    ColumnRefExpr,
+    ContextRefExpr,
+    RowLabelRefExpr,
+    AlternationExpr,
+    UnaryExpr,
+    BinaryExpr,
+    ModuleDecl,
+    ImportDecl,
+    DimensionDecl,
+    UnitDecl,
+    ActivityDecl,
+    ScopeDecl,
+    ContextDecl,
+    PrecedenceStmt,
+    RefineStmt,
+    TtlStmt,
+    SupportsStmt,
+    FrameDecl,
+    TokenDecl,
+    FallbackTokenDecl,
+    ParserDecl,
+    BuildStmt,
+    BindStmt,
+    ParserInheritStmt,
+    TagStmt,
+    InheritRule,
+    InferRule,
+    RequireRule,
+    ForbidRule,
+    DiagnosticRule,
+    ResolverDecl,
+    AssignStmt,
+    CandidatePoolBlock,
+    CommitStmt,
+    ReviewStmt,
+    RejectStmt,
+    GovernanceDecl,
+    EmitStmt,
+    MergeStmt,
+    ForbidMergeStmt,
+)
+from spec_nodes import (
+    ProgramSpec,
+    DimensionSpec,
+    NormalizeSpec,
+    UnitSpec,
+    ActivitySpec,
+    ContextPolicy,
+    FieldSpec,
+    FrameSpec,
+    TokenSpec,
+    ParserSpec,
+    InheritSpec,
+    InferSpec,
+    ConstraintSpec,
+    DiagnosticSpec,
+    ResolverPolicy,
+    GovernancePolicy,
+)
+
+
+class LoweringError(ValueError):
+    pass
+
+
+class Lowerer:
+    """
+    Program(AST) -> ProgramSpec(runtime-friendly spec)
+
+    원칙:
+    - expression tree는 최대한 보존한다
+    - duplicate / cross-reference / shape validation을 여기서 처리한다
+    - resolver/governance는 '정책 데이터'로만 내린다
+    """
+
+    def lower(self, program: Program) -> ProgramSpec:
+        if not isinstance(program, Program):
+            raise TypeError("lower() expects Program AST")
+
+        spec = ProgramSpec(module_name="main")
+
+        seen_module = False
+        seen_scope = False
+
+        for stmt in program.statements:
+            if isinstance(stmt, ModuleDecl):
+                if seen_module:
+                    raise LoweringError("module declaration may appear only once")
+                spec.module_name = stmt.name
+                seen_module = True
+
+            elif isinstance(stmt, ImportDecl):
+                spec.imports.append(stmt.name)
+
+            elif isinstance(stmt, DimensionDecl):
+                self._add_unique(
+                    spec.dimensions,
+                    stmt.name,
+                    DimensionSpec(name=stmt.name),
+                    kind="dimension",
+                )
+
+            elif isinstance(stmt, UnitDecl):
+                self._lower_unit_decl(spec, stmt)
+
+            elif isinstance(stmt, ActivityDecl):
+                self._add_unique(
+                    spec.activities,
+                    stmt.name,
+                    ActivitySpec(
+                        name=stmt.name,
+                        dimension=stmt.dimension,
+                        scope_category=stmt.scope_category,
+                    ),
+                    kind="activity",
+                )
+
+            elif isinstance(stmt, ScopeDecl):
+                if seen_scope:
+                    raise LoweringError("scope declaration may appear only once")
+                spec.scope_chain = list(stmt.chain)
+                seen_scope = True
+
+            elif isinstance(stmt, ContextDecl):
+                self._lower_context_decl(spec, stmt)
+
+            elif isinstance(stmt, FrameDecl):
+                self._lower_frame_decl(spec, stmt)
+
+            elif isinstance(stmt, TokenDecl):
+                self._lower_token_decl(spec, stmt, is_fallback=False)
+
+            elif isinstance(stmt, FallbackTokenDecl):
+                self._lower_token_decl(spec, stmt, is_fallback=True)
+
+            elif isinstance(stmt, ParserDecl):
+                self._lower_parser_decl(spec, stmt)
+
+            elif isinstance(stmt, InheritRule):
+                spec.inherit_rules.append(
+                    InheritSpec(
+                        role_name=stmt.role_name,
+                        source_expr=self._expr(stmt.source_expr),
+                        condition=self._expr(stmt.condition),
+                    )
+                )
+
+            elif isinstance(stmt, InferRule):
+                spec.infer_rules.append(
+                    InferSpec(
+                        target_name=stmt.target_name,
+                        op=stmt.op,
+                        value_expr=self._expr(stmt.value_expr),
+                        condition=self._expr(stmt.condition),
+                        weight=stmt.weight,
+                    )
+                )
+
+            elif isinstance(stmt, RequireRule):
+                spec.constraints.append(
+                    ConstraintSpec(
+                        kind="require",
+                        condition=self._expr(stmt.condition),
+                    )
+                )
+
+            elif isinstance(stmt, ForbidRule):
+                spec.constraints.append(
+                    ConstraintSpec(
+                        kind="forbid",
+                        condition=self._expr(stmt.condition),
+                        frame_name=stmt.frame_name,
+                    )
+                )
+
+            elif isinstance(stmt, DiagnosticRule):
+                spec.diagnostics.append(
+                    DiagnosticSpec(
+                        level=stmt.level,
+                        code=stmt.code,
+                        condition=self._expr(stmt.condition),
+                    )
+                )
+
+            elif isinstance(stmt, ResolverDecl):
+                self._lower_resolver_decl(spec, stmt)
+
+            elif isinstance(stmt, GovernanceDecl):
+                self._lower_governance_decl(spec, stmt)
+
+            else:
+                raise LoweringError(f"unsupported top-level AST node: {type(stmt).__name__}")
+
+        self._validate_spec(spec)
+        return spec
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _add_unique(self, target: dict[str, Any], key: str, value: Any, *, kind: str) -> None:
+        if key in target:
+            raise LoweringError(f"duplicate {kind}: {key}")
+        target[key] = value
+
+    def _get_or_create_token(self, spec: ProgramSpec, name: str) -> TokenSpec:
+        tok = spec.tokens.get(name)
+        if tok is None:
+            tok = TokenSpec(name=name)
+            spec.tokens[name] = tok
+        return tok
+
+    # ------------------------------------------------------------------
+    # Expression normalization
+    # ------------------------------------------------------------------
+
+    def _expr(self, value: Any) -> Expr:
+        """
+        ASTBuilder 단계에서 bare string이 qname일 수 있으므로
+        lowering 단계에서 NameExpr로 정규화한다.
+        """
+        if isinstance(value, Expr):
+            return self._normalize_expr_tree(value)
+
+        if isinstance(value, str):
+            return NameExpr(name=value)
+
+        if isinstance(value, (int, float, bool)):
+            return LiteralExpr(value=value)
+
+        raise LoweringError(f"cannot normalize value into Expr: {value!r}")
+
+    def _normalize_expr_tree(self, expr: Expr) -> Expr:
+        if isinstance(expr, NameExpr):
+            return expr
+
+        if isinstance(expr, LiteralExpr):
+            return expr
+
+        if isinstance(expr, FunctionCallExpr):
+            return FunctionCallExpr(
+                name=expr.name,
+                args=[self._expr(a) for a in expr.args],
+            )
+
+        if isinstance(expr, SetExpr):
+            return SetExpr(items=[self._expr(i) for i in expr.items])
+
+        if isinstance(expr, ColumnRefExpr):
+            return expr
+
+        if isinstance(expr, ContextRefExpr):
+            return expr
+
+        if isinstance(expr, RowLabelRefExpr):
+            return expr
+
+        if isinstance(expr, AlternationExpr):
+            return AlternationExpr(options=[self._expr(o) for o in expr.options])
+
+        if isinstance(expr, UnaryExpr):
+            return UnaryExpr(op=expr.op, operand=self._expr(expr.operand))
+
+        if isinstance(expr, BinaryExpr):
+            return BinaryExpr(
+                left=self._expr(expr.left),
+                op=expr.op,
+                right=self._expr(expr.right),
+            )
+
+        raise LoweringError(f"unsupported Expr node: {type(expr).__name__}")
+
+    # ------------------------------------------------------------------
+    # Lower individual declarations
+    # ------------------------------------------------------------------
+
+    def _lower_unit_decl(self, spec: ProgramSpec, stmt: UnitDecl) -> None:
+        normalize = None
+        if stmt.normalize is not None:
+            normalize = NormalizeSpec(
+                target_unit=stmt.normalize.target_unit,
+                op=stmt.normalize.op,
+                factor=float(stmt.normalize.factor),
+            )
+
+        self._add_unique(
+            spec.units,
+            stmt.name,
+            UnitSpec(
+                name=stmt.name,
+                dimension=stmt.dimension,
+                normalize=normalize,
+            ),
+            kind="unit",
+        )
+
+    def _lower_context_decl(self, spec: ProgramSpec, stmt: ContextDecl) -> None:
+        if stmt.role_name in spec.contexts:
+            raise LoweringError(f"duplicate context block: {stmt.role_name}")
+
+        policy = ContextPolicy(role_name=stmt.role_name)
+
+        seen_precedence = False
+        seen_ttl = False
+
+        for s in stmt.statements:
+            if isinstance(s, PrecedenceStmt):
+                if seen_precedence:
+                    raise LoweringError(
+                        f"context {stmt.role_name}: precedence may appear only once"
+                    )
+                policy.precedence_chain = list(s.chain)
+                seen_precedence = True
+
+            elif isinstance(s, RefineStmt):
+                policy.refine_pairs.append((s.specific, s.broad))
+
+            elif isinstance(s, TtlStmt):
+                if seen_ttl:
+                    raise LoweringError(
+                        f"context {stmt.role_name}: ttl may appear only once"
+                    )
+                policy.ttl_levels = list(s.values)
+                seen_ttl = True
+
+            elif isinstance(s, SupportsStmt):
+                policy.supports.extend(s.values)
+
+            else:
+                raise LoweringError(
+                    f"context {stmt.role_name}: unsupported stmt {type(s).__name__}"
+                )
+
+        spec.contexts[stmt.role_name] = policy
+
+    def _lower_frame_decl(self, spec: ProgramSpec, stmt: FrameDecl) -> None:
+        if stmt.name in spec.frames:
+            raise LoweringError(f"duplicate frame: {stmt.name}")
+
+        seen_fields: set[str] = set()
+        fields: list[FieldSpec] = []
+
+        for f in stmt.fields:
+            if f.name in seen_fields:
+                raise LoweringError(f"frame {stmt.name}: duplicate field {f.name}")
+            seen_fields.add(f.name)
+
+            fields.append(
+                FieldSpec(
+                    name=f.name,
+                    type_name=f.type_ref.name,
+                    generic=f.type_ref.generic,
+                    optional=f.optional,
+                )
+            )
+
+        spec.frames[stmt.name] = FrameSpec(name=stmt.name, fields=fields)
+
+    def _lower_token_decl(
+        self,
+        spec: ProgramSpec,
+        stmt: TokenDecl | FallbackTokenDecl,
+        *,
+        is_fallback: bool,
+    ) -> None:
+        tok = self._get_or_create_token(spec, stmt.name)
+        expr = self._expr(stmt.expr)
+
+        if is_fallback:
+            if tok.fallback_expr is not None:
+                raise LoweringError(f"duplicate fallback token rule: {stmt.name}")
+            tok.fallback_expr = expr
+        else:
+            if tok.primary_expr is not None:
+                raise LoweringError(f"duplicate token rule: {stmt.name}")
+            tok.primary_expr = expr
+
+    def _lower_parser_decl(self, spec: ProgramSpec, stmt: ParserDecl) -> None:
+        if stmt.name in spec.parsers:
+            raise LoweringError(f"duplicate parser: {stmt.name}")
+
+        build_frame = None
+        lowered_actions = []
+
+        for action in stmt.actions:
+            if isinstance(action, BuildStmt):
+                if build_frame is not None:
+                    raise LoweringError(
+                        f"parser {stmt.name}: build may appear only once"
+                    )
+                build_frame = action.frame_name
+                lowered_actions.append(action)
+
+            elif isinstance(action, BindStmt):
+                lowered_actions.append(
+                    BindStmt(
+                        role_name=action.role_name,
+                        source_expr=self._expr(action.source_expr),
+                        optional=action.optional,
+                    )
+                )
+
+            elif isinstance(action, ParserInheritStmt):
+                lowered_actions.append(
+                    ParserInheritStmt(
+                        role_name=action.role_name,
+                        source_expr=self._expr(action.source_expr),
+                        condition=self._expr(action.condition) if action.condition is not None else None,
+                    )
+                )
+
+            elif isinstance(action, TagStmt):
+                lowered_actions.append(
+                    TagStmt(
+                        role_name=action.role_name,
+                        source_expr=self._expr(action.source_expr),
+                    )
+                )
+
+            else:
+                raise LoweringError(
+                    f"parser {stmt.name}: unsupported action {type(action).__name__}"
+                )
+
+        if build_frame is None:
+            raise LoweringError(f"parser {stmt.name}: missing build statement")
+
+        spec.parsers[stmt.name] = ParserSpec(
+            name=stmt.name,
+            source_selectors=list(stmt.source_selectors),
+            build_frame=build_frame,
+            actions=lowered_actions,
+        )
+
+    def _lower_resolver_decl(self, spec: ProgramSpec, stmt: ResolverDecl) -> None:
+        if stmt.frame_name in spec.resolvers:
+            raise LoweringError(f"duplicate resolver for frame: {stmt.frame_name}")
+
+        policy = ResolverPolicy(frame_name=stmt.frame_name)
+
+        for s in stmt.statements:
+            if isinstance(s, AssignStmt):
+                if s.name in policy.assigns:
+                    raise LoweringError(
+                        f"resolver {stmt.frame_name}: duplicate assign {s.name}"
+                    )
+                policy.assigns[s.name] = self._expr(s.value)
+
+            elif isinstance(s, CandidatePoolBlock):
+                for a in s.assigns:
+                    if a.name in policy.candidate_pool_assigns:
+                        raise LoweringError(
+                            f"resolver {stmt.frame_name}: duplicate candidate_pool assign {a.name}"
+                        )
+                    policy.candidate_pool_assigns[a.name] = self._expr(a.value)
+
+            elif isinstance(s, CommitStmt):
+                if policy.commit_condition is not None:
+                    raise LoweringError(
+                        f"resolver {stmt.frame_name}: duplicate commit clause"
+                    )
+                policy.commit_condition = self._expr(s.condition)
+
+            elif isinstance(s, ReviewStmt):
+                if policy.review_condition is not None:
+                    raise LoweringError(
+                        f"resolver {stmt.frame_name}: duplicate review clause"
+                    )
+                policy.review_condition = self._expr(s.condition)
+
+            elif isinstance(s, RejectStmt):
+                if policy.reject_otherwise:
+                    raise LoweringError(
+                        f"resolver {stmt.frame_name}: duplicate reject otherwise"
+                    )
+                policy.reject_otherwise = True
+
+            else:
+                raise LoweringError(
+                    f"resolver {stmt.frame_name}: unsupported stmt {type(s).__name__}"
+                )
+
+        spec.resolvers[stmt.frame_name] = policy
+
+    def _lower_governance_decl(self, spec: ProgramSpec, stmt: GovernanceDecl) -> None:
+        if stmt.frame_name in spec.governances:
+            raise LoweringError(f"duplicate governance for frame: {stmt.frame_name}")
+
+        policy = GovernancePolicy(frame_name=stmt.frame_name)
+
+        for s in stmt.statements:
+            if isinstance(s, EmitStmt):
+                if policy.emit_condition is not None:
+                    raise LoweringError(
+                        f"governance {stmt.frame_name}: duplicate emit row clause"
+                    )
+                policy.emit_condition = self._expr(s.condition)
+
+            elif isinstance(s, MergeStmt):
+                policy.merge_conditions.append(self._expr(s.condition))
+
+            elif isinstance(s, ForbidMergeStmt):
+                policy.forbid_merge_conditions.append(self._expr(s.condition))
+
+            else:
+                raise LoweringError(
+                    f"governance {stmt.frame_name}: unsupported stmt {type(s).__name__}"
+                )
+
+        spec.governances[stmt.frame_name] = policy
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def _validate_spec(self, spec: ProgramSpec) -> None:
+        # Unit dimensions must exist
+        for unit in spec.units.values():
+            if unit.dimension not in spec.dimensions:
+                raise LoweringError(
+                    f"unit {unit.name}: unknown dimension {unit.dimension}"
+                )
+            if unit.normalize is not None and unit.normalize.target_unit not in spec.units:
+                raise LoweringError(
+                    f"unit {unit.name}: normalize target unit {unit.normalize.target_unit} not declared"
+                )
+
+        # Activity dimensions must exist
+        for act in spec.activities.values():
+            if act.dimension not in spec.dimensions:
+                raise LoweringError(
+                    f"activity {act.name}: unknown dimension {act.dimension}"
+                )
+
+        # Token specs must have at least one implementation
+        for tok in spec.tokens.values():
+            if tok.primary_expr is None and tok.fallback_expr is None:
+                raise LoweringError(f"token {tok.name}: no primary/fallback expr")
+
+        # Parser build frame must exist
+        for parser in spec.parsers.values():
+            if parser.build_frame not in spec.frames:
+                raise LoweringError(
+                    f"parser {parser.name}: unknown build frame {parser.build_frame}"
+                )
+
+        # Forbid frame references must exist
+        for c in spec.constraints:
+            if c.frame_name is not None and c.frame_name not in spec.frames:
+                raise LoweringError(
+                    f"constraint references unknown frame: {c.frame_name}"
+                )
+
+        # Resolver/governance target frames must exist
+        for frame_name in spec.resolvers:
+            if frame_name not in spec.frames:
+                raise LoweringError(
+                    f"resolver references unknown frame: {frame_name}"
+                )
+
+        for frame_name in spec.governances:
+            if frame_name not in spec.frames:
+                raise LoweringError(
+                    f"governance references unknown frame: {frame_name}"
+                )

--- a/legacy/archive/pipeline_legacy_20260518/modules/parse_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/parse_pass.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from itertools import count
+from typing import Any, Optional
+
+from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact, TokenOccurrence
+from compiled_spec import CompiledBindAction, CompiledParserInheritAction, CompiledProgramSpec, CompiledTagAction
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv
+from source_eval import SourceEvaluator
+
+
+class ParsePass:
+    def __init__(self, source_evaluator: Optional[SourceEvaluator] = None, rule_evaluator: Optional[RuleEvaluator] = None) -> None:
+        self.source_evaluator = source_evaluator or SourceEvaluator()
+        self.rule_evaluator = rule_evaluator or RuleEvaluator()
+        self._frame_seq = count(1)
+        self._claim_seq = count(1)
+
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("ParsePass requires CompiledProgramSpec")
+        tokens_by_fragment = self._index_tokens(artifacts.tokens)
+        new_frames: list[PartialFrameArtifact] = []
+        new_claims: list[ClaimArtifact] = []
+        for fragment in artifacts.fragments:
+            frag_kind = self._fragment_kind(fragment)
+            for parser_spec in spec.compiled_parsers.values():
+                if frag_kind not in parser_spec.syntax.source_selectors:
+                    continue
+                frame = PartialFrameArtifact(
+                    frame_id=f"FRM-{next(self._frame_seq):07d}",
+                    parser_name=parser_spec.syntax.name,
+                    frame_type=parser_spec.syntax.build_frame,
+                    fragment_ids=[getattr(fragment, "fragment_id", "FRG-UNKNOWN")],
+                    slots={},
+                )
+                ctx = self._build_eval_context(fragment, env, frame)
+                for action in parser_spec.actions:
+                    if isinstance(action, CompiledBindAction):
+                        claims = self._resolve_source_to_claims(source_ir=action.source_ir, fragment=fragment, tokens_by_fragment=tokens_by_fragment, ctx=ctx, parser_name=parser_spec.syntax.name, frame_id=frame.frame_id, role_name=action.syntax.role_name, extraction_mode_override="explicit")
+                        self._apply_role_binding(frame=frame, role_name=action.syntax.role_name, claims=claims, claims_out=new_claims, optional=action.syntax.optional, missing_tag_if_empty="missing_parser_failed")
+                    elif isinstance(action, CompiledParserInheritAction):
+                        if action.condition_ir is not None and not self.rule_evaluator.eval_bool(action.condition_ir, ctx):
+                            continue
+                        claims = self._resolve_source_to_claims(source_ir=action.source_ir, fragment=fragment, tokens_by_fragment=tokens_by_fragment, ctx=ctx, parser_name=parser_spec.syntax.name, frame_id=frame.frame_id, role_name=action.syntax.role_name, extraction_mode_override="inherited")
+                        self._apply_role_binding(frame=frame, role_name=action.syntax.role_name, claims=claims, claims_out=new_claims, optional=True, missing_tag_if_empty="missing_waiting_context")
+                    elif isinstance(action, CompiledTagAction):
+                        claims = self._resolve_source_to_claims(source_ir=action.source_ir, fragment=fragment, tokens_by_fragment=tokens_by_fragment, ctx=ctx, parser_name=parser_spec.syntax.name, frame_id=frame.frame_id, role_name=action.syntax.role_name, extraction_mode_override="explicit")
+                        self._apply_role_binding(frame=frame, role_name=action.syntax.role_name, claims=claims, claims_out=new_claims, optional=True, missing_tag_if_empty=None)
+                    ctx.frame = frame
+                    ctx.local_vars["status"] = frame.status
+                new_frames.append(frame)
+        artifacts.claims.extend(new_claims)
+        artifacts.frames.extend(new_frames)
+        return artifacts
+
+    def _index_tokens(self, tokens: list[TokenOccurrence]) -> dict[str, dict[str, list[TokenOccurrence]]]:
+        out: dict[str, dict[str, list[TokenOccurrence]]] = {}
+        for tok in tokens:
+            out.setdefault(tok.fragment_id, {}).setdefault(tok.token_name, []).append(tok)
+        for frag_map in out.values():
+            for bucket in frag_map.values():
+                bucket.sort(key=lambda t: (-t.confidence, t.rank))
+        return out
+
+    def _resolve_source_to_claims(self, *, source_ir, fragment: Any, tokens_by_fragment: dict[str, dict[str, list[TokenOccurrence]]], ctx, parser_name: str, frame_id: str, role_name: str, extraction_mode_override: Optional[str] = None) -> list[ClaimArtifact]:
+        candidates = self.source_evaluator.resolve(source_ir, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+        claims: list[ClaimArtifact] = []
+        fragment_id = getattr(fragment, "fragment_id", "FRG-UNKNOWN")
+        for idx, cand in enumerate(candidates, start=1):
+            claims.append(ClaimArtifact(claim_id=f"CLM-{next(self._claim_seq):07d}", frame_id=frame_id, fragment_id=fragment_id, parser_name=parser_name, role_name=role_name, value=cand.value, extraction_mode=extraction_mode_override or cand.extraction_mode, confidence=float(cand.confidence), candidate_state="active" if idx == 1 else "shadow", source_token_id=cand.source_token_id, source_fragment_id=cand.source_fragment_id or fragment_id, span=cand.span, metadata=dict(cand.metadata)))
+        return claims
+
+    def _apply_role_binding(self, *, frame: PartialFrameArtifact, role_name: str, claims: list[ClaimArtifact], claims_out: list[ClaimArtifact], optional: bool, missing_tag_if_empty: Optional[str]) -> None:
+        slot = frame.slots.get(role_name)
+        if slot is None:
+            slot = RoleSlotArtifact(role_name=role_name)
+            frame.slots[role_name] = slot
+        if not claims:
+            if slot.active_claim_id is None and missing_tag_if_empty is not None:
+                slot.missing_tag = missing_tag_if_empty
+                if missing_tag_if_empty not in slot.reason_codes:
+                    slot.reason_codes.append(missing_tag_if_empty)
+            return
+        if slot.active_claim_id is None:
+            claims[0].candidate_state = "active"
+            slot.active_claim_id = claims[0].claim_id
+            slot.resolved_value = claims[0].value
+            slot.confidence = claims[0].confidence
+            for c in claims[1:]:
+                c.candidate_state = "shadow"
+                slot.shadow_claim_ids.append(c.claim_id)
+            slot.missing_tag = None
+            claims_out.extend(claims)
+            return
+        for c in claims:
+            c.candidate_state = "shadow"
+            slot.shadow_claim_ids.append(c.claim_id)
+        claims_out.extend(claims)
+
+    def _build_eval_context(self, fragment: Any, env: RuntimeEnv, frame: PartialFrameArtifact):
+        from expr_eval import EvalContext
+        metadata = getattr(fragment, "metadata", {}) or {}
+        row = metadata.get("row", {}) if isinstance(metadata, dict) else {}
+        row_label = metadata.get("row_label") if isinstance(metadata, dict) else None
+        column_key = metadata.get("column_key") if isinstance(metadata, dict) else None
+        return EvalContext(env=env, text=getattr(fragment, "text", ""), scope_path=getattr(fragment, "scope_path", tuple()), row=row, row_label=row_label, column_key=column_key, frame=frame, claims_by_id={}, local_vars={"frame_type": frame.frame_type, "status": frame.status})
+
+    def _fragment_kind(self, fragment: Any) -> str:
+        value = getattr(fragment, "fragment_type", None)
+        return getattr(value, "value", value)

--- a/legacy/archive/pipeline_legacy_20260518/modules/pipeline_runner.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/pipeline_runner.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Protocol, Sequence
+
+from artifacts import CompileArtifacts
+from binder import Binder
+from esg_builtins import register_default_builtins
+from calculation_pass import CalculationPass
+from compiled_spec import CompiledProgramSpec
+from emit_pass import EmitPass
+from governance_pass import GovernancePass
+from inference_pass import InferencePass
+from lex_pass import LexPass
+from parse_pass import ParsePass
+from repair_pass import RepairPass
+from runtime_env import RuntimeEnv, SiteRecord, build_runtime_env
+from scope_resolution_pass import ScopeResolutionPass
+from semantic_pass import SemanticPass, SemanticPassConfig
+from spec_nodes import ProgramSpec
+
+
+class Fragmentizer(Protocol):
+    def __call__(self, documents: Sequence[Any]) -> list[Any]:
+        ...
+
+
+class CompilerPass(Protocol):
+    def run(self, spec: ProgramSpec | CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        ...
+
+
+@dataclass
+class PipelineResources:
+    site_records: Sequence[SiteRecord] = field(default_factory=list)
+    factor_rows: Sequence[dict[str, Any]] = field(default_factory=list)
+    policy_flags: dict[str, Any] = field(default_factory=dict)
+    activity_aliases: dict[str, list[str]] = field(default_factory=dict)
+    unit_aliases: dict[str, list[str]] = field(default_factory=dict)
+    llm_fallback: Optional[Any] = None
+    llm_budget: int = 0
+
+
+@dataclass
+class PipelineRunResult:
+    spec: ProgramSpec | CompiledProgramSpec
+    env: RuntimeEnv
+    artifacts: CompileArtifacts
+
+    def summary(self) -> dict[str, Any]:
+        frame_status_counts: dict[str, int] = {}
+        for f in self.artifacts.frames:
+            frame_status_counts[f.status] = frame_status_counts.get(f.status, 0) + 1
+
+        row_status_counts: dict[str, int] = {}
+        for r in self.artifacts.rows:
+            row_status_counts[r.status] = row_status_counts.get(r.status, 0) + 1
+
+        calc_status_counts: dict[str, int] = {}
+        for c in self.artifacts.calculations:
+            calc_status_counts[c.calculation_status] = calc_status_counts.get(c.calculation_status, 0) + 1
+
+        return {
+            "module_name": self.spec.module_name,
+            "fragments": len(self.artifacts.fragments),
+            "tokens": len(self.artifacts.tokens),
+            "claims": len(self.artifacts.claims),
+            "frames": len(self.artifacts.frames),
+            "rows": len(self.artifacts.rows),
+            "calculations": len(self.artifacts.calculations),
+            "frame_status_counts": frame_status_counts,
+            "row_status_counts": row_status_counts,
+            "calculation_status_counts": calc_status_counts,
+            "merge_decisions": len(self.artifacts.merge_log),
+            "events": len(self.artifacts.event_log),
+            "diagnostics": len(self.artifacts.diagnostics),
+            "llm_budget_remaining": self.env.llm_budget_remaining,
+        }
+
+
+def load_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> ProgramSpec:
+    if dsl_text is None and dsl_path is None:
+        raise ValueError("one of dsl_text or dsl_path must be provided")
+    grammar = Path(grammar_path).read_text(encoding="utf-8")
+    source = dsl_text if dsl_text is not None else Path(dsl_path).read_text(encoding="utf-8")
+    from lark import Lark
+    from ast_builder import ASTBuilder
+    from lowering import Lowerer
+
+    parser = Lark(grammar, parser="lalr", lexer="contextual", start="start")
+    tree = parser.parse(source)
+    return Lowerer().lower(ASTBuilder().transform(tree))
+
+
+def compile_program_spec(program_spec: ProgramSpec) -> CompiledProgramSpec:
+    return Binder().bind(program_spec)
+
+
+def load_compiled_program_spec_from_dsl(*, grammar_path: str | Path, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
+    return compile_program_spec(load_program_spec_from_dsl(grammar_path=grammar_path, dsl_path=dsl_path, dsl_text=dsl_text))
+
+
+def build_default_passes(*, include_post_repair_semantic: bool = False) -> list[CompilerPass]:
+    passes: list[CompilerPass] = [
+        LexPass(),
+        ParsePass(),
+        ScopeResolutionPass(),
+        InferencePass(),
+        SemanticPass(config=SemanticPassConfig(phase_label="semantic_pre")),
+        RepairPass(),
+    ]
+    if include_post_repair_semantic:
+        passes.append(SemanticPass(config=SemanticPassConfig(phase_label="semantic_post")))
+    passes.extend([EmitPass(), GovernancePass(), CalculationPass()])
+    return passes
+
+
+class ESGPipelineRunner:
+    def __init__(self, *, grammar_path: str | Path = "esgdl.lark", passes: Optional[list[CompilerPass]] = None, fragmentizer: Optional[Fragmentizer] = None) -> None:
+        self.grammar_path = Path(grammar_path)
+        self.fragmentizer = fragmentizer
+        self.passes = passes or build_default_passes()
+
+    def load_spec(self, *, dsl_path: str | Path | None = None, dsl_text: str | None = None) -> CompiledProgramSpec:
+        return load_compiled_program_spec_from_dsl(grammar_path=self.grammar_path, dsl_path=dsl_path, dsl_text=dsl_text)
+
+    def build_env(self, *, spec: ProgramSpec | CompiledProgramSpec, resources: Optional[PipelineResources] = None) -> RuntimeEnv:
+        resources = resources or PipelineResources()
+        syntax_spec = spec.syntax if isinstance(spec, CompiledProgramSpec) else spec
+        env = build_runtime_env(spec=syntax_spec, site_records=list(resources.site_records), factor_rows=list(resources.factor_rows), policy_flags=dict(resources.policy_flags), activity_aliases=dict(resources.activity_aliases), unit_aliases=dict(resources.unit_aliases), llm_fallback=resources.llm_fallback, llm_budget=resources.llm_budget)
+        register_default_builtins(env)
+        return env
+
+    def prepare_fragments(self, *, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None) -> list[Any]:
+        if fragments is not None:
+            return fragments
+        if documents is None:
+            raise ValueError("one of fragments or documents must be provided")
+        if self.fragmentizer is None:
+            raise ValueError("documents were provided but no fragmentizer is configured. Either pass pre-built fragments or inject a fragmentizer callable.")
+        return self.fragmentizer(documents)
+
+    def run(self, *, spec: Optional[ProgramSpec | CompiledProgramSpec] = None, dsl_path: str | Path | None = None, dsl_text: str | None = None, fragments: Optional[list[Any]] = None, documents: Optional[Sequence[Any]] = None, resources: Optional[PipelineResources] = None) -> PipelineRunResult:
+        if spec is None:
+            spec = self.load_spec(dsl_path=dsl_path, dsl_text=dsl_text)
+        elif not isinstance(spec, CompiledProgramSpec):
+            spec = compile_program_spec(spec)
+
+        env = self.build_env(spec=spec, resources=resources)
+        prepared_fragments = self.prepare_fragments(fragments=fragments, documents=documents)
+        artifacts = CompileArtifacts(fragments=prepared_fragments)
+        for p in self.passes:
+            artifacts = p.run(spec, artifacts, env)
+        return PipelineRunResult(spec=spec, env=env, artifacts=artifacts)

--- a/legacy/archive/pipeline_legacy_20260518/modules/repair_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/repair_pass.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+from typing import Any, Optional
+
+from artifacts import (
+    ClaimArtifact,
+    CompileArtifacts,
+    PartialFrameArtifact,
+    RoleSlotArtifact,
+    diagnostic_codes,
+)
+from compiled_spec import CompiledProgramSpec, CompiledResolverPolicy
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv
+
+
+@dataclass
+class RepairPassConfig:
+    # DSL candidate_pool에 없더라도 엔진 기본값으로 둠
+    freeze_after: int = 3
+    drop_after: int = 6
+    oscillation_window: int = 4
+
+    # explicit 보호 정도
+    explicit_protection_margin: float = 0.08
+
+    # diagnostics에 따른 shadow 보너스
+    conflict_shadow_bonus: float = 0.05
+    mismatch_shadow_bonus: float = 0.08
+    missing_shadow_bonus: float = 0.04
+
+    trace_enabled: bool = True
+
+
+@dataclass
+class CandidateScore:
+    claim_id: str
+    total_score: float
+    base_score: float
+    mode_bonus: float
+    aging_bonus: float
+    diagnostic_bonus: float
+
+
+class RepairPass:
+    """
+    frames -> repaired frames
+
+    핵심 역할:
+    1) slot별 active/shadow/frozen/rejected 재정렬
+    2) aging 적용
+    3) replace_margin 기반 교체
+    4) frame-level score/stability 계산
+    5) commit / review / reject 판정
+    """
+
+    def __init__(
+        self,
+        evaluator: RuleEvaluator | None = None,
+        config: RepairPassConfig | None = None,
+    ) -> None:
+        self.evaluator = evaluator or RuleEvaluator()
+        self.config = config or RepairPassConfig()
+        self._event_seq = count(1)
+
+    def run(
+        self,
+        spec: CompiledProgramSpec,
+        artifacts: CompileArtifacts,
+        env: RuntimeEnv,
+    ) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("RepairPass requires CompiledProgramSpec")
+
+        claims_by_id = {c.claim_id: c for c in artifacts.claims}
+
+        for frame in artifacts.frames:
+            policy = spec.compiled_resolvers.get(frame.frame_type)
+            if policy is None:
+                continue
+
+            self._repair_frame(
+                frame=frame,
+                policy=policy,
+                claims_by_id=claims_by_id,
+                env=env,
+            )
+
+        return artifacts
+
+    # ------------------------------------------------------------------
+    # Frame loop
+    # ------------------------------------------------------------------
+
+    def _repair_frame(
+        self,
+        *,
+        frame: PartialFrameArtifact,
+        policy: CompiledResolverPolicy,
+        claims_by_id: dict[str, ClaimArtifact],
+        env: RuntimeEnv,
+    ) -> None:
+        params = self._extract_policy_params(policy, env, frame, claims_by_id)
+
+        max_iter = int(params.get("max_iter", 6))
+        epsilon = float(params.get("epsilon", 0.02))
+        replace_margin = float(params.get("replace_margin", 0.05))
+
+        shadow_limit = int(params.get("candidate_pool.shadow", 2))
+        allow_frozen = bool(params.get("candidate_pool.frozen", True))
+        aging_step = float(params.get("candidate_pool.aging_step", 0.03))
+        aging_cap = float(params.get("candidate_pool.aging_cap", 0.15))
+
+        frame.metadata.setdefault("repair_trace", [])
+        frame.metadata["resolver_frame_type"] = frame.frame_type
+
+        prev_signature = None
+        prev_score = 0.0
+        no_improve_count = 0
+        frame_stable = 0
+        state_history: list[tuple] = []
+
+        termination_reason = None
+        last_iter_no = 0
+
+        for iter_no in range(1, max_iter + 1):
+            last_iter_no = iter_no
+
+            # 1) diagnostics snapshot
+            warning_codes = self._diag_codes(frame, severity="warning")
+            error_codes = self._diag_codes(frame, severity="error")
+
+            # 2) slot별 후보 재정렬
+            for role_name, slot in frame.slots.items():
+                self._revive_frozen_if_needed(
+                    frame=frame,
+                    slot=slot,
+                    role_name=role_name,
+                    claims_by_id=claims_by_id,
+                    warning_codes=warning_codes,
+                    error_codes=error_codes,
+                    shadow_limit=shadow_limit,
+                    allow_frozen=allow_frozen,
+                )
+
+                self._rerank_slot(
+                    frame=frame,
+                    slot=slot,
+                    role_name=role_name,
+                    claims_by_id=claims_by_id,
+                    replace_margin=replace_margin,
+                    aging_step=aging_step,
+                    aging_cap=aging_cap,
+                    shadow_limit=shadow_limit,
+                    warning_codes=warning_codes,
+                    error_codes=error_codes,
+                )
+
+            # 3) frame-level score / stability
+            frame_score = self._frame_score(frame, claims_by_id)
+            signature = self._frame_signature(frame)
+
+            if prev_signature is not None and signature == prev_signature:
+                frame_stable += 1
+            else:
+                frame_stable = 0
+
+            if self.config.trace_enabled:
+                frame.metadata["repair_trace"].append(
+                    {
+                        "iter": iter_no,
+                        "frame_score": frame_score,
+                        "frame_status": frame.status,
+                        "frame_stable": frame_stable,
+                        "signature": signature,
+                        "warning_codes": sorted(warning_codes),
+                        "error_codes": sorted(error_codes),
+                        "slots": self._snapshot_slots(frame, claims_by_id),
+                    }
+                )
+
+            # 4) commit condition
+            eval_ctx = EvalContext(
+                env=env,
+                frame=frame,
+                claims_by_id=claims_by_id,
+                local_vars={
+                    "score": frame_score,
+                    "stable": frame_stable,
+                    "status": frame.status,
+                    "iteration": iter_no,
+                    "no_improve_count": no_improve_count,
+                },
+                warning_codes=warning_codes,
+                error_codes=error_codes,
+            )
+
+            if policy.commit_condition_ir is not None and self.evaluator.eval_bool(policy.commit_condition_ir, eval_ctx):
+                frame.status = "committed"
+                termination_reason = "commit_condition_satisfied"
+                break
+
+            # 5) seen state / oscillation
+            if signature in state_history:
+                termination_reason = "seen_state_repeated"
+                break
+
+            state_history.append(signature)
+
+            if self._detect_oscillation(state_history):
+                termination_reason = "oscillation_detected"
+                break
+
+            # 6) improvement
+            improvement = frame_score - prev_score
+            if improvement < epsilon:
+                no_improve_count += 1
+            else:
+                no_improve_count = 0
+
+            if no_improve_count >= 2:
+                termination_reason = "no_meaningful_improvement"
+                break
+
+            prev_score = frame_score
+            prev_signature = signature
+
+        if last_iter_no > 0 and termination_reason is None:
+            termination_reason = "max_iter_exhausted"
+
+        final_score = self._frame_score(frame, claims_by_id)
+
+        # loop 종료 후 최종 판정
+        final_ctx = EvalContext(
+            env=env,
+            frame=frame,
+            claims_by_id=claims_by_id,
+            local_vars={
+                "score": final_score,
+                "stable": frame_stable,
+                "status": frame.status,
+                "iteration": last_iter_no,
+                "no_improve_count": no_improve_count,
+            },
+            warning_codes=self._diag_codes(frame, severity="warning"),
+            error_codes=self._diag_codes(frame, severity="error"),
+        )
+
+        if frame.status != "committed":
+            if policy.review_condition_ir is not None and self.evaluator.eval_bool(policy.review_condition_ir, final_ctx):
+                frame.status = "review_required"
+            elif policy.syntax.reject_otherwise:
+                frame.status = "rejected"
+            else:
+                frame.status = "resolving"
+
+        frame.runtime.resolution_score = final_score
+        frame.runtime.iteration_count = last_iter_no
+        frame.runtime.stable_count = frame_stable
+        frame.runtime.termination_reason = termination_reason
+
+        # backward-compatible mirrors; read paths should prefer frame.runtime.
+        frame.metadata["termination_reason"] = termination_reason
+        frame.metadata["final_score"] = final_score
+
+    # ------------------------------------------------------------------
+    # Slot repair
+    # ------------------------------------------------------------------
+
+    def _rerank_slot(
+        self,
+        *,
+        frame: PartialFrameArtifact,
+        slot: RoleSlotArtifact,
+        role_name: str,
+        claims_by_id: dict[str, ClaimArtifact],
+        replace_margin: float,
+        aging_step: float,
+        aging_cap: float,
+        shadow_limit: int,
+        warning_codes: set[str],
+        error_codes: set[str],
+    ) -> None:
+        active_claim = claims_by_id.get(slot.active_claim_id) if slot.active_claim_id else None
+
+        pool_ids = []
+        if slot.active_claim_id:
+            pool_ids.append(slot.active_claim_id)
+        pool_ids.extend(slot.shadow_claim_ids)
+
+        if not pool_ids:
+            slot.missing_tag = slot.missing_tag or "missing_parser_failed"
+            return
+
+        scored: list[CandidateScore] = []
+
+        for cid in pool_ids:
+            claim = claims_by_id.get(cid)
+            if claim is None:
+                continue
+
+            base = float(claim.confidence)
+            mode_bonus = self._mode_bonus(claim)
+            aging_bonus = self._aging_bonus(claim)
+            diagnostic_bonus = self._diagnostic_bonus(
+                role_name=role_name,
+                claim=claim,
+                slot=slot,
+                warning_codes=warning_codes,
+                error_codes=error_codes,
+            )
+
+            total = base + mode_bonus + aging_bonus + diagnostic_bonus
+
+            claim.metadata["repair_score"] = {
+                "base": base,
+                "mode_bonus": mode_bonus,
+                "aging_bonus": aging_bonus,
+                "diagnostic_bonus": diagnostic_bonus,
+                "total": total,
+            }
+
+            scored.append(
+                CandidateScore(
+                    claim_id=cid,
+                    total_score=total,
+                    base_score=base,
+                    mode_bonus=mode_bonus,
+                    aging_bonus=aging_bonus,
+                    diagnostic_bonus=diagnostic_bonus,
+                )
+            )
+
+        scored.sort(key=lambda s: s.total_score, reverse=True)
+        best = scored[0]
+        best_claim = claims_by_id[best.claim_id]
+
+        if active_claim is None:
+            self._promote_to_active(slot, best_claim, claims_by_id)
+        else:
+            if best_claim.claim_id != active_claim.claim_id:
+                active_score = self._claim_total_score(active_claim)
+                best_score = best.total_score
+
+                if self._can_replace_active(
+                    active_claim=active_claim,
+                    active_score=active_score,
+                    challenger=best_claim,
+                    challenger_score=best_score,
+                    replace_margin=replace_margin,
+                ):
+                    self._promote_to_active(slot, best_claim, claims_by_id)
+
+        self._update_candidate_lifecycle(
+            slot=slot,
+            claims_by_id=claims_by_id,
+            active_claim_id=slot.active_claim_id,
+            aging_step=aging_step,
+            aging_cap=aging_cap,
+            shadow_limit=shadow_limit,
+        )
+
+        active = claims_by_id.get(slot.active_claim_id) if slot.active_claim_id else None
+        if active is not None:
+            slot.resolved_value = active.value
+            slot.confidence = active.confidence
+            if slot.missing_tag in {"missing_waiting_context", "missing_parser_failed", "missing_conflicted"}:
+                slot.missing_tag = None
+
+    def _revive_frozen_if_needed(
+        self,
+        *,
+        frame: PartialFrameArtifact,
+        slot: RoleSlotArtifact,
+        role_name: str,
+        claims_by_id: dict[str, ClaimArtifact],
+        warning_codes: set[str],
+        error_codes: set[str],
+        shadow_limit: int,
+        allow_frozen: bool,
+    ) -> None:
+        if not allow_frozen:
+            return
+
+        should_revive = False
+
+        if slot.active_claim_id is None:
+            should_revive = True
+
+        if "context_conflict" in slot.reason_codes or slot.missing_tag == "missing_conflicted":
+            should_revive = True
+
+        if role_name in {"raw_unit", "activity_type"} and "UnitActivityMismatch" in error_codes:
+            should_revive = True
+
+        if role_name == "period" and "InvalidPeriod" in error_codes:
+            should_revive = True
+
+        if role_name == "site" and "MissingSite" in warning_codes:
+            should_revive = True
+
+        if not should_revive or not slot.frozen_claim_ids:
+            return
+
+        frozen_claims = [claims_by_id[cid] for cid in slot.frozen_claim_ids if cid in claims_by_id]
+        frozen_claims.sort(key=lambda c: float(c.confidence), reverse=True)
+
+        revive = frozen_claims[:1]
+        revive_ids = {c.claim_id for c in revive}
+
+        slot.frozen_claim_ids = [cid for cid in slot.frozen_claim_ids if cid not in revive_ids]
+        for claim in revive:
+            claim.candidate_state = "shadow"
+            claim.metadata["not_selected_iters"] = 0
+            slot.shadow_claim_ids.append(claim.claim_id)
+
+        slot.shadow_claim_ids = slot.shadow_claim_ids[:shadow_limit]
+
+    def _update_candidate_lifecycle(
+        self,
+        *,
+        slot: RoleSlotArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+        active_claim_id: Optional[str],
+        aging_step: float,
+        aging_cap: float,
+        shadow_limit: int,
+    ) -> None:
+        slot.shadow_claim_ids = [cid for cid in slot.shadow_claim_ids if cid != active_claim_id]
+
+        new_shadow: list[str] = []
+        new_frozen: list[str] = list(slot.frozen_claim_ids)
+        new_rejected: list[str] = list(slot.rejected_claim_ids)
+
+        for cid in slot.shadow_claim_ids:
+            claim = claims_by_id.get(cid)
+            if claim is None:
+                continue
+
+            not_selected_iters = int(claim.metadata.get("not_selected_iters", 0)) + 1
+            claim.metadata["not_selected_iters"] = not_selected_iters
+
+            aging_bonus = min(
+                aging_cap,
+                float(claim.metadata.get("aging_bonus", 0.0)) + aging_step,
+            )
+            claim.metadata["aging_bonus"] = aging_bonus
+
+            if not_selected_iters >= self.config.drop_after:
+                claim.candidate_state = "rejected"
+                new_rejected.append(cid)
+                continue
+
+            if not_selected_iters >= self.config.freeze_after:
+                claim.candidate_state = "frozen"
+                new_frozen.append(cid)
+                continue
+
+            claim.candidate_state = "shadow"
+            new_shadow.append(cid)
+
+        if active_claim_id and active_claim_id in claims_by_id:
+            active = claims_by_id[active_claim_id]
+            active.candidate_state = "active"
+            active.metadata["aging_bonus"] = 0.0
+            active.metadata["not_selected_iters"] = 0
+
+        new_shadow.sort(
+            key=lambda cid: -self._claim_total_score(claims_by_id[cid]) if cid in claims_by_id else 0.0
+        )
+        slot.shadow_claim_ids = new_shadow[:shadow_limit]
+        slot.frozen_claim_ids = new_frozen
+        slot.rejected_claim_ids = new_rejected
+
+    def _promote_to_active(
+        self,
+        slot: RoleSlotArtifact,
+        claim: ClaimArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+    ) -> None:
+        old_active_id = slot.active_claim_id
+        if old_active_id and old_active_id != claim.claim_id:
+            old_active = claims_by_id.get(old_active_id)
+            if old_active is not None:
+                old_active.candidate_state = "shadow"
+                if old_active_id not in slot.shadow_claim_ids:
+                    slot.shadow_claim_ids.append(old_active_id)
+
+        slot.active_claim_id = claim.claim_id
+        claim.candidate_state = "active"
+
+        if claim.claim_id in slot.shadow_claim_ids:
+            slot.shadow_claim_ids.remove(claim.claim_id)
+
+    # ------------------------------------------------------------------
+    # Scoring helpers
+    # ------------------------------------------------------------------
+
+    def _mode_bonus(self, claim: ClaimArtifact) -> float:
+        return {
+            "explicit": 0.10,
+            "inherited": 0.05,
+            "backward_inferred": 0.00,
+            "derived": -0.02,
+        }.get(claim.extraction_mode, 0.0)
+
+    def _aging_bonus(self, claim: ClaimArtifact) -> float:
+        return float(claim.metadata.get("aging_bonus", 0.0))
+
+    def _diagnostic_bonus(
+        self,
+        *,
+        role_name: str,
+        claim: ClaimArtifact,
+        slot: RoleSlotArtifact,
+        warning_codes: set[str],
+        error_codes: set[str],
+    ) -> float:
+        bonus = 0.0
+
+        if "context_conflict" in slot.reason_codes or slot.missing_tag == "missing_conflicted":
+            if claim.candidate_state == "shadow":
+                bonus += self.config.conflict_shadow_bonus
+
+        if role_name in {"raw_unit", "activity_type"} and "UnitActivityMismatch" in error_codes:
+            if claim.candidate_state == "shadow":
+                bonus += self.config.mismatch_shadow_bonus
+
+        if role_name == "period" and "InvalidPeriod" in error_codes:
+            if claim.candidate_state == "shadow":
+                bonus += self.config.mismatch_shadow_bonus
+
+        if role_name == "site" and "MissingSite" in warning_codes:
+            if claim.extraction_mode in {"inherited", "backward_inferred"}:
+                bonus += self.config.missing_shadow_bonus
+
+        return bonus
+
+    def _claim_total_score(self, claim: ClaimArtifact) -> float:
+        data = claim.metadata.get("repair_score")
+        if isinstance(data, dict) and "total" in data:
+            return float(data["total"])
+        return float(claim.confidence)
+
+    def _frame_score(
+        self,
+        frame: PartialFrameArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+    ) -> float:
+        scores = []
+        completeness_penalty = 0.0
+
+        for slot in frame.slots.values():
+            if slot.active_claim_id and slot.active_claim_id in claims_by_id:
+                scores.append(self._claim_total_score(claims_by_id[slot.active_claim_id]))
+            else:
+                completeness_penalty += 0.10
+
+        if not scores:
+            return 0.0
+
+        avg = sum(scores) / len(scores)
+        return max(0.0, avg - completeness_penalty)
+
+    def _can_replace_active(
+        self,
+        *,
+        active_claim: ClaimArtifact,
+        active_score: float,
+        challenger: ClaimArtifact,
+        challenger_score: float,
+        replace_margin: float,
+    ) -> bool:
+        margin = replace_margin
+        if active_claim.extraction_mode == "explicit":
+            margin += self.config.explicit_protection_margin
+
+        return challenger_score >= active_score + margin
+
+    # ------------------------------------------------------------------
+    # Loop helpers
+    # ------------------------------------------------------------------
+
+    def _frame_signature(self, frame: PartialFrameArtifact) -> tuple:
+        items = []
+        for role_name in sorted(frame.slots.keys()):
+            slot = frame.slots[role_name]
+            items.append((role_name, slot.active_claim_id, slot.missing_tag))
+        return tuple(items)
+
+    def _detect_oscillation(self, state_history: list[tuple]) -> bool:
+        win = self.config.oscillation_window
+        if len(state_history) < win:
+            return False
+
+        tail = state_history[-win:]
+        if win == 4:
+            a, b, c, d = tail
+            return (a == c) and (b == d) and (a != b)
+
+        unique = list(dict.fromkeys(tail))
+        return len(unique) == 2 and tail[0] == tail[2] and tail[1] == tail[3]
+
+    def _snapshot_slots(
+        self,
+        frame: PartialFrameArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+    ) -> dict[str, Any]:
+        out = {}
+        for role_name, slot in frame.slots.items():
+            active = claims_by_id.get(slot.active_claim_id) if slot.active_claim_id else None
+            out[role_name] = {
+                "active_claim_id": slot.active_claim_id,
+                "active_value": None if active is None else active.value,
+                "active_mode": None if active is None else active.extraction_mode,
+                "active_score": None if active is None else self._claim_total_score(active),
+                "shadow_count": len(slot.shadow_claim_ids),
+                "frozen_count": len(slot.frozen_claim_ids),
+                "rejected_count": len(slot.rejected_claim_ids),
+                "missing_tag": slot.missing_tag,
+                "reason_codes": list(slot.reason_codes),
+            }
+        return out
+
+    def _diag_codes(
+        self,
+        frame: PartialFrameArtifact,
+        *,
+        severity: str,
+    ) -> set[str]:
+        return set(diagnostic_codes(frame.diagnostics, severity=severity))
+
+    def _extract_policy_params(
+        self,
+        policy: CompiledResolverPolicy,
+        env: RuntimeEnv,
+        frame: PartialFrameArtifact,
+        claims_by_id: dict[str, ClaimArtifact],
+    ) -> dict[str, Any]:
+        """
+        resolver block의 literal-ish assign들을 실제 값으로 평가.
+        """
+        params: dict[str, Any] = {}
+
+        ctx = EvalContext(
+            env=env,
+            frame=frame,
+            claims_by_id=claims_by_id,
+            local_vars={},
+        )
+
+        for key, expr in policy.assigns_ir.items():
+            params[key] = self.evaluator.eval(expr, ctx)
+
+        for key, expr in policy.candidate_pool_assigns_ir.items():
+            params[f"candidate_pool.{key}"] = self.evaluator.eval(expr, ctx)
+
+        return params

--- a/legacy/archive/pipeline_legacy_20260518/modules/rule_builtins.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/rule_builtins.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+from esg_builtins import (
+    compatible as builtin_compatible,
+    dimension as builtin_dimension,
+    evidence as builtin_evidence,
+    missing as builtin_missing,
+    origin as builtin_origin,
+    valid as builtin_valid,
+    valid_period as builtin_valid_period,
+)
+
+if TYPE_CHECKING:
+    from rule_eval import RuleEvalContext
+
+
+@dataclass(frozen=True)
+class RuleBuiltinSpec:
+    name: str
+    arg_modes: tuple[str, ...]
+    impl: Callable[..., Any]
+
+
+# ------------------------------------------------------------------
+# Rule builtin implementations
+# ------------------------------------------------------------------
+
+
+def _missing(ctx: RuleEvalContext, role_name: str) -> bool:
+    return builtin_missing(role_name, ctx.frame)
+
+
+def _origin(ctx: RuleEvalContext, role_name: str):
+    return builtin_origin(role_name, ctx.frame, ctx.claims_by_id)
+
+
+def _evidence(ctx: RuleEvalContext, kind: str) -> int:
+    return builtin_evidence(kind, ctx.frame, ctx.claims_by_id)
+
+
+def _dimension(ctx: RuleEvalContext, raw_unit: Any):
+    return builtin_dimension(raw_unit, ctx.env)
+
+
+def _compatible(ctx: RuleEvalContext, activity_type: Any, raw_unit: Any) -> bool:
+    return builtin_compatible(activity_type, raw_unit, ctx.env)
+
+
+def _valid(ctx: RuleEvalContext, value: Any) -> bool:
+    return builtin_valid(value, ctx.env)
+
+
+def _valid_period(ctx: RuleEvalContext, value: Any) -> bool:
+    return builtin_valid_period(value)
+
+
+DEFAULT_RULE_BUILTIN_REGISTRY: dict[str, RuleBuiltinSpec] = {
+    "missing": RuleBuiltinSpec(
+        name="missing",
+        arg_modes=("slot_name",),
+        impl=_missing,
+    ),
+    "origin": RuleBuiltinSpec(
+        name="origin",
+        arg_modes=("slot_name",),
+        impl=_origin,
+    ),
+    "evidence": RuleBuiltinSpec(
+        name="evidence",
+        arg_modes=("symbol_name",),
+        impl=_evidence,
+    ),
+    "dimension": RuleBuiltinSpec(
+        name="dimension",
+        arg_modes=("value",),
+        impl=_dimension,
+    ),
+    "compatible": RuleBuiltinSpec(
+        name="compatible",
+        arg_modes=("value", "value"),
+        impl=_compatible,
+    ),
+    "valid": RuleBuiltinSpec(
+        name="valid",
+        arg_modes=("value",),
+        impl=_valid,
+    ),
+    "valid_period": RuleBuiltinSpec(
+        name="valid_period",
+        arg_modes=("value",),
+        impl=_valid_period,
+    ),
+}
+
+
+def get_default_rule_builtin_registry() -> dict[str, RuleBuiltinSpec]:
+    return dict(DEFAULT_RULE_BUILTIN_REGISTRY)

--- a/legacy/archive/pipeline_legacy_20260518/modules/rule_eval.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/rule_eval.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from rule_builtins import get_default_rule_builtin_registry
+from rule_ir import *
+
+
+RuleEvalContext = Any
+
+
+class RuleEvalError(ValueError):
+    pass
+
+
+class RuleEvaluator:
+    def __init__(self, *, builtin_registry=None):
+        self.builtin_registry = get_default_rule_builtin_registry() if builtin_registry is None else builtin_registry
+
+    def eval(self, expr, ctx):
+        if not isinstance(expr, RuleExpr):
+            return expr
+        if isinstance(expr, RuleLiteral):
+            return expr.value
+        if isinstance(expr, LocalVarRef):
+            return ctx.local_vars.get(expr.name)
+        if isinstance(expr, FrameSlotRef):
+            return self._frame_value(ctx.frame, expr.role_name)
+        if isinstance(expr, RowFieldRef):
+            return ctx.row.get(expr.field_name) if isinstance(ctx.row, dict) else getattr(ctx.row, expr.field_name, None)
+        if isinstance(expr, ContextValueRef):
+            res = ctx.env.context_store.resolve_best(expr.role_name, ctx.scope_path, column_key=getattr(ctx, "column_key", None))
+            return None if res.chosen is None else res.chosen.value
+        if isinstance(expr, PolicyRef):
+            return ctx.env.policy_flags.get(expr.key)
+        if isinstance(expr, HasDiagnostic):
+            return expr.code in (ctx.warning_codes if expr.severity == "warning" else ctx.error_codes)
+        if isinstance(expr, HasApproval):
+            return bool(ctx.approvals.get(expr.key, False))
+        if isinstance(expr, SymbolConst):
+            return expr.name
+        if isinstance(expr, RuleBuiltinCall):
+            return self._call(expr, ctx)
+        if isinstance(expr, RuleSetExpr):
+            return [self.eval(x, ctx) for x in expr.items]
+        if isinstance(expr, RuleCoalesce):
+            for x in expr.options:
+                v = self.eval(x, ctx)
+                if self._present(v):
+                    return v
+            return None
+        if isinstance(expr, RuleUnary):
+            if expr.op == "not":
+                return not self.eval_bool(expr.operand, ctx)
+            raise RuleEvalError(f"unsupported unary op: {expr.op}")
+        if isinstance(expr, RuleBinary):
+            return self._binary(expr, ctx)
+        raise RuleEvalError(f"unsupported RuleExpr type: {type(expr).__name__}")
+
+    def eval_bool(self, expr, ctx):
+        return self._present(self.eval(expr, ctx))
+
+    def _binary(self, expr, ctx):
+        l, r, op = self.eval(expr.left, ctx), self.eval(expr.right, ctx), expr.op
+        if op == "or":
+            return self._present(l) or self._present(r)
+        if op == "and":
+            return self._present(l) and self._present(r)
+        if op == "==":
+            return l == r
+        if op == "!=":
+            return l != r
+        if op == ">=":
+            return l >= r
+        if op == "<=":
+            return l <= r
+        if op == ">":
+            return l > r
+        if op == "<":
+            return l < r
+        if op == "in":
+            return False if r is None else l in r
+        if op == "matches":
+            return re.search(str(r), str(l or "")) is not None
+        raise RuleEvalError(f"unsupported binary op: {op}")
+
+    def _call(self, expr, ctx):
+        spec = self.builtin_registry.get(expr.name)
+        if spec is None:
+            raise RuleEvalError(f"unknown rule builtin: {expr.name}")
+        if len(expr.args) != len(spec.arg_modes):
+            raise RuleEvalError(f"builtin {expr.name} expected {len(spec.arg_modes)} args, got {len(expr.args)}")
+        args = [self._arg(a, m, ctx) for a, m in zip(expr.args, spec.arg_modes)]
+        return spec.impl(ctx, *args)
+
+    def _arg(self, arg, mode, ctx):
+        if mode == "value":
+            return self.eval(arg, ctx)
+        if mode in {"slot_name", "symbol_name"}:
+            if isinstance(arg, RowFieldRef):
+                raise RuleEvalError(
+                    f"row field ref '{arg.field_name}' cannot be used as {mode}; "
+                    "bind a value expression instead or use a row-aware builtin"
+                )
+            if isinstance(arg, FrameSlotRef):
+                return arg.role_name
+            if isinstance(arg, SymbolConst):
+                return arg.name
+            if isinstance(arg, RuleLiteral):
+                return str(arg.value)
+            return str(self.eval(arg, ctx))
+        raise RuleEvalError(f"unsupported builtin arg mode: {mode}")
+
+    def _frame_value(self, frame, role_name):
+        if frame is None:
+            return None
+        b = getattr(frame, "bindings", None)
+        if isinstance(b, dict) and role_name in b:
+            v = b[role_name]
+            return getattr(v, "value", v)
+        s = getattr(frame, "slots", None)
+        if isinstance(s, dict):
+            if role_name in s:
+                v = getattr(s[role_name], "resolved_value", None)
+                if v not in (None, ""):
+                    return v
+            for k, slot in s.items():
+                if getattr(k, "value", k) == role_name:
+                    v = getattr(slot, "resolved_value", None)
+                    if v not in (None, ""):
+                        return v
+        return None
+
+    def _present(self, v):
+        if v is None:
+            return False
+        if isinstance(v, str):
+            return v != ""
+        if isinstance(v, (list, tuple, set, dict)):
+            return len(v) > 0
+        return bool(v)

--- a/legacy/archive/pipeline_legacy_20260518/modules/rule_ir.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/rule_ir.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class RuleExpr:
+    pass
+
+
+@dataclass
+class RuleLiteral(RuleExpr):
+    value: Any
+
+
+@dataclass
+class LocalVarRef(RuleExpr):
+    name: str
+
+
+@dataclass
+class FrameSlotRef(RuleExpr):
+    role_name: str
+
+
+@dataclass
+class RowFieldRef(RuleExpr):
+    field_name: str
+
+
+@dataclass
+class ContextValueRef(RuleExpr):
+    role_name: str
+
+
+@dataclass
+class PolicyRef(RuleExpr):
+    key: str
+
+
+@dataclass
+class HasDiagnostic(RuleExpr):
+    severity: str
+    code: str
+
+
+@dataclass
+class HasApproval(RuleExpr):
+    key: str
+
+
+@dataclass
+class SymbolConst(RuleExpr):
+    name: str
+
+
+@dataclass
+class RuleBuiltinCall(RuleExpr):
+    name: str
+    args: list[RuleExpr] = field(default_factory=list)
+
+
+@dataclass
+class RuleSetExpr(RuleExpr):
+    items: list[RuleExpr] = field(default_factory=list)
+
+
+@dataclass
+class RuleCoalesce(RuleExpr):
+    options: list[RuleExpr] = field(default_factory=list)
+
+
+@dataclass
+class RuleUnary(RuleExpr):
+    op: str
+    operand: RuleExpr
+
+
+@dataclass
+class RuleBinary(RuleExpr):
+    left: RuleExpr
+    op: str
+    right: RuleExpr

--- a/legacy/archive/pipeline_legacy_20260518/modules/runtime_env.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/runtime_env.py
@@ -1,0 +1,313 @@
+# runtime_env.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Optional, Sequence
+
+from spec_nodes import ProgramSpec
+
+
+# ---------------------------------
+# Small runtime primitives
+# ---------------------------------
+
+@dataclass
+class LexCandidate:
+    value: Any
+    start: Optional[int] = None
+    end: Optional[int] = None
+    confidence: float = 1.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ScopeFrame:
+    level: str        # document / section / table / row / cell
+    ref_id: str       # e.g. "doc:1", "table:2", "row:8"
+
+
+ScopePath = tuple[ScopeFrame, ...]
+
+
+@dataclass
+class ContextEntry:
+    context_id: str
+    role_name: str
+    value: Any
+
+    scope_path: ScopePath
+    ttl: str                      # document / section / table / column / row / cell_only
+    precedence: int = 0
+    operation: str = "override"  # override / refine / conflict / mask
+
+    source_fragment_id: Optional[str] = None
+    source_claim_id: Optional[str] = None
+    column_key: Optional[str] = None
+
+    confidence: float = 1.0
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class ContextResolution:
+    role_name: str
+    chosen: Optional[ContextEntry]
+    candidates: list[ContextEntry] = field(default_factory=list)
+    reason: Optional[str] = None
+
+
+@dataclass
+class UnitRuntimeInfo:
+    name: str
+    dimension: str
+    normalize_to: Optional[str] = None
+    normalize_op: Optional[str] = None
+    normalize_factor: Optional[float] = None
+
+
+@dataclass
+class ActivityRuntimeInfo:
+    name: str
+    dimension: str
+    scope_category: str
+
+
+@dataclass
+class SiteRecord:
+    site_id: str
+    aliases: list[str]
+    entity_id: Optional[str] = None
+    country: Optional[str] = None
+
+
+class ContextStore:
+    """
+    역할별 context entry 저장소.
+    resolve()는 '현재 scope에서 쓸 수 있는 가장 적절한 context'를 골라준다.
+    """
+
+    def __init__(self) -> None:
+        self._entries_by_role: dict[str, list[ContextEntry]] = {}
+
+    def push(self, entry: ContextEntry) -> None:
+        self._entries_by_role.setdefault(entry.role_name, []).append(entry)
+
+    def resolve_all(
+        self,
+        role_name: str,
+        target_scope: ScopePath,
+        *,
+        column_key: Optional[str] = None,
+    ) -> list[ContextEntry]:
+        out: list[ContextEntry] = []
+        for entry in self._entries_by_role.get(role_name, []):
+            if not _same_document(entry.scope_path, target_scope):
+                continue
+            if not _ttl_allows(entry, target_scope, column_key=column_key):
+                continue
+            out.append(entry)
+
+        out.sort(
+            key=lambda e: (
+                -e.precedence,
+                _scope_distance(e.scope_path, target_scope),
+                -e.created_at.timestamp(),
+            )
+        )
+        return out
+
+    def resolve_best(
+        self,
+        role_name: str,
+        target_scope: ScopePath,
+        *,
+        column_key: Optional[str] = None,
+    ) -> ContextResolution:
+        candidates = self.resolve_all(
+            role_name,
+            target_scope,
+            column_key=column_key,
+        )
+        chosen = candidates[0] if candidates else None
+        reason = None if chosen else "no_applicable_context"
+        return ContextResolution(
+            role_name=role_name,
+            chosen=chosen,
+            candidates=candidates,
+            reason=reason,
+        )
+
+
+@dataclass
+class RuntimeEnv:
+    """
+    실제 compiler passes가 들고 다니는 실행 환경.
+    """
+    unit_index: dict[str, UnitRuntimeInfo] = field(default_factory=dict)
+    activity_index: dict[str, ActivityRuntimeInfo] = field(default_factory=dict)
+
+    # alias -> canonical
+    site_alias_index: dict[str, str] = field(default_factory=dict)
+    activity_alias_index: dict[str, str] = field(default_factory=dict)
+    unit_alias_index: dict[str, str] = field(default_factory=dict)
+
+    site_records: dict[str, SiteRecord] = field(default_factory=dict)
+    factor_index: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
+
+    policy_flags: dict[str, Any] = field(default_factory=dict)
+    context_store: ContextStore = field(default_factory=ContextStore)
+
+    builtin_registry: dict[str, Callable[..., Any]] = field(default_factory=dict)
+
+    allow_llm_fallback: bool = False
+    llm_fallback: Optional[Callable[[str, str], list[LexCandidate]]] = None
+    llm_budget_remaining: int = 0
+
+    def can_call_llm(self) -> bool:
+        return self.allow_llm_fallback and self.llm_fallback is not None and self.llm_budget_remaining > 0
+
+    def consume_llm_budget(self, n: int = 1) -> bool:
+        if self.llm_budget_remaining >= n:
+            self.llm_budget_remaining -= n
+            return True
+        return False
+
+
+def build_runtime_env(
+    spec: ProgramSpec,
+    *,
+    site_records: Sequence[SiteRecord] | None = None,
+    factor_rows: Sequence[dict[str, Any]] | None = None,
+    policy_flags: dict[str, Any] | None = None,
+    activity_aliases: dict[str, list[str]] | None = None,
+    unit_aliases: dict[str, list[str]] | None = None,
+    llm_fallback: Optional[Callable[[str, str], list[LexCandidate]]] = None,
+    llm_budget: int = 0,
+) -> RuntimeEnv:
+    env = RuntimeEnv()
+
+    # units
+    for unit in spec.units.values():
+        env.unit_index[unit.name] = UnitRuntimeInfo(
+            name=unit.name,
+            dimension=unit.dimension,
+            normalize_to=unit.normalize.target_unit if unit.normalize else None,
+            normalize_op=unit.normalize.op if unit.normalize else None,
+            normalize_factor=unit.normalize.factor if unit.normalize else None,
+        )
+        env.unit_alias_index[_norm_key(unit.name)] = unit.name
+
+    # unit aliases
+    for canonical, aliases in (unit_aliases or {}).items():
+        for alias in aliases:
+            env.unit_alias_index[_norm_key(alias)] = canonical
+
+    # activities
+    for act in spec.activities.values():
+        env.activity_index[act.name] = ActivityRuntimeInfo(
+            name=act.name,
+            dimension=act.dimension,
+            scope_category=act.scope_category,
+        )
+        env.activity_alias_index[_norm_key(act.name)] = act.name
+
+    # activity aliases
+    for canonical, aliases in (activity_aliases or {}).items():
+        for alias in aliases:
+            env.activity_alias_index[_norm_key(alias)] = canonical
+
+    # sites
+    for rec in site_records or []:
+        env.site_records[rec.site_id] = rec
+        for alias in rec.aliases:
+            env.site_alias_index[_norm_key(alias)] = rec.site_id
+
+    # factors
+    for row in factor_rows or []:
+        key = (str(row["activity_type"]), str(row["unit"]))
+        env.factor_index[key] = dict(row)
+
+    # policy / llm
+    env.policy_flags = dict(policy_flags or {})
+    env.allow_llm_fallback = llm_fallback is not None
+    env.llm_fallback = llm_fallback
+    env.llm_budget_remaining = max(0, llm_budget)
+
+    return env
+
+
+# ---------------------------------
+# Helpers
+# ---------------------------------
+
+def _norm_key(s: str) -> str:
+    return s.strip().lower()
+
+
+def _same_document(a: ScopePath, b: ScopePath) -> bool:
+    return _ref_at(a, "document") == _ref_at(b, "document")
+
+
+def _ref_at(path: ScopePath, level: str) -> Optional[str]:
+    for frame in path:
+        if frame.level == level:
+            return frame.ref_id
+    return None
+
+
+def _scope_distance(a: ScopePath, b: ScopePath) -> int:
+    """
+    값이 작을수록 가깝다.
+    대충 '가장 깊은 공통 prefix 이후 차이' 정도로 본다.
+    """
+    a_pairs = [(x.level, x.ref_id) for x in a]
+    b_pairs = [(x.level, x.ref_id) for x in b]
+
+    i = 0
+    while i < min(len(a_pairs), len(b_pairs)) and a_pairs[i] == b_pairs[i]:
+        i += 1
+
+    return (len(a_pairs) - i) + (len(b_pairs) - i)
+
+
+def _ttl_allows(
+    entry: ContextEntry,
+    target_scope: ScopePath,
+    *,
+    column_key: Optional[str],
+) -> bool:
+    if entry.ttl == "document":
+        return _same_document(entry.scope_path, target_scope)
+
+    if entry.ttl == "section":
+        return (
+            _same_document(entry.scope_path, target_scope)
+            and _ref_at(entry.scope_path, "section") == _ref_at(target_scope, "section")
+        )
+
+    if entry.ttl == "table":
+        return (
+            _same_document(entry.scope_path, target_scope)
+            and _ref_at(entry.scope_path, "table") == _ref_at(target_scope, "table")
+        )
+
+    if entry.ttl == "row":
+        return (
+            _same_document(entry.scope_path, target_scope)
+            and _ref_at(entry.scope_path, "row") == _ref_at(target_scope, "row")
+        )
+
+    if entry.ttl == "column":
+        return (
+            _same_document(entry.scope_path, target_scope)
+            and _ref_at(entry.scope_path, "table") == _ref_at(target_scope, "table")
+            and entry.column_key is not None
+            and column_key is not None
+            and entry.column_key == column_key
+        )
+
+    if entry.ttl == "cell_only":
+        return entry.scope_path == target_scope
+
+    return False

--- a/legacy/archive/pipeline_legacy_20260518/modules/scope_resolution_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/scope_resolution_pass.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from itertools import count
+from typing import Any, Optional
+
+from artifacts import ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
+from compiled_spec import CompiledProgramSpec
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv, ScopePath
+from source_eval import SourceEvaluator
+from spec_nodes import ContextPolicy
+
+
+YEAR_ONLY_RE = re.compile(r"^20\d{2}$")
+YEAR_MONTH_RE = re.compile(r"^20\d{2}-\d{2}$")
+
+
+@dataclass
+class CandidateView:
+    claim: ClaimArtifact
+    score: float
+    source_scope_rank: int
+    mode_rank: int
+    specificity_rank: int
+
+
+class ScopeResolutionPass:
+    def __init__(self, rule_evaluator: Optional[RuleEvaluator] = None, source_evaluator: Optional[SourceEvaluator] = None) -> None:
+        self.rule_evaluator = rule_evaluator or RuleEvaluator()
+        self.source_evaluator = source_evaluator or SourceEvaluator()
+        self._claim_seq = count(1)
+
+    def run(self, spec: CompiledProgramSpec, artifacts: CompileArtifacts, env: RuntimeEnv) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("ScopeResolutionPass requires CompiledProgramSpec")
+        fragments_by_id = self._index_fragments(artifacts.fragments)
+        claims_by_id = {c.claim_id: c for c in artifacts.claims}
+        new_claims: list[ClaimArtifact] = []
+        for frame in artifacts.frames:
+            base_scope = self._frame_scope(frame, fragments_by_id)
+            frame_ctx = self._make_eval_context(env=env, scope_path=base_scope, frame=frame, claims_by_id=claims_by_id)
+            added = self._apply_inherit_rules(spec=spec, frame=frame, frame_ctx=frame_ctx, fragments_by_id=fragments_by_id, claims_by_id=claims_by_id)
+            for c in added:
+                claims_by_id[c.claim_id] = c
+            new_claims.extend(added)
+            frame_fields = spec.frames.get(frame.frame_type)
+            role_names = set(frame.slots.keys())
+            if frame_fields is not None:
+                role_names.update(f.name for f in frame_fields.fields)
+            for role_name in role_names:
+                slot = frame.slots.get(role_name)
+                if slot is None:
+                    slot = RoleSlotArtifact(role_name=role_name)
+                    frame.slots[role_name] = slot
+                policy = spec.contexts.get(role_name)
+                self._resolve_slot_with_policy(frame=frame, slot=slot, role_name=role_name, policy=policy, claims_by_id=claims_by_id, fragments_by_id=fragments_by_id)
+        artifacts.claims.extend(new_claims)
+        return artifacts
+
+    def _apply_inherit_rules(self, *, spec: CompiledProgramSpec, frame: PartialFrameArtifact, frame_ctx, fragments_by_id: dict[str, Any], claims_by_id: dict[str, ClaimArtifact]) -> list[ClaimArtifact]:
+        created: list[ClaimArtifact] = []
+        base_fragment = fragments_by_id.get(frame.fragment_ids[0]) if frame.fragment_ids else None
+        for rule in spec.compiled_inherit_rules:
+            role_name = rule.syntax.role_name
+            slot = frame.slots.get(role_name)
+            if slot is None:
+                slot = RoleSlotArtifact(role_name=role_name)
+                frame.slots[role_name] = slot
+            if slot.active_claim_id is not None:
+                continue
+            if not self.rule_evaluator.eval_bool(rule.condition_ir, frame_ctx):
+                continue
+            source_candidates = self.source_evaluator.resolve(rule.source_ir, ctx=frame_ctx, fragment=base_fragment, tokens_by_fragment=None)
+            if not source_candidates:
+                if slot.missing_tag is None:
+                    slot.missing_tag = "missing_waiting_context"
+                if "missing_waiting_context" not in slot.reason_codes:
+                    slot.reason_codes.append("missing_waiting_context")
+                continue
+            claims = []
+            for idx, cand in enumerate(source_candidates, start=1):
+                claims.append(ClaimArtifact(claim_id=f"CLM-{next(self._claim_seq):07d}", frame_id=frame.frame_id, fragment_id=frame.fragment_ids[0] if frame.fragment_ids else "FRG-UNKNOWN", parser_name=frame.parser_name, role_name=role_name, value=cand.value, extraction_mode=cand.extraction_mode or "inherited", confidence=float(cand.confidence), candidate_state="active" if idx == 1 else "shadow", source_token_id=cand.source_token_id, source_fragment_id=cand.source_fragment_id, span=cand.span, reason_codes=["inherited_from_context"], metadata=dict(cand.metadata)))
+            slot.active_claim_id = claims[0].claim_id
+            slot.resolved_value = claims[0].value
+            slot.confidence = claims[0].confidence
+            slot.missing_tag = None
+            for c in claims[1:]:
+                slot.shadow_claim_ids.append(c.claim_id)
+            created.extend(claims)
+        return created
+
+    def _resolve_slot_with_policy(self, *, frame: PartialFrameArtifact, slot: RoleSlotArtifact, role_name: str, policy: Optional[ContextPolicy], claims_by_id: dict[str, ClaimArtifact], fragments_by_id: dict[str, Any]) -> None:
+        candidate_ids = []
+        if slot.active_claim_id:
+            candidate_ids.append(slot.active_claim_id)
+        candidate_ids.extend(slot.shadow_claim_ids)
+        candidates = []
+        for cid in candidate_ids:
+            claim = claims_by_id.get(cid)
+            if claim is None:
+                continue
+            candidates.append(self._score_candidate(claim=claim, role_name=role_name, policy=policy, fragments_by_id=fragments_by_id))
+        if not candidates:
+            if slot.missing_tag is None:
+                slot.missing_tag = "missing_waiting_context"
+                slot.reason_codes.append("missing_waiting_context")
+            return
+        candidates = self._apply_refine_resolution(role_name, policy, candidates)
+        best, shadows, conflicted = self._pick_best_and_shadows(candidates)
+        best.claim.candidate_state = "active"
+        for s in shadows:
+            s.claim.candidate_state = "shadow"
+        slot.active_claim_id = best.claim.claim_id
+        slot.shadow_claim_ids = [s.claim.claim_id for s in shadows]
+        slot.resolved_value = best.claim.value
+        slot.confidence = best.claim.confidence
+        if conflicted:
+            slot.reason_codes.append("context_conflict")
+            if slot.missing_tag is None and best.mode_rank < 3:
+                slot.missing_tag = "missing_conflicted"
+        elif slot.missing_tag == "missing_conflicted":
+            slot.missing_tag = None
+
+    def _score_candidate(self, *, claim: ClaimArtifact, role_name: str, policy: Optional[ContextPolicy], fragments_by_id: dict[str, Any]) -> CandidateView:
+        mode_rank = self._mode_rank(claim.extraction_mode)
+        source_scope_rank = 0
+        if policy is not None and claim.source_fragment_id is not None:
+            source_scope_rank = self._scope_rank_for_claim(claim=claim, policy=policy, fragments_by_id=fragments_by_id)
+        specificity_rank = self._specificity_rank(role_name, claim.value)
+        score = mode_rank * 100.0 + float(claim.confidence) * 10.0 + source_scope_rank * 1.0 + specificity_rank * 0.1
+        return CandidateView(claim=claim, score=score, source_scope_rank=source_scope_rank, mode_rank=mode_rank, specificity_rank=specificity_rank)
+
+    def _mode_rank(self, extraction_mode: str) -> int:
+        return {"explicit": 4, "inherited": 3, "backward_inferred": 2, "derived": 1}.get(extraction_mode, 0)
+
+    def _scope_rank_for_claim(self, *, claim: ClaimArtifact, policy: ContextPolicy, fragments_by_id: dict[str, Any]) -> int:
+        frag = fragments_by_id.get(claim.source_fragment_id)
+        if frag is None:
+            return 0
+        scope_path = getattr(frag, "scope_path", tuple())
+        levels = [getattr(s, "level", None) for s in scope_path]
+        precedence = policy.precedence_chain or []
+        for idx, label in enumerate(precedence):
+            if label in levels:
+                return len(precedence) - idx
+        return 0
+
+    def _specificity_rank(self, role_name: str, value: Any) -> int:
+        if role_name == "period" and isinstance(value, str):
+            if YEAR_MONTH_RE.fullmatch(value):
+                return 2
+            if YEAR_ONLY_RE.fullmatch(value):
+                return 1
+        return 0
+
+    def _apply_refine_resolution(self, role_name: str, policy: Optional[ContextPolicy], candidates: list[CandidateView]) -> list[CandidateView]:
+        if not candidates:
+            return candidates
+        if role_name != "period" or policy is None:
+            return candidates
+        has_period_refine = any(pair == ("YYYY_MM", "YYYY") for pair in policy.refine_pairs)
+        if not has_period_refine:
+            return candidates
+        year_month_vals = {c.claim.value for c in candidates if isinstance(c.claim.value, str) and YEAR_MONTH_RE.fullmatch(c.claim.value)}
+        out = []
+        for c in candidates:
+            if isinstance(c.claim.value, str) and YEAR_ONLY_RE.fullmatch(c.claim.value):
+                year = c.claim.value
+                if any(str(v).startswith(year + "-") for v in year_month_vals):
+                    c = CandidateView(claim=c.claim, score=c.score - 0.5, source_scope_rank=c.source_scope_rank, mode_rank=c.mode_rank, specificity_rank=c.specificity_rank)
+            out.append(c)
+        return out
+
+    def _pick_best_and_shadows(self, candidates: list[CandidateView]) -> tuple[CandidateView, list[CandidateView], bool]:
+        candidates = sorted(candidates, key=lambda c: c.score, reverse=True)
+        best = candidates[0]
+        shadows = candidates[1:]
+        conflicted = False
+        if len(candidates) >= 2:
+            second = candidates[1]
+            if best.claim.value != second.claim.value and abs(best.score - second.score) < 0.75:
+                conflicted = True
+        return best, shadows, conflicted
+
+    def _index_fragments(self, fragments: list[Any]) -> dict[str, Any]:
+        return {getattr(f, "fragment_id", f"FRG-{i:06d}"): f for i, f in enumerate(fragments, start=1)}
+
+    def _frame_scope(self, frame: PartialFrameArtifact, fragments_by_id: dict[str, Any]) -> ScopePath:
+        if not frame.fragment_ids:
+            return tuple()
+        frag = fragments_by_id.get(frame.fragment_ids[0])
+        if frag is None:
+            return tuple()
+        return getattr(frag, "scope_path", tuple())
+
+    def _make_eval_context(self, *, env: RuntimeEnv, scope_path: ScopePath, frame: PartialFrameArtifact, claims_by_id: dict[str, ClaimArtifact]):
+        from expr_eval import EvalContext
+        return EvalContext(env=env, text="", scope_path=scope_path, frame=frame, claims_by_id=claims_by_id, local_vars={"frame_type": frame.frame_type, "status": frame.status})

--- a/legacy/archive/pipeline_legacy_20260518/modules/semantic_pass.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/semantic_pass.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+from typing import Any
+
+from artifacts import CompileArtifacts, DiagnosticArtifact, PartialFrameArtifact
+from compiled_spec import CompiledProgramSpec
+from expr_eval import EvalContext
+from rule_eval import RuleEvaluator
+from runtime_env import RuntimeEnv
+
+
+@dataclass
+class SemanticPassConfig:
+    phase_label: str = "semantic_pre"
+    dedupe: bool = True
+    clear_same_phase_before_run: bool = True
+
+
+class SemanticPass:
+    def __init__(
+        self,
+        evaluator: RuleEvaluator | None = None,
+        config: SemanticPassConfig | None = None,
+    ) -> None:
+        self.evaluator = evaluator or RuleEvaluator()
+        self.config = config or SemanticPassConfig()
+        self._diag_seq = count(1)
+
+    def run(
+        self,
+        spec: CompiledProgramSpec,
+        artifacts: CompileArtifacts,
+        env: RuntimeEnv,
+    ) -> CompileArtifacts:
+        if not isinstance(spec, CompiledProgramSpec):
+            raise TypeError("SemanticPass requires CompiledProgramSpec")
+
+        claims_by_id = {c.claim_id: c for c in artifacts.claims}
+        if self.config.clear_same_phase_before_run:
+            self._clear_same_phase(artifacts)
+
+        new_global_diags: list[DiagnosticArtifact] = []
+
+        for frame in artifacts.frames:
+            frame_diags: list[DiagnosticArtifact] = []
+            ctx = EvalContext(
+                env=env,
+                text="",
+                scope_path=self._frame_scope(frame, artifacts.fragments),
+                frame=frame,
+                claims_by_id=claims_by_id,
+                local_vars={"frame_type": frame.frame_type, "status": frame.status},
+                warning_codes=self._existing_codes(frame, severity="warning"),
+                error_codes=self._existing_codes(frame, severity="error"),
+            )
+
+            for idx, compiled_constraint in enumerate(spec.compiled_constraints, start=1):
+                constraint = compiled_constraint.syntax
+                if constraint.frame_name is not None and constraint.frame_name != frame.frame_type:
+                    continue
+
+                if constraint.kind == "require":
+                    passed = self.evaluator.eval_bool(compiled_constraint.condition_ir, ctx)
+                    if not passed:
+                        diag = self._make_diagnostic(
+                            severity="error",
+                            code="RequireViolation",
+                            message=f"require failed on frame {frame.frame_id}",
+                            frame=frame,
+                            rule_kind="require",
+                            source_key=f"require:{idx}",
+                        )
+                        if self._accept_diag(frame, diag):
+                            frame_diags.append(diag)
+                            ctx.error_codes.add(diag.code)
+                elif constraint.kind == "forbid":
+                    violated = self.evaluator.eval_bool(compiled_constraint.condition_ir, ctx)
+                    if violated:
+                        diag = self._make_diagnostic(
+                            severity="error",
+                            code="ForbidViolation",
+                            message=f"forbid violated on frame {frame.frame_id}",
+                            frame=frame,
+                            rule_kind="forbid",
+                            source_key=f"forbid:{idx}",
+                        )
+                        if self._accept_diag(frame, diag):
+                            frame_diags.append(diag)
+                            ctx.error_codes.add(diag.code)
+
+            for compiled_rule in spec.compiled_diagnostics:
+                rule = compiled_rule.syntax
+                if not self.evaluator.eval_bool(compiled_rule.condition_ir, ctx):
+                    continue
+
+                diag = self._make_diagnostic(
+                    severity=rule.level,
+                    code=rule.code,
+                    message=f"{rule.code} triggered on frame {frame.frame_id}",
+                    frame=frame,
+                    rule_kind="diagnostic",
+                    source_key=f"{rule.level}:{rule.code}",
+                )
+                if self._accept_diag(frame, diag):
+                    frame_diags.append(diag)
+                    if rule.level == "warning":
+                        ctx.warning_codes.add(rule.code)
+                    elif rule.level == "error":
+                        ctx.error_codes.add(rule.code)
+
+            frame.diagnostics.extend(frame_diags)
+            new_global_diags.extend(frame_diags)
+
+        artifacts.diagnostics.extend(new_global_diags)
+        return artifacts
+
+    def _make_diagnostic(
+        self,
+        *,
+        severity: str,
+        code: str,
+        message: str,
+        frame: PartialFrameArtifact,
+        rule_kind: str,
+        source_key: str,
+    ) -> DiagnosticArtifact:
+        return DiagnosticArtifact(
+            diagnostic_id=f"DGN-{next(self._diag_seq):07d}",
+            severity=severity,
+            code=code,
+            message=message,
+            scope_kind="frame",
+            scope_id=frame.frame_id,
+            frame_id=frame.frame_id,
+            fragment_id=frame.fragment_ids[0] if frame.fragment_ids else None,
+            rule_kind=rule_kind,
+            source_key=source_key,
+            phase=self.config.phase_label,
+        )
+
+    def _accept_diag(self, frame: PartialFrameArtifact, diag: DiagnosticArtifact) -> bool:
+        if not self.config.dedupe:
+            return True
+
+        key = (diag.phase, diag.severity, diag.code, diag.source_key)
+        for existing in frame.diagnostics:
+            old_key = (
+                getattr(existing, "phase", None),
+                getattr(existing, "severity", None),
+                getattr(existing, "code", None),
+                getattr(existing, "source_key", None),
+            )
+            if old_key == key:
+                return False
+        return True
+
+    def _clear_same_phase(self, artifacts: CompileArtifacts) -> None:
+        phase = self.config.phase_label
+        for frame in artifacts.frames:
+            frame.diagnostics = [d for d in frame.diagnostics if getattr(d, "phase", None) != phase]
+        artifacts.diagnostics = [d for d in artifacts.diagnostics if getattr(d, "phase", None) != phase]
+
+    def _existing_codes(self, frame: PartialFrameArtifact, *, severity: str) -> set[str]:
+        codes = set()
+        for d in frame.diagnostics:
+            if getattr(d, "severity", None) == severity:
+                code = getattr(d, "code", None)
+                if code:
+                    codes.add(code)
+        return codes
+
+    def _frame_scope(self, frame: PartialFrameArtifact, fragments: list[Any]):
+        frag_map = {getattr(f, "fragment_id", f"FRG-{i:06d}"): f for i, f in enumerate(fragments, start=1)}
+        if not frame.fragment_ids:
+            return tuple()
+        frag = frag_map.get(frame.fragment_ids[0])
+        if frag is None:
+            return tuple()
+        return getattr(frag, "scope_path", tuple())

--- a/legacy/archive/pipeline_legacy_20260518/modules/source_eval.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/source_eval.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from expr_eval import EvalContext
+from runtime_env import LexCandidate
+from source_ir import (
+    SourceBuiltinCall,
+    SourceCandidate,
+    SourceColumnRef,
+    SourceContextRef,
+    SourceExpr,
+    SourceFirstOf,
+    SourceLiteral,
+    SourceRowLabelMatch,
+    SourceSetExpr,
+    SourceSymbolConst,
+    SourceTokenRef,
+)
+
+
+class SourceEvalError(ValueError):
+    pass
+
+
+class SourceEvaluator:
+    ALLOWED_BUILTINS = {
+        "site_alias",
+        "activity_alias",
+        "unit_symbol",
+        "period_expr",
+        "number",
+        "one_of",
+        "llm.fuzzy_lex",
+    }
+
+    def resolve(
+        self,
+        expr: SourceExpr | None,
+        *,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> list[SourceCandidate]:
+        if expr is None:
+            return []
+
+        if isinstance(expr, SourceFirstOf):
+            for option in expr.options:
+                out = self.resolve(
+                    option,
+                    ctx=ctx,
+                    fragment=fragment,
+                    tokens_by_fragment=tokens_by_fragment,
+                )
+                if out:
+                    return out
+            return []
+
+        if isinstance(expr, SourceTokenRef):
+            return self._resolve_token(expr.token_name, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+
+        if isinstance(expr, SourceColumnRef):
+            row = self._row(fragment, ctx)
+            value = row.get(expr.column_name)
+            if value in (None, ""):
+                return []
+            return [
+                SourceCandidate(
+                    value=value,
+                    confidence=0.95,
+                    extraction_mode="explicit",
+                    source_fragment_id=self._fragment_id(fragment),
+                    metadata={
+                        "source_kind": "column",
+                        "column_name": expr.column_name,
+                    },
+                )
+            ]
+
+        if isinstance(expr, SourceContextRef):
+            resolutions = ctx.env.context_store.resolve_all(
+                expr.role_name,
+                ctx.scope_path,
+                column_key=ctx.column_key,
+            )
+            return [
+                SourceCandidate(
+                    value=entry.value,
+                    confidence=float(entry.confidence),
+                    extraction_mode="inherited",
+                    source_fragment_id=entry.source_fragment_id,
+                    metadata={
+                        "source_kind": "context",
+                        "context_id": entry.context_id,
+                        "operation": entry.operation,
+                        "precedence": entry.precedence,
+                    },
+                )
+                for entry in resolutions
+            ]
+
+        if isinstance(expr, SourceRowLabelMatch):
+            row_label = self._row_label(fragment, ctx)
+            if row_label is None or expr.label not in str(row_label):
+                return []
+            return [
+                SourceCandidate(
+                    value=expr.label,
+                    confidence=0.92,
+                    extraction_mode="explicit",
+                    source_fragment_id=self._fragment_id(fragment),
+                    metadata={
+                        "source_kind": "row_label",
+                        "row_label": row_label,
+                    },
+                )
+            ]
+
+        value = self.eval_value(
+            expr,
+            ctx=ctx,
+            fragment=fragment,
+            tokens_by_fragment=tokens_by_fragment,
+        )
+        return self._coerce_to_candidates(value, fragment_id=self._fragment_id(fragment))
+
+    def eval_value(
+        self,
+        expr: SourceExpr | Any,
+        *,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> Any:
+        if not isinstance(expr, SourceExpr):
+            return expr
+
+        if isinstance(expr, SourceLiteral):
+            return expr.value
+
+        if isinstance(expr, SourceSymbolConst):
+            return expr.name
+
+        if isinstance(expr, SourceSetExpr):
+            return [
+                self.eval_value(item, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+                for item in expr.items
+            ]
+
+        if isinstance(expr, SourceBuiltinCall):
+            return self._call(
+                expr,
+                ctx=ctx,
+                fragment=fragment,
+                tokens_by_fragment=tokens_by_fragment,
+            )
+
+        if isinstance(expr, SourceTokenRef):
+            candidates = self._resolve_token(expr.token_name, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            return None if not candidates else candidates[0].value
+
+        if isinstance(expr, SourceColumnRef):
+            return self._row(fragment, ctx).get(expr.column_name)
+
+        if isinstance(expr, SourceContextRef):
+            res = ctx.env.context_store.resolve_best(
+                expr.role_name,
+                ctx.scope_path,
+                column_key=ctx.column_key,
+            )
+            return None if res.chosen is None else res.chosen.value
+
+        if isinstance(expr, SourceRowLabelMatch):
+            row_label = self._row_label(fragment, ctx)
+            if row_label is None:
+                return None
+            return expr.label if expr.label in str(row_label) else None
+
+        if isinstance(expr, SourceFirstOf):
+            for option in expr.options:
+                value = self.eval_value(
+                    option,
+                    ctx=ctx,
+                    fragment=fragment,
+                    tokens_by_fragment=tokens_by_fragment,
+                )
+                if self._present(value):
+                    return value
+            return None
+
+        raise SourceEvalError(f"unsupported SourceExpr type: {type(expr).__name__}")
+
+    def _resolve_token(
+        self,
+        token_name: str,
+        *,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> list[SourceCandidate]:
+        if fragment is None or not tokens_by_fragment:
+            return []
+
+        fragment_id = self._fragment_id(fragment)
+        token_bucket = tokens_by_fragment.get(fragment_id, {}).get(token_name, [])
+
+        out: list[SourceCandidate] = []
+        for tok in token_bucket:
+            span = (tok.start, tok.end) if tok.start is not None and tok.end is not None else None
+            out.append(
+                SourceCandidate(
+                    value=tok.value,
+                    confidence=float(tok.confidence),
+                    extraction_mode="explicit",
+                    source_token_id=tok.token_id,
+                    source_fragment_id=tok.fragment_id,
+                    span=span,
+                    metadata={
+                        "source_kind": "token",
+                        "token_name": tok.token_name,
+                        "source_channel": tok.source_channel,
+                        "rank": tok.rank,
+                    },
+                )
+            )
+        return out
+
+    def _call(
+        self,
+        expr: SourceBuiltinCall,
+        *,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> Any:
+        name = expr.name
+        if name not in self.ALLOWED_BUILTINS:
+            raise SourceEvalError(f"builtin '{name}' is not allowed in SourceEvaluator")
+
+        fn = self._lookup_builtin(name, ctx)
+
+        if name in {"site_alias", "activity_alias", "unit_symbol", "period_expr", "number"}:
+            return fn(ctx.text, ctx.env)
+
+        if name == "one_of":
+            choices = [
+                self.eval_value(arg, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+                for arg in expr.args
+            ]
+            return fn(ctx.text, *choices, env=ctx.env)
+
+        if name == "llm.fuzzy_lex":
+            role_name = self._raw_identifier(expr.args, index=0, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            return fn(role_name, ctx.text, ctx.env)
+
+        args = [
+            self.eval_value(arg, ctx=ctx, fragment=fragment, tokens_by_fragment=tokens_by_fragment)
+            for arg in expr.args
+        ]
+        for pattern in (
+            lambda: fn(*args, env=ctx.env),
+            lambda: fn(*args),
+        ):
+            try:
+                return pattern()
+            except TypeError:
+                continue
+
+        raise SourceEvalError(f"builtin call failed: {name}")
+
+    def _lookup_builtin(self, name: str, ctx: EvalContext):
+        fn = ctx.env.builtin_registry.get(name)
+        if fn is None:
+            raise SourceEvalError(f"unknown builtin: {name}")
+        return fn
+
+    def _raw_identifier(
+        self,
+        args: list[SourceExpr],
+        *,
+        index: int,
+        ctx: EvalContext,
+        fragment: Any = None,
+        tokens_by_fragment: Optional[dict[str, dict[str, list[Any]]]] = None,
+    ) -> str:
+        if index >= len(args):
+            raise SourceEvalError("missing function arg")
+        value = self.eval_value(
+            args[index],
+            ctx=ctx,
+            fragment=fragment,
+            tokens_by_fragment=tokens_by_fragment,
+        )
+        return str(value)
+
+    def _coerce_to_candidates(self, value: Any, *, fragment_id: Optional[str]) -> list[SourceCandidate]:
+        if value is None:
+            return []
+
+        if isinstance(value, SourceCandidate):
+            return [value]
+
+        if isinstance(value, LexCandidate):
+            span = (value.start, value.end) if value.start is not None and value.end is not None else None
+            return [
+                SourceCandidate(
+                    value=value.value,
+                    confidence=float(value.confidence),
+                    extraction_mode="explicit",
+                    source_fragment_id=fragment_id,
+                    span=span,
+                    metadata=dict(value.metadata),
+                )
+            ]
+
+        if isinstance(value, list):
+            out: list[SourceCandidate] = []
+            for item in value:
+                out.extend(self._coerce_to_candidates(item, fragment_id=fragment_id))
+            return out
+
+        if isinstance(value, tuple) and len(value) == 3:
+            return [
+                SourceCandidate(
+                    value=value[0],
+                    confidence=0.80,
+                    extraction_mode="derived",
+                    source_fragment_id=fragment_id,
+                    span=(value[1], value[2]),
+                    metadata={"source_kind": "tuple_expr"},
+                )
+            ]
+
+        return [
+            SourceCandidate(
+                value=value,
+                confidence=0.70,
+                extraction_mode="derived",
+                source_fragment_id=fragment_id,
+                metadata={"source_kind": "generic_expr"},
+            )
+        ]
+
+    def _row(self, fragment: Any, ctx: EvalContext) -> dict[str, Any]:
+        if fragment is None:
+            return ctx.row
+        metadata = getattr(fragment, "metadata", {}) or {}
+        row = metadata.get("row", {}) if isinstance(metadata, dict) else {}
+        return row or ctx.row
+
+    def _row_label(self, fragment: Any, ctx: EvalContext) -> Any:
+        if fragment is None:
+            return ctx.row_label
+        metadata = getattr(fragment, "metadata", {}) or {}
+        row_label = metadata.get("row_label") if isinstance(metadata, dict) else None
+        return row_label if row_label is not None else ctx.row_label
+
+    def _fragment_id(self, fragment: Any) -> Optional[str]:
+        if fragment is None:
+            return None
+        return getattr(fragment, "fragment_id", None)
+
+    def _present(self, value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return value != ""
+        if isinstance(value, (list, tuple, set, dict)):
+            return len(value) > 0
+        return bool(value)

--- a/legacy/archive/pipeline_legacy_20260518/modules/source_ir.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/source_ir.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class SourceCandidate:
+    value: Any
+    confidence: float
+    extraction_mode: str
+    source_token_id: Optional[str] = None
+    source_fragment_id: Optional[str] = None
+    span: Optional[tuple[int, int]] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class SourceExpr:
+    pass
+
+
+@dataclass
+class SourceLiteral(SourceExpr):
+    value: Any
+
+
+@dataclass
+class SourceSymbolConst(SourceExpr):
+    name: str
+
+
+@dataclass
+class SourceSetExpr(SourceExpr):
+    items: list[SourceExpr] = field(default_factory=list)
+
+
+@dataclass
+class SourceBuiltinCall(SourceExpr):
+    name: str
+    args: list[SourceExpr] = field(default_factory=list)
+
+
+@dataclass
+class SourceTokenRef(SourceExpr):
+    token_name: str
+
+
+@dataclass
+class SourceColumnRef(SourceExpr):
+    column_name: str
+
+
+@dataclass
+class SourceContextRef(SourceExpr):
+    role_name: str
+
+
+@dataclass
+class SourceRowLabelMatch(SourceExpr):
+    label: str
+
+
+@dataclass
+class SourceFirstOf(SourceExpr):
+    options: list[SourceExpr] = field(default_factory=list)

--- a/legacy/archive/pipeline_legacy_20260518/modules/spec_nodes.py
+++ b/legacy/archive/pipeline_legacy_20260518/modules/spec_nodes.py
@@ -1,0 +1,146 @@
+# spec_nodes.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ast_nodes import Expr, ParserAction, ResolverStmt, GovernanceStmt
+
+
+@dataclass
+class DimensionSpec:
+    name: str
+
+
+@dataclass
+class NormalizeSpec:
+    target_unit: str
+    op: str
+    factor: float
+
+
+@dataclass
+class UnitSpec:
+    name: str
+    dimension: str
+    normalize: Optional[NormalizeSpec] = None
+
+
+@dataclass
+class ActivitySpec:
+    name: str
+    dimension: str
+    scope_category: str
+
+
+@dataclass
+class ContextPolicy:
+    role_name: str
+    precedence_chain: list[str] = field(default_factory=list)
+    ttl_levels: list[str] = field(default_factory=list)
+    supports: list[str] = field(default_factory=list)
+    refine_pairs: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class FieldSpec:
+    name: str
+    type_name: str
+    generic: Optional[str] = None
+    optional: bool = False
+
+
+@dataclass
+class FrameSpec:
+    name: str
+    fields: list[FieldSpec] = field(default_factory=list)
+
+
+@dataclass
+class TokenSpec:
+    name: str
+    primary_expr: Optional[Expr] = None
+    fallback_expr: Optional[Expr] = None
+
+
+@dataclass
+class ParserSpec:
+    name: str
+    source_selectors: list[str]
+    build_frame: str
+    actions: list[ParserAction] = field(default_factory=list)
+
+
+@dataclass
+class InheritSpec:
+    role_name: str
+    source_expr: Expr
+    condition: Expr
+
+
+@dataclass
+class InferSpec:
+    target_name: str
+    op: str
+    value_expr: Expr
+    condition: Expr
+    weight: Optional[float] = None
+
+
+@dataclass
+class ConstraintSpec:
+    kind: str            # require | forbid
+    condition: Expr
+    frame_name: Optional[str] = None
+
+
+@dataclass
+class DiagnosticSpec:
+    level: str           # error | warning
+    code: str
+    condition: Expr
+
+
+@dataclass
+class ResolverPolicy:
+    frame_name: str
+    assigns: dict[str, Expr] = field(default_factory=dict)
+    candidate_pool_assigns: dict[str, Expr] = field(default_factory=dict)
+    commit_condition: Optional[Expr] = None
+    review_condition: Optional[Expr] = None
+    reject_otherwise: bool = False
+
+
+@dataclass
+class GovernancePolicy:
+    frame_name: str
+    emit_condition: Optional[Expr] = None
+    merge_conditions: list[Expr] = field(default_factory=list)
+    forbid_merge_conditions: list[Expr] = field(default_factory=list)
+
+
+@dataclass
+class ProgramSpec:
+    module_name: str
+    imports: list[str] = field(default_factory=list)
+
+    dimensions: dict[str, DimensionSpec] = field(default_factory=dict)
+    units: dict[str, UnitSpec] = field(default_factory=dict)
+    activities: dict[str, ActivitySpec] = field(default_factory=dict)
+
+    scope_chain: list[str] = field(
+        default_factory=lambda: ["document", "section", "table", "row", "cell"]
+    )
+
+    contexts: dict[str, ContextPolicy] = field(default_factory=dict)
+    frames: dict[str, FrameSpec] = field(default_factory=dict)
+    tokens: dict[str, TokenSpec] = field(default_factory=dict)
+    parsers: dict[str, ParserSpec] = field(default_factory=dict)
+
+    inherit_rules: list[InheritSpec] = field(default_factory=list)
+    infer_rules: list[InferSpec] = field(default_factory=list)
+    constraints: list[ConstraintSpec] = field(default_factory=list)
+    diagnostics: list[DiagnosticSpec] = field(default_factory=list)
+
+    resolvers: dict[str, ResolverPolicy] = field(default_factory=dict)
+    governances: dict[str, GovernancePolicy] = field(default_factory=dict)

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/builtins/__init__.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/builtins/__init__.py.txt
@@ -1,0 +1,9 @@
+"""Builtin registries and helpers."""
+
+from esg_builtins import register_default_builtins
+from rule_builtins import get_default_rule_builtin_registry
+
+__all__ = [
+    "register_default_builtins",
+    "get_default_rule_builtin_registry",
+]

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/compat/__init__.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/compat/__init__.py.txt
@@ -1,0 +1,4 @@
+"""Compatibility layer for existing top-level artifacts and specs."""
+
+from comp.compat.artifacts import *
+from comp.compat.compiled_spec import *

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/compat/artifacts.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/compat/artifacts.py.txt
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for legacy artifact types."""
+
+from artifacts import *

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/compat/compiled_spec.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/compat/compiled_spec.py.txt
@@ -1,0 +1,33 @@
+"""Compatibility wrapper for legacy compiled spec types."""
+
+from compiled_spec import (
+    CompiledBindAction,
+    CompiledConstraintSpec,
+    CompiledDiagnosticSpec,
+    CompiledGovernancePolicy,
+    CompiledInheritSpec,
+    CompiledInferSpec,
+    CompiledParserAction,
+    CompiledParserInheritAction,
+    CompiledParserSpec,
+    CompiledProgramSpec,
+    CompiledResolverPolicy,
+    CompiledTagAction,
+    CompiledTokenSpec,
+)
+
+__all__ = [
+    "CompiledTokenSpec",
+    "CompiledInheritSpec",
+    "CompiledConstraintSpec",
+    "CompiledDiagnosticSpec",
+    "CompiledInferSpec",
+    "CompiledBindAction",
+    "CompiledParserInheritAction",
+    "CompiledTagAction",
+    "CompiledParserAction",
+    "CompiledParserSpec",
+    "CompiledResolverPolicy",
+    "CompiledGovernancePolicy",
+    "CompiledProgramSpec",
+]

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/dsl/__init__.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/dsl/__init__.py.txt
@@ -1,0 +1,14 @@
+"""DSL-facing package exports for ESGDL."""
+
+from ast_builder import ASTBuilder
+from binder import Binder, BindingError
+from lowering import Lowerer
+from spec_nodes import ProgramSpec
+
+__all__ = [
+    "ASTBuilder",
+    "Binder",
+    "BindingError",
+    "Lowerer",
+    "ProgramSpec",
+]

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/dsl/esgdl.lark
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/dsl/esgdl.lark
@@ -1,0 +1,188 @@
+start: program
+
+program: statement*
+
+?statement: module_decl
+          | import_decl
+          | dimension_decl
+          | unit_decl
+          | activity_decl
+          | scope_decl
+          | context_decl
+          | frame_decl
+          | token_decl
+          | fallback_token_decl
+          | parser_decl
+          | inherit_rule
+          | infer_rule
+          | require_rule
+          | forbid_rule
+          | diagnostic_rule
+          | resolver_decl
+          | governance_decl
+
+module_decl: "module" qname                         -> module_decl
+import_decl: "import" qname                         -> import_decl
+
+dimension_decl: "dimension" IDENT                   -> dimension_decl
+
+unit_decl: "unit" IDENT ":" IDENT normalize_clause? -> unit_decl
+normalize_clause: "normalize" "(" IDENT "," NORM_OP NUMBER ")" -> normalize_clause
+
+activity_decl: "activity" IDENT ":" IDENT "->" IDENT -> activity_decl
+
+scope_decl: "scope" scope_chain                     -> scope_decl
+scope_chain: IDENT (">" IDENT)+
+
+context_decl: "context" IDENT "{" context_stmt* "}" -> context_decl
+?context_stmt: precedence_stmt
+             | refine_stmt
+             | ttl_stmt
+             | supports_stmt
+
+precedence_stmt: "precedence" precedence_chain      -> precedence_stmt
+precedence_chain: IDENT (">" IDENT)+
+
+refine_stmt: "refine" IDENT "over" IDENT            -> refine_stmt
+
+ttl_stmt: "ttl" ttl_chain                           -> ttl_stmt
+ttl_chain: IDENT ("|" IDENT)+
+
+supports_stmt: "supports" supports_chain            -> supports_stmt
+supports_chain: IDENT ("," IDENT)*
+
+frame_decl: "frame" IDENT "{" field_decl* "}"       -> frame_decl
+field_decl: IDENT ":" type_ref optional_marker?     -> field_decl
+optional_marker: "?"
+type_ref: IDENT generic_arg?                        -> type_ref
+generic_arg: "<" IDENT ">"
+
+token_decl: "token" IDENT ":=" token_expr           -> token_decl
+fallback_token_decl: "fallback" "token" IDENT ":=" token_expr -> fallback_token_decl
+
+token_expr: source_expr
+
+parser_decl: "parser" IDENT "on" selector_chain "{" parser_stmt* "}" -> parser_decl
+selector_chain: IDENT ("|" IDENT)*
+
+?parser_stmt: build_stmt
+            | bind_stmt
+            | parser_inherit_stmt
+            | tag_stmt
+
+build_stmt: "build" IDENT                           -> build_stmt
+bind_stmt: "bind" IDENT optional_marker? "from" source_expr -> bind_stmt
+parser_inherit_stmt: "inherit" IDENT "from" source_expr ("when" bool_expr)? -> parser_inherit_stmt
+tag_stmt: "tag" IDENT "from" source_expr            -> tag_stmt
+
+inherit_rule: "inherit" IDENT "from" source_expr "when" bool_expr -> inherit_rule
+
+infer_rule: "infer" IDENT INFER_OP expr infer_weight? "when" bool_expr -> infer_rule
+infer_weight: "weight" NUMBER
+
+require_rule: "require" bool_expr                   -> require_rule
+forbid_rule: "forbid" bool_expr ("for" "frame" IDENT)? -> forbid_rule
+
+diagnostic_rule: DIAG_LEVEL IDENT "when" bool_expr -> diagnostic_rule
+
+resolver_decl: "resolver" IDENT "{" resolver_stmt* "}" -> resolver_decl
+?resolver_stmt: assign_stmt
+              | candidate_pool_block
+              | commit_stmt
+              | review_stmt
+              | reject_stmt
+
+assign_stmt: IDENT "=" expr                         -> assign_stmt
+
+candidate_pool_block: "candidate_pool" "{" assign_stmt* "}" -> candidate_pool_block
+
+commit_stmt: "commit" "when" bool_expr             -> commit_stmt
+review_stmt: "review" "when" bool_expr             -> review_stmt
+reject_stmt: "reject" "otherwise"                  -> reject_stmt
+
+governance_decl: "governance" IDENT "{" governance_stmt* "}" -> governance_decl
+?governance_stmt: emit_stmt
+                | merge_stmt
+                | forbid_merge_stmt
+
+emit_stmt: "emit" "row" "when" bool_expr           -> emit_stmt
+merge_stmt: "merge" "when" bool_expr               -> merge_stmt
+forbid_merge_stmt: "forbid" "merge" "when" bool_expr -> forbid_merge_stmt
+
+
+// -----------------------------
+// Expressions
+// -----------------------------
+
+?source_expr: source_atom ("|" source_atom)*        -> source_expr
+
+?source_atom: function_call
+            | column_ref
+            | context_ref
+            | row_label_ref
+            | qname
+            | literal
+
+?expr: function_call
+     | column_ref
+     | context_ref
+     | row_label_ref
+     | set_literal
+     | qname
+     | literal
+
+?bool_expr: bool_or
+
+?bool_or: bool_or "or" bool_and                     -> bool_or
+        | bool_and
+
+?bool_and: bool_and "and" bool_not                  -> bool_and
+         | bool_not
+
+?bool_not: "not" bool_not                           -> bool_not
+         | comparison
+         | predicate
+         | "(" bool_expr ")"                        -> grouped_bool
+
+?comparison: expr COMP_OP expr                      -> comparison
+           | expr "in" set_literal                  -> in_expr
+           | expr "matches" expr                    -> matches_expr
+
+?predicate: function_call                           -> bool_call
+          | qname                                   -> bool_ref
+
+function_call: qname "(" [arg_list] ")"            -> function_call
+arg_list: expr ("," expr)*
+
+set_literal: "{" [expr ("," expr)*] "}"            -> set_literal
+
+column_ref: "column" "(" STRING ")"                -> column_ref
+context_ref: "context" "." IDENT                   -> context_ref
+row_label_ref: "row_label" "(" STRING ")"          -> row_label_ref
+
+qname: IDENT ("." IDENT)*                          -> qname
+
+literal: STRING                                    -> string_lit
+       | NUMBER                                    -> number_lit
+       | BOOL                                      -> bool_lit
+
+
+// -----------------------------
+// Tokens
+// -----------------------------
+
+BOOL: "true" | "false"
+COMP_OP: "==" | "!=" | ">=" | "<=" | ">" | "<"
+NORM_OP: "*" | "/" | "+" | "-"
+INFER_OP: "=" | "~"
+DIAG_LEVEL: "error" | "warning"
+
+IDENT: /[A-Za-z_][A-Za-z0-9_]*/
+NUMBER: /-?[0-9]+(\.[0-9]+)?/
+
+%import common.ESCAPED_STRING -> STRING
+%import common.WS
+
+%ignore WS
+%ignore /\/\/[^\n]*/
+%ignore /\#[^\n]*/

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/eval/__init__.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/eval/__init__.py.txt
@@ -1,0 +1,15 @@
+"""Public evaluator exports."""
+
+from compiled_expr_eval import CompiledExprEvaluator
+from expr_eval import ExprEvaluator
+from lex_eval import LexEvaluator
+from rule_eval import RuleEvaluator
+from source_eval import SourceEvaluator
+
+__all__ = [
+    "ExprEvaluator",
+    "CompiledExprEvaluator",
+    "LexEvaluator",
+    "SourceEvaluator",
+    "RuleEvaluator",
+]

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/pipeline/__init__.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/pipeline/__init__.py.txt
@@ -1,0 +1,24 @@
+"""Public pass exports for the current staged pipeline."""
+
+from calculation_pass import CalculationPass
+from emit_pass import EmitPass
+from governance_pass import GovernancePass
+from inference_pass import InferencePass
+from lex_pass import LexPass
+from parse_pass import ParsePass
+from repair_pass import RepairPass
+from scope_resolution_pass import ScopeResolutionPass
+from semantic_pass import SemanticPass, SemanticPassConfig
+
+__all__ = [
+    "LexPass",
+    "ParsePass",
+    "ScopeResolutionPass",
+    "InferencePass",
+    "SemanticPass",
+    "SemanticPassConfig",
+    "RepairPass",
+    "EmitPass",
+    "GovernancePass",
+    "CalculationPass",
+]

--- a/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/runner.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/package_surfaces/comp/runner.py.txt
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from compiled_pipeline_runner import CompiledESGPipelineRunner as _LegacyCompiledRunner
+from pipeline_runner import (
+    ESGPipelineRunner as _LegacyRunner,
+    PipelineResources,
+    PipelineRunResult,
+    compile_program_spec,
+    load_compiled_program_spec_from_dsl,
+    load_program_spec_from_dsl,
+)
+
+_DEFAULT_GRAMMAR_PATH = Path(__file__).resolve().parent / "dsl" / "esgdl.lark"
+
+
+class ESGPipelineRunner(_LegacyRunner):
+    def __init__(
+        self,
+        *,
+        grammar_path: str | Path | None = None,
+        passes: Optional[list[Any]] = None,
+        fragmentizer: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            grammar_path=grammar_path or _DEFAULT_GRAMMAR_PATH,
+            passes=passes,
+            fragmentizer=fragmentizer,
+        )
+
+
+class CompiledESGPipelineRunner(_LegacyCompiledRunner):
+    def __init__(
+        self,
+        *,
+        grammar_path: str | Path | None = None,
+        passes: Optional[list[Any]] = None,
+        fragmentizer: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            grammar_path=grammar_path or _DEFAULT_GRAMMAR_PATH,
+            passes=passes,
+            fragmentizer=fragmentizer,
+        )
+
+
+__all__ = [
+    "ESGPipelineRunner",
+    "CompiledESGPipelineRunner",
+    "PipelineResources",
+    "PipelineRunResult",
+    "compile_program_spec",
+    "load_program_spec_from_dsl",
+    "load_compiled_program_spec_from_dsl",
+]

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/conftest.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/conftest.py.txt
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def golden_dir() -> Path:
+    return Path(__file__).parent / "golden"
+
+
+@pytest.fixture
+def load_golden(golden_dir: Path):
+    def _load(name: str):
+        path = golden_dir / name
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    return _load

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/fixtures/cases.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/fixtures/cases.py.txt
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from runtime_env import SiteRecord
+from tests.support.builders import make_fragment, make_resources
+
+
+BASE_DSL = """
+module test
+
+dimension amount
+unit kwh: amount
+activity electricity: amount -> scope2
+
+frame ActivityObservation {
+  site: String
+  activity_type: String
+  period: String?
+  raw_amount: Number
+  raw_unit: String
+}
+
+token SiteToken := site_alias()
+token ActivityToken := activity_alias()
+token PeriodToken := period_expr()
+token AmountToken := number()
+token UnitToken := unit_symbol()
+
+parser LineParser on line {
+  build ActivityObservation
+  bind site from SiteToken
+  bind activity_type from ActivityToken
+  bind period ? from PeriodToken
+  bind raw_amount from AmountToken
+  bind raw_unit from UnitToken
+}
+
+require valid_period(period)
+
+resolver ActivityObservation {
+  commit when true
+}
+
+governance ActivityObservation {
+  emit row when true
+  merge when true
+}
+""".strip()
+
+AGG_WARNING_DSL = BASE_DSL + "\n\nwarning AggregateRow when true\n"
+
+
+@dataclass
+class Case:
+    name: str
+    dsl_text: str
+    fragments: list
+    resources: object
+    golden_name: str
+
+
+COMMON_RESOURCES = make_resources(
+    site_records=[
+        SiteRecord(site_id="SITE-SEOUL", aliases=["seoul hq"], entity_id="ENT-1"),
+    ],
+    factor_rows=[
+        {
+            "factor_id": "FAC-1",
+            "activity_type": "electricity",
+            "unit": "kwh",
+            "factor_unit": "kgco2e/kwh",
+            "emission_factor": 0.5,
+        }
+    ],
+    activity_aliases={"electricity": ["electricity"]},
+    unit_aliases={"kwh": ["kwh"]},
+)
+
+
+CASES = [
+    Case(
+        name="semantic_error_blocks_merge",
+        dsl_text=BASE_DSL,
+        fragments=[
+            make_fragment(
+                fragment_id="FRG-1",
+                text="seoul hq electricity 120 kwh",
+            )
+        ],
+        resources=COMMON_RESOURCES,
+        golden_name="semantic_error_blocks_merge.json",
+    ),
+    Case(
+        name="aggregate_warning_calculation_excluded",
+        dsl_text=AGG_WARNING_DSL,
+        fragments=[
+            make_fragment(
+                fragment_id="FRG-2",
+                text="seoul hq electricity 2025-03 150 kwh",
+            )
+        ],
+        resources=COMMON_RESOURCES,
+        golden_name="aggregate_warning_calculation_excluded.json",
+    ),
+    Case(
+        name="happy_path_merge_and_calculate",
+        dsl_text=BASE_DSL,
+        fragments=[
+            make_fragment(
+                fragment_id="FRG-3",
+                text="seoul hq electricity 2025-03 200 kwh",
+            )
+        ],
+        resources=COMMON_RESOURCES,
+        golden_name="happy_path_merge_and_calculate.json",
+    ),
+]

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/aggregate_warning_calculation_excluded.json
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/aggregate_warning_calculation_excluded.json
@@ -1,0 +1,43 @@
+{
+  "frames": [
+    {
+      "parser_name": "LineParser",
+      "frame_type": "ActivityObservation",
+      "status": "committed",
+      "diagnostic_codes": [
+        "warning:AggregateRow"
+      ]
+    }
+  ],
+  "rows": [
+    {
+      "frame_type": "ActivityObservation",
+      "status": "merged",
+      "site_id": "SITE-SEOUL",
+      "activity_type": "electricity",
+      "period": "2025-03",
+      "warning_codes": [
+        "AggregateRow"
+      ],
+      "error_codes": []
+    }
+  ],
+  "merge_log": [
+    {
+      "action": "merge",
+      "from_status": "committed",
+      "to_status": "merged",
+      "reason_codes": [
+        "merge_condition_satisfied"
+      ]
+    }
+  ],
+  "calculations": [
+    {
+      "calculation_status": "excluded",
+      "exclusion_reason": "aggregate_row_excluded",
+      "activity_type": "electricity",
+      "co2e_kg": null
+    }
+  ]
+}

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/happy_path_merge_and_calculate.json
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/happy_path_merge_and_calculate.json
@@ -1,0 +1,39 @@
+{
+  "frames": [
+    {
+      "parser_name": "LineParser",
+      "frame_type": "ActivityObservation",
+      "status": "committed",
+      "diagnostic_codes": []
+    }
+  ],
+  "rows": [
+    {
+      "frame_type": "ActivityObservation",
+      "status": "merged",
+      "site_id": "SITE-SEOUL",
+      "activity_type": "electricity",
+      "period": "2025-03",
+      "warning_codes": [],
+      "error_codes": []
+    }
+  ],
+  "merge_log": [
+    {
+      "action": "merge",
+      "from_status": "committed",
+      "to_status": "merged",
+      "reason_codes": [
+        "merge_condition_satisfied"
+      ]
+    }
+  ],
+  "calculations": [
+    {
+      "calculation_status": "success",
+      "exclusion_reason": null,
+      "activity_type": "electricity",
+      "co2e_kg": 100.0
+    }
+  ]
+}

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/repair_stage_smoke.json
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/repair_stage_smoke.json
@@ -1,0 +1,13 @@
+{
+  "frames": [
+    {
+      "parser_name": "LineParser",
+      "frame_type": "ActivityObservation",
+      "status": "committed",
+      "diagnostic_codes": []
+    }
+  ],
+  "rows": [],
+  "merge_log": [],
+  "calculations": []
+}

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/semantic_error_blocks_merge.json
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/golden/semantic_error_blocks_merge.json
@@ -1,0 +1,37 @@
+{
+  "frames": [
+    {
+      "parser_name": "LineParser",
+      "frame_type": "ActivityObservation",
+      "status": "committed",
+      "diagnostic_codes": [
+        "error:RequireViolation"
+      ]
+    }
+  ],
+  "rows": [
+    {
+      "frame_type": "ActivityObservation",
+      "status": "committed",
+      "site_id": "SITE-SEOUL",
+      "activity_type": "electricity",
+      "period": null,
+      "warning_codes": [],
+      "error_codes": [
+        "RequireViolation"
+      ]
+    }
+  ],
+  "merge_log": [
+    {
+      "action": "hold",
+      "from_status": "committed",
+      "to_status": "committed",
+      "reason_codes": [
+        "RequireViolation",
+        "row_has_error_diagnostics"
+      ]
+    }
+  ],
+  "calculations": []
+}

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/support/builders.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/support/builders.py.txt
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from runtime_env import ScopeFrame, SiteRecord
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRAMMAR_PATH = REPO_ROOT / "esgdl.lark"
+
+
+@dataclass
+class TestFragment:
+    fragment_id: str
+    fragment_type: str
+    text: str
+    scope_path: tuple[ScopeFrame, ...]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def make_scope_path(*, doc: str = "doc:1", section: str = "sec:1", table: str = "tbl:1", row: str = "row:1") -> tuple[ScopeFrame, ...]:
+    return (
+        ScopeFrame(level="document", ref_id=doc),
+        ScopeFrame(level="section", ref_id=section),
+        ScopeFrame(level="table", ref_id=table),
+        ScopeFrame(level="row", ref_id=row),
+    )
+
+
+def make_fragment(
+    *,
+    fragment_id: str,
+    text: str,
+    fragment_type: str = "line",
+    scope_path: tuple[ScopeFrame, ...] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> TestFragment:
+    return TestFragment(
+        fragment_id=fragment_id,
+        fragment_type=fragment_type,
+        text=text,
+        scope_path=scope_path or make_scope_path(),
+        metadata=metadata or {},
+    )
+
+
+def make_resources(
+    *,
+    site_records: Iterable[SiteRecord] | None = None,
+    factor_rows: Iterable[dict[str, Any]] | None = None,
+    policy_flags: dict[str, Any] | None = None,
+    activity_aliases: dict[str, list[str]] | None = None,
+    unit_aliases: dict[str, list[str]] | None = None,
+    llm_fallback=None,
+    llm_budget: int = 0,
+) -> Any:
+    from pipeline_runner import PipelineResources
+
+    return PipelineResources(
+        site_records=list(site_records or []),
+        factor_rows=list(factor_rows or []),
+        policy_flags=dict(policy_flags or {}),
+        activity_aliases=dict(activity_aliases or {}),
+        unit_aliases=dict(unit_aliases or {}),
+        llm_fallback=llm_fallback,
+        llm_budget=llm_budget,
+    )
+
+
+def run_pipeline_full(*, dsl_text: str, fragments: list[TestFragment], resources: object):
+    from pipeline_runner import ESGPipelineRunner
+
+    runner = ESGPipelineRunner(grammar_path=GRAMMAR_PATH)
+    return runner.run(dsl_text=dsl_text, fragments=fragments, resources=resources)
+
+
+def run_pipeline_until(
+    *,
+    dsl_text: str,
+    fragments: list[TestFragment],
+    resources: object,
+    pass_name: str,
+):
+    from pipeline_runner import ESGPipelineRunner, build_default_passes
+
+    selected = []
+    for compiler_pass in build_default_passes():
+        selected.append(compiler_pass)
+        if compiler_pass.__class__.__name__ == pass_name:
+            break
+
+    if not selected or selected[-1].__class__.__name__ != pass_name:
+        raise ValueError(f"unknown pass_name: {pass_name}")
+
+    runner = ESGPipelineRunner(grammar_path=GRAMMAR_PATH, passes=selected)
+    return runner.run(dsl_text=dsl_text, fragments=fragments, resources=resources)

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/support/serialize.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/support/serialize.py.txt
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+from artifacts import CompileArtifacts, DiagnosticArtifact
+
+
+def project_result(result: Any) -> dict[str, Any]:
+    return project_artifacts(result.artifacts)
+
+
+def project_artifacts(artifacts: CompileArtifacts) -> dict[str, Any]:
+    return {
+        "frames": [
+            {
+                "parser_name": f.parser_name,
+                "frame_type": f.frame_type,
+                "status": f.status,
+                "diagnostic_codes": _diagnostic_codes(f.diagnostics),
+            }
+            for f in artifacts.frames
+        ],
+        "rows": [
+            {
+                "frame_type": r.frame_type,
+                "status": r.status,
+                "site_id": r.site_id,
+                "activity_type": r.activity_type,
+                "period": r.period,
+                "warning_codes": sorted(list(r.warning_codes)),
+                "error_codes": sorted(list(r.error_codes)),
+            }
+            for r in artifacts.rows
+        ],
+        "merge_log": [
+            {
+                "action": m.action,
+                "from_status": m.from_status,
+                "to_status": m.to_status,
+                "reason_codes": sorted(list(m.reason_codes)),
+            }
+            for m in artifacts.merge_log
+        ],
+        "calculations": [
+            {
+                "calculation_status": c.calculation_status,
+                "exclusion_reason": c.exclusion_reason,
+                "activity_type": c.activity_type,
+                "co2e_kg": c.co2e_kg,
+            }
+            for c in artifacts.calculations
+        ],
+    }
+
+
+def _diagnostic_codes(diagnostics: list[DiagnosticArtifact]) -> list[str]:
+    codes: list[str] = []
+    for diag in diagnostics:
+        if not isinstance(diag, DiagnosticArtifact):
+            raise TypeError("frame.diagnostics must contain DiagnosticArtifact only")
+        if diag.severity and diag.code:
+            codes.append(f"{diag.severity}:{diag.code}")
+    return sorted(codes)

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_artifact_contract.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_artifact_contract.py.txt
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from artifacts import DiagnosticArtifact, diagnostic_codes
+from tests.fixtures.cases import CASES
+from tests.support.builders import run_pipeline_full, run_pipeline_until
+
+
+def _case(name: str):
+    return next(c for c in CASES if c.name == name)
+
+
+def test_frame_diagnostics_are_diagnostic_artifacts():
+    case = _case("aggregate_warning_calculation_excluded")
+    result = run_pipeline_full(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+
+    for frame in result.artifacts.frames:
+        assert all(isinstance(d, DiagnosticArtifact) for d in frame.diagnostics)
+
+
+def test_diagnostic_helpers_fail_fast_on_unexpected_types():
+    with pytest.raises(TypeError):
+        diagnostic_codes([{"severity": "warning", "code": "AggregateRow"}], severity="warning")
+
+
+def test_repair_populates_frame_runtime_state():
+    case = _case("happy_path_merge_and_calculate")
+    result = run_pipeline_until(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+        pass_name="RepairPass",
+    )
+
+    frame = result.artifacts.frames[0]
+    assert frame.status == "committed"
+    assert frame.runtime.iteration_count >= 1
+    assert isinstance(frame.runtime.resolution_score, float)
+    assert frame.runtime.termination_reason is not None
+
+
+def test_row_error_codes_come_from_frame_diagnostics():
+    case = _case("semantic_error_blocks_merge")
+    result = run_pipeline_full(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+
+    frame = result.artifacts.frames[0]
+    row = result.artifacts.rows[0]
+    frame_error_codes = sorted(
+        d.code for d in frame.diagnostics if d.severity == "error"
+    )
+
+    assert row.error_codes == frame_error_codes
+    assert result.artifacts.merge_log[0].action == "hold"

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_binder_rule_ir.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_binder_rule_ir.py.txt
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from binder import Binder, BindingError
+from compiled_spec import CompiledProgramSpec
+from pipeline_runner import load_program_spec_from_dsl
+from rule_ir import (
+    FrameSlotRef,
+    HasApproval,
+    HasDiagnostic,
+    LocalVarRef,
+    PolicyRef,
+    RowFieldRef,
+    RuleBinary,
+    RuleBuiltinCall,
+    SymbolConst,
+)
+from tests.support.builders import GRAMMAR_PATH
+
+
+BINDER_DSL = """
+module binder_test
+
+dimension amount
+unit kwh: amount
+activity electricity: amount -> scope2
+
+frame ActivityObservation {
+  site: String
+  activity_type: String
+  period: String?
+  raw_amount: Number
+  raw_unit: String
+}
+
+token AmountToken := number()
+
+parser LineParser on line {
+  build ActivityObservation
+  bind raw_amount from AmountToken
+}
+
+infer raw_unit = kwh when frame_type == ActivityObservation
+require status == committed
+warning InvalidPeriod when warning.InvalidPeriod
+
+resolver ActivityObservation {
+  commit when score >= 0.8 and not missing(raw_amount)
+}
+
+governance ActivityObservation {
+  emit row when raw_amount > 0
+  merge when approval.human_reviewer or policy.auto_merge
+  forbid merge when error.InvalidPeriod
+}
+""".strip()
+
+
+def _load_program_spec(dsl_text: str = BINDER_DSL):
+    return load_program_spec_from_dsl(
+        grammar_path=GRAMMAR_PATH,
+        dsl_text=dsl_text,
+    )
+
+
+def test_binder_binds_constraint_and_infer_hosts():
+    program = _load_program_spec()
+    spec = Binder().bind(program)
+
+    assert isinstance(spec, CompiledProgramSpec)
+
+    compiled_require = spec.compiled_constraints[0]
+    assert isinstance(compiled_require.condition_ir, RuleBinary)
+    assert isinstance(compiled_require.condition_ir.left, LocalVarRef)
+    assert compiled_require.condition_ir.left.name == "status"
+    assert isinstance(compiled_require.condition_ir.right, SymbolConst)
+    assert compiled_require.condition_ir.right.name == "committed"
+
+    compiled_infer = spec.compiled_infer_rules[0]
+    assert isinstance(compiled_infer.value_ir, SymbolConst)
+    assert compiled_infer.value_ir.name == "kwh"
+    assert isinstance(compiled_infer.condition_ir, RuleBinary)
+    assert isinstance(compiled_infer.condition_ir.left, LocalVarRef)
+    assert compiled_infer.condition_ir.left.name == "frame_type"
+    assert isinstance(compiled_infer.condition_ir.right, SymbolConst)
+    assert compiled_infer.condition_ir.right.name == "ActivityObservation"
+
+
+def test_binder_binds_diagnostic_resolver_and_governance_hosts():
+    program = _load_program_spec()
+    spec = Binder().bind(program)
+
+    compiled_diag = spec.compiled_diagnostics[0]
+    assert isinstance(compiled_diag.condition_ir, HasDiagnostic)
+    assert compiled_diag.condition_ir.severity == "warning"
+    assert compiled_diag.condition_ir.code == "InvalidPeriod"
+
+    compiled_resolver = spec.compiled_resolvers["ActivityObservation"]
+    assert isinstance(compiled_resolver.commit_condition_ir, RuleBinary)
+    left = compiled_resolver.commit_condition_ir.left
+    right = compiled_resolver.commit_condition_ir.right
+    assert isinstance(left, RuleBinary)
+    assert isinstance(left.left, LocalVarRef)
+    assert left.left.name == "score"
+    assert isinstance(right, RuleBuiltinCall)
+    assert right.name == "missing"
+    assert isinstance(right.args[0], FrameSlotRef)
+    assert right.args[0].role_name == "raw_amount"
+
+    compiled_governance = spec.compiled_governances["ActivityObservation"]
+    assert isinstance(compiled_governance.emit_condition_ir, RuleBinary)
+    assert isinstance(compiled_governance.emit_condition_ir.left, RowFieldRef)
+    assert compiled_governance.emit_condition_ir.left.field_name == "raw_amount"
+
+    merge_ir = compiled_governance.merge_conditions_ir[0]
+    assert isinstance(merge_ir, RuleBinary)
+    assert isinstance(merge_ir.left, HasApproval)
+    assert merge_ir.left.key == "human_reviewer"
+    assert isinstance(merge_ir.right, PolicyRef)
+    assert merge_ir.right.key == "auto_merge"
+
+    forbid_ir = compiled_governance.forbid_merge_conditions_ir[0]
+    assert isinstance(forbid_ir, HasDiagnostic)
+    assert forbid_ir.severity == "error"
+    assert forbid_ir.code == "InvalidPeriod"
+
+
+def test_binder_rejects_lexical_builtin_in_rule_host():
+    bad_dsl = """
+module bad_rule
+
+dimension amount
+unit kwh: amount
+activity electricity: amount -> scope2
+
+frame ActivityObservation {
+  raw_amount: Number
+}
+
+require number() > 0
+""".strip()
+
+    with pytest.raises(BindingError):
+        Binder().bind(_load_program_spec(bad_dsl))

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_compiled_runner.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_compiled_runner.py.txt
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from compiled_pipeline_runner import CompiledESGPipelineRunner, load_compiled_program_spec_from_dsl
+from compiled_spec import CompiledProgramSpec
+from pipeline_runner import ESGPipelineRunner
+from tests.fixtures.cases import CASES
+from tests.support.builders import GRAMMAR_PATH
+from tests.support.serialize import project_result
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.name for c in CASES])
+def test_compiled_runner_matches_existing_runner(case):
+    base_runner = ESGPipelineRunner(grammar_path=GRAMMAR_PATH)
+    compiled_runner = CompiledESGPipelineRunner(grammar_path=GRAMMAR_PATH)
+
+    base_result = base_runner.run(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+    compiled_result = compiled_runner.run(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+
+    assert project_result(compiled_result) == project_result(base_result)
+
+
+def test_compiled_loader_returns_compiled_program_spec():
+    case = CASES[0]
+    compiled_spec = load_compiled_program_spec_from_dsl(
+        grammar_path=GRAMMAR_PATH,
+        dsl_text=case.dsl_text,
+    )
+
+    assert isinstance(compiled_spec, CompiledProgramSpec)
+    assert compiled_spec.module_name == "test"
+    assert compiled_spec.compiled_constraints
+    assert compiled_spec.compiled_resolvers
+    assert compiled_spec.compiled_governances

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_e2e_contracts.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_e2e_contracts.py.txt
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from tests.fixtures.cases import CASES
+from tests.support.builders import run_pipeline_full
+from tests.support.serialize import project_result
+
+
+@pytest.mark.e2e
+@pytest.mark.golden
+@pytest.mark.parametrize("case", CASES, ids=[c.name for c in CASES])
+def test_e2e_contracts(case, load_golden):
+    result = run_pipeline_full(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+    )
+
+    actual = project_result(result)
+    expected = load_golden(case.golden_name)
+    assert actual == expected

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_harness_contract.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_harness_contract.py.txt
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.support.builders import make_resources
+
+
+def test_make_resources_matches_runner_contract():
+    pytest.importorskip("lark")
+
+    from pipeline_runner import PipelineResources
+
+    resources = make_resources()
+    assert isinstance(resources, PipelineResources)
+    assert hasattr(resources, "llm_fallback")
+    assert hasattr(resources, "llm_budget")

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_lex_source_ir.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_lex_source_ir.py.txt
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from binder import Binder, BindingError
+from compiled_spec import CompiledBindAction, CompiledParserInheritAction, CompiledProgramSpec
+from lex_ir import LexBuiltinCall, LexUnion
+from pipeline_runner import load_program_spec_from_dsl
+from rule_ir import LocalVarRef, RuleBinary, SymbolConst
+from source_ir import SourceColumnRef, SourceContextRef, SourceFirstOf, SourceTokenRef
+from tests.support.builders import GRAMMAR_PATH
+
+
+LEX_SOURCE_DSL = """
+module lex_source_split
+
+dimension amount
+unit kwh: amount
+activity electricity: amount -> scope2
+
+context site {}
+context period {}
+
+frame ActivityObservation {
+  site: String
+  period: String?
+  raw_amount: Number
+  raw_unit: String
+}
+
+token SiteToken := one_of("alpha") | one_of("beta")
+token AmountToken := number()
+token UnitToken := one_of("kwh")
+
+parser LineParser on line {
+  build ActivityObservation
+  bind site from column("site_name") | SiteToken
+  inherit period from context.period when frame_type == ActivityObservation
+  bind raw_amount from AmountToken
+  bind raw_unit from UnitToken
+}
+
+inherit site from context.site when frame_type == ActivityObservation
+
+resolver ActivityObservation {
+  commit when true
+}
+
+governance ActivityObservation {
+  emit row when true
+  merge when true
+}
+""".strip()
+
+
+def _bind_dsl(dsl_text: str):
+    return Binder().bind(load_program_spec_from_dsl(grammar_path=GRAMMAR_PATH, dsl_text=dsl_text))
+
+
+def test_binder_compiles_token_and_source_hosts_into_stage_specific_ir():
+    compiled = _bind_dsl(LEX_SOURCE_DSL)
+
+    assert isinstance(compiled, CompiledProgramSpec)
+
+    compiled_token = compiled.compiled_tokens["SiteToken"]
+    assert isinstance(compiled_token.primary_ir, LexUnion)
+    assert [type(option) for option in compiled_token.primary_ir.options] == [LexBuiltinCall, LexBuiltinCall]
+
+    compiled_parser = compiled.compiled_parsers["LineParser"]
+    bind_action = compiled_parser.actions[0]
+    assert isinstance(bind_action, CompiledBindAction)
+    assert isinstance(bind_action.source_ir, SourceFirstOf)
+    assert isinstance(bind_action.source_ir.options[0], SourceColumnRef)
+    assert isinstance(bind_action.source_ir.options[1], SourceTokenRef)
+
+    inherit_action = compiled_parser.actions[1]
+    assert isinstance(inherit_action, CompiledParserInheritAction)
+    assert isinstance(inherit_action.source_ir, SourceContextRef)
+    assert isinstance(inherit_action.condition_ir, RuleBinary)
+    assert isinstance(inherit_action.condition_ir.left, LocalVarRef)
+    assert inherit_action.condition_ir.left.name == "frame_type"
+    assert isinstance(inherit_action.condition_ir.right, SymbolConst)
+    assert inherit_action.condition_ir.right.name == "ActivityObservation"
+
+    compiled_inherit = compiled.compiled_inherit_rules[0]
+    assert isinstance(compiled_inherit.source_ir, SourceContextRef)
+
+
+def test_binder_rejects_unknown_bare_name_in_token_host():
+    bad_dsl = LEX_SOURCE_DSL.replace(
+        'token SiteToken := one_of("alpha") | one_of("beta")',
+        "token SiteToken := UnknownAlias",
+    )
+    with pytest.raises(BindingError, match="UnknownAlias"):
+        _bind_dsl(bad_dsl)
+
+
+def test_binder_rejects_unknown_bare_name_in_source_host():
+    bad_dsl = LEX_SOURCE_DSL.replace(
+        'bind site from column("site_name") | SiteToken',
+        'bind site from column("site_name") | SiteTokne',
+    )
+    with pytest.raises(BindingError, match="SiteTokne"):
+        _bind_dsl(bad_dsl)
+
+
+@pytest.mark.parametrize(
+    "bad_dsl, expected",
+    [
+        (
+            LEX_SOURCE_DSL.replace(
+                'token SiteToken := one_of("alpha") | one_of("beta")',
+                'token SiteToken := missing("site")',
+            ),
+            "token host",
+        ),
+        (
+            LEX_SOURCE_DSL.replace(
+                'bind site from column("site_name") | SiteToken',
+                'bind site from missing("site")',
+            ),
+            "source host",
+        ),
+    ],
+)
+def test_binder_rejects_rule_builtins_in_lex_and_source_hosts(bad_dsl: str, expected: str):
+    with pytest.raises(BindingError, match=expected):
+        _bind_dsl(bad_dsl)

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_lex_source_stage_semantics.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_lex_source_stage_semantics.py.txt
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from tests.support.builders import make_fragment, make_resources, run_pipeline_until
+
+
+DSL = """
+module lex_source_stage_semantics
+
+dimension amount
+unit kwh: amount
+activity electricity: amount -> scope2
+
+frame ActivityObservation {
+  site: String
+  raw_amount: Number
+  raw_unit: String
+}
+
+token SiteToken := one_of("alpha") | one_of("beta")
+token AmountToken := number()
+token UnitToken := one_of("kwh")
+
+parser LineParser on line {
+  build ActivityObservation
+  bind site from column("site_name") | SiteToken
+  bind raw_amount from AmountToken
+  bind raw_unit from UnitToken
+}
+
+resolver ActivityObservation {
+  commit when true
+}
+
+governance ActivityObservation {
+  emit row when true
+  merge when true
+}
+""".strip()
+
+
+def test_lex_union_and_source_first_of_are_preserved_end_to_end():
+    fragments = [
+        make_fragment(
+            fragment_id="FRG-1",
+            text="alpha beta 10 kwh",
+            metadata={"row": {"site_name": "COLUMN-SITE"}},
+        )
+    ]
+    resources = make_resources()
+
+    lex_result = run_pipeline_until(
+        dsl_text=DSL,
+        fragments=fragments,
+        resources=resources,
+        pass_name="LexPass",
+    )
+    site_values = {tok.value for tok in lex_result.artifacts.tokens if tok.token_name == "SiteToken"}
+    assert site_values == {"alpha", "beta"}
+
+    parse_result = run_pipeline_until(
+        dsl_text=DSL,
+        fragments=fragments,
+        resources=resources,
+        pass_name="ParsePass",
+    )
+    frame = parse_result.artifacts.frames[0]
+
+    assert frame.slots["site"].resolved_value == "COLUMN-SITE"
+    assert frame.slots["raw_amount"].resolved_value == 10
+    assert frame.slots["raw_unit"].resolved_value == "kwh"

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_pr4_compiled_rule_path.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_pr4_compiled_rule_path.py.txt
@@ -1,0 +1,152 @@
+import pytest
+
+from artifacts import (
+    CanonicalRowArtifact,
+    ClaimArtifact,
+    PartialFrameArtifact,
+    RoleSlotArtifact,
+)
+from ast_nodes import BinaryExpr, FunctionCallExpr, LiteralExpr, NameExpr
+from binder import BindingError
+from compiled_spec import CompiledProgramSpec
+from governance_pass import GovernancePass
+from pipeline_runner import ESGPipelineRunner, compile_program_spec
+from repair_pass import RepairPass
+from spec_nodes import FieldSpec, FrameSpec, GovernancePolicy, ProgramSpec, ResolverPolicy
+
+
+class SeedFramePass:
+    def run(self, spec, artifacts, env):
+        claim = ClaimArtifact(
+            claim_id="CLM-000001",
+            frame_id="FRM-000001",
+            fragment_id="FRG-000001",
+            parser_name="seed",
+            role_name="raw_amount",
+            value=100.0,
+            confidence=0.95,
+            extraction_mode="explicit",
+            candidate_state="active",
+        )
+        slot = RoleSlotArtifact(
+            role_name="raw_amount",
+            active_claim_id=claim.claim_id,
+            resolved_value=claim.value,
+            confidence=claim.confidence,
+        )
+        frame = PartialFrameArtifact(
+            frame_id="FRM-000001",
+            parser_name="seed",
+            frame_type="Observation",
+            slots={"raw_amount": slot},
+        )
+        artifacts.claims.append(claim)
+        artifacts.frames.append(frame)
+        return artifacts
+
+
+class SeedRowPass:
+    def run(self, spec, artifacts, env):
+        artifacts.rows.append(
+            CanonicalRowArtifact(
+                row_id="ROW-000001",
+                frame_id="FRM-000001",
+                parser_name="seed",
+                frame_type="Observation",
+                status="committed",
+                raw_amount=10.0,
+            )
+        )
+        return artifacts
+
+
+def make_base_spec() -> ProgramSpec:
+    spec = ProgramSpec(module_name="test_module")
+    spec.frames["Observation"] = FrameSpec(
+        name="Observation",
+        fields=[FieldSpec(name="raw_amount", type_name="number")],
+    )
+    return spec
+
+
+def test_repair_pass_uses_compiled_resolver_ir_even_if_syntax_policy_is_poisoned():
+    spec = make_base_spec()
+    spec.resolvers["Observation"] = ResolverPolicy(
+        frame_name="Observation",
+        commit_condition=BinaryExpr(NameExpr("score"), ">=", LiteralExpr(0.90)),
+    )
+
+    compiled = compile_program_spec(spec)
+    compiled.syntax.resolvers["Observation"].commit_condition = LiteralExpr(False)
+
+    runner = ESGPipelineRunner(passes=[SeedFramePass(), RepairPass()])
+    result = runner.run(spec=compiled, fragments=[])
+
+    frame = result.artifacts.frames[0]
+    assert frame.status == "committed"
+    assert frame.runtime.iteration_count >= 1
+    assert frame.runtime.resolution_score >= 0.90
+
+
+def test_default_runner_compiles_raw_spec_before_repair():
+    spec = make_base_spec()
+    spec.resolvers["Observation"] = ResolverPolicy(
+        frame_name="Observation",
+        commit_condition=BinaryExpr(NameExpr("score"), ">=", LiteralExpr(0.90)),
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedFramePass(), RepairPass()])
+    result = runner.run(spec=spec, fragments=[])
+
+    assert isinstance(result.spec, CompiledProgramSpec)
+    frame = result.artifacts.frames[0]
+    assert frame.status == "committed"
+    assert frame.runtime.resolution_score >= 0.90
+
+
+def test_default_runner_raises_binding_error_for_unresolved_resolver_name():
+    spec = make_base_spec()
+    spec.resolvers["Observation"] = ResolverPolicy(
+        frame_name="Observation",
+        commit_condition=BinaryExpr(NameExpr("mystery_name"), "==", LiteralExpr(True)),
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedFramePass(), RepairPass()])
+
+    with pytest.raises(BindingError):
+        runner.run(spec=spec, fragments=[])
+
+
+def test_default_runner_rejects_frame_only_builtin_in_governance_host():
+    spec = make_base_spec()
+    spec.governances["Observation"] = GovernancePolicy(
+        frame_name="Observation",
+        merge_conditions=[
+            FunctionCallExpr("missing", [NameExpr("raw_amount")]),
+        ],
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedRowPass(), GovernancePass()])
+
+    with pytest.raises(BindingError):
+        runner.run(spec=spec, fragments=[])
+
+
+def test_governance_row_field_rule_still_merges_via_compiled_default_path():
+    spec = make_base_spec()
+    spec.governances["Observation"] = GovernancePolicy(
+        frame_name="Observation",
+        merge_conditions=[
+            BinaryExpr(NameExpr("raw_amount"), ">", LiteralExpr(0)),
+        ],
+    )
+
+    runner = ESGPipelineRunner(passes=[SeedRowPass(), GovernancePass()])
+    result = runner.run(spec=spec, fragments=[])
+
+    assert isinstance(result.spec, CompiledProgramSpec)
+    row = result.artifacts.rows[0]
+    decision = result.artifacts.merge_log[0]
+
+    assert row.status == "merged"
+    assert decision.action == "merge"

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_pr6_closure.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_pr6_closure.py.txt
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import unittest
+
+from artifacts import CanonicalRowArtifact, ClaimArtifact, CompileArtifacts, PartialFrameArtifact, RoleSlotArtifact
+from ast_nodes import BinaryExpr, FunctionCallExpr, NameExpr
+from binder import Binder, BindingError
+from esg_builtins import register_default_builtins
+from calculation_pass import CalculationPass
+from emit_pass import EmitPass
+from governance_pass import GovernancePass
+from pipeline_runner import build_default_passes
+from runtime_env import build_runtime_env
+from semantic_pass import SemanticPass, SemanticPassConfig
+from spec_nodes import ActivitySpec, ConstraintSpec, FieldSpec, FrameSpec, GovernancePolicy, ProgramSpec
+
+
+class PR6ClosureTests(unittest.TestCase):
+    def _make_program_spec(self) -> ProgramSpec:
+        return ProgramSpec(
+            module_name="test_module",
+            activities={
+                "electricity": ActivitySpec(
+                    name="electricity",
+                    dimension="energy",
+                    scope_category="scope2",
+                )
+            },
+            frames={
+                "ActivityObservation": FrameSpec(
+                    name="ActivityObservation",
+                    fields=[
+                        FieldSpec(name="activity_type", type_name="str"),
+                        FieldSpec(name="raw_amount", type_name="number"),
+                    ],
+                )
+            },
+            constraints=[
+                ConstraintSpec(
+                    kind="require",
+                    condition=FunctionCallExpr("valid", [NameExpr("raw_amount")]),
+                    frame_name="ActivityObservation",
+                )
+            ],
+            governances={
+                "ActivityObservation": GovernancePolicy(
+                    frame_name="ActivityObservation",
+                    merge_conditions=[
+                        BinaryExpr(NameExpr("status"), "==", NameExpr("committed"))
+                    ],
+                )
+            },
+        )
+
+    def _make_env(self, spec: ProgramSpec):
+        env = build_runtime_env(spec)
+        register_default_builtins(env)
+        return env
+
+    def _make_artifacts(self) -> CompileArtifacts:
+        claim = ClaimArtifact(
+            claim_id="CLM-0000001",
+            frame_id="FRM-0000001",
+            fragment_id="FRG-0000001",
+            parser_name="parser.activity",
+            role_name="activity_type",
+            value="electricity",
+            extraction_mode="explicit",
+            confidence=0.95,
+            candidate_state="active",
+            status="resolved",
+            source_fragment_id="FRG-0000001",
+        )
+        slot = RoleSlotArtifact(
+            role_name="activity_type",
+            active_claim_id=claim.claim_id,
+            resolved_value=claim.value,
+            confidence=claim.confidence,
+        )
+        frame = PartialFrameArtifact(
+            frame_id="FRM-0000001",
+            parser_name="parser.activity",
+            frame_type="ActivityObservation",
+            fragment_ids=["FRG-0000001"],
+            slots={"activity_type": slot},
+            status="committed",
+        )
+        return CompileArtifacts(
+            fragments=[],
+            claims=[claim],
+            frames=[frame],
+        )
+
+    def test_build_default_passes_uses_distinct_semantic_phases(self):
+        passes = build_default_passes(include_post_repair_semantic=True)
+        phase_labels = [p.config.phase_label for p in passes if isinstance(p, SemanticPass)]
+        self.assertEqual(["semantic_pre", "semantic_post"], phase_labels)
+
+    def test_binder_rejects_unresolved_rule_name(self):
+        spec = ProgramSpec(
+            module_name="broken_module",
+            frames={
+                "ActivityObservation": FrameSpec(name="ActivityObservation", fields=[])
+            },
+            constraints=[
+                ConstraintSpec(
+                    kind="require",
+                    condition=NameExpr("ghost_symbol"),
+                    frame_name="ActivityObservation",
+                )
+            ],
+        )
+        with self.assertRaises(BindingError):
+            Binder().bind(spec)
+
+    def test_semantic_pre_and_post_both_survive_on_frame(self):
+        spec = self._make_program_spec()
+        compiled = Binder().bind(spec)
+        env = self._make_env(spec)
+        artifacts = self._make_artifacts()
+
+        artifacts = SemanticPass(
+            config=SemanticPassConfig(phase_label="semantic_pre")
+        ).run(compiled, artifacts, env)
+        artifacts = SemanticPass(
+            config=SemanticPassConfig(phase_label="semantic_post")
+        ).run(compiled, artifacts, env)
+
+        phases = {diag.phase for diag in artifacts.frames[0].diagnostics}
+        self.assertIn("semantic_pre", phases)
+        self.assertIn("semantic_post", phases)
+
+    def test_semantic_error_reaches_row_and_governance_holds(self):
+        spec = self._make_program_spec()
+        compiled = Binder().bind(spec)
+        env = self._make_env(spec)
+        artifacts = self._make_artifacts()
+
+        artifacts = SemanticPass().run(compiled, artifacts, env)
+        artifacts = EmitPass().run(compiled, artifacts, env)
+        artifacts = GovernancePass().run(compiled, artifacts, env)
+
+        self.assertEqual(1, len(artifacts.rows))
+        row = artifacts.rows[0]
+        self.assertIn("RequireViolation", row.error_codes)
+        self.assertEqual("hold", artifacts.merge_log[-1].action)
+        self.assertIn("row_has_error_diagnostics", artifacts.merge_log[-1].reason_codes)
+
+    def test_calculation_excludes_merged_row_with_errors(self):
+        spec = ProgramSpec(module_name="calc_module")
+        env = self._make_env(spec)
+        row = CanonicalRowArtifact(
+            row_id="ROW-0000001",
+            frame_id="FRM-0000001",
+            parser_name="parser.activity",
+            frame_type="ActivityObservation",
+            status="merged",
+            activity_type="electricity",
+            standardized_amount=1.0,
+            standardized_unit="kwh",
+            error_codes=["RequireViolation"],
+        )
+        artifacts = CompileArtifacts(rows=[row])
+
+        artifacts = CalculationPass().run(None, artifacts, env)
+
+        self.assertEqual(1, len(artifacts.calculations))
+        calc = artifacts.calculations[0]
+        self.assertEqual("excluded", calc.calculation_status)
+        self.assertEqual("row_has_error_diagnostics", calc.exclusion_reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_repair_stage_smoke.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_repair_stage_smoke.py.txt
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("lark")
+
+from tests.fixtures.cases import CASES
+from tests.support.builders import run_pipeline_until
+from tests.support.serialize import project_result
+
+
+
+def test_repair_stage_smoke(load_golden):
+    case = next(c for c in CASES if c.name == "happy_path_merge_and_calculate")
+
+    result = run_pipeline_until(
+        dsl_text=case.dsl_text,
+        fragments=case.fragments,
+        resources=case.resources,
+        pass_name="RepairPass",
+    )
+
+    actual = project_result(result)
+    expected = load_golden("repair_stage_smoke.json")
+
+    assert actual == expected

--- a/legacy/archive/pipeline_legacy_20260518/reference_tests/test_rule_eval.py.txt
+++ b/legacy/archive/pipeline_legacy_20260518/reference_tests/test_rule_eval.py.txt
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from artifacts import CanonicalRowArtifact, ClaimArtifact, PartialFrameArtifact, RoleSlotArtifact
+from rule_eval import RuleEvaluator
+from rule_ir import FrameSlotRef, HasApproval, LocalVarRef, PolicyRef, RowFieldRef, RuleBinary, RuleBuiltinCall, RuleLiteral, SymbolConst
+from runtime_env import RuntimeEnv
+
+def _ctx():
+    env = RuntimeEnv(); env.policy_flags["auto_merge"] = True
+    c = ClaimArtifact(claim_id="CLM-1", frame_id="FRM-1", fragment_id="FRG-1", parser_name="p", role_name="raw_amount", value=42, extraction_mode="explicit", confidence=0.9, evidence_ids=["pair:raw_amount"])
+    s = RoleSlotArtifact(role_name="raw_amount", active_claim_id=c.claim_id, resolved_value=42)
+    f = PartialFrameArtifact(frame_id="FRM-1", parser_name="p", frame_type="ActivityObservation", slots={"raw_amount": s})
+    r = CanonicalRowArtifact(row_id="ROW-1", frame_id="FRM-1", parser_name="p", frame_type="ActivityObservation", raw_amount=42.0, status="committed")
+    return SimpleNamespace(env=env, scope_path=tuple(), column_key=None, row=r, frame=f, claims_by_id={c.claim_id: c}, local_vars={"status": "committed", "score": 0.9}, warning_codes={"AggregateRow"}, error_codes={"InvalidPeriod"}, approvals={"human_reviewer": False})
+
+def test_rule_refs():
+    ev, ctx = RuleEvaluator(), _ctx()
+    assert ev.eval_bool(RuleBinary(LocalVarRef("status"), "==", SymbolConst("committed")), ctx)
+    assert ev.eval_bool(RuleBinary(RowFieldRef("raw_amount"), ">", RuleLiteral(0)), ctx)
+    assert ev.eval_bool(RuleBinary(HasApproval("human_reviewer"), "or", PolicyRef("auto_merge")), ctx)
+
+def test_rule_builtins():
+    ev, ctx = RuleEvaluator(), _ctx()
+    assert ev.eval(RuleBuiltinCall("missing", [FrameSlotRef("raw_amount")]), ctx) is False
+    assert ev.eval(RuleBuiltinCall("origin", [FrameSlotRef("raw_amount")]), ctx) == "explicit"
+    assert ev.eval(RuleBuiltinCall("evidence", [RuleLiteral("pair")]), ctx) == 1


### PR DESCRIPTION
## Summary

- Copy the legacy pipeline implementation into `legacy/archive/pipeline_legacy_20260518/modules/` without deleting or moving the active files.
- Copy the legacy grammar and package facade surfaces as archive snapshots.
- Copy legacy-oriented tests, fixtures, and goldens under `reference_tests/`, with Python test files stored as `.py.txt` so active pytest does not collect them.
- Update the archive README with the PR3 snapshot layout and copy boundary.

## Scope

This is PR3 in the authority-first rebuild cutover. It intentionally does not remove active files, change `pyproject.toml`, change package exports, alter runtime behavior, implement CompilerTool, or create public projection.

## Validation

- `git diff --cached --check` passed before commit.
- Archive module/grammar snapshots matched the current source files by SHA-256: 30 checked.
- `python -m pytest tests/test_package_smoke.py tests/test_judgment_core.py -q` passed: 6 passed.
- `python -m pytest --collect-only -q` collected 40 tests and no `legacy/archive` paths.
- `python -m pytest -q` currently reports 20 failed, 20 passed from existing legacy pipeline tests. Failures are in legacy runner/parser/binder/e2e areas, primarily `Lowerer().lower(...)` receiving a Lark `Tree` and grammar/token expectations. This PR is a copy-only archive snapshot and does not change active runtime behavior.