### PR TITLE
feat: add deterministic compiler tool contract

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -1,0 +1,29 @@
+"""Deterministic compiler-tool contract surface."""
+
+from comp.compiler_tool.models import (
+    CheckedClaim,
+    ClaimHypothesis,
+    CompileReport,
+    EvidenceWitness,
+    FailedClaim,
+    Hazard,
+    InterpretationHypothesis,
+    ProofObligation,
+    UncheckedArea,
+    UnknownClaim,
+)
+from comp.compiler_tool.tool import CompilerTool
+
+__all__ = [
+    "InterpretationHypothesis",
+    "ClaimHypothesis",
+    "EvidenceWitness",
+    "CompileReport",
+    "CheckedClaim",
+    "FailedClaim",
+    "UnknownClaim",
+    "UncheckedArea",
+    "ProofObligation",
+    "Hazard",
+    "CompilerTool",
+]

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+CompileStatus = Literal[
+    "accepted",
+    "blocked",
+    "review_required",
+    "underconstrained",
+    "unchecked",
+]
+
+
+@dataclass(frozen=True)
+class ClaimHypothesis:
+    field: str
+    value: Any
+    witness_id: str | None = None
+    origin: str = "llm_inferred"
+
+
+@dataclass(frozen=True)
+class EvidenceWitness:
+    witness_id: str
+    field: str
+    source: str | None = None
+    span: str | None = None
+    text: str | None = None
+
+    @property
+    def grounded(self) -> bool:
+        return self.source is not None or self.span is not None
+
+
+@dataclass(frozen=True)
+class InterpretationHypothesis:
+    hypothesis_id: str
+    subject_id: str
+    claims: tuple[ClaimHypothesis, ...] = field(default_factory=tuple)
+    witnesses: tuple[EvidenceWitness, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class CheckedClaim:
+    field: str
+    value: Any
+    witness_id: str
+    origin: str
+
+
+@dataclass(frozen=True)
+class FailedClaim:
+    field: str
+    value: Any
+    reason: str
+    origin: str
+    witness_id: str | None = None
+
+
+@dataclass(frozen=True)
+class UnknownClaim:
+    field: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class UncheckedArea:
+    field: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ProofObligation:
+    kind: str
+    field: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class Hazard:
+    kind: str
+    field: str
+    severity: str
+
+
+@dataclass(frozen=True)
+class CompileReport:
+    status: CompileStatus
+    checked_claims: tuple[CheckedClaim, ...] = field(default_factory=tuple)
+    failed_claims: tuple[FailedClaim, ...] = field(default_factory=tuple)
+    unknowns: tuple[UnknownClaim, ...] = field(default_factory=tuple)
+    unchecked_areas: tuple[UncheckedArea, ...] = field(default_factory=tuple)
+    obligations: tuple[ProofObligation, ...] = field(default_factory=tuple)
+    hazards: tuple[Hazard, ...] = field(default_factory=tuple)
+    can_project_public_row: bool = False

--- a/comp/compiler_tool/tool.py
+++ b/comp/compiler_tool/tool.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from comp.compiler_tool.models import (
+    CheckedClaim,
+    ClaimHypothesis,
+    CompileReport,
+    EvidenceWitness,
+    FailedClaim,
+    Hazard,
+    InterpretationHypothesis,
+    ProofObligation,
+    UncheckedArea,
+    UnknownClaim,
+)
+
+
+class CompilerTool:
+    """Deterministic obligation oracle for interpretation hypotheses."""
+
+    def __init__(
+        self,
+        *,
+        allowed_units: frozenset[str] = frozenset({"kwh"}),
+        known_fields: frozenset[str] = frozenset(
+            {"activity", "amount", "unit", "reporting_year"}
+        ),
+    ) -> None:
+        self.allowed_units = frozenset(unit.lower() for unit in allowed_units)
+        self.known_fields = known_fields
+
+    def compile_interpretation(
+        self,
+        hypothesis: InterpretationHypothesis,
+    ) -> CompileReport:
+        witnesses = {witness.witness_id: witness for witness in hypothesis.witnesses}
+        checked: list[CheckedClaim] = []
+        failed: list[FailedClaim] = []
+        unknowns: list[UnknownClaim] = []
+        unchecked: list[UncheckedArea] = []
+        obligations: list[ProofObligation] = []
+        hazards: list[Hazard] = []
+
+        claim_fields = {claim.field for claim in hypothesis.claims}
+
+        for claim in hypothesis.claims:
+            if claim.field not in self.known_fields:
+                unchecked.append(
+                    UncheckedArea(
+                        field=claim.field,
+                        reason="missing_rule_coverage",
+                    )
+                )
+                self._add_obligation(
+                    obligations,
+                    ProofObligation(
+                        kind="define_rule_coverage",
+                        field=claim.field,
+                        reason="missing_rule_coverage",
+                    ),
+                )
+                continue
+
+            if claim.value is None:
+                unknowns.append(
+                    UnknownClaim(field=claim.field, reason="context_required")
+                )
+                self._add_obligation(
+                    obligations,
+                    ProofObligation(
+                        kind="find_context",
+                        field=claim.field,
+                        reason="context_required",
+                    ),
+                )
+                continue
+
+            witness_failure = self._validate_witness(claim, witnesses)
+            if witness_failure is not None:
+                failed.append(witness_failure)
+                self._add_find_source_witness(obligations, claim.field, witness_failure.reason)
+                continue
+
+            if claim.field == "unit" and str(claim.value).lower() not in self.allowed_units:
+                failed.append(
+                    FailedClaim(
+                        field=claim.field,
+                        value=claim.value,
+                        reason="unsupported_unit",
+                        origin=claim.origin,
+                        witness_id=claim.witness_id,
+                    )
+                )
+                self._add_find_source_witness(obligations, claim.field, "unsupported_unit")
+                continue
+
+            checked.append(
+                CheckedClaim(
+                    field=claim.field,
+                    value=claim.value,
+                    witness_id=claim.witness_id or "",
+                    origin=claim.origin,
+                )
+            )
+
+        if "unit" not in claim_fields:
+            hazards.append(Hazard(kind="missing_unit", field="unit", severity="review"))
+            self._add_find_source_witness(obligations, "unit", "missing_unit")
+
+        return CompileReport(
+            status=self._status_for(failed, hazards, unchecked, unknowns),
+            checked_claims=tuple(checked),
+            failed_claims=tuple(failed),
+            unknowns=tuple(unknowns),
+            unchecked_areas=tuple(unchecked),
+            obligations=tuple(obligations),
+            hazards=tuple(hazards),
+            can_project_public_row=False,
+        )
+
+    @staticmethod
+    def _validate_witness(
+        claim: ClaimHypothesis,
+        witnesses: dict[str, EvidenceWitness],
+    ) -> FailedClaim | None:
+        if claim.witness_id is None:
+            return FailedClaim(
+                field=claim.field,
+                value=claim.value,
+                reason="missing_source_witness",
+                origin=claim.origin,
+                witness_id=None,
+            )
+
+        witness = witnesses.get(claim.witness_id)
+        if witness is None:
+            return FailedClaim(
+                field=claim.field,
+                value=claim.value,
+                reason="missing_source_witness",
+                origin=claim.origin,
+                witness_id=claim.witness_id,
+            )
+
+        if witness.field != claim.field:
+            return FailedClaim(
+                field=claim.field,
+                value=claim.value,
+                reason="witness_field_mismatch",
+                origin=claim.origin,
+                witness_id=claim.witness_id,
+            )
+
+        if not witness.grounded:
+            return FailedClaim(
+                field=claim.field,
+                value=claim.value,
+                reason="ungrounded_source_witness",
+                origin=claim.origin,
+                witness_id=claim.witness_id,
+            )
+
+        return None
+
+    @staticmethod
+    def _status_for(
+        failed: list[FailedClaim],
+        hazards: list[Hazard],
+        unchecked: list[UncheckedArea],
+        unknowns: list[UnknownClaim],
+    ) -> str:
+        if failed:
+            return "blocked"
+        if hazards:
+            return "review_required"
+        if unchecked:
+            return "unchecked"
+        if unknowns:
+            return "underconstrained"
+        return "accepted"
+
+    @staticmethod
+    def _add_find_source_witness(
+        obligations: list[ProofObligation],
+        field: str,
+        reason: str,
+    ) -> None:
+        CompilerTool._add_obligation(
+            obligations,
+            ProofObligation(kind="find_source_witness", field=field, reason=reason),
+        )
+
+    @staticmethod
+    def _add_obligation(
+        obligations: list[ProofObligation],
+        obligation: ProofObligation,
+    ) -> None:
+        if obligation not in obligations:
+            obligations.append(obligation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,6 @@ requires-python = ">=3.11"
 [tool.setuptools]
 packages = [
   "comp",
+  "comp.compiler_tool",
   "comp.judgment",
 ]

--- a/tests/test_compiler_tool_contract.py
+++ b/tests/test_compiler_tool_contract.py
@@ -1,0 +1,185 @@
+from comp.compiler_tool import (
+    ClaimHypothesis,
+    CheckedClaim,
+    CompileReport,
+    CompilerTool,
+    EvidenceWitness,
+    FailedClaim,
+    Hazard,
+    InterpretationHypothesis,
+    ProofObligation,
+    UnknownClaim,
+    UncheckedArea,
+)
+
+
+def _hypothesis(*, claims, witnesses=()):
+    return InterpretationHypothesis(
+        hypothesis_id="hyp-1",
+        subject_id="draft-1",
+        claims=tuple(claims),
+        witnesses=tuple(witnesses),
+    )
+
+
+def _claim(field, value, witness_id=None):
+    return ClaimHypothesis(
+        field=field,
+        value=value,
+        witness_id=witness_id,
+        origin="llm_inferred",
+    )
+
+
+def _witness(witness_id, field, *, source="invoice.csv", span="A1"):
+    return EvidenceWitness(
+        witness_id=witness_id,
+        field=field,
+        source=source,
+        span=span,
+    )
+
+
+def test_compiler_tool_contract_model_set_is_exported():
+    assert InterpretationHypothesis is not None
+    assert ClaimHypothesis is not None
+    assert EvidenceWitness is not None
+    assert CompileReport is not None
+    assert CheckedClaim is not None
+    assert FailedClaim is not None
+    assert UnknownClaim is not None
+    assert UncheckedArea is not None
+    assert ProofObligation is not None
+    assert Hazard is not None
+
+
+def test_unsupported_unit_blocks_and_requests_source_witness():
+    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+        _hypothesis(
+            claims=(
+                _claim("activity", "electricity", "w-activity"),
+                _claim("amount", 1200, "w-amount"),
+                _claim("unit", "mwh", "w-unit"),
+            ),
+            witnesses=(
+                _witness("w-activity", "activity"),
+                _witness("w-amount", "amount"),
+                _witness("w-unit", "unit"),
+            ),
+        )
+    )
+
+    assert report.status == "blocked"
+    assert [failed.field for failed in report.failed_claims] == ["unit"]
+    assert report.failed_claims[0].reason == "unsupported_unit"
+    assert any(
+        obligation.kind == "find_source_witness" and obligation.field == "unit"
+        for obligation in report.obligations
+    )
+    assert report.can_project_public_row is False
+
+
+def test_witness_id_must_resolve_to_grounded_matching_witness():
+    tool = CompilerTool(allowed_units=frozenset({"kwh"}))
+
+    cases = [
+        ((), "missing_source_witness"),
+        ((_witness("w-amount", "unit"),), "witness_field_mismatch"),
+        ((_witness("w-amount", "amount", source=None, span=None),), "ungrounded_source_witness"),
+    ]
+
+    for witnesses, expected_reason in cases:
+        report = tool.compile_interpretation(
+            _hypothesis(
+                claims=(
+                    _claim("amount", 1200, "w-amount"),
+                    _claim("unit", "kwh", "w-unit"),
+                ),
+                witnesses=(*witnesses, _witness("w-unit", "unit")),
+            )
+        )
+
+        assert report.status == "blocked"
+        assert report.failed_claims[0].field == "amount"
+        assert report.failed_claims[0].reason == expected_reason
+        assert any(
+            obligation.kind == "find_source_witness" and obligation.field == "amount"
+            for obligation in report.obligations
+        )
+
+
+def test_unknown_and_unchecked_are_distinct_and_not_pass():
+    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+        _hypothesis(
+            claims=(
+                _claim("reporting_year", None),
+                _claim("factor_period_compatibility", "jan-2026-factor"),
+                _claim("unit", "kwh", "w-unit"),
+            ),
+            witnesses=(_witness("w-unit", "unit"),),
+        )
+    )
+
+    assert report.status == "unchecked"
+    assert report.unknowns == (
+        UnknownClaim(field="reporting_year", reason="context_required"),
+    )
+    assert report.unchecked_areas == (
+        UncheckedArea(
+            field="factor_period_compatibility",
+            reason="missing_rule_coverage",
+        ),
+    )
+    assert [claim.field for claim in report.checked_claims] == ["unit"]
+    assert report.can_project_public_row is False
+
+
+def test_missing_unit_is_review_required_hazard_not_public_projection():
+    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+        _hypothesis(
+            claims=(
+                _claim("activity", "electricity", "w-activity"),
+                _claim("amount", 1200, "w-amount"),
+            ),
+            witnesses=(
+                _witness("w-activity", "activity"),
+                _witness("w-amount", "amount"),
+            ),
+        )
+    )
+
+    assert report.status == "review_required"
+    assert report.failed_claims == ()
+    assert report.hazards == (
+        Hazard(kind="missing_unit", field="unit", severity="review"),
+    )
+    assert any(
+        obligation.kind == "find_source_witness" and obligation.field == "unit"
+        for obligation in report.obligations
+    )
+    assert report.can_project_public_row is False
+
+
+def test_accepted_report_is_not_public_projection_authority():
+    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+        _hypothesis(
+            claims=(
+                _claim("activity", "electricity", "w-activity"),
+                _claim("amount", 1200, "w-amount"),
+                _claim("unit", "kwh", "w-unit"),
+            ),
+            witnesses=(
+                _witness("w-activity", "activity"),
+                _witness("w-amount", "amount"),
+                _witness("w-unit", "unit"),
+            ),
+        )
+    )
+
+    assert report.status == "accepted"
+    assert [claim.field for claim in report.checked_claims] == [
+        "activity",
+        "amount",
+        "unit",
+    ]
+    assert report.can_project_public_row is False

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -74,7 +74,11 @@ def test_pyproject_only_packages_active_surface():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
 
     setuptools_config = pyproject["tool"]["setuptools"]
-    assert setuptools_config["packages"] == ["comp", "comp.judgment"]
+    assert setuptools_config["packages"] == [
+        "comp",
+        "comp.compiler_tool",
+        "comp.judgment",
+    ]
     assert "py-modules" not in setuptools_config
 
     dependencies = pyproject["project"].get("dependencies", [])


### PR DESCRIPTION
## Summary

Adds the PR5 compiler-tool contract slice as an active package surface.

- Add `comp.compiler_tool` with deterministic contract models: `InterpretationHypothesis`, `ClaimHypothesis`, `EvidenceWitness`, `CompileReport`, checked/failed/unknown/unchecked/obligation/hazard records, and `CompilerTool`.
- Validate source witnesses by real witness lookup, matching claim field, and source/span grounding.
- Keep report acceptance separate from public projection authority: `can_project_public_row` remains `False`, including accepted reports.
- Distinguish `UnknownClaim` from `UncheckedArea`; unchecked does not count as pass.
- Add active tests for unsupported units, missing units, witness grounding failures, unknown vs unchecked behavior, and no-projection acceptance.

## Non-goals

- No real LLM provider/API calls.
- No `CompileReport -> Fact` adapter; that is PR6.
- No receipt-gated projection; that is PR7.

## Validation

- `python -m pytest --collect-only -q` -> 14 tests collected.
- `python -m pytest -q` -> 14 passed.
- `git diff --check HEAD~1..HEAD` -> clean.
- `python -m pip wheel . --no-deps -w .tmp_pr5_wheel` -> wheel built.
- Wheel inspection confirmed `comp/compiler_tool/*` included, legacy modules excluded, and no `Requires-Dist: lark`.
- Installed wheel into `.tmp_pr5_install` and imported `CompilerTool` and `InterpretationHypothesis`.
- `rg -n "openai|anthropic|api_key|provider|requests\.|http://|https://" comp/compiler_tool tests/test_compiler_tool_contract.py` -> no matches.