### PR TITLE
build: narrow active package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,53 +8,9 @@ version = "0.1.0a0"
 description = "Experimental ESG evidence compiler driven by ESGDL"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = [
-  "lark>=1.1.8",
-]
 
 [tool.setuptools]
 packages = [
   "comp",
-  "comp.dsl",
-  "comp.pipeline",
-  "comp.eval",
-  "comp.builtins",
-  "comp.compat",
   "comp.judgment",
-  "comp.views",
 ]
-py-modules = [
-  "artifacts",
-  "ast_builder",
-  "ast_nodes",
-  "binder",
-  "calculation_pass",
-  "compiled_expr_eval",
-  "compiled_pipeline_runner",
-  "compiled_spec",
-  "emit_pass",
-  "esg_builtins",
-  "expr_eval",
-  "governance_pass",
-  "inference_pass",
-  "lex_eval",
-  "lex_ir",
-  "lex_pass",
-  "lowering",
-  "parse_pass",
-  "pipeline_runner",
-  "repair_pass",
-  "rule_builtins",
-  "rule_eval",
-  "rule_ir",
-  "runtime_env",
-  "scope_resolution_pass",
-  "semantic_pass",
-  "source_eval",
-  "source_ir",
-  "spec_nodes",
-]
-include-package-data = true
-
-[tool.setuptools.package-data]
-"comp.dsl" = ["*.lark"]

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+import tomllib
+
 import comp
 from comp import (
     CommitReceipt,
@@ -23,3 +26,14 @@ def test_top_level_package_no_longer_exports_legacy_runner_surface():
     assert not hasattr(comp, "CompiledESGPipelineRunner")
     assert not hasattr(comp, "PipelineResources")
     assert not hasattr(comp, "PipelineRunResult")
+
+
+def test_pyproject_only_packages_active_surface():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+
+    setuptools_config = pyproject["tool"]["setuptools"]
+    assert setuptools_config["packages"] == ["comp", "comp.judgment"]
+    assert "py-modules" not in setuptools_config
+
+    dependencies = pyproject["project"].get("dependencies", [])
+    assert not any(dependency.startswith("lark") for dependency in dependencies)


### PR DESCRIPTION
## Summary

- Narrow `pyproject.toml` packaging metadata to active packages: `comp` and `comp.judgment`.
- Remove legacy root `py-modules`, legacy wrapper subpackages, legacy package data, and the `lark` runtime dependency from active package metadata.
- Add a package smoke assertion so `pyproject.toml` cannot reintroduce legacy package metadata accidentally.

## Scope

This is PR4b in the authority-first rebuild cutover and is stacked on PR4a (`test/active-boundary-pr4a`). It intentionally does not delete root legacy source modules or package wrapper source files; that remains PR4c source cleanup.

## Known Limitation

A built wheel still contains `comp/runner.py` because it is a direct module inside the included `comp` package. Setuptools package metadata alone cannot exclude that file while `comp` is packaged. PR4c should remove the package wrapper/source file and reconcile the remaining docs around `comp.runner`.

## Validation

- Red check before changing `pyproject.toml`: `python -m pytest tests/test_package_smoke.py::test_pyproject_only_packages_active_surface -q` failed because legacy packages were still listed.
- `python -m pytest --collect-only -q` collected 7 active tests.
- `python -m pytest -q` passed: 7 passed.
- `git diff --check HEAD~1..HEAD` passed.
- `python -m pip wheel . --no-deps -w .tmp_pr4b_wheel` built the package.
- Wheel inspection confirmed no legacy root modules, no legacy wrapper subpackages, and no `Requires-Dist: lark` metadata.
- `python -m pip install --no-deps --target .tmp_pr4b_install ...` plus installed import check passed for `Fact`, `JudgmentState`, and `SubjectRef`.