### PR TITLE
feat: map compile reports to judgment facts

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -13,6 +13,10 @@ from comp.compiler_tool.models import (
     UnknownClaim,
 )
 from comp.compiler_tool.tool import CompilerTool
+from comp.compiler_tool.judgment_adapter import (
+    add_compile_report_facts,
+    compile_report_to_facts,
+)
 
 __all__ = [
     "InterpretationHypothesis",
@@ -26,4 +30,6 @@ __all__ = [
     "ProofObligation",
     "Hazard",
     "CompilerTool",
+    "compile_report_to_facts",
+    "add_compile_report_facts",
 ]

--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from comp.compiler_tool.models import CompileReport, ProofObligation
+from comp.judgment import Fact, FactTag, JudgmentState, SubjectRef
+
+
+def compile_report_to_facts(report: CompileReport, subject: SubjectRef) -> set[Fact]:
+    facts: set[Fact] = set()
+
+    for claim in report.checked_claims:
+        facts.add(
+            Fact(
+                tag="evidence",
+                subject=subject,
+                key=claim.field,
+                value=claim.value,
+                witness=claim.witness_id,
+                weight=1.0,
+                meta=(
+                    ("origin", claim.origin),
+                    ("report_section", "checked_claim"),
+                    ("report_status", report.status),
+                ),
+            )
+        )
+
+    for claim in report.failed_claims:
+        facts.add(
+            Fact(
+                tag="hazard_open",
+                subject=subject,
+                key=f"failed_claim:{claim.field}",
+                value=_failed_claim_id(claim.field, claim.reason),
+                witness=claim.witness_id,
+                meta=(
+                    ("origin", claim.origin),
+                    ("reason", claim.reason),
+                    ("report_section", "failed_claim"),
+                    ("report_status", report.status),
+                ),
+            )
+        )
+
+    for unknown in report.unknowns:
+        facts.add(
+            Fact(
+                tag="hazard_open",
+                subject=subject,
+                key=f"unknown_claim:{unknown.field}",
+                value=_unknown_claim_id(unknown.field, unknown.reason),
+                meta=(
+                    ("reason", unknown.reason),
+                    ("report_section", "unknown_claim"),
+                    ("report_status", report.status),
+                ),
+            )
+        )
+
+    for unchecked in report.unchecked_areas:
+        facts.add(
+            Fact(
+                tag="hazard_open",
+                subject=subject,
+                key=f"unchecked_area:{unchecked.field}",
+                value=_unchecked_area_id(unchecked.field, unchecked.reason),
+                meta=(
+                    ("reason", unchecked.reason),
+                    ("report_section", "unchecked_area"),
+                    ("report_status", report.status),
+                ),
+            )
+        )
+
+    for obligation in report.obligations:
+        facts.add(_obligation_fact("hazard_open", report.status, subject, obligation))
+
+    for obligation in report.resolved_obligations:
+        facts.add(
+            _obligation_fact(
+                "hazard_discharge",
+                report.status,
+                subject,
+                obligation,
+                section="resolved_obligation",
+            )
+        )
+
+    for hazard in report.hazards:
+        facts.add(
+            Fact(
+                tag="hazard_open",
+                subject=subject,
+                key=f"hazard:{hazard.field}",
+                value=_hazard_id(hazard.kind, hazard.field, hazard.severity),
+                meta=(
+                    ("kind", hazard.kind),
+                    ("report_section", "hazard"),
+                    ("report_status", report.status),
+                    ("severity", hazard.severity),
+                ),
+            )
+        )
+
+    return facts
+
+
+def add_compile_report_facts(
+    state: JudgmentState, report: CompileReport, subject: SubjectRef
+) -> set[Fact]:
+    return state.add_facts(compile_report_to_facts(report, subject))
+
+
+def _obligation_fact(
+    tag: FactTag,
+    status: str,
+    subject: SubjectRef,
+    obligation: ProofObligation,
+    *,
+    section: str = "proof_obligation",
+) -> Fact:
+    return Fact(
+        tag=tag,
+        subject=subject,
+        key=f"proof_obligation:{obligation.field}",
+        value=_obligation_id(obligation.kind, obligation.field, obligation.reason),
+        meta=(
+            ("kind", obligation.kind),
+            ("reason", obligation.reason),
+            ("report_section", section),
+            ("report_status", status),
+        ),
+    )
+
+
+def _failed_claim_id(field: str, reason: str) -> str:
+    return _stable_id("failed_claim", field, reason)
+
+
+def _unknown_claim_id(field: str, reason: str) -> str:
+    return _stable_id("unknown_claim", field, reason)
+
+
+def _unchecked_area_id(field: str, reason: str) -> str:
+    return _stable_id("unchecked_area", field, reason)
+
+
+def _obligation_id(kind: str, field: str, reason: str) -> str:
+    return _stable_id("proof_obligation", kind, field, reason)
+
+
+def _hazard_id(kind: str, field: str, severity: str) -> str:
+    return _stable_id("hazard", kind, field, severity)
+
+
+def _stable_id(*parts: str) -> str:
+    return ":".join(str(part) for part in parts)
+
+
+__all__ = [
+    "compile_report_to_facts",
+    "add_compile_report_facts",
+]

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -92,5 +92,6 @@ class CompileReport:
     unknowns: tuple[UnknownClaim, ...] = field(default_factory=tuple)
     unchecked_areas: tuple[UncheckedArea, ...] = field(default_factory=tuple)
     obligations: tuple[ProofObligation, ...] = field(default_factory=tuple)
+    resolved_obligations: tuple[ProofObligation, ...] = field(default_factory=tuple)
     hazards: tuple[Hazard, ...] = field(default_factory=tuple)
     can_project_public_row: bool = False

--- a/tests/test_compile_report_to_judgment_facts.py
+++ b/tests/test_compile_report_to_judgment_facts.py
@@ -1,0 +1,197 @@
+from comp.compiler_tool import (
+    CheckedClaim,
+    CompileReport,
+    FailedClaim,
+    Hazard,
+    ProofObligation,
+    UncheckedArea,
+    UnknownClaim,
+    add_compile_report_facts,
+    compile_report_to_facts,
+)
+from comp.judgment import Fact, JudgmentState, SubjectRef
+
+
+def test_compile_report_to_facts_maps_each_report_category():
+    subject = SubjectRef("claim", "hyp-1")
+    report = CompileReport(
+        status="blocked",
+        checked_claims=(
+            CheckedClaim(
+                field="amount",
+                value=100,
+                witness_id="w-amount",
+                origin="llm_inferred",
+            ),
+        ),
+        failed_claims=(
+            FailedClaim(
+                field="unit",
+                value="mwh",
+                reason="unsupported_unit",
+                origin="llm_inferred",
+                witness_id="w-unit",
+            ),
+        ),
+        unknowns=(UnknownClaim(field="reporting_year", reason="context_required"),),
+        unchecked_areas=(
+            UncheckedArea(
+                field="factor_period_compatibility",
+                reason="missing_rule_coverage",
+            ),
+        ),
+        obligations=(
+            ProofObligation(
+                kind="find_source_witness",
+                field="unit",
+                reason="unsupported_unit",
+            ),
+        ),
+        hazards=(Hazard(kind="missing_unit", field="unit", severity="review"),),
+    )
+
+    facts = compile_report_to_facts(report, subject)
+
+    assert Fact(
+        tag="evidence",
+        subject=subject,
+        key="amount",
+        value=100,
+        witness="w-amount",
+        weight=1.0,
+        meta=(
+            ("origin", "llm_inferred"),
+            ("report_section", "checked_claim"),
+            ("report_status", "blocked"),
+        ),
+    ) in facts
+    assert Fact(
+        tag="hazard_open",
+        subject=subject,
+        key="failed_claim:unit",
+        value="failed_claim:unit:unsupported_unit",
+        witness="w-unit",
+        meta=(
+            ("origin", "llm_inferred"),
+            ("reason", "unsupported_unit"),
+            ("report_section", "failed_claim"),
+            ("report_status", "blocked"),
+        ),
+    ) in facts
+    assert Fact(
+        tag="hazard_open",
+        subject=subject,
+        key="unknown_claim:reporting_year",
+        value="unknown_claim:reporting_year:context_required",
+        meta=(
+            ("reason", "context_required"),
+            ("report_section", "unknown_claim"),
+            ("report_status", "blocked"),
+        ),
+    ) in facts
+    assert Fact(
+        tag="hazard_open",
+        subject=subject,
+        key="unchecked_area:factor_period_compatibility",
+        value="unchecked_area:factor_period_compatibility:missing_rule_coverage",
+        meta=(
+            ("reason", "missing_rule_coverage"),
+            ("report_section", "unchecked_area"),
+            ("report_status", "blocked"),
+        ),
+    ) in facts
+    assert Fact(
+        tag="hazard_open",
+        subject=subject,
+        key="proof_obligation:unit",
+        value="proof_obligation:find_source_witness:unit:unsupported_unit",
+        meta=(
+            ("kind", "find_source_witness"),
+            ("reason", "unsupported_unit"),
+            ("report_section", "proof_obligation"),
+            ("report_status", "blocked"),
+        ),
+    ) in facts
+    assert Fact(
+        tag="hazard_open",
+        subject=subject,
+        key="hazard:unit",
+        value="hazard:missing_unit:unit:review",
+        meta=(
+            ("kind", "missing_unit"),
+            ("report_section", "hazard"),
+            ("report_status", "blocked"),
+            ("severity", "review"),
+        ),
+    ) in facts
+    assert not any(
+        fact.tag == "evidence" and fact.key == "factor_period_compatibility"
+        for fact in facts
+    )
+
+
+def test_resolved_obligations_discharge_matching_hazard_ids():
+    subject = SubjectRef("claim", "hyp-1")
+    obligation = ProofObligation(
+        kind="find_source_witness",
+        field="unit",
+        reason="unsupported_unit",
+    )
+    report = CompileReport(status="accepted", resolved_obligations=(obligation,))
+
+    facts = compile_report_to_facts(report, subject)
+
+    assert facts == {
+        Fact(
+            tag="hazard_discharge",
+            subject=subject,
+            key="proof_obligation:unit",
+            value="proof_obligation:find_source_witness:unit:unsupported_unit",
+            meta=(
+                ("kind", "find_source_witness"),
+                ("reason", "unsupported_unit"),
+                ("report_section", "resolved_obligation"),
+                ("report_status", "accepted"),
+            ),
+        )
+    }
+    state = JudgmentState()
+    state.add_facts(
+        [
+            Fact(
+                tag="hazard_open",
+                subject=subject,
+                key="proof_obligation:unit",
+                value="proof_obligation:find_source_witness:unit:unsupported_unit",
+            )
+        ]
+    )
+
+    add_compile_report_facts(state, report, subject)
+
+    assert "proof_obligation:find_source_witness:unit:unsupported_unit" not in (
+        state.active_hazard_ids(subject)
+    )
+
+
+def test_add_compile_report_facts_is_append_only_and_idempotent():
+    subject = SubjectRef("claim", "hyp-1")
+    report = CompileReport(
+        status="accepted",
+        checked_claims=(
+            CheckedClaim(
+                field="unit",
+                value="kwh",
+                witness_id="w-unit",
+                origin="source_text",
+            ),
+        ),
+    )
+    state = JudgmentState()
+
+    first_delta = add_compile_report_facts(state, report, subject)
+    second_delta = add_compile_report_facts(state, report, subject)
+
+    assert first_delta == compile_report_to_facts(report, subject)
+    assert second_delta == set()
+    assert state.version_of(subject) == 1


### PR DESCRIPTION
## Summary

Adds the PR6 adapter from `CompileReport` into append-only `comp.judgment` facts.

- Add `compile_report_to_facts(report, subject)` and `add_compile_report_facts(state, report, subject)` on the `comp.compiler_tool` surface.
- Map `CheckedClaim` to `Fact(tag="evidence")`.
- Map `FailedClaim`, `UnknownClaim`, `UncheckedArea`, `ProofObligation`, and `Hazard` to `Fact(tag="hazard_open")`.
- Add `CompileReport.resolved_obligations` and map those obligations to `Fact(tag="hazard_discharge")` using the same stable hazard ids as open proof obligations.
- Preserve the PR5 boundary: no projection authority is introduced here.

## Non-goals

- No public projection.
- No legacy `CompileArtifacts` adapter.
- No real LLM/API/provider calls.
- No PR7 receipt-gated projection behavior.

## Validation

- `python -m pytest --collect-only -q` -> 17 tests collected.
- `python -m pytest -q` -> 17 passed.
- `git diff --check HEAD~1..HEAD` -> clean.
- `python -m pip wheel . --no-deps -w .tmp_pr6_wheel` -> wheel built.
- Wheel inspection confirmed `comp/compiler_tool/judgment_adapter.py` included, compiler-tool files included, legacy modules excluded, and no `Requires-Dist: lark`.
- Installed wheel into `.tmp_pr6_install` and imported `compile_report_to_facts` / `add_compile_report_facts` from `comp.compiler_tool`.
- `rg -n "openai|anthropic|api_key|provider|requests\.|http://|https://" comp/compiler_tool tests/test_compile_report_to_judgment_facts.py` -> no matches.