### PR TITLE
feat: import minchoagnt agent layer

### DIFF
--- a/minchoagnt/__init__.py
+++ b/minchoagnt/__init__.py
@@ -1,0 +1,32 @@
+"""A tiny Hermes-style memory, skills, and review loop."""
+
+from minchoagnt.agent import ChatResult, MiniAgent, ReviewSummary
+from minchoagnt.comp_adapter import CompCompileResult, CompCompilerAdapter
+from minchoagnt.memory import MemoryStore
+from minchoagnt.ollama import OllamaHTTPClient, OllamaReviewEngine
+from minchoagnt.review import (
+    RegexReviewEngine,
+    ReviewEngine,
+    ReviewPlan,
+    ReviewPlanValidationError,
+)
+from minchoagnt.skills import SkillStore
+from minchoagnt.workbench import ReviewWorkbench, WorkbenchRun
+
+__all__ = [
+    "ChatResult",
+    "CompCompileResult",
+    "CompCompilerAdapter",
+    "MemoryStore",
+    "MiniAgent",
+    "OllamaHTTPClient",
+    "OllamaReviewEngine",
+    "RegexReviewEngine",
+    "ReviewEngine",
+    "ReviewPlan",
+    "ReviewPlanValidationError",
+    "ReviewSummary",
+    "ReviewWorkbench",
+    "SkillStore",
+    "WorkbenchRun",
+]

--- a/minchoagnt/__main__.py
+++ b/minchoagnt/__main__.py
@@ -1,0 +1,5 @@
+from minchoagnt.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/minchoagnt/agent.py
+++ b/minchoagnt/agent.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from minchoagnt.memory import MemoryStore
+from minchoagnt.review import RegexReviewEngine, ReviewEngine, ReviewPlan
+from minchoagnt.sessions import SessionDB
+from minchoagnt.skills import SkillExistsError, SkillStore
+
+
+@dataclass(frozen=True)
+class ReviewSummary:
+    memory_saved: int = 0
+    skills_created: int = 0
+
+
+@dataclass(frozen=True)
+class ChatResult:
+    session_id: str
+    response: str
+    review: ReviewSummary
+
+
+class MiniAgent:
+    """Small orchestration shell around memory, skills, sessions, and review."""
+
+    def __init__(
+        self,
+        home: Path | str,
+        memory_interval: int = 10,
+        skill_interval: int = 10,
+        session_id: str | None = None,
+        review_engine: ReviewEngine | None = None,
+    ):
+        self.home = Path(home)
+        self.home.mkdir(parents=True, exist_ok=True)
+        self.memory = MemoryStore(self.home).load()
+        self.skills = SkillStore(self.home)
+        self.sessions = SessionDB(self.home / "state.db")
+        self.review_engine = review_engine if review_engine is not None else RegexReviewEngine()
+        self.session_id = session_id or self.sessions.create_session(source="cli")
+        self.memory_interval = max(1, memory_interval)
+        self.skill_interval = max(1, skill_interval)
+        self._turns_since_memory = 0
+        self._iters_since_skill = 0
+
+    def context(self) -> str:
+        memory = MemoryStore(self.home).load()
+        sections = ["# MiniAgent Context"]
+        for target in ("user", "memory"):
+            snapshot = memory.snapshot(target)  # type: ignore[arg-type]
+            if snapshot:
+                sections.append(snapshot)
+        skill_names = self.skills.list_names()
+        if skill_names:
+            sections.append("Available skills:\n" + "\n".join(f"- {name}" for name in skill_names))
+        else:
+            sections.append("Available skills: none")
+        return "\n\n".join(sections)
+
+    def chat(self, user_text: str, tool_iterations: int = 0) -> ChatResult:
+        self.sessions.append_message(self.session_id, "user", user_text)
+        response = self._response_for(user_text)
+        self.sessions.append_message(self.session_id, "assistant", response)
+
+        self._turns_since_memory += 1
+        self._iters_since_skill += max(0, tool_iterations)
+
+        memory_saved = 0
+        skills_created = 0
+        messages = self.sessions.get_messages(self.session_id)
+
+        if self._turns_since_memory >= self.memory_interval:
+            plan = self.review_engine.review(messages, review_memory=True, review_skills=False)
+            memory_saved = self._apply_memory(plan)
+            self._turns_since_memory = 0
+
+        if self._iters_since_skill >= self.skill_interval:
+            plan = self.review_engine.review(messages, review_memory=False, review_skills=True)
+            skills_created = self._apply_skills(plan)
+            self._iters_since_skill = 0
+
+        return ChatResult(
+            session_id=self.session_id,
+            response=response,
+            review=ReviewSummary(memory_saved=memory_saved, skills_created=skills_created),
+        )
+
+    def _apply_memory(self, plan: ReviewPlan) -> int:
+        count = 0
+        for addition in plan.memory_additions:
+            if self.memory.add(addition.target, addition.content):  # type: ignore[arg-type]
+                count += 1
+        return count
+
+    def _apply_skills(self, plan: ReviewPlan) -> int:
+        count = 0
+        for creation in plan.skill_creations:
+            try:
+                self.skills.create(creation.name, creation.content, category=creation.category)
+            except SkillExistsError:
+                continue
+            count += 1
+        return count
+
+    @staticmethod
+    def _response_for(user_text: str) -> str:
+        lowered = user_text.lower()
+        if "remember" in lowered:
+            return "Queued that fact for the next memory review."
+        if "skill:" in lowered:
+            return "Queued that workflow for the next skill review."
+        return "Recorded this turn."

--- a/minchoagnt/cli.py
+++ b/minchoagnt/cli.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from minchoagnt.agent import MiniAgent
+from minchoagnt.memory import MemoryStore
+from minchoagnt.ollama import OllamaReviewEngine
+from minchoagnt.sessions import SessionDB
+from minchoagnt.skills import SkillStore
+from minchoagnt.web import serve_workbench
+
+
+def default_home() -> Path:
+    configured = os.environ.get("MINCHOAGNT_HOME")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.cwd() / ".minchoagnt"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Tiny Hermes-style agent slice.")
+    parser.add_argument("--home", type=Path, default=default_home(), help="State directory.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    say = sub.add_parser("say", help="Record a user turn and maybe run review.")
+    say.add_argument("text")
+    say.add_argument("--tool-iterations", type=int, default=0)
+    say.add_argument("--memory-interval", type=int, default=10)
+    say.add_argument("--skill-interval", type=int, default=10)
+    say.add_argument("--reviewer", choices=["regex", "ollama"], default="regex")
+    say.add_argument("--model", default="qwen2.5:7b", help="Ollama model for --reviewer ollama.")
+    say.add_argument(
+        "--ollama-url",
+        default="http://127.0.0.1:11434",
+        help="Ollama base URL for --reviewer ollama.",
+    )
+    say.add_argument(
+        "--timeout",
+        type=float,
+        default=30,
+        help="Ollama request timeout in seconds for --reviewer ollama.",
+    )
+
+    sub.add_parser("context", help="Print the assembled prompt context.")
+
+    memory = sub.add_parser("memory", help="Inspect memory.")
+    memory_sub = memory.add_subparsers(dest="memory_command", required=True)
+    memory_list = memory_sub.add_parser("list")
+    memory_list.add_argument("--target", choices=["memory", "user"], default="memory")
+
+    skills = sub.add_parser("skills", help="Inspect skills.")
+    skills_sub = skills.add_subparsers(dest="skills_command", required=True)
+    skills_sub.add_parser("list")
+    skill_view = skills_sub.add_parser("view")
+    skill_view.add_argument("name")
+
+    search = sub.add_parser("search", help="Search session messages.")
+    search.add_argument("query")
+
+    workbench = sub.add_parser("workbench", help="Start the local Review Workbench.")
+    workbench.add_argument("--host", default="127.0.0.1")
+    workbench.add_argument("--port", type=int, default=8000)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    home = args.home.expanduser()
+
+    if args.command == "say":
+        agent = MiniAgent(
+            home,
+            memory_interval=args.memory_interval,
+            skill_interval=args.skill_interval,
+            review_engine=review_engine_from_args(args),
+        )
+        result = agent.chat(args.text, tool_iterations=args.tool_iterations)
+        print(result.response)
+        if result.review.memory_saved or result.review.skills_created:
+            print(
+                "review: "
+                f"memory_saved={result.review.memory_saved}, "
+                f"skills_created={result.review.skills_created}"
+            )
+        return 0
+
+    if args.command == "context":
+        print(MiniAgent(home).context())
+        return 0
+
+    if args.command == "memory":
+        store = MemoryStore(home).load()
+        for entry in store.entries(args.target):
+            print(f"- {entry}")
+        return 0
+
+    if args.command == "skills":
+        store = SkillStore(home)
+        if args.skills_command == "list":
+            for name in store.list_names():
+                print(name)
+            return 0
+        print(store.view(args.name), end="")
+        return 0
+
+    if args.command == "search":
+        db = SessionDB(home / "state.db")
+        for message in db.search_messages(args.query):
+            print(f"{message.session_id} {message.role}: {message.content}")
+        return 0
+
+    if args.command == "workbench":
+        serve_workbench(host=args.host, port=args.port)
+        return 0
+
+    return 1
+
+
+def review_engine_from_args(args):
+    if args.reviewer == "ollama":
+        return OllamaReviewEngine(
+            model=args.model,
+            base_url=args.ollama_url,
+            timeout_seconds=args.timeout,
+        )
+    return None

--- a/minchoagnt/comp_adapter.py
+++ b/minchoagnt/comp_adapter.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from comp.compiler_tool import (
+    CompileReport,
+    CompilerTool,
+    InterpretationHypothesis,
+    compile_report_to_facts,
+)
+from comp.judgment import CommitReceipt, Fact, JudgmentState, SubjectRef
+
+
+@dataclass(frozen=True)
+class CompCompileResult:
+    hypothesis: InterpretationHypothesis
+    subject: SubjectRef
+    report: CompileReport
+    judgment: JudgmentState = field(default_factory=JudgmentState)
+    receipt: CommitReceipt | None = None
+
+
+class CompCompilerAdapter:
+    """Agent-side adapter for calling comp without gaining comp authority."""
+
+    def __init__(
+        self,
+        compiler: CompilerTool | None = None,
+        *,
+        allowed_units: frozenset[str] | None = None,
+        known_fields: frozenset[str] | None = None,
+    ):
+        if compiler is not None:
+            self.compiler = compiler
+            return
+
+        options = {}
+        if allowed_units is not None:
+            options["allowed_units"] = allowed_units
+        if known_fields is not None:
+            options["known_fields"] = known_fields
+        self.compiler = CompilerTool(**options)
+
+    def compile(self, hypothesis: InterpretationHypothesis) -> CompCompileResult:
+        subject = SubjectRef("claim", hypothesis.hypothesis_id)
+        report = self.compiler.compile_interpretation(hypothesis)
+        return CompCompileResult(
+            hypothesis=hypothesis,
+            subject=subject,
+            report=report,
+        )
+
+    def record(self, result: CompCompileResult) -> set[Fact]:
+        facts = compile_report_to_facts(result.report, result.subject)
+        return result.judgment.add_facts(facts)
+
+
+__all__ = ["CompCompileResult", "CompCompilerAdapter"]

--- a/minchoagnt/memory.py
+++ b/minchoagnt/memory.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+Target = Literal["memory", "user"]
+ENTRY_DELIMITER = "\n§\n"
+
+
+class MemoryErrorBase(Exception):
+    """Base class for memory store errors."""
+
+
+class MemoryLimitError(MemoryErrorBase):
+    def __init__(self, message: str, current_entries: list[str]):
+        super().__init__(message)
+        self.current_entries = current_entries
+
+
+class MemoryMatchError(MemoryErrorBase):
+    """Raised when replace/remove cannot identify exactly one entry."""
+
+
+@dataclass(frozen=True)
+class MemoryUsage:
+    target: Target
+    chars: int
+    limit: int
+    entries: int
+
+
+class MemoryStore:
+    """Bounded file-backed memory with Hermes-style frozen snapshots."""
+
+    def __init__(
+        self,
+        home: Path | str,
+        memory_limit: int = 2200,
+        user_limit: int = 1375,
+    ):
+        self.home = Path(home)
+        self.memory_dir = self.home / "memories"
+        self.memory_limit = memory_limit
+        self.user_limit = user_limit
+        self._entries: dict[Target, list[str]] = {"memory": [], "user": []}
+        self._snapshot: dict[Target, str | None] = {"memory": None, "user": None}
+
+    def load(self) -> "MemoryStore":
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
+        self._entries["memory"] = self._read_entries(self._path_for("memory"))
+        self._entries["user"] = self._read_entries(self._path_for("user"))
+        self._snapshot["memory"] = self._render_snapshot("memory")
+        self._snapshot["user"] = self._render_snapshot("user")
+        return self
+
+    def entries(self, target: Target) -> list[str]:
+        self._validate_target(target)
+        return list(self._entries[target])
+
+    def snapshot(self, target: Target) -> str | None:
+        self._validate_target(target)
+        return self._snapshot[target]
+
+    def usage(self, target: Target) -> MemoryUsage:
+        self._validate_target(target)
+        return MemoryUsage(
+            target=target,
+            chars=self._char_count(target),
+            limit=self._limit_for(target),
+            entries=len(self._entries[target]),
+        )
+
+    def add(self, target: Target, content: str) -> bool:
+        self._validate_target(target)
+        entry = self._clean(content)
+        if entry in self._entries[target]:
+            return False
+        proposed = self._entries[target] + [entry]
+        self._ensure_within_limit(target, proposed)
+        self._entries[target] = proposed
+        self._save(target)
+        return True
+
+    def replace(self, target: Target, old_text: str, content: str) -> None:
+        self._validate_target(target)
+        old = self._clean(old_text)
+        new_entry = self._clean(content)
+        index = self._unique_match_index(target, old)
+        proposed = list(self._entries[target])
+        proposed[index] = new_entry
+        self._ensure_within_limit(target, proposed)
+        self._entries[target] = proposed
+        self._save(target)
+
+    def remove(self, target: Target, old_text: str) -> None:
+        self._validate_target(target)
+        old = self._clean(old_text)
+        index = self._unique_match_index(target, old)
+        entries = list(self._entries[target])
+        entries.pop(index)
+        self._entries[target] = entries
+        self._save(target)
+
+    def _unique_match_index(self, target: Target, old_text: str) -> int:
+        matches = [i for i, entry in enumerate(self._entries[target]) if old_text in entry]
+        if len(matches) != 1:
+            raise MemoryMatchError(
+                f"Expected one memory entry to match {old_text!r}, found {len(matches)}."
+            )
+        return matches[0]
+
+    def _save(self, target: Target) -> None:
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
+        self._atomic_write(self._path_for(target), ENTRY_DELIMITER.join(self._entries[target]))
+
+    def _ensure_within_limit(self, target: Target, entries: list[str]) -> None:
+        total = len(ENTRY_DELIMITER.join(entries))
+        limit = self._limit_for(target)
+        if total > limit:
+            raise MemoryLimitError(
+                f"{target} memory would be {total}/{limit} chars.",
+                current_entries=list(self._entries[target]),
+            )
+
+    def _render_snapshot(self, target: Target) -> str | None:
+        entries = self._entries[target]
+        if not entries:
+            return None
+        usage = self.usage(target)
+        label = "USER PROFILE" if target == "user" else "MEMORY"
+        bar = "=" * 46
+        body = ENTRY_DELIMITER.join(entries)
+        return f"{bar}\n{label} [{usage.chars}/{usage.limit} chars]\n{bar}\n{body}"
+
+    def _path_for(self, target: Target) -> Path:
+        filename = "USER.md" if target == "user" else "MEMORY.md"
+        return self.memory_dir / filename
+
+    def _limit_for(self, target: Target) -> int:
+        return self.user_limit if target == "user" else self.memory_limit
+
+    def _char_count(self, target: Target) -> int:
+        return len(ENTRY_DELIMITER.join(self._entries[target]))
+
+    @staticmethod
+    def _read_entries(path: Path) -> list[str]:
+        if not path.exists():
+            return []
+        raw = path.read_text(encoding="utf-8")
+        entries = [entry.strip() for entry in raw.split(ENTRY_DELIMITER)]
+        return list(dict.fromkeys(entry for entry in entries if entry))
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".memory-", suffix=".tmp", dir=path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def _clean(value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Memory content cannot be empty.")
+        return cleaned
+
+    @staticmethod
+    def _validate_target(target: str) -> None:
+        if target not in {"memory", "user"}:
+            raise ValueError("target must be 'memory' or 'user'.")

--- a/minchoagnt/ollama.py
+++ b/minchoagnt/ollama.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Protocol, Sequence
+
+from minchoagnt.review import ReviewPlan
+from minchoagnt.sessions import Message
+
+
+class OllamaClientProtocol(Protocol):
+    def post_json(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        """POST JSON to an Ollama-compatible endpoint and return decoded JSON."""
+
+
+class OllamaHTTPClient:
+    """Small stdlib HTTP client for Ollama's `/api/chat` endpoint."""
+
+    def post_json(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read().decode("utf-8")
+        decoded = json.loads(body)
+        if not isinstance(decoded, dict):
+            raise ValueError("Ollama response JSON must be an object.")
+        return decoded
+
+
+class OllamaReviewEngine:
+    """ReviewEngine implementation backed by an Ollama local chat model."""
+
+    def __init__(
+        self,
+        model: str,
+        base_url: str = "http://127.0.0.1:11434",
+        client: OllamaClientProtocol | None = None,
+        timeout_seconds: float = 30,
+        temperature: float = 0,
+    ):
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.client = client if client is not None else OllamaHTTPClient()
+        self.timeout_seconds = timeout_seconds
+        self.temperature = temperature
+        self.last_error: str | None = None
+
+    def review(
+        self,
+        messages: Sequence[Message],
+        review_memory: bool = True,
+        review_skills: bool = True,
+    ) -> ReviewPlan:
+        self.last_error = None
+        try:
+            response = self.client.post_json(
+                f"{self.base_url}/api/chat",
+                self._payload(messages, review_memory, review_skills),
+                self.timeout_seconds,
+            )
+            plan = ReviewPlan.from_json(self._content_from_response(response))
+            return self._filter_plan(plan, review_memory, review_skills)
+        except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+            self.last_error = str(exc)
+            return ReviewPlan()
+
+    def _payload(
+        self,
+        messages: Sequence[Message],
+        review_memory: bool,
+        review_skills: bool,
+    ) -> dict[str, Any]:
+        return {
+            "model": self.model,
+            "stream": False,
+            "format": "json",
+            "options": {"temperature": self.temperature},
+            "messages": [
+                {"role": "system", "content": self._system_prompt()},
+                {
+                    "role": "user",
+                    "content": self._review_prompt(messages, review_memory, review_skills),
+                },
+            ],
+        }
+
+    @staticmethod
+    def _content_from_response(response: dict[str, Any]) -> str:
+        message = response.get("message")
+        if not isinstance(message, dict):
+            raise ValueError("Ollama response is missing message object.")
+        content = message.get("content")
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError("Ollama response message.content must be a non-empty string.")
+        return content
+
+    @staticmethod
+    def _filter_plan(
+        plan: ReviewPlan,
+        review_memory: bool,
+        review_skills: bool,
+    ) -> ReviewPlan:
+        return ReviewPlan(
+            memory_additions=plan.memory_additions if review_memory else [],
+            skill_creations=plan.skill_creations if review_skills else [],
+        )
+
+    @staticmethod
+    def _system_prompt() -> str:
+        return """You are a background review engine for a local agent.
+Return only JSON. Do not wrap the JSON in markdown.
+
+The JSON must match this shape:
+{
+  "memory_additions": [
+    {
+      "target": "user" or "memory",
+      "content": "durable fact to remember",
+      "evidence": "short exact evidence from the conversation"
+    }
+  ],
+  "skill_creations": [
+    {
+      "name": "safe skill name",
+      "content": "complete SKILL.md markdown",
+      "category": "learned",
+      "evidence": "short exact evidence from the conversation"
+    }
+  ]
+}
+
+Use target "user" for stable user preferences or profile facts.
+Use target "memory" for stable project, environment, or workflow facts.
+Only include items that are durable enough to be useful in future sessions."""
+
+    @staticmethod
+    def _review_prompt(
+        messages: Sequence[Message],
+        review_memory: bool,
+        review_skills: bool,
+    ) -> str:
+        flags = (
+            f"review_memory={str(review_memory).lower()}\n"
+            f"review_skills={str(review_skills).lower()}"
+        )
+        conversation = "\n".join(
+            f"{message.role}: {message.content}" for message in messages
+        )
+        return f"""{flags}
+
+If review_memory=false, return an empty memory_additions list.
+If review_skills=false, return an empty skill_creations list.
+
+Conversation:
+{conversation}"""

--- a/minchoagnt/review.py
+++ b/minchoagnt/review.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Protocol, Sequence
+
+from minchoagnt.sessions import Message
+
+VALID_MEMORY_TARGETS = {"memory", "user"}
+SAFE_SKILL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _-]{0,79}$")
+SAFE_CATEGORY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,79}$")
+
+
+class ReviewPlanValidationError(ValueError):
+    """Raised when reviewer output cannot be converted into a safe ReviewPlan."""
+
+
+@dataclass(frozen=True)
+class MemoryAddition:
+    target: str
+    content: str
+    evidence: str | None = None
+
+    def __post_init__(self) -> None:
+        target = _required_text(self.target, "memory target")
+        if target not in VALID_MEMORY_TARGETS:
+            raise ReviewPlanValidationError(
+                f"memory target must be one of {sorted(VALID_MEMORY_TARGETS)}, got {self.target!r}."
+            )
+        object.__setattr__(self, "target", target)
+        object.__setattr__(self, "content", _required_text(self.content, "memory content"))
+        object.__setattr__(self, "evidence", _optional_text(self.evidence, "memory evidence"))
+
+    def to_dict(self) -> dict[str, str]:
+        data = {"target": self.target, "content": self.content}
+        if self.evidence is not None:
+            data["evidence"] = self.evidence
+        return data
+
+
+@dataclass(frozen=True)
+class SkillCreation:
+    name: str
+    content: str
+    category: str | None = "learned"
+    evidence: str | None = None
+
+    def __post_init__(self) -> None:
+        name = _required_text(self.name, "skill name")
+        if not SAFE_SKILL_NAME.fullmatch(name):
+            raise ReviewPlanValidationError(
+                "skill name must start with a letter or number and contain only letters, "
+                "numbers, spaces, underscores, or hyphens."
+            )
+        category = _optional_text(self.category, "skill category")
+        if category is not None and not SAFE_CATEGORY.fullmatch(category):
+            raise ReviewPlanValidationError(
+                "skill category must start with a letter or number and contain only letters, "
+                "numbers, underscores, or hyphens."
+            )
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "content", _required_text(self.content, "skill content"))
+        object.__setattr__(self, "category", category)
+        object.__setattr__(self, "evidence", _optional_text(self.evidence, "skill evidence"))
+
+    def to_dict(self) -> dict[str, str]:
+        data = {"name": self.name, "content": self.content}
+        if self.category is not None:
+            data["category"] = self.category
+        if self.evidence is not None:
+            data["evidence"] = self.evidence
+        return data
+
+
+@dataclass
+class ReviewPlan:
+    memory_additions: list[MemoryAddition] = field(default_factory=list)
+    skill_creations: list[SkillCreation] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.memory_additions = [
+            item if isinstance(item, MemoryAddition) else _memory_from_dict(item)
+            for item in self.memory_additions
+        ]
+        self.skill_creations = [
+            item if isinstance(item, SkillCreation) else _skill_from_dict(item)
+            for item in self.skill_creations
+        ]
+
+    @classmethod
+    def from_json(cls, raw: str) -> "ReviewPlan":
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ReviewPlanValidationError(f"ReviewPlan JSON is invalid: {exc.msg}.") from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ReviewPlan":
+        if not isinstance(data, dict):
+            raise ReviewPlanValidationError("ReviewPlan JSON must be an object.")
+        memory_additions = _list_field(data, "memory_additions")
+        skill_creations = _list_field(data, "skill_creations")
+        return cls(
+            memory_additions=[_memory_from_dict(item) for item in memory_additions],
+            skill_creations=[_skill_from_dict(item) for item in skill_creations],
+        )
+
+    def to_dict(self) -> dict[str, list[dict[str, str]]]:
+        return {
+            "memory_additions": [item.to_dict() for item in self.memory_additions],
+            "skill_creations": [item.to_dict() for item in self.skill_creations],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, sort_keys=True)
+
+
+class ReviewEngine(Protocol):
+    """Contract implemented by heuristic, fake, and future LLM reviewers."""
+
+    def review(
+        self,
+        messages: Sequence[Message],
+        review_memory: bool = True,
+        review_skills: bool = True,
+    ) -> ReviewPlan:
+        """Return memory and skill candidates extracted from conversation messages."""
+
+
+class RegexReviewEngine:
+    """Heuristic reviewer that mimics Hermes' background reflection slot."""
+
+    _remember = re.compile(r"\bremember(?:\s+that)?\s*[:\-]?\s*(.+)$", re.IGNORECASE)
+    _skill = re.compile(
+        r"\bskill\s*:\s*([a-zA-Z0-9 _-]+)\s*\|\s*(.+)$",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    def review(
+        self,
+        messages: Sequence[Message],
+        review_memory: bool = True,
+        review_skills: bool = True,
+    ) -> ReviewPlan:
+        plan = ReviewPlan()
+        for message in messages:
+            if message.role != "user":
+                continue
+            if review_memory:
+                addition = self._memory_from_text(message.content)
+                if addition:
+                    plan.memory_additions.append(addition)
+            if review_skills:
+                skill = self._skill_from_text(message.content)
+                if skill:
+                    plan.skill_creations.append(skill)
+        return plan
+
+    def _memory_from_text(self, text: str) -> MemoryAddition | None:
+        match = self._remember.search(text.strip())
+        if not match:
+            return None
+        fact = match.group(1).strip()
+        if not fact:
+            return None
+        target = "user" if self._looks_user_profile_fact(fact) else "memory"
+        return MemoryAddition(target=target, content=fact)
+
+    def _skill_from_text(self, text: str) -> SkillCreation | None:
+        match = self._skill.search(text.strip())
+        if not match:
+            return None
+        name = match.group(1).strip()
+        raw_steps = match.group(2).strip()
+        steps = [step.strip() for step in raw_steps.split(";") if step.strip()]
+        if not name or not steps:
+            return None
+        content = self._skill_content(name, steps)
+        return SkillCreation(name=name, content=content)
+
+    @staticmethod
+    def _looks_user_profile_fact(fact: str) -> bool:
+        lowered = fact.lower()
+        return any(
+            marker in lowered
+            for marker in [
+                "i prefer",
+                "my ",
+                "i use",
+                "i work",
+                "i am",
+                "i'm",
+                "me ",
+            ]
+        )
+
+    @staticmethod
+    def _skill_content(name: str, steps: list[str]) -> str:
+        slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", name.strip().lower()).strip("-")
+        title = slug.replace("-", " ").title()
+        numbered = "\n".join(f"{idx}. {step}" for idx, step in enumerate(steps, start=1))
+        return f"""---
+name: {slug}
+description: Agent-created workflow captured from conversation.
+---
+
+# {title}
+
+## When To Use
+
+Use this when the same workflow appears again.
+
+## Procedure
+
+{numbered}
+
+## Verification
+
+Confirm the final step completed and summarize any files, commands, or decisions involved.
+"""
+
+
+def _memory_from_dict(data: Any) -> MemoryAddition:
+    if not isinstance(data, dict):
+        raise ReviewPlanValidationError("memory_additions entries must be objects.")
+    return MemoryAddition(
+        target=_required_key(data, "target", "memory addition"),
+        content=_required_key(data, "content", "memory addition"),
+        evidence=data.get("evidence"),
+    )
+
+
+def _skill_from_dict(data: Any) -> SkillCreation:
+    if not isinstance(data, dict):
+        raise ReviewPlanValidationError("skill_creations entries must be objects.")
+    return SkillCreation(
+        name=_required_key(data, "name", "skill creation"),
+        content=_required_key(data, "content", "skill creation"),
+        category=data.get("category", "learned"),
+        evidence=data.get("evidence"),
+    )
+
+
+def _list_field(data: dict[str, Any], key: str) -> list[Any]:
+    value = data.get(key, [])
+    if not isinstance(value, list):
+        raise ReviewPlanValidationError(f"{key} must be a list.")
+    return value
+
+
+def _required_key(data: dict[str, Any], key: str, context: str) -> str:
+    if key not in data:
+        raise ReviewPlanValidationError(f"{context} is missing required field {key!r}.")
+    return _required_text(data[key], key)
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ReviewPlanValidationError(f"{field_name} must be a string.")
+    cleaned = value.strip()
+    if not cleaned:
+        raise ReviewPlanValidationError(f"{field_name} cannot be empty.")
+    return cleaned
+
+
+def _optional_text(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ReviewPlanValidationError(f"{field_name} must be a string when present.")
+    cleaned = value.strip()
+    return cleaned or None

--- a/minchoagnt/sessions.py
+++ b/minchoagnt/sessions.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Message:
+    id: int
+    session_id: str
+    role: str
+    content: str
+    timestamp: float
+
+
+class SessionDB:
+    """SQLite conversation log with a small search API."""
+
+    def __init__(self, db_path: Path | str):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def create_session(self, source: str = "cli") -> str:
+        session_id = uuid.uuid4().hex
+        with self._connection() as conn:
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                (session_id, source, time.time()),
+            )
+        return session_id
+
+    def append_message(self, session_id: str, role: str, content: str) -> int:
+        with self._connection() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO messages (session_id, role, content, timestamp)
+                VALUES (?, ?, ?, ?)
+                """,
+                (session_id, role, content, time.time()),
+            )
+            return int(cursor.lastrowid)
+
+    def get_messages(self, session_id: str) -> list[Message]:
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, session_id, role, content, timestamp
+                FROM messages
+                WHERE session_id = ?
+                ORDER BY timestamp, id
+                """,
+                (session_id,),
+            ).fetchall()
+        return [self._message(row) for row in rows]
+
+    def search_messages(self, query: str, limit: int = 20) -> list[Message]:
+        needle = query.strip()
+        if not needle:
+            return []
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, session_id, role, content, timestamp
+                FROM messages
+                WHERE lower(content) LIKE lower(?)
+                ORDER BY timestamp DESC, id DESC
+                LIMIT ?
+                """,
+                (f"%{needle}%", limit),
+            ).fetchall()
+        return [self._message(row) for row in rows]
+
+    def _init_schema(self) -> None:
+        with self._connection() as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    started_at REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL REFERENCES sessions(id),
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    timestamp REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp)"
+            )
+
+    @contextmanager
+    def _connection(self):
+        conn = self._connect()
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    @staticmethod
+    def _message(row: sqlite3.Row) -> Message:
+        return Message(
+            id=int(row["id"]),
+            session_id=str(row["session_id"]),
+            role=str(row["role"]),
+            content=str(row["content"]),
+            timestamp=float(row["timestamp"]),
+        )

--- a/minchoagnt/skills.py
+++ b/minchoagnt/skills.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class SkillError(Exception):
+    """Base class for skill store errors."""
+
+
+class SkillExistsError(SkillError):
+    """Raised when creating a skill that already exists."""
+
+
+class SkillMatchError(SkillError):
+    """Raised when a patch target is missing or ambiguous."""
+
+
+@dataclass(frozen=True)
+class Skill:
+    name: str
+    path: Path
+    category: str | None = None
+    description: str = ""
+
+
+class SkillStore:
+    """File-backed procedural memory stored as SKILL.md documents."""
+
+    def __init__(self, home: Path | str):
+        self.home = Path(home)
+        self.skills_dir = self.home / "skills"
+
+    def create(self, name: str, content: str, category: str | None = None) -> Skill:
+        slug = self._slug(name)
+        if self._find_path(slug):
+            raise SkillExistsError(f"Skill {slug!r} already exists.")
+        skill_dir = self._directory_for(slug, category)
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        path = skill_dir / "SKILL.md"
+        self._atomic_write(path, content.strip() + "\n")
+        return self._skill_from_path(path)
+
+    def list_names(self) -> list[str]:
+        if not self.skills_dir.exists():
+            return []
+        names = [path.parent.name for path in self.skills_dir.rglob("SKILL.md")]
+        return sorted(dict.fromkeys(names))
+
+    def view(self, name: str) -> str:
+        path = self._require_path(name)
+        return path.read_text(encoding="utf-8")
+
+    def patch(self, name: str, old_string: str, new_string: str) -> None:
+        path = self._require_path(name)
+        content = path.read_text(encoding="utf-8")
+        count = content.count(old_string)
+        if count != 1:
+            raise SkillMatchError(
+                f"Expected one match for {old_string!r} in {name!r}, found {count}."
+            )
+        self._atomic_write(path, content.replace(old_string, new_string, 1))
+
+    def _directory_for(self, slug: str, category: str | None) -> Path:
+        if category:
+            return self.skills_dir / self._slug(category) / slug
+        return self.skills_dir / slug
+
+    def _require_path(self, name: str) -> Path:
+        path = self._find_path(self._slug(name))
+        if path is None:
+            raise FileNotFoundError(f"Skill {name!r} does not exist.")
+        return path
+
+    def _find_path(self, slug: str) -> Path | None:
+        direct = self.skills_dir / slug / "SKILL.md"
+        if direct.exists():
+            return direct
+        if not self.skills_dir.exists():
+            return None
+        for path in self.skills_dir.rglob("SKILL.md"):
+            if path.parent.name == slug:
+                return path
+        return None
+
+    def _skill_from_path(self, path: Path) -> Skill:
+        category = None
+        try:
+            relative = path.parent.relative_to(self.skills_dir)
+            if len(relative.parts) > 1:
+                category = relative.parts[0]
+        except ValueError:
+            category = None
+        return Skill(
+            name=path.parent.name,
+            path=path,
+            category=category,
+            description=self._description(path.read_text(encoding="utf-8")),
+        )
+
+    @staticmethod
+    def _description(content: str) -> str:
+        match = re.search(r"^description:\s*(.+)$", content, flags=re.MULTILINE)
+        return match.group(1).strip().strip('"') if match else ""
+
+    @staticmethod
+    def _slug(value: str) -> str:
+        slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip().lower()).strip("-")
+        if not slug:
+            raise ValueError("Skill name cannot be empty.")
+        return slug
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".skill-", suffix=".tmp", dir=path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise

--- a/minchoagnt/web.py
+++ b/minchoagnt/web.py
@@ -1,0 +1,648 @@
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from minchoagnt.ollama import OllamaReviewEngine
+from minchoagnt.workbench import ReviewWorkbench, WorkbenchRun
+
+
+WORKBENCH_HTML = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Review Workbench</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --ink: #18202a;
+      --muted: #667085;
+      --line: #d7dce3;
+      --accent: #0d766e;
+      --accent-dark: #0a5f59;
+      --warn: #9a6700;
+      --error: #b42318;
+      --ok: #067647;
+      --idle: #667085;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--ink);
+    }
+    button, input, textarea, select {
+      font: inherit;
+    }
+    .shell {
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto 1fr minmax(112px, 22vh);
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--line);
+      background: #ffffff;
+    }
+    h1 {
+      margin: 0;
+      font-size: 18px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+    .status {
+      min-width: 128px;
+      text-align: right;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    main {
+      display: grid;
+      grid-template-columns: minmax(260px, 360px) minmax(360px, 1fr) minmax(320px, 460px);
+      min-height: 0;
+    }
+    section {
+      min-width: 0;
+      min-height: 0;
+      padding: 16px;
+      border-right: 1px solid var(--line);
+    }
+    section:last-child { border-right: 0; }
+    .section-title {
+      margin: 0 0 12px;
+      font-size: 13px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .08em;
+    }
+    .builder {
+      display: grid;
+      grid-template-rows: auto auto auto 1fr;
+      gap: 14px;
+      background: var(--panel);
+    }
+    label {
+      display: block;
+      margin-bottom: 6px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    textarea {
+      width: 100%;
+      min-height: 136px;
+      resize: vertical;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+      color: var(--ink);
+      background: #fff;
+    }
+    input, select {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 9px 10px;
+      color: var(--ink);
+      background: #fff;
+    }
+    .actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+    }
+    button {
+      border: 1px solid transparent;
+      border-radius: 8px;
+      padding: 10px 12px;
+      color: #fff;
+      background: var(--accent);
+      cursor: pointer;
+      min-height: 42px;
+    }
+    button:hover { background: var(--accent-dark); }
+    button:disabled {
+      cursor: not-allowed;
+      color: #98a2b3;
+      border-color: var(--line);
+      background: #eef1f5;
+    }
+    .target {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      color: var(--muted);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #fbfcfd;
+      font-size: 13px;
+    }
+    .graph {
+      display: grid;
+      align-content: start;
+      gap: 12px;
+    }
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(116px, 1fr));
+      gap: 10px;
+      align-items: stretch;
+    }
+    .node {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      padding: 12px;
+      text-align: left;
+      min-height: 96px;
+      color: var(--ink);
+    }
+    .node strong {
+      display: block;
+      font-size: 14px;
+      margin-bottom: 8px;
+    }
+    .node span {
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 12px;
+      color: #fff;
+      background: var(--idle);
+    }
+    .node[data-status="success"] span { background: var(--ok); }
+    .node[data-status="running"] span { background: var(--accent); }
+    .node[data-status="no-op"] span { background: var(--warn); }
+    .node[data-status="error"] span { background: var(--error); }
+    .node.selected {
+      border-color: var(--accent);
+      outline: 2px solid rgba(13, 118, 110, .16);
+    }
+    .operation {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+    }
+    .operation div {
+      min-height: 64px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+      padding: 10px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .operation strong {
+      display: block;
+      color: var(--ink);
+      font-size: 16px;
+      margin-bottom: 4px;
+    }
+    .detail {
+      background: var(--panel);
+    }
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      min-height: 360px;
+      max-height: calc(100vh - 240px);
+      background: #101828;
+      color: #eef4ff;
+      font-size: 12px;
+      line-height: 1.55;
+    }
+    footer {
+      min-height: 0;
+      border-top: 1px solid var(--line);
+      background: #ffffff;
+      padding: 12px 16px;
+      overflow: auto;
+    }
+    .log {
+      display: grid;
+      gap: 6px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      font-size: 13px;
+    }
+    .log li {
+      display: grid;
+      grid-template-columns: 96px 92px 1fr;
+      gap: 10px;
+      align-items: start;
+      color: var(--muted);
+    }
+    @media (max-width: 980px) {
+      main {
+        grid-template-columns: 1fr;
+      }
+      section {
+        border-right: 0;
+        border-bottom: 1px solid var(--line);
+      }
+      .flow {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <header>
+      <h1>Review Workbench</h1>
+      <div class="status" id="status">Sandbox</div>
+    </header>
+    <main>
+      <section class="builder">
+        <h2 class="section-title">Command Builder</h2>
+        <div>
+          <label for="message">UserMessage</label>
+          <textarea id="message">remember: I prefer Korean summaries.</textarea>
+        </div>
+        <div>
+          <label for="reviewer">Reviewer @ Target</label>
+          <select id="reviewer">
+            <option value="regex">regex</option>
+            <option value="fake">fake</option>
+            <option value="ollama">ollama</option>
+          </select>
+        </div>
+        <div>
+          <label for="model">Ollama Model</label>
+          <input id="model" value="qwen2.5:7b">
+        </div>
+        <div>
+          <label for="base-url">Ollama Base URL</label>
+          <input id="base-url" value="http://127.0.0.1:11434">
+        </div>
+        <div>
+          <label for="timeout">Ollama Timeout</label>
+          <input id="timeout" type="number" min="0.1" step="0.1" value="30">
+        </div>
+        <div class="actions">
+          <button id="review">~ Review</button>
+          <button id="apply" disabled>! Apply</button>
+        </div>
+        <div>
+          <label for="expect-target">Expect Target</label>
+          <select id="expect-target">
+            <option value="user">user memory</option>
+            <option value="memory">memory</option>
+            <option value="skills">skills</option>
+            <option value="review_plan">review plan</option>
+          </select>
+        </div>
+        <div>
+          <label for="expect-contains">Expect Contains</label>
+          <input id="expect-contains" value="Korean summaries">
+        </div>
+        <div class="actions">
+          <button id="expect" disabled>? Verify</button>
+        </div>
+        <div class="target">
+          <span>? Verify</span>
+          <strong id="verify">pending</strong>
+        </div>
+      </section>
+      <section class="graph">
+        <h2 class="section-title">Review Graph</h2>
+        <div class="flow" id="graph"></div>
+        <div class="operation">
+          <div><strong>~</strong>review input</div>
+          <div><strong>!</strong>apply plan</div>
+          <div><strong>?</strong>inspect diff</div>
+        </div>
+      </section>
+      <section class="detail">
+        <h2 class="section-title" id="detail-title">Detail</h2>
+        <pre id="detail">{}</pre>
+      </section>
+    </main>
+    <footer>
+      <h2 class="section-title">Execution Log</h2>
+      <ul class="log" id="log"></ul>
+    </footer>
+  </div>
+  <script>
+    const nodes = ["UserMessage", "ReviewEngine", "ReviewPlan", "StateDiff"];
+    let currentRun = null;
+    let selectedNode = "UserMessage";
+
+    function setStatus(text) {
+      document.getElementById("status").textContent = text;
+    }
+
+    function render(run) {
+      currentRun = run;
+      const graph = document.getElementById("graph");
+      graph.innerHTML = "";
+      nodes.forEach((name) => {
+        const button = document.createElement("button");
+        button.className = "node" + (selectedNode === name ? " selected" : "");
+        button.dataset.status = run.node_status[name] || "pending";
+        button.innerHTML = `<strong>${name}</strong><span>${run.node_status[name] || "pending"}</span>`;
+        button.addEventListener("click", () => {
+          selectedNode = name;
+          render(currentRun);
+        });
+        graph.appendChild(button);
+      });
+      document.getElementById("apply").disabled = !run.run_id;
+      document.getElementById("expect").disabled = !run.run_id;
+      document.getElementById("verify").textContent = verifyLabel(run);
+      document.getElementById("detail-title").textContent = selectedNode;
+      document.getElementById("detail").textContent = JSON.stringify(detailFor(run, selectedNode), null, 2);
+      const log = document.getElementById("log");
+      log.innerHTML = "";
+      run.events.forEach((event) => {
+        const item = document.createElement("li");
+        item.innerHTML = `<strong>${event.step}</strong><span>${event.status}</span><span>${event.message}</span>`;
+        log.appendChild(item);
+      });
+    }
+
+    function detailFor(run, node) {
+      if (node === "UserMessage") return run.input;
+      if (node === "ReviewEngine") return run.reviewer;
+      if (node === "ReviewPlan") return run.review_plan;
+      return { apply_result: run.apply_result, diff: run.diff, check_result: run.check_result };
+    }
+
+    function verifyLabel(run) {
+      if (run.check_result && run.check_result.message !== "not run") {
+        return run.check_result.passed ? "pass" : "fail";
+      }
+      return run.node_status.StateDiff || "pending";
+    }
+
+    async function postJSON(path, payload) {
+      const response = await fetch(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "request failed");
+      return data;
+    }
+
+    document.getElementById("review").addEventListener("click", async () => {
+      try {
+        setStatus("Reviewing");
+        selectedNode = "ReviewPlan";
+        const run = await postJSON("/api/review", {
+          message: document.getElementById("message").value,
+          reviewer: document.getElementById("reviewer").value,
+          model: document.getElementById("model").value,
+          base_url: document.getElementById("base-url").value,
+          timeout: Number(document.getElementById("timeout").value),
+        });
+        render(run);
+        setStatus("Review ready");
+      } catch (error) {
+        setStatus(error.message);
+      }
+    });
+
+    document.getElementById("apply").addEventListener("click", async () => {
+      if (!currentRun) return;
+      try {
+        setStatus("Applying");
+        selectedNode = "StateDiff";
+        const run = await postJSON("/api/apply", { run_id: currentRun.run_id });
+        render(run);
+        setStatus("Applied");
+      } catch (error) {
+        setStatus(error.message);
+      }
+    });
+
+    document.getElementById("expect").addEventListener("click", async () => {
+      if (!currentRun) return;
+      try {
+        setStatus("Verifying");
+        selectedNode = "StateDiff";
+        const run = await postJSON("/api/expect", {
+          run_id: currentRun.run_id,
+          target: document.getElementById("expect-target").value,
+          contains: document.getElementById("expect-contains").value,
+        });
+        render(run);
+        setStatus(run.check_result.passed ? "Verify passed" : "Verify failed");
+      } catch (error) {
+        setStatus(error.message);
+      }
+    });
+  </script>
+</body>
+</html>
+"""
+
+
+class WorkbenchRequestHandler(BaseHTTPRequestHandler):
+    workbench: ReviewWorkbench
+    runs: dict[str, WorkbenchRun]
+
+    def do_GET(self) -> None:
+        if self.path in {"/", "/index.html"}:
+            self._send(HTTPStatus.OK, WORKBENCH_HTML, "text/html; charset=utf-8")
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        try:
+            payload = self._read_json()
+        except ValueError:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid JSON"})
+            return
+
+        if self.path == "/api/review":
+            self._handle_review(payload)
+            return
+        if self.path == "/api/apply":
+            self._handle_apply(payload)
+            return
+        if self.path == "/api/expect":
+            self._handle_expect(payload)
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+    def _handle_review(self, payload: dict[str, Any]) -> None:
+        message = payload.get("message")
+        reviewer = payload.get("reviewer", "regex")
+        if not isinstance(message, str) or not message.strip():
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "message is required"})
+            return
+        if reviewer not in {"regex", "fake", "ollama"}:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"error": "reviewer must be regex, fake, or ollama"},
+            )
+            return
+        try:
+            reviewer_config, review_engine = self._reviewer_options(reviewer, payload)
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        if reviewer != self.workbench.reviewer_type or reviewer_config != self.workbench.reviewer_config:
+            self.workbench.close()
+            type(self).workbench = ReviewWorkbench.sandbox(
+                reviewer_type=reviewer,
+                review_engine=review_engine,
+                reviewer_config=reviewer_config,
+            )
+            type(self).runs = {}
+        run = self.workbench.review(message)
+        self.runs[run.run_id] = run
+        self._send_json(HTTPStatus.OK, run.to_dict())
+
+    def _handle_apply(self, payload: dict[str, Any]) -> None:
+        run_id = payload.get("run_id")
+        if not isinstance(run_id, str):
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "run_id is required"})
+            return
+        run = self.runs.get(run_id)
+        if run is None:
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "run not found"})
+            return
+        applied = self.workbench.apply(run)
+        self.runs[run_id] = applied
+        self._send_json(HTTPStatus.OK, applied.to_dict())
+
+    def _handle_expect(self, payload: dict[str, Any]) -> None:
+        run_id = payload.get("run_id")
+        target = payload.get("target")
+        contains = payload.get("contains")
+        if not isinstance(run_id, str):
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "run_id is required"})
+            return
+        if not isinstance(target, str):
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "target is required"})
+            return
+        if not isinstance(contains, str) or not contains.strip():
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "contains cannot be empty"})
+            return
+        run = self.runs.get(run_id)
+        if run is None:
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "run not found"})
+            return
+        try:
+            checked = self.workbench.expect(run, target=target, contains=contains)
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        self.runs[run_id] = checked
+        self._send_json(HTTPStatus.OK, checked.to_dict())
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw.decode("utf-8") if raw else "{}")
+        except json.JSONDecodeError as exc:
+            raise ValueError("invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("invalid JSON")
+        return payload
+
+    def _reviewer_options(
+        self,
+        reviewer: str,
+        payload: dict[str, Any],
+    ) -> tuple[dict[str, Any], object | None]:
+        if reviewer != "ollama":
+            return {}, None
+        model = _text_option(payload.get("model"), "qwen2.5:7b")
+        base_url = _text_option(payload.get("base_url"), "http://127.0.0.1:11434")
+        timeout_seconds = _timeout_option(payload.get("timeout"), 30)
+        config = {
+            "model": model,
+            "base_url": base_url,
+            "timeout_seconds": timeout_seconds,
+        }
+        return (
+            config,
+            OllamaReviewEngine(
+                model=model,
+                base_url=base_url,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    def _send(self, status: HTTPStatus, body: str, content_type: str) -> None:
+        encoded = body.encode("utf-8")
+        self.send_response(int(status))
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        self._send(status, json.dumps(payload, ensure_ascii=False), "application/json")
+
+
+def create_workbench_handler(
+    workbench: ReviewWorkbench | None = None,
+) -> type[WorkbenchRequestHandler]:
+    selected_workbench = workbench if workbench is not None else ReviewWorkbench.sandbox()
+
+    class Handler(WorkbenchRequestHandler):
+        workbench = selected_workbench
+        runs: dict[str, WorkbenchRun] = {}
+
+    return Handler
+
+
+def serve_workbench(host: str = "127.0.0.1", port: int = 8000) -> None:
+    server = ThreadingHTTPServer((host, port), create_workbench_handler())
+    address, selected_port = server.server_address
+    print(f"Review Workbench: http://{address}:{selected_port}/")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+def _text_option(value: Any, default: str) -> str:
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise ValueError("Ollama options must be strings")
+    cleaned = value.strip()
+    return cleaned or default
+
+
+def _timeout_option(value: Any, default: float) -> float:
+    if value is None:
+        return default
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("timeout must be a number") from exc
+    if timeout <= 0:
+        raise ValueError("timeout must be greater than 0")
+    return timeout

--- a/minchoagnt/workbench.py
+++ b/minchoagnt/workbench.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Literal, Sequence
+
+from minchoagnt.memory import MemoryErrorBase, MemoryStore
+from minchoagnt.ollama import OllamaReviewEngine
+from minchoagnt.review import RegexReviewEngine, ReviewEngine, ReviewPlan
+from minchoagnt.sessions import Message
+from minchoagnt.skills import SkillError, SkillExistsError, SkillStore
+
+NodeStatus = Literal["pending", "running", "success", "error", "no-op"]
+
+
+@dataclass(frozen=True)
+class WorkbenchInput:
+    role: str
+    content: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"role": self.role, "content": self.content}
+
+
+@dataclass(frozen=True)
+class WorkbenchReviewer:
+    type: str
+    config: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.type, **self.config}
+
+
+@dataclass(frozen=True)
+class WorkbenchEvent:
+    step: str
+    status: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"step": self.step, "status": self.status, "message": self.message}
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    memory_saved: int = 0
+    memory_duplicates: int = 0
+    memory_failed: int = 0
+    skills_created: int = 0
+    skill_duplicates: int = 0
+    skill_failed: int = 0
+    empty_plan: bool = False
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, int | bool | list[str]]:
+        return {
+            "memory_saved": self.memory_saved,
+            "memory_duplicates": self.memory_duplicates,
+            "memory_failed": self.memory_failed,
+            "skills_created": self.skills_created,
+            "skill_duplicates": self.skill_duplicates,
+            "skill_failed": self.skill_failed,
+            "empty_plan": self.empty_plan,
+            "errors": list(self.errors),
+        }
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    target: str = ""
+    contains: str = ""
+    passed: bool = False
+    message: str = "not run"
+
+    def to_dict(self) -> dict[str, str | bool]:
+        return {
+            "target": self.target,
+            "contains": self.contains,
+            "passed": self.passed,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ListDiff:
+    added: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    unchanged: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, list[str]]:
+        return {
+            "added": list(self.added),
+            "removed": list(self.removed),
+            "unchanged": list(self.unchanged),
+        }
+
+
+@dataclass(frozen=True)
+class SkillDiff:
+    created: list[str] = field(default_factory=list)
+    unchanged: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, list[str]]:
+        return {"created": list(self.created), "unchanged": list(self.unchanged)}
+
+
+@dataclass(frozen=True)
+class WorkbenchDiff:
+    memory: ListDiff = field(default_factory=ListDiff)
+    user: ListDiff = field(default_factory=ListDiff)
+    skills: SkillDiff = field(default_factory=SkillDiff)
+
+    def to_dict(self) -> dict[str, dict[str, list[str]]]:
+        return {
+            "memory": self.memory.to_dict(),
+            "user": self.user.to_dict(),
+            "skills": self.skills.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class WorkbenchRun:
+    run_id: str
+    input: WorkbenchInput
+    reviewer: WorkbenchReviewer
+    review_plan: ReviewPlan
+    apply_result: ApplyResult = field(default_factory=ApplyResult)
+    diff: WorkbenchDiff = field(default_factory=WorkbenchDiff)
+    check_result: CheckResult = field(default_factory=CheckResult)
+    events: list[WorkbenchEvent] = field(default_factory=list)
+    node_status: dict[str, NodeStatus] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "input": self.input.to_dict(),
+            "reviewer": self.reviewer.to_dict(),
+            "review_plan": self.review_plan.to_dict(),
+            "apply_result": self.apply_result.to_dict(),
+            "diff": self.diff.to_dict(),
+            "check_result": self.check_result.to_dict(),
+            "events": [event.to_dict() for event in self.events],
+            "node_status": dict(self.node_status),
+        }
+
+
+class FakeReviewEngine:
+    """Deterministic reviewer for tests and future UI demos."""
+
+    def __init__(self, plan: ReviewPlan | None = None):
+        self.plan = plan if plan is not None else ReviewPlan()
+
+    def review(
+        self,
+        messages: Sequence[Message],
+        review_memory: bool = True,
+        review_skills: bool = True,
+    ) -> ReviewPlan:
+        plan = ReviewPlan.from_dict(self.plan.to_dict())
+        if not review_memory:
+            plan.memory_additions = []
+        if not review_skills:
+            plan.skill_creations = []
+        return plan
+
+
+class ReviewWorkbench:
+    """Runs the review/apply cycle behind the Review Workbench UI."""
+
+    def __init__(
+        self,
+        home: Path | str,
+        reviewer_type: str = "regex",
+        review_engine: ReviewEngine | None = None,
+        reviewer_config: dict[str, Any] | None = None,
+    ):
+        self.home = Path(home)
+        self.home.mkdir(parents=True, exist_ok=True)
+        self.reviewer_type = reviewer_type
+        self.reviewer_config = dict(reviewer_config or {})
+        self.review_engine = review_engine or self._reviewer_for(
+            reviewer_type, self.reviewer_config
+        )
+        self._run_count = 0
+        self._sandbox: tempfile.TemporaryDirectory[str] | None = None
+
+    @classmethod
+    def sandbox(
+        cls,
+        reviewer_type: str = "regex",
+        review_engine: ReviewEngine | None = None,
+        reviewer_config: dict[str, Any] | None = None,
+    ) -> "ReviewWorkbench":
+        sandbox = tempfile.TemporaryDirectory(prefix="minchoagnt-workbench-")
+        workbench = cls(
+            sandbox.name,
+            reviewer_type=reviewer_type,
+            review_engine=review_engine,
+            reviewer_config=reviewer_config,
+        )
+        workbench._sandbox = sandbox
+        return workbench
+
+    def close(self) -> None:
+        if self._sandbox is not None:
+            self._sandbox.cleanup()
+            self._sandbox = None
+
+    def review(self, user_text: str) -> WorkbenchRun:
+        self._run_count += 1
+        run_id = f"run_{self._run_count:03d}"
+        message = Message(
+            id=1,
+            session_id=run_id,
+            role="user",
+            content=user_text,
+            timestamp=0.0,
+        )
+        events = [
+            WorkbenchEvent("input", "success", "input received"),
+            WorkbenchEvent("reviewer", "success", "reviewer selected"),
+            WorkbenchEvent("review", "running", "review started"),
+        ]
+        plan = self.review_engine.review([message], review_memory=True, review_skills=True)
+        events.append(WorkbenchEvent("review", "success", "review completed"))
+        reviewer_config = dict(self.reviewer_config)
+        last_error = getattr(self.review_engine, "last_error", None)
+        if last_error:
+            reviewer_config["last_error"] = str(last_error)
+        return WorkbenchRun(
+            run_id=run_id,
+            input=WorkbenchInput(role="user", content=user_text),
+            reviewer=WorkbenchReviewer(
+                type=self.reviewer_type,
+                config=reviewer_config,
+            ),
+            review_plan=plan,
+            events=events,
+            node_status={
+                "UserMessage": "success",
+                "ReviewEngine": "success",
+                "ReviewPlan": "no-op" if _plan_is_empty(plan) else "success",
+                "StateDiff": "pending",
+            },
+        )
+
+    def apply(self, run: WorkbenchRun) -> WorkbenchRun:
+        events = list(run.events)
+        events.append(WorkbenchEvent("apply", "running", "apply started"))
+        before_memory = self._memory_entries()
+        before_skills = self._skill_names()
+
+        memory_saved = 0
+        memory_duplicates = 0
+        memory_failed = 0
+        skills_created = 0
+        skill_duplicates = 0
+        skill_failed = 0
+        errors: list[str] = []
+
+        memory = MemoryStore(self.home).load()
+        for addition in run.review_plan.memory_additions:
+            try:
+                if memory.add(addition.target, addition.content):  # type: ignore[arg-type]
+                    memory_saved += 1
+                    events.append(
+                        WorkbenchEvent("apply", "success", "memory addition saved")
+                    )
+                else:
+                    memory_duplicates += 1
+                    events.append(
+                        WorkbenchEvent("apply", "no-op", "memory addition duplicate")
+                    )
+            except (ValueError, MemoryErrorBase) as exc:
+                memory_failed += 1
+                errors.append(str(exc))
+                events.append(WorkbenchEvent("apply", "error", "memory addition rejected"))
+
+        skills = SkillStore(self.home)
+        for creation in run.review_plan.skill_creations:
+            try:
+                skills.create(creation.name, creation.content, category=creation.category)
+                skills_created += 1
+                events.append(WorkbenchEvent("apply", "success", "skill creation saved"))
+            except SkillExistsError:
+                skill_duplicates += 1
+                events.append(WorkbenchEvent("apply", "no-op", "skill creation duplicate"))
+            except (ValueError, SkillError) as exc:
+                skill_failed += 1
+                errors.append(str(exc))
+                events.append(WorkbenchEvent("apply", "error", "skill creation rejected"))
+
+        result = ApplyResult(
+            memory_saved=memory_saved,
+            memory_duplicates=memory_duplicates,
+            memory_failed=memory_failed,
+            skills_created=skills_created,
+            skill_duplicates=skill_duplicates,
+            skill_failed=skill_failed,
+            empty_plan=_plan_is_empty(run.review_plan),
+            errors=errors,
+        )
+        after_memory = self._memory_entries()
+        after_skills = self._skill_names()
+        diff = WorkbenchDiff(
+            memory=_list_diff(before_memory["memory"], after_memory["memory"]),
+            user=_list_diff(before_memory["user"], after_memory["user"]),
+            skills=SkillDiff(
+                created=_added(before_skills, after_skills),
+                unchanged=_unchanged(before_skills, after_skills),
+            ),
+        )
+        state_status = _state_status(result)
+        events.append(WorkbenchEvent("apply", state_status, "apply completed"))
+        return replace(
+            run,
+            apply_result=result,
+            diff=diff,
+            events=events,
+            node_status={
+                **run.node_status,
+                "StateDiff": state_status,
+            },
+        )
+
+    def expect(self, run: WorkbenchRun, target: str, contains: str) -> WorkbenchRun:
+        target = target.strip()
+        needle = contains.strip()
+        if target not in {"user", "memory", "skills", "review_plan"}:
+            raise ValueError("target must be user, memory, skills, or review_plan.")
+        if not needle:
+            raise ValueError("contains cannot be empty.")
+        haystack = _expectation_values(run, target)
+        passed = any(needle in value for value in haystack)
+        target_label = _target_label(target)
+        message = (
+            f"matched {target_label}"
+            if passed
+            else f"no match in {target_label}"
+        )
+        result = CheckResult(
+            target=target,
+            contains=needle,
+            passed=passed,
+            message=message,
+        )
+        events = list(run.events)
+        events.append(
+            WorkbenchEvent(
+                "expect",
+                "success" if passed else "no-op",
+                "? verify passed" if passed else "? verify failed",
+            )
+        )
+        return replace(run, check_result=result, events=events)
+
+    @staticmethod
+    def _reviewer_for(reviewer_type: str, config: dict[str, Any]) -> ReviewEngine:
+        if reviewer_type == "regex":
+            return RegexReviewEngine()
+        if reviewer_type == "fake":
+            return FakeReviewEngine()
+        if reviewer_type == "ollama":
+            return OllamaReviewEngine(
+                model=str(config.get("model", "qwen2.5:7b")),
+                base_url=str(config.get("base_url", "http://127.0.0.1:11434")),
+                timeout_seconds=float(config.get("timeout_seconds", 30)),
+            )
+        raise ValueError("reviewer_type must be 'regex', 'fake', or 'ollama'.")
+
+    def _memory_entries(self) -> dict[str, list[str]]:
+        memory = MemoryStore(self.home).load()
+        return {
+            "memory": memory.entries("memory"),
+            "user": memory.entries("user"),
+        }
+
+    def _skill_names(self) -> list[str]:
+        return SkillStore(self.home).list_names()
+
+
+def _plan_is_empty(plan: ReviewPlan) -> bool:
+    return not plan.memory_additions and not plan.skill_creations
+
+
+def _list_diff(before: list[str], after: list[str]) -> ListDiff:
+    return ListDiff(
+        added=_added(before, after),
+        removed=[entry for entry in before if entry not in after],
+        unchanged=_unchanged(before, after),
+    )
+
+
+def _added(before: list[str], after: list[str]) -> list[str]:
+    return [entry for entry in after if entry not in before]
+
+
+def _unchanged(before: list[str], after: list[str]) -> list[str]:
+    return [entry for entry in after if entry in before]
+
+
+def _state_status(result: ApplyResult) -> NodeStatus:
+    if result.memory_failed or result.skill_failed:
+        return "error"
+    if result.memory_saved or result.skills_created:
+        return "success"
+    return "no-op"
+
+
+def _expectation_values(run: WorkbenchRun, target: str) -> list[str]:
+    if target == "user":
+        return run.diff.user.added + run.diff.user.unchanged
+    if target == "memory":
+        return run.diff.memory.added + run.diff.memory.unchanged
+    if target == "skills":
+        return run.diff.skills.created + run.diff.skills.unchanged
+    return [run.review_plan.to_json()]
+
+
+def _target_label(target: str) -> str:
+    if target == "user":
+        return "user memory"
+    if target == "memory":
+        return "memory"
+    if target == "skills":
+        return "skills"
+    return "review plan"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,8 @@ packages = [
   "comp",
   "comp.compiler_tool",
   "comp.judgment",
+  "minchoagnt",
 ]
+
+[project.scripts]
+minchoagnt = "minchoagnt.cli:main"

--- a/tests/minchoagnt/test_agent_review.py
+++ b/tests/minchoagnt/test_agent_review.py
@@ -1,0 +1,95 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from minchoagnt.agent import MiniAgent
+from minchoagnt.memory import MemoryStore
+from minchoagnt.review import MemoryAddition, ReviewPlan
+from minchoagnt.skills import SkillStore
+
+
+class FakeReviewEngine:
+    def __init__(self):
+        self.calls = []
+
+    def review(self, messages, review_memory=True, review_skills=True):
+        self.calls.append((messages, review_memory, review_skills))
+        return ReviewPlan(
+            memory_additions=[
+                MemoryAddition(
+                    target="user",
+                    content="사용자는 한국어 요약을 선호한다.",
+                )
+            ],
+            skill_creations=[],
+        )
+
+
+class MiniAgentReviewTests(unittest.TestCase):
+    def test_review_engine_can_be_injected_for_deterministic_tests(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            reviewer = FakeReviewEngine()
+            agent = MiniAgent(home, memory_interval=1, review_engine=reviewer)
+
+            result = agent.chat("this text does not match regex review rules")
+
+            self.assertEqual(result.review.memory_saved, 1)
+            self.assertEqual(len(reviewer.calls), 1)
+            self.assertEqual(reviewer.calls[0][1:], (True, False))
+
+            memory = MemoryStore(home)
+            memory.load()
+            self.assertEqual(memory.entries("user"), ["사용자는 한국어 요약을 선호한다."])
+
+    def test_memory_review_runs_after_configured_user_turns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            agent = MiniAgent(home, memory_interval=2, skill_interval=99)
+
+            first = agent.chat("remember: I prefer Korean summaries.")
+            self.assertFalse(first.review.memory_saved)
+
+            second = agent.chat("hello again")
+            self.assertEqual(second.review.memory_saved, 1)
+
+            memory = MemoryStore(home)
+            memory.load()
+            self.assertEqual(memory.entries("user"), ["I prefer Korean summaries."])
+
+    def test_skill_review_creates_skill_after_tool_iteration_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            agent = MiniAgent(home, memory_interval=99, skill_interval=3)
+
+            result = agent.chat(
+                "skill: release-checklist | run tests; inspect git status; push branch",
+                tool_iterations=3,
+            )
+
+            self.assertEqual(result.review.skills_created, 1)
+
+            skills = SkillStore(home)
+            self.assertEqual(skills.list_names(), ["release-checklist"])
+            self.assertIn("inspect git status", skills.view("release-checklist"))
+
+    def test_context_includes_memory_snapshot_and_skill_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            memory = MemoryStore(home)
+            memory.load()
+            memory.add("memory", "Project conventions live in AGENTS.md.")
+            SkillStore(home).create("repo-review", "# Repo Review\n\nRead the tree first.")
+
+            agent = MiniAgent(home)
+
+            context = agent.context()
+
+            self.assertIn("MEMORY", context)
+            self.assertIn("Project conventions", context)
+            self.assertIn("Available skills", context)
+            self.assertIn("repo-review", context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_cli.py
+++ b/tests/minchoagnt/test_cli.py
@@ -1,0 +1,113 @@
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from minchoagnt import cli
+from minchoagnt.agent import ChatResult, ReviewSummary
+
+
+class FakeAgent:
+    instances = []
+
+    def __init__(self, home, memory_interval=10, skill_interval=10, review_engine=None):
+        self.home = home
+        self.memory_interval = memory_interval
+        self.skill_interval = skill_interval
+        self.review_engine = review_engine
+        self.chat_calls = []
+        self.__class__.instances.append(self)
+
+    def chat(self, text, tool_iterations=0):
+        self.chat_calls.append((text, tool_iterations))
+        return ChatResult(
+            session_id="session-1",
+            response="recorded",
+            review=ReviewSummary(memory_saved=0, skills_created=0),
+        )
+
+
+class FakeOllamaReviewEngine:
+    def __init__(self, model, base_url, timeout_seconds):
+        self.model = model
+        self.base_url = base_url
+        self.timeout_seconds = timeout_seconds
+
+
+class FakeWorkbenchServer:
+    calls = []
+
+    @classmethod
+    def serve(cls, host, port):
+        cls.calls.append((host, port))
+
+
+class CLITests(unittest.TestCase):
+    def setUp(self):
+        FakeAgent.instances = []
+        FakeWorkbenchServer.calls = []
+
+    def test_say_defaults_to_regex_reviewer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(cli, "MiniAgent", FakeAgent):
+                with redirect_stdout(io.StringIO()):
+                    exit_code = cli.main(["--home", tmp, "say", "hello"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(FakeAgent.instances[0].home, Path(tmp))
+        self.assertIsNone(FakeAgent.instances[0].review_engine)
+        self.assertEqual(FakeAgent.instances[0].chat_calls, [("hello", 0)])
+
+    def test_say_can_inject_ollama_reviewer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(cli, "MiniAgent", FakeAgent):
+                with patch.object(cli, "OllamaReviewEngine", FakeOllamaReviewEngine):
+                    with redirect_stdout(io.StringIO()):
+                        exit_code = cli.main(
+                            [
+                                "--home",
+                                tmp,
+                                "say",
+                                "기억해줘: 나는 한국어 요약을 선호해",
+                                "--reviewer",
+                                "ollama",
+                                "--model",
+                                "qwen2.5:7b",
+                                "--ollama-url",
+                                "http://127.0.0.1:11434",
+                                "--timeout",
+                                "2.5",
+                                "--memory-interval",
+                                "1",
+                            ]
+                        )
+
+        self.assertEqual(exit_code, 0)
+        engine = FakeAgent.instances[0].review_engine
+        self.assertIsInstance(engine, FakeOllamaReviewEngine)
+        self.assertEqual(engine.model, "qwen2.5:7b")
+        self.assertEqual(engine.base_url, "http://127.0.0.1:11434")
+        self.assertEqual(engine.timeout_seconds, 2.5)
+        self.assertEqual(FakeAgent.instances[0].memory_interval, 1)
+
+    def test_workbench_command_starts_local_server(self):
+        with patch.object(cli, "serve_workbench", FakeWorkbenchServer.serve):
+            with redirect_stdout(io.StringIO()):
+                exit_code = cli.main(
+                    [
+                        "workbench",
+                        "--host",
+                        "127.0.0.1",
+                        "--port",
+                        "9001",
+                    ]
+                )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(FakeWorkbenchServer.calls, [("127.0.0.1", 9001)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_memory.py
+++ b/tests/minchoagnt/test_memory.py
@@ -1,0 +1,62 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from minchoagnt.memory import MemoryLimitError, MemoryMatchError, MemoryStore
+
+
+class MemoryStoreTests(unittest.TestCase):
+    def test_add_persists_but_current_snapshot_stays_frozen(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            store = MemoryStore(home, memory_limit=200, user_limit=120)
+            store.load()
+
+            store.add("memory", "Project uses Python unittest for the mini slice.")
+
+            self.assertEqual(
+                store.entries("memory"),
+                ["Project uses Python unittest for the mini slice."],
+            )
+            self.assertIsNone(store.snapshot("memory"))
+
+            next_session = MemoryStore(home, memory_limit=200, user_limit=120)
+            next_session.load()
+
+            self.assertIn("MEMORY", next_session.snapshot("memory"))
+            self.assertIn("Python unittest", next_session.snapshot("memory"))
+
+    def test_replace_requires_a_unique_substring(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MemoryStore(Path(tmp))
+            store.load()
+            store.add("user", "User prefers short Korean answers.")
+            store.add("user", "User prefers examples after the summary.")
+
+            with self.assertRaises(MemoryMatchError):
+                store.replace("user", "prefers", "User prefers concise Korean answers.")
+
+            store.replace("user", "short Korean", "User prefers concise Korean answers.")
+
+            self.assertEqual(
+                store.entries("user"),
+                [
+                    "User prefers concise Korean answers.",
+                    "User prefers examples after the summary.",
+                ],
+            )
+
+    def test_limit_error_reports_current_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MemoryStore(Path(tmp), memory_limit=32)
+            store.load()
+            store.add("memory", "small fact")
+
+            with self.assertRaises(MemoryLimitError) as caught:
+                store.add("memory", "this fact is too long to fit in this tiny store")
+
+            self.assertIn("small fact", caught.exception.current_entries)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_ollama_review.py
+++ b/tests/minchoagnt/test_ollama_review.py
@@ -1,0 +1,145 @@
+import json
+import unittest
+
+from minchoagnt.ollama import OllamaReviewEngine
+from minchoagnt.sessions import Message
+
+
+class FakeOllamaClient:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = []
+
+    def post_json(self, url, payload, timeout_seconds):
+        self.calls.append((url, payload, timeout_seconds))
+        if self.error:
+            raise self.error
+        return self.response
+
+
+def user_message(content):
+    return Message(
+        id=1,
+        session_id="session-1",
+        role="user",
+        content=content,
+        timestamp=1.0,
+    )
+
+
+class OllamaReviewEngineTests(unittest.TestCase):
+    def test_calls_ollama_chat_and_parses_review_plan_json(self):
+        raw_plan = {
+            "memory_additions": [
+                {
+                    "target": "user",
+                    "content": "사용자는 한국어 요약을 선호한다.",
+                    "evidence": "기억해줘: 나는 한국어 요약을 선호해",
+                }
+            ],
+            "skill_creations": [],
+        }
+        client = FakeOllamaClient(
+            response={
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps(raw_plan, ensure_ascii=False),
+                }
+            }
+        )
+        engine = OllamaReviewEngine(
+            model="qwen2.5:7b",
+            base_url="http://127.0.0.1:11434",
+            client=client,
+            timeout_seconds=7,
+        )
+
+        plan = engine.review([user_message("기억해줘: 나는 한국어 요약을 선호해")])
+
+        self.assertEqual(plan.memory_additions[0].content, "사용자는 한국어 요약을 선호한다.")
+        self.assertEqual(plan.memory_additions[0].evidence, "기억해줘: 나는 한국어 요약을 선호해")
+        self.assertIsNone(engine.last_error)
+
+        url, payload, timeout = client.calls[0]
+        self.assertEqual(url, "http://127.0.0.1:11434/api/chat")
+        self.assertEqual(timeout, 7)
+        self.assertEqual(payload["model"], "qwen2.5:7b")
+        self.assertEqual(payload["stream"], False)
+        self.assertEqual(payload["format"], "json")
+        self.assertEqual(payload["options"]["temperature"], 0)
+        self.assertIn("Return only JSON", payload["messages"][0]["content"])
+        self.assertIn("기억해줘", payload["messages"][1]["content"])
+
+    def test_filters_output_by_requested_review_flags(self):
+        raw_plan = {
+            "memory_additions": [
+                {"target": "user", "content": "사용자는 한국어 요약을 선호한다."}
+            ],
+            "skill_creations": [
+                {
+                    "name": "release-checklist",
+                    "content": "# Release Checklist\n\n1. Run tests.",
+                    "category": "learned",
+                }
+            ],
+        }
+        client = FakeOllamaClient(
+            response={"message": {"content": json.dumps(raw_plan, ensure_ascii=False)}}
+        )
+        engine = OllamaReviewEngine(model="qwen2.5:7b", client=client)
+
+        plan = engine.review(
+            [user_message("릴리즈 절차를 스킬로 저장해줘")],
+            review_memory=False,
+            review_skills=True,
+        )
+
+        self.assertEqual(plan.memory_additions, [])
+        self.assertEqual(len(plan.skill_creations), 1)
+        self.assertIn("review_memory=false", client.calls[0][1]["messages"][1]["content"])
+        self.assertIn("review_skills=true", client.calls[0][1]["messages"][1]["content"])
+
+    def test_returns_empty_plan_when_client_fails(self):
+        client = FakeOllamaClient(error=TimeoutError("ollama timed out"))
+        engine = OllamaReviewEngine(model="qwen2.5:7b", client=client)
+
+        plan = engine.review([user_message("anything")])
+
+        self.assertEqual(plan.memory_additions, [])
+        self.assertEqual(plan.skill_creations, [])
+        self.assertIn("ollama timed out", engine.last_error)
+
+    def test_does_not_swallow_unexpected_programming_errors(self):
+        client = FakeOllamaClient(error=RuntimeError("programmer mistake"))
+        engine = OllamaReviewEngine(model="qwen2.5:7b", client=client)
+
+        with self.assertRaisesRegex(RuntimeError, "programmer mistake"):
+            engine.review([user_message("anything")])
+
+    def test_returns_empty_plan_when_model_returns_invalid_schema(self):
+        client = FakeOllamaClient(
+            response={
+                "message": {
+                    "content": json.dumps(
+                        {
+                            "memory_additions": [
+                                {"target": "profile", "content": "bad target"}
+                            ],
+                            "skill_creations": [],
+                        }
+                    )
+                }
+            }
+        )
+        engine = OllamaReviewEngine(model="qwen2.5:7b", client=client)
+
+        plan = engine.review([user_message("anything")])
+
+        self.assertEqual(plan.memory_additions, [])
+        self.assertEqual(plan.skill_creations, [])
+        self.assertIn("target", engine.last_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_review_schema.py
+++ b/tests/minchoagnt/test_review_schema.py
@@ -1,0 +1,100 @@
+import json
+import unittest
+
+from minchoagnt.review import MemoryAddition, ReviewPlan, ReviewPlanValidationError
+
+
+class ReviewPlanSchemaTests(unittest.TestCase):
+    def test_parses_korean_memory_json_and_round_trips(self):
+        raw = json.dumps(
+            {
+                "memory_additions": [
+                    {
+                        "target": "user",
+                        "content": "사용자는 한국어 요약을 선호한다.",
+                        "evidence": "기억해줘: 나는 한국어 요약을 선호해",
+                    }
+                ],
+                "skill_creations": [],
+            },
+            ensure_ascii=False,
+        )
+
+        plan = ReviewPlan.from_json(raw)
+
+        self.assertEqual(len(plan.memory_additions), 1)
+        self.assertEqual(plan.memory_additions[0].target, "user")
+        self.assertEqual(plan.memory_additions[0].content, "사용자는 한국어 요약을 선호한다.")
+        self.assertEqual(
+            plan.memory_additions[0].evidence,
+            "기억해줘: 나는 한국어 요약을 선호해",
+        )
+        self.assertEqual(ReviewPlan.from_json(plan.to_json()), plan)
+
+    def test_parses_skill_json_with_evidence(self):
+        plan = ReviewPlan.from_dict(
+            {
+                "memory_additions": [],
+                "skill_creations": [
+                    {
+                        "name": "release-checklist",
+                        "content": "# Release Checklist\n\n1. Run tests.",
+                        "category": "learned",
+                        "evidence": "릴리즈할 때 테스트 돌리고 git 상태 확인하는 절차",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(len(plan.skill_creations), 1)
+        self.assertEqual(plan.skill_creations[0].name, "release-checklist")
+        self.assertEqual(plan.skill_creations[0].category, "learned")
+        self.assertIn("Run tests", plan.skill_creations[0].content)
+
+    def test_rejects_invalid_memory_target(self):
+        with self.assertRaisesRegex(ReviewPlanValidationError, "target"):
+            ReviewPlan.from_dict(
+                {
+                    "memory_additions": [
+                        {"target": "profile", "content": "bad target"},
+                    ],
+                    "skill_creations": [],
+                }
+            )
+
+    def test_rejects_non_string_memory_target_from_direct_constructor(self):
+        with self.assertRaisesRegex(ReviewPlanValidationError, "memory target"):
+            MemoryAddition(target=123, content="valid content")
+
+    def test_rejects_empty_content(self):
+        with self.assertRaisesRegex(ReviewPlanValidationError, "content"):
+            ReviewPlan.from_dict(
+                {
+                    "memory_additions": [
+                        {"target": "user", "content": "   "},
+                    ],
+                    "skill_creations": [],
+                }
+            )
+
+    def test_rejects_unsafe_skill_name(self):
+        with self.assertRaisesRegex(ReviewPlanValidationError, "skill name"):
+            ReviewPlan.from_dict(
+                {
+                    "memory_additions": [],
+                    "skill_creations": [
+                        {
+                            "name": "../release",
+                            "content": "# Release\n\n1. Run tests.",
+                        }
+                    ],
+                }
+            )
+
+    def test_rejects_malformed_json(self):
+        with self.assertRaisesRegex(ReviewPlanValidationError, "JSON"):
+            ReviewPlan.from_json("not json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_sessions.py
+++ b/tests/minchoagnt/test_sessions.py
@@ -1,0 +1,37 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from minchoagnt.sessions import SessionDB
+
+
+class SessionDBTests(unittest.TestCase):
+    def test_appends_messages_and_searches_history(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(Path(tmp) / "state.db")
+            session_id = db.create_session(source="cli")
+
+            db.append_message(session_id, "user", "remember: deploy uses fly.io")
+            db.append_message(session_id, "assistant", "Noted for review.")
+
+            results = db.search_messages("deploy")
+
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].session_id, session_id)
+            self.assertEqual(results[0].role, "user")
+            self.assertIn("fly.io", results[0].content)
+
+    def test_loads_conversation_in_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(Path(tmp) / "state.db")
+            session_id = db.create_session(source="cli")
+            db.append_message(session_id, "user", "first")
+            db.append_message(session_id, "assistant", "second")
+
+            messages = db.get_messages(session_id)
+
+            self.assertEqual([m.content for m in messages], ["first", "second"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_skills.py
+++ b/tests/minchoagnt/test_skills.py
@@ -1,0 +1,46 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from minchoagnt.skills import SkillMatchError, SkillStore
+
+
+class SkillStoreTests(unittest.TestCase):
+    def test_create_list_view_and_patch_skill(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = SkillStore(Path(tmp))
+            content = """---
+name: release-checklist
+description: Repeatable release verification.
+---
+
+# Release Checklist
+
+1. Run tests.
+2. Check git status.
+"""
+
+            skill = store.create("release-checklist", content, category="dev")
+
+            self.assertEqual(skill.name, "release-checklist")
+            self.assertEqual(store.list_names(), ["release-checklist"])
+            self.assertIn("Run tests.", store.view("release-checklist"))
+
+            store.patch("release-checklist", "Run tests.", "Run the full test suite.")
+
+            self.assertIn("Run the full test suite.", store.view("release-checklist"))
+
+    def test_patch_rejects_ambiguous_matches(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = SkillStore(Path(tmp))
+            store.create(
+                "ambiguous",
+                "# Ambiguous\n\nRun tests.\nRun tests again.\n",
+            )
+
+            with self.assertRaises(SkillMatchError):
+                store.patch("ambiguous", "Run tests", "Run focused tests")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_web.py
+++ b/tests/minchoagnt/test_web.py
@@ -1,0 +1,215 @@
+import http.client
+import json
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from unittest.mock import patch
+
+from minchoagnt.web import create_workbench_handler
+
+
+class WebServerContext:
+    def __enter__(self):
+        self.handler = create_workbench_handler()
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), self.handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.host, self.port = self.server.server_address
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.server.shutdown()
+        self.thread.join(timeout=5)
+        self.server.server_close()
+        self.handler.workbench.close()
+
+    def request(self, method, path, body=None, headers=None):
+        conn = http.client.HTTPConnection(self.host, self.port, timeout=5)
+        conn.request(method, path, body=body, headers=headers or {})
+        response = conn.getresponse()
+        data = response.read()
+        conn.close()
+        return response, data
+
+    def post_json(self, path, payload):
+        return self.request(
+            "POST",
+            path,
+            body=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+        )
+
+
+class ReviewWorkbenchWebTests(unittest.TestCase):
+    def test_root_serves_workbench_html(self):
+        with WebServerContext() as server:
+            response, data = server.request("GET", "/")
+
+        html = data.decode("utf-8")
+        self.assertEqual(response.status, 200)
+        self.assertIn("Review Workbench", html)
+        self.assertIn("~ Review", html)
+        self.assertIn("! Apply", html)
+        self.assertIn("ollama", html)
+        self.assertIn("Ollama Model", html)
+        self.assertIn("? Verify", html)
+        self.assertIn("Expect Target", html)
+
+    def test_review_and_apply_api_flow(self):
+        with WebServerContext() as server:
+            review_response, review_data = server.post_json(
+                "/api/review",
+                {
+                    "message": "remember: I prefer Korean summaries.",
+                    "reviewer": "regex",
+                },
+            )
+            review_payload = json.loads(review_data)
+
+            apply_response, apply_data = server.post_json(
+                "/api/apply",
+                {"run_id": review_payload["run_id"]},
+            )
+            apply_payload = json.loads(apply_data)
+
+        self.assertEqual(review_response.status, 200)
+        self.assertEqual(review_payload["run_id"], "run_001")
+        self.assertEqual(
+            review_payload["review_plan"]["memory_additions"],
+            [{"target": "user", "content": "I prefer Korean summaries."}],
+        )
+        self.assertEqual(apply_response.status, 200)
+        self.assertEqual(apply_payload["apply_result"]["memory_saved"], 1)
+        self.assertEqual(apply_payload["diff"]["user"]["added"], ["I prefer Korean summaries."])
+        self.assertEqual(apply_payload["node_status"]["StateDiff"], "success")
+
+    def test_expect_api_checks_applied_run(self):
+        with WebServerContext() as server:
+            _, review_data = server.post_json(
+                "/api/review",
+                {
+                    "message": "remember: I prefer Korean summaries.",
+                    "reviewer": "regex",
+                },
+            )
+            run_id = json.loads(review_data)["run_id"]
+            server.post_json("/api/apply", {"run_id": run_id})
+
+            expect_response, expect_data = server.post_json(
+                "/api/expect",
+                {
+                    "run_id": run_id,
+                    "target": "user",
+                    "contains": "Korean summaries",
+                },
+            )
+            expect_payload = json.loads(expect_data)
+
+        self.assertEqual(expect_response.status, 200)
+        self.assertEqual(
+            expect_payload["check_result"],
+            {
+                "target": "user",
+                "contains": "Korean summaries",
+                "passed": True,
+                "message": "matched user memory",
+            },
+        )
+        self.assertIn(
+            {"step": "expect", "status": "success", "message": "? verify passed"},
+            expect_payload["events"],
+        )
+
+    def test_expect_api_rejects_empty_contains(self):
+        with WebServerContext() as server:
+            response, data = server.post_json(
+                "/api/expect",
+                {
+                    "run_id": "run_404",
+                    "target": "user",
+                    "contains": "",
+                },
+            )
+
+        payload = json.loads(data)
+        self.assertEqual(response.status, 400)
+        self.assertEqual(payload["error"], "contains cannot be empty")
+
+    def test_review_api_rejects_malformed_json(self):
+        with WebServerContext() as server:
+            response, data = server.request(
+                "POST",
+                "/api/review",
+                body="{bad json",
+                headers={"Content-Type": "application/json"},
+            )
+
+        payload = json.loads(data)
+        self.assertEqual(response.status, 400)
+        self.assertEqual(payload["error"], "invalid JSON")
+
+    def test_review_api_can_select_ollama_reviewer_with_config(self):
+        created = []
+
+        class FakeOllamaReviewEngine:
+            def __init__(self, model, base_url, timeout_seconds):
+                self.model = model
+                self.base_url = base_url
+                self.timeout_seconds = timeout_seconds
+                created.append((model, base_url, timeout_seconds))
+
+            def review(self, messages, review_memory=True, review_skills=True):
+                from minchoagnt.review import MemoryAddition, ReviewPlan
+
+                return ReviewPlan(
+                    memory_additions=[
+                        MemoryAddition(target="user", content="I prefer Korean summaries.")
+                    ],
+                    skill_creations=[],
+                )
+
+        with patch("minchoagnt.web.OllamaReviewEngine", FakeOllamaReviewEngine):
+            with WebServerContext() as server:
+                response, data = server.post_json(
+                    "/api/review",
+                    {
+                        "message": "remember: I prefer Korean summaries.",
+                        "reviewer": "ollama",
+                        "model": "qwen2.5:7b",
+                        "base_url": "http://127.0.0.1:11434",
+                        "timeout": 2.5,
+                    },
+                )
+
+        payload = json.loads(data)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(created, [("qwen2.5:7b", "http://127.0.0.1:11434", 2.5)])
+        self.assertEqual(
+            payload["reviewer"],
+            {
+                "type": "ollama",
+                "model": "qwen2.5:7b",
+                "base_url": "http://127.0.0.1:11434",
+                "timeout_seconds": 2.5,
+            },
+        )
+        self.assertEqual(payload["node_status"]["ReviewPlan"], "success")
+
+    def test_review_api_rejects_invalid_ollama_timeout(self):
+        with WebServerContext() as server:
+            response, data = server.post_json(
+                "/api/review",
+                {
+                    "message": "remember: I prefer Korean summaries.",
+                    "reviewer": "ollama",
+                    "timeout": 0,
+                },
+            )
+
+        payload = json.loads(data)
+        self.assertEqual(response.status, 400)
+        self.assertEqual(payload["error"], "timeout must be greater than 0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/minchoagnt/test_workbench.py
+++ b/tests/minchoagnt/test_workbench.py
@@ -1,0 +1,195 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from minchoagnt.memory import MemoryStore
+from minchoagnt.review import ReviewPlan
+from minchoagnt.skills import SkillStore
+from minchoagnt.workbench import ReviewWorkbench
+
+
+class EmptyReviewEngine:
+    def review(self, messages, review_memory=True, review_skills=True):
+        return ReviewPlan()
+
+
+class FailingReviewEngine:
+    def __init__(self):
+        self.last_error = None
+
+    def review(self, messages, review_memory=True, review_skills=True):
+        self.last_error = "connection refused"
+        return ReviewPlan()
+
+
+class ReviewWorkbenchTests(unittest.TestCase):
+    def test_review_returns_renderable_run_object(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workbench = ReviewWorkbench(Path(tmp), reviewer_type="regex")
+
+            run = workbench.review("remember: I prefer Korean summaries.")
+
+            self.assertEqual(run.run_id, "run_001")
+            self.assertEqual(run.input.role, "user")
+            self.assertEqual(run.input.content, "remember: I prefer Korean summaries.")
+            self.assertEqual(run.reviewer.type, "regex")
+            self.assertEqual(
+                run.review_plan.to_dict()["memory_additions"],
+                [{"target": "user", "content": "I prefer Korean summaries."}],
+            )
+            self.assertEqual(run.apply_result.memory_saved, 0)
+            self.assertEqual(run.node_status["StateDiff"], "pending")
+            self.assertEqual(run.to_dict()["reviewer"], {"type": "regex"})
+            self.assertIn("review completed", [event.message for event in run.events])
+
+    def test_apply_writes_memory_and_reports_state_diff(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            workbench = ReviewWorkbench(home, reviewer_type="regex")
+            run = workbench.review("remember: I prefer Korean summaries.")
+
+            applied = workbench.apply(run)
+
+            self.assertEqual(applied.apply_result.memory_saved, 1)
+            self.assertEqual(applied.diff.user.added, ["I prefer Korean summaries."])
+            self.assertEqual(applied.diff.user.removed, [])
+            self.assertEqual(applied.diff.skills.created, [])
+            self.assertEqual(applied.node_status["StateDiff"], "success")
+            self.assertIn("memory addition saved", [event.message for event in applied.events])
+
+    def test_apply_reports_duplicate_memory_as_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            memory = MemoryStore(home).load()
+            memory.add("user", "I prefer Korean summaries.")
+            workbench = ReviewWorkbench(home, reviewer_type="regex")
+            run = workbench.review("remember: I prefer Korean summaries.")
+
+            applied = workbench.apply(run)
+
+            self.assertEqual(applied.apply_result.memory_saved, 0)
+            self.assertEqual(applied.apply_result.memory_duplicates, 1)
+            self.assertEqual(applied.apply_result.errors, [])
+            self.assertEqual(applied.diff.user.added, [])
+            self.assertEqual(applied.diff.user.unchanged, ["I prefer Korean summaries."])
+            self.assertEqual(applied.node_status["StateDiff"], "no-op")
+
+    def test_apply_creates_skill_and_reports_skill_diff(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            workbench = ReviewWorkbench(home, reviewer_type="regex")
+            run = workbench.review(
+                "skill: release-checklist | run tests; inspect git status; push branch"
+            )
+
+            applied = workbench.apply(run)
+
+            self.assertEqual(applied.apply_result.skills_created, 1)
+            self.assertEqual(applied.diff.skills.created, ["release-checklist"])
+            self.assertEqual(applied.node_status["StateDiff"], "success")
+            self.assertIn("inspect git status", SkillStore(home).view("release-checklist"))
+
+    def test_apply_reports_duplicate_skill_as_noop_without_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            workbench = ReviewWorkbench(home, reviewer_type="regex")
+            run = workbench.review("skill: release-checklist | run tests")
+            workbench.apply(run)
+
+            duplicate = workbench.apply(run)
+
+            self.assertEqual(duplicate.apply_result.skills_created, 0)
+            self.assertEqual(duplicate.apply_result.skill_duplicates, 1)
+            self.assertEqual(duplicate.apply_result.errors, [])
+            self.assertEqual(duplicate.diff.skills.created, [])
+            self.assertEqual(duplicate.diff.skills.unchanged, ["release-checklist"])
+            self.assertEqual(duplicate.node_status["StateDiff"], "no-op")
+
+    def test_empty_plan_apply_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workbench = ReviewWorkbench(Path(tmp), reviewer_type="regex")
+            run = workbench.review("hello there")
+
+            applied = workbench.apply(run)
+
+            self.assertTrue(applied.apply_result.empty_plan)
+            self.assertEqual(applied.apply_result.memory_saved, 0)
+            self.assertEqual(applied.apply_result.skills_created, 0)
+            self.assertEqual(applied.node_status["StateDiff"], "no-op")
+
+    def test_fake_reviewer_produces_empty_plan_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workbench = ReviewWorkbench(Path(tmp), reviewer_type="fake")
+
+            run = workbench.review("remember: I prefer Korean summaries.")
+
+            self.assertEqual(run.review_plan.to_dict()["memory_additions"], [])
+            self.assertEqual(run.node_status["ReviewPlan"], "no-op")
+
+    def test_reviewer_metadata_includes_optional_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workbench = ReviewWorkbench(
+                Path(tmp),
+                reviewer_type="ollama",
+                review_engine=EmptyReviewEngine(),
+                reviewer_config={
+                    "model": "qwen2.5:7b",
+                    "base_url": "http://127.0.0.1:11434",
+                    "timeout_seconds": 2.5,
+                },
+            )
+
+            run = workbench.review("remember: I prefer Korean summaries.")
+
+            self.assertEqual(
+                run.reviewer.to_dict(),
+                {
+                    "type": "ollama",
+                    "model": "qwen2.5:7b",
+                    "base_url": "http://127.0.0.1:11434",
+                    "timeout_seconds": 2.5,
+                },
+            )
+
+    def test_reviewer_metadata_includes_last_error_when_available(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workbench = ReviewWorkbench(
+                Path(tmp),
+                reviewer_type="ollama",
+                review_engine=FailingReviewEngine(),
+            )
+
+            run = workbench.review("remember: I prefer Korean summaries.")
+
+            self.assertEqual(run.reviewer.to_dict()["last_error"], "connection refused")
+            self.assertEqual(run.node_status["ReviewPlan"], "no-op")
+
+    def test_expect_passes_when_user_memory_contains_text(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workbench = ReviewWorkbench(Path(tmp), reviewer_type="regex")
+            run = workbench.review("remember: I prefer Korean summaries.")
+            applied = workbench.apply(run)
+
+            checked = workbench.expect(applied, target="user", contains="Korean summaries")
+
+            self.assertTrue(checked.check_result.passed)
+            self.assertEqual(checked.check_result.target, "user")
+            self.assertEqual(checked.check_result.contains, "Korean summaries")
+            self.assertEqual(checked.check_result.message, "matched user memory")
+            self.assertIn("? verify passed", [event.message for event in checked.events])
+
+    def test_expect_fails_when_text_is_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workbench = ReviewWorkbench(Path(tmp), reviewer_type="regex")
+            run = workbench.review("remember: I prefer Korean summaries.")
+            applied = workbench.apply(run)
+
+            checked = workbench.expect(applied, target="user", contains="Spanish summaries")
+
+            self.assertFalse(checked.check_result.passed)
+            self.assertEqual(checked.check_result.message, "no match in user memory")
+            self.assertIn("? verify failed", [event.message for event in checked.events])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minchoagnt_comp_adapter.py
+++ b/tests/test_minchoagnt_comp_adapter.py
@@ -1,0 +1,73 @@
+import pytest
+
+import comp
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from comp.compiler_tool import (
+    ClaimHypothesis,
+    EvidenceWitness,
+    InterpretationHypothesis,
+)
+from minchoagnt import MemoryStore, MiniAgent, ReviewWorkbench, SkillStore
+from minchoagnt.comp_adapter import CompCompilerAdapter
+
+
+def test_minchoagnt_layer_is_available_without_expanding_comp_surface():
+    assert MiniAgent is not None
+    assert MemoryStore is not None
+    assert SkillStore is not None
+    assert ReviewWorkbench is not None
+
+    assert not hasattr(comp, "MiniAgent")
+    assert not hasattr(comp, "MemoryStore")
+    assert not hasattr(comp, "SkillStore")
+    assert not hasattr(comp, "ReviewWorkbench")
+
+
+def test_comp_adapter_calls_compiler_tool_without_projection_authority():
+    adapter = CompCompilerAdapter(allowed_units=frozenset({"kwh"}))
+    hypothesis = InterpretationHypothesis(
+        hypothesis_id="hyp-1",
+        subject_id="claim-1",
+        claims=(
+            ClaimHypothesis("activity", "electricity", witness_id="w-activity"),
+            ClaimHypothesis("amount", 1200, witness_id="w-amount"),
+            ClaimHypothesis("unit", "kwh", witness_id="w-unit"),
+        ),
+        witnesses=(
+            EvidenceWitness("w-activity", "activity", source="fragment-1"),
+            EvidenceWitness("w-amount", "amount", source="fragment-1"),
+            EvidenceWitness("w-unit", "unit", source="header-1"),
+        ),
+    )
+
+    result = adapter.compile(hypothesis)
+
+    assert result.subject.kind == "claim"
+    assert result.subject.id == "hyp-1"
+    assert result.report.status == "accepted"
+    assert result.report.can_project_public_row is False
+
+    projection = ProjectionSpec("public-row", ("activity", "amount", "unit"))
+    with pytest.raises(ProjectionBlocked):
+        project_public_row(
+            {"activity": "electricity", "amount": 1200, "unit": "kwh"},
+            projection,
+        )
+
+
+def test_comp_adapter_can_append_report_facts_without_minting_receipts():
+    adapter = CompCompilerAdapter(allowed_units=frozenset({"kwh"}))
+    hypothesis = InterpretationHypothesis(
+        hypothesis_id="hyp-2",
+        subject_id="claim-2",
+        claims=(ClaimHypothesis("unit", "mwh", witness_id="w-unit"),),
+        witnesses=(EvidenceWitness("w-unit", "unit", source="fragment-1"),),
+    )
+
+    result = adapter.compile(hypothesis)
+    delta = adapter.record(result)
+
+    assert result.report.status == "blocked"
+    assert result.receipt is None
+    assert any(fact.tag == "hazard_open" for fact in delta)
+    assert result.judgment.active_hazard_ids(result.subject)

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -70,7 +70,7 @@ def test_top_level_package_no_longer_exports_legacy_runner_surface():
     assert not hasattr(comp, "PipelineRunResult")
 
 
-def test_pyproject_only_packages_active_surface():
+def test_pyproject_packages_comp_core_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
 
     setuptools_config = pyproject["tool"]["setuptools"]
@@ -78,8 +78,12 @@ def test_pyproject_only_packages_active_surface():
         "comp",
         "comp.compiler_tool",
         "comp.judgment",
+        "minchoagnt",
     ]
     assert "py-modules" not in setuptools_config
+
+    scripts = pyproject["project"].get("scripts", {})
+    assert scripts["minchoagnt"] == "minchoagnt.cli:main"
 
     dependencies = pyproject["project"].get("dependencies", [])
     assert not any(dependency.startswith("lark") for dependency in dependencies)
@@ -88,3 +92,12 @@ def test_pyproject_only_packages_active_surface():
 def test_legacy_pipeline_sources_are_not_active_files():
     assert not [path for path in LEGACY_ACTIVE_PATHS if Path(path).exists()]
     assert "comp.runner" not in (comp.__doc__ or "")
+
+
+def test_comp_core_does_not_import_agent_layer():
+    comp_sources = Path("comp").rglob("*.py")
+    assert not [
+        path
+        for path in comp_sources
+        if "minchoagnt" in path.read_text(encoding="utf-8")
+    ]


### PR DESCRIPTION
## Summary

Imports the `minchoagnt` agent layer as a separate top-level package that can orchestrate `comp` without becoming part of the compiler authority core.

- Add the `minchoagnt` package: memory store, skill store, session DB, review engines, optional Ollama reviewer, CLI, and review workbench.
- Add `minchoagnt.comp_adapter.CompCompilerAdapter`, which calls `comp.CompilerTool` and can append `CompileReport` facts into a `JudgmentState` without minting receipts.
- Expose the `minchoagnt` console script via `pyproject.toml`.
- Port the upstream `minchoagnt` tests into `tests/minchoagnt/`.
- Add boundary tests proving `comp` does not expose or import the agent layer and that accepted/blocked reports still do not create projection authority.

## Authority boundary

This keeps the architecture from `docs/architecture/memory-assisted-compiler-loop.md` intact:

```text
comp does not import minchoagnt.
minchoagnt may import comp.
Memory/skills guide hypothesis generation.
CompilerTool validates.
Judgment records.
CommitReceipt authorizes projection.
```

## Non-goals

- No `comp` core import of `minchoagnt`.
- No real Ollama call in tests.
- No replacement of `CommitReceipt` with memory, sessions, skills, or review plans.
- No public projection path outside the existing receipt-gated helper.

## Validation

- `git diff --check HEAD~1..HEAD` -> clean.
- `python -m pytest --collect-only -q` -> 68 tests collected.
- `python -m pytest -q` -> 68 passed.
- `python -m pip wheel . --no-deps -w .tmp_agent_wheel` -> wheel built.
- Wheel inspection confirmed `minchoagnt/*` and `minchoagnt` entry point are included, tests are excluded, legacy modules are excluded, and no `Requires-Dist: lark`.
- Installed wheel into `.tmp_agent_install` and imported `CompCompilerAdapter`, `MiniAgent`, `MemoryStore`, `ReviewWorkbench`, and `ProjectionBlocked`.
- Installed CLI smoke: `python -m minchoagnt --home <temp> say "remember: I prefer Korean summaries." --memory-interval 1` then `memory list --target user` returned the saved preference.
- Installed adapter smoke: unsupported unit compile returned `blocked`, `receipt is None`, and `record(...)` appended judgment facts.