### PR TITLE
[codex] feat: add semantic judgment obligation validation

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -9,9 +9,12 @@ from comp.compiler_tool.models import (
     Hazard,
     InterpretationHypothesis,
     ProofObligation,
+    SemanticJudgment,
+    SemanticJudgmentRequirement,
     UncheckedArea,
     UnknownClaim,
 )
+from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
     add_compile_report_facts,
@@ -28,8 +31,11 @@ __all__ = [
     "UnknownClaim",
     "UncheckedArea",
     "ProofObligation",
+    "SemanticJudgmentRequirement",
+    "SemanticJudgment",
     "Hazard",
     "CompilerTool",
+    "apply_semantic_judgments",
     "compile_report_to_facts",
     "add_compile_report_facts",
 ]

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -71,10 +71,37 @@ class UncheckedArea:
 
 
 @dataclass(frozen=True)
+class SemanticJudgmentRequirement:
+    question: str
+    claim_id: str
+    evidence_span_ids: tuple[str, ...] = field(default_factory=tuple)
+    rubric_id: str = ""
+    acceptable_verdicts: tuple[str, ...] = field(default_factory=tuple)
+    required_verdict: str = "supports"
+    allowed_judges: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
 class ProofObligation:
     kind: str
     field: str
     reason: str
+    obligation_id: str | None = None
+    claim_id: str | None = None
+    blocking: bool = True
+    semantic_requirement: SemanticJudgmentRequirement | None = None
+
+
+@dataclass(frozen=True)
+class SemanticJudgment:
+    judgment_id: str
+    obligation_id: str
+    verdict: str
+    rubric_id: str
+    judge: str
+    cited_span_ids: tuple[str, ...]
+    rationale: str
+    confidence: float | None = None
 
 
 @dataclass(frozen=True)

--- a/comp/compiler_tool/semantic.py
+++ b/comp/compiler_tool/semantic.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from comp.compiler_tool.models import (
+    CompileReport,
+    Hazard,
+    ProofObligation,
+    SemanticJudgment,
+)
+
+
+def apply_semantic_judgments(
+    report: CompileReport,
+    judgments: Iterable[SemanticJudgment],
+    *,
+    available_span_ids: Iterable[str] | None = None,
+) -> CompileReport:
+    """Discharge semantic obligations when submitted judgments satisfy protocol."""
+
+    judgments_by_obligation: dict[str, list[SemanticJudgment]] = {}
+    for judgment in judgments:
+        judgments_by_obligation.setdefault(judgment.obligation_id, []).append(judgment)
+
+    available_spans = (
+        frozenset(available_span_ids) if available_span_ids is not None else None
+    )
+    open_obligations: list[ProofObligation] = []
+    newly_resolved: list[ProofObligation] = []
+    hazards = list(report.hazards)
+
+    for obligation in report.obligations:
+        if obligation.kind != "semantic_judgment_required":
+            open_obligations.append(obligation)
+            continue
+
+        matching = judgments_by_obligation.get(_obligation_id(obligation), [])
+        valid = [
+            judgment
+            for judgment in matching
+            if _judgment_satisfies_protocol(
+                obligation,
+                judgment,
+                available_span_ids=available_spans,
+            )
+        ]
+
+        verdicts = {judgment.verdict for judgment in valid}
+        if len(verdicts) > 1:
+            open_obligations.append(obligation)
+            _add_hazard(
+                hazards,
+                Hazard(
+                    kind="conflicting_semantic_judgment",
+                    field=obligation.field,
+                    severity="review",
+                ),
+            )
+            continue
+
+        required_verdict = obligation.semantic_requirement.required_verdict if (
+            obligation.semantic_requirement is not None
+        ) else "supports"
+        if valid and valid[0].verdict == required_verdict:
+            newly_resolved.append(obligation)
+            continue
+
+        open_obligations.append(obligation)
+
+    return CompileReport(
+        status=_status_for(
+            report=report,
+            open_obligations=tuple(open_obligations),
+            hazards=tuple(hazards),
+        ),
+        checked_claims=report.checked_claims,
+        failed_claims=report.failed_claims,
+        unknowns=report.unknowns,
+        unchecked_areas=report.unchecked_areas,
+        obligations=tuple(open_obligations),
+        resolved_obligations=(
+            *report.resolved_obligations,
+            *tuple(newly_resolved),
+        ),
+        hazards=tuple(hazards),
+        can_project_public_row=report.can_project_public_row,
+    )
+
+
+def _judgment_satisfies_protocol(
+    obligation: ProofObligation,
+    judgment: SemanticJudgment,
+    *,
+    available_span_ids: frozenset[str] | None,
+) -> bool:
+    requirement = obligation.semantic_requirement
+    if requirement is None:
+        return False
+
+    if judgment.rubric_id != requirement.rubric_id:
+        return False
+
+    if judgment.verdict not in requirement.acceptable_verdicts:
+        return False
+
+    if requirement.allowed_judges and judgment.judge not in requirement.allowed_judges:
+        return False
+
+    cited_span_ids = set(judgment.cited_span_ids)
+    if not set(requirement.evidence_span_ids).issubset(cited_span_ids):
+        return False
+
+    if available_span_ids is not None and not cited_span_ids.issubset(available_span_ids):
+        return False
+
+    return True
+
+
+def _status_for(
+    *,
+    report: CompileReport,
+    open_obligations: tuple[ProofObligation, ...],
+    hazards: tuple[Hazard, ...],
+) -> str:
+    if report.failed_claims:
+        return "blocked"
+    if hazards:
+        return "review_required"
+    if any(
+        obligation.kind == "semantic_judgment_required" and obligation.blocking
+        for obligation in open_obligations
+    ):
+        return "review_required"
+    if report.unchecked_areas:
+        return "unchecked"
+    if report.unknowns:
+        return "underconstrained"
+    return "accepted"
+
+
+def _obligation_id(obligation: ProofObligation) -> str:
+    if obligation.obligation_id:
+        return obligation.obligation_id
+    return f"{obligation.kind}:{obligation.field}:{obligation.reason}"
+
+
+def _add_hazard(hazards: list[Hazard], hazard: Hazard) -> None:
+    if hazard not in hazards:
+        hazards.append(hazard)
+
+
+__all__ = ["apply_semantic_judgments"]

--- a/tests/test_semantic_judgment_obligations.py
+++ b/tests/test_semantic_judgment_obligations.py
@@ -1,0 +1,168 @@
+from comp.compiler_tool import (
+    CompileReport,
+    ProofObligation,
+    SemanticJudgment,
+    SemanticJudgmentRequirement,
+    UncheckedArea,
+    apply_semantic_judgments,
+)
+
+
+def _semantic_obligation():
+    return ProofObligation(
+        kind="semantic_judgment_required",
+        field="scope2_method",
+        reason="semantic_support_required",
+        obligation_id="obl-scope2-method",
+        claim_id="claim-scope2-method",
+        semantic_requirement=SemanticJudgmentRequirement(
+            question="Does the cited span support the claimed Scope 2 method?",
+            claim_id="claim-scope2-method",
+            evidence_span_ids=("span-17",),
+            rubric_id="ghg-protocol-scope2-method-v1",
+            acceptable_verdicts=("supports", "refutes", "ambiguous"),
+            required_verdict="supports",
+            allowed_judges=("human/reviewer", "llm/model@policy-v1"),
+        ),
+    )
+
+
+def _judgment(**overrides):
+    data = {
+        "judgment_id": "judgment-1",
+        "obligation_id": "obl-scope2-method",
+        "verdict": "supports",
+        "rubric_id": "ghg-protocol-scope2-method-v1",
+        "judge": "llm/model@policy-v1",
+        "cited_span_ids": ("span-17",),
+        "rationale": "The cited wording supports the requested method.",
+        "confidence": 0.82,
+    }
+    data.update(overrides)
+    return SemanticJudgment(**data)
+
+
+def test_semantic_judgment_model_set_is_exported():
+    assert SemanticJudgmentRequirement is not None
+    assert SemanticJudgment is not None
+    assert apply_semantic_judgments is not None
+
+
+def test_matching_semantic_judgment_discharges_obligation():
+    obligation = _semantic_obligation()
+    report = CompileReport(status="review_required", obligations=(obligation,))
+
+    resolved = apply_semantic_judgments(
+        report,
+        (_judgment(),),
+        available_span_ids=("span-17",),
+    )
+
+    assert resolved.status == "accepted"
+    assert resolved.obligations == ()
+    assert resolved.resolved_obligations == (obligation,)
+    assert resolved.hazards == ()
+
+
+def test_wrong_rubric_does_not_discharge_obligation():
+    obligation = _semantic_obligation()
+    report = CompileReport(status="review_required", obligations=(obligation,))
+
+    resolved = apply_semantic_judgments(
+        report,
+        (_judgment(rubric_id="wrong-rubric"),),
+        available_span_ids=("span-17",),
+    )
+
+    assert resolved.status == "review_required"
+    assert resolved.obligations == (obligation,)
+    assert resolved.resolved_obligations == ()
+
+
+def test_unaccepted_or_non_required_verdict_does_not_discharge_obligation():
+    obligation = _semantic_obligation()
+    report = CompileReport(status="review_required", obligations=(obligation,))
+
+    refuted = apply_semantic_judgments(
+        report,
+        (_judgment(verdict="refutes"),),
+        available_span_ids=("span-17",),
+    )
+    unsupported = apply_semantic_judgments(
+        report,
+        (_judgment(verdict="not_sure"),),
+        available_span_ids=("span-17",),
+    )
+
+    assert refuted.status == "review_required"
+    assert refuted.obligations == (obligation,)
+    assert refuted.resolved_obligations == ()
+    assert unsupported.status == "review_required"
+    assert unsupported.obligations == (obligation,)
+    assert unsupported.resolved_obligations == ()
+
+
+def test_unallowed_judge_or_missing_cited_span_does_not_discharge_obligation():
+    obligation = _semantic_obligation()
+    report = CompileReport(status="review_required", obligations=(obligation,))
+
+    unallowed_judge = apply_semantic_judgments(
+        report,
+        (_judgment(judge="llm/unapproved"),),
+        available_span_ids=("span-17",),
+    )
+    missing_span = apply_semantic_judgments(
+        report,
+        (_judgment(cited_span_ids=("span-missing",)),),
+        available_span_ids=("span-17",),
+    )
+
+    assert unallowed_judge.obligations == (obligation,)
+    assert unallowed_judge.resolved_obligations == ()
+    assert missing_span.obligations == (obligation,)
+    assert missing_span.resolved_obligations == ()
+
+
+def test_conflicting_semantic_judgments_keep_obligation_open_and_add_hazard():
+    obligation = _semantic_obligation()
+    report = CompileReport(status="review_required", obligations=(obligation,))
+
+    resolved = apply_semantic_judgments(
+        report,
+        (
+            _judgment(judgment_id="judgment-supports", verdict="supports"),
+            _judgment(judgment_id="judgment-refutes", verdict="refutes"),
+        ),
+        available_span_ids=("span-17",),
+    )
+
+    assert resolved.status == "review_required"
+    assert resolved.obligations == (obligation,)
+    assert resolved.resolved_obligations == ()
+    assert len(resolved.hazards) == 1
+    assert resolved.hazards[0].kind == "conflicting_semantic_judgment"
+    assert resolved.hazards[0].field == "scope2_method"
+
+
+def test_nonsemantic_obligations_do_not_reclassify_unchecked_report():
+    obligation = ProofObligation(
+        kind="define_rule_coverage",
+        field="factor_period_compatibility",
+        reason="missing_rule_coverage",
+    )
+    report = CompileReport(
+        status="unchecked",
+        unchecked_areas=(
+            UncheckedArea(
+                field="factor_period_compatibility",
+                reason="missing_rule_coverage",
+            ),
+        ),
+        obligations=(obligation,),
+    )
+
+    resolved = apply_semantic_judgments(report, ())
+
+    assert resolved.status == "unchecked"
+    assert resolved.obligations == (obligation,)
+    assert resolved.resolved_obligations == ()


### PR DESCRIPTION
## Summary

- Add `SemanticJudgmentRequirement` and `SemanticJudgment` models to the compiler-tool contract.
- Extend `ProofObligation` with optional semantic-obligation metadata while preserving the existing positional contract.
- Add `apply_semantic_judgments(...)` to discharge matching semantic obligations only when submitted judgments satisfy rubric, verdict, judge, and cited-span protocol checks.
- Cover wrong rubric, unsupported verdict, unallowed judge, missing cited span, conflicting judgments, and non-semantic status preservation.

## Why

This is the first implementation slice from the obligation-kernel working theory: the validator should expose semantic judgment obligations and only discharge them when a resolver returns a sufficient judgment artifact. It keeps semantic judgment explicit instead of hiding LLM/human judgment inside compiler pass/fail behavior.

## Impact

- Adds a small semantic-obligation helper under `comp.compiler_tool`.
- No LLM integration, domain pack implementation, governance change, or projection behavior change.
- Existing `ProofObligation(kind, field, reason)` construction still works with defaulted metadata.

## Validation

- `python -m pytest tests/test_semantic_judgment_obligations.py -q` -> 7 passed
- `python -m pytest -q` -> 75 passed in 4.38s
- `git diff --check origin/main..HEAD`