### PR TITLE
[codex] feat: add compiler profile contract

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -14,6 +14,16 @@ from comp.compiler_tool.models import (
     UncheckedArea,
     UnknownClaim,
 )
+from comp.compiler_tool.profiles import (
+    CompilerProfile,
+    DomainPack,
+    JudgePolicy,
+    ProfileValidationError,
+    RuleFamily,
+    SemanticRubric,
+    active_rule_families,
+    validate_compiler_profile,
+)
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
@@ -34,6 +44,14 @@ __all__ = [
     "SemanticJudgmentRequirement",
     "SemanticJudgment",
     "Hazard",
+    "RuleFamily",
+    "SemanticRubric",
+    "JudgePolicy",
+    "DomainPack",
+    "CompilerProfile",
+    "ProfileValidationError",
+    "validate_compiler_profile",
+    "active_rule_families",
     "CompilerTool",
     "apply_semantic_judgments",
     "compile_report_to_facts",

--- a/comp/compiler_tool/profiles.py
+++ b/comp/compiler_tool/profiles.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+
+class ProfileValidationError(ValueError):
+    """Raised when a compiler profile cannot lock a coherent behavior set."""
+
+
+@dataclass(frozen=True)
+class RuleFamily:
+    rule_id: str
+    required_rubric_ids: tuple[str, ...] = field(default_factory=tuple)
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class SemanticRubric:
+    rubric_id: str
+    acceptable_verdicts: tuple[str, ...]
+    required_verdict: str = "supports"
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class JudgePolicy:
+    judge_policy_id: str
+    allowed_judges: tuple[str, ...] = field(default_factory=tuple)
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class DomainPack:
+    domain_id: str
+    version: str
+    rule_families: tuple[RuleFamily, ...] = field(default_factory=tuple)
+    rubrics: tuple[SemanticRubric, ...] = field(default_factory=tuple)
+    judge_policies: tuple[JudgePolicy, ...] = field(default_factory=tuple)
+    disabled_core_invariants: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class CompilerProfile:
+    profile_id: str
+    domain_packs: tuple[DomainPack, ...] = field(default_factory=tuple)
+    active_rule_ids: tuple[str, ...] = field(default_factory=tuple)
+    active_rubric_ids: tuple[str, ...] = field(default_factory=tuple)
+    judge_policy_id: str | None = None
+    projection_policy_id: str | None = None
+    core_invariant_version: str = "core-invariants-v1"
+
+
+def validate_compiler_profile(profile: CompilerProfile) -> None:
+    rules, rubrics, judge_policies = _catalogs(profile)
+
+    for domain in profile.domain_packs:
+        if domain.disabled_core_invariants:
+            disabled = ", ".join(domain.disabled_core_invariants)
+            raise ProfileValidationError(
+                f"domain pack {domain.domain_id!r} cannot disable core invariant(s): {disabled}"
+            )
+
+    for rule_id in profile.active_rule_ids:
+        if rule_id not in rules:
+            raise ProfileValidationError(f"unknown active rule id: {rule_id}")
+
+    for rubric_id in profile.active_rubric_ids:
+        if rubric_id not in rubrics:
+            raise ProfileValidationError(f"unknown active rubric id: {rubric_id}")
+
+    if profile.judge_policy_id is not None and profile.judge_policy_id not in judge_policies:
+        raise ProfileValidationError(f"unknown judge policy id: {profile.judge_policy_id}")
+
+    active_rubrics = set(profile.active_rubric_ids)
+    for rule in active_rule_families(profile, validate=False):
+        for rubric_id in rule.required_rubric_ids:
+            if rubric_id not in rubrics:
+                raise ProfileValidationError(
+                    f"unknown required rubric id {rubric_id} for rule {rule.rule_id}"
+                )
+            if rubric_id not in active_rubrics:
+                raise ProfileValidationError(
+                    f"inactive required rubric id {rubric_id} for rule {rule.rule_id}"
+                )
+
+
+def active_rule_families(
+    profile: CompilerProfile,
+    *,
+    validate: bool = True,
+) -> tuple[RuleFamily, ...]:
+    if validate:
+        validate_compiler_profile(profile)
+    rules, _, _ = _catalogs(profile)
+    return tuple(rules[rule_id] for rule_id in profile.active_rule_ids)
+
+
+def _catalogs(
+    profile: CompilerProfile,
+) -> tuple[dict[str, RuleFamily], dict[str, SemanticRubric], dict[str, JudgePolicy]]:
+    return (
+        _unique_by_id(
+            [
+                rule
+                for domain in profile.domain_packs
+                for rule in domain.rule_families
+            ],
+            attr="rule_id",
+            label="rule id",
+        ),
+        _unique_by_id(
+            [
+                rubric
+                for domain in profile.domain_packs
+                for rubric in domain.rubrics
+            ],
+            attr="rubric_id",
+            label="rubric id",
+        ),
+        _unique_by_id(
+            [
+                policy
+                for domain in profile.domain_packs
+                for policy in domain.judge_policies
+            ],
+            attr="judge_policy_id",
+            label="judge policy id",
+        ),
+    )
+
+
+T = TypeVar("T")
+
+
+def _unique_by_id(items: list[T], *, attr: str, label: str) -> dict[str, T]:
+    out: dict[str, T] = {}
+    for item in items:
+        item_id = getattr(item, attr)
+        if item_id in out:
+            raise ProfileValidationError(f"duplicate {label}: {item_id}")
+        out[item_id] = item
+    return out
+
+
+__all__ = [
+    "RuleFamily",
+    "SemanticRubric",
+    "JudgePolicy",
+    "DomainPack",
+    "CompilerProfile",
+    "ProfileValidationError",
+    "validate_compiler_profile",
+    "active_rule_families",
+]

--- a/tests/test_compiler_profile_contract.py
+++ b/tests/test_compiler_profile_contract.py
@@ -1,0 +1,166 @@
+import pytest
+
+from comp.compiler_tool import (
+    CompilerProfile,
+    DomainPack,
+    JudgePolicy,
+    ProfileValidationError,
+    RuleFamily,
+    SemanticRubric,
+    active_rule_families,
+    validate_compiler_profile,
+)
+
+
+def _rule(rule_id, *, rubric_ids=()):
+    return RuleFamily(
+        rule_id=rule_id,
+        required_rubric_ids=tuple(rubric_ids),
+    )
+
+
+def _rubric(rubric_id):
+    return SemanticRubric(
+        rubric_id=rubric_id,
+        acceptable_verdicts=("supports", "refutes", "ambiguous"),
+        required_verdict="supports",
+    )
+
+
+def _judge_policy(policy_id):
+    return JudgePolicy(
+        judge_policy_id=policy_id,
+        allowed_judges=("human/reviewer", "llm/model@policy-v1"),
+    )
+
+
+def _domain(
+    *,
+    rules,
+    rubrics=(),
+    judge_policies=(),
+    disabled_core_invariants=(),
+):
+    return DomainPack(
+        domain_id="fixture",
+        version="2026.1",
+        rule_families=tuple(rules),
+        rubrics=tuple(rubrics),
+        judge_policies=tuple(judge_policies),
+        disabled_core_invariants=tuple(disabled_core_invariants),
+    )
+
+
+def test_compiler_profile_model_set_is_exported():
+    assert DomainPack is not None
+    assert CompilerProfile is not None
+    assert RuleFamily is not None
+    assert SemanticRubric is not None
+    assert JudgePolicy is not None
+    assert ProfileValidationError is not None
+    assert active_rule_families is not None
+    assert validate_compiler_profile is not None
+
+
+def test_profile_only_activates_named_rules_in_profile_order():
+    inactive = _rule("fixture.inactive_rule.v1")
+    first = _rule("fixture.first_rule.v1")
+    second = _rule("fixture.second_rule.v1")
+    domain = _domain(rules=(inactive, first, second))
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(domain,),
+        active_rule_ids=("fixture.second_rule.v1", "fixture.first_rule.v1"),
+    )
+
+    validate_compiler_profile(profile)
+
+    assert active_rule_families(profile) == (second, first)
+
+
+def test_profile_validation_rejects_unknown_active_rule_id():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(_domain(rules=(_rule("fixture.known_rule.v1"),)),),
+        active_rule_ids=("fixture.missing_rule.v1",),
+    )
+
+    with pytest.raises(ProfileValidationError, match="unknown active rule"):
+        validate_compiler_profile(profile)
+
+
+def test_profile_validation_rejects_unknown_active_rubric_id():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(_domain(rules=(), rubrics=(_rubric("fixture.rubric.v1"),)),),
+        active_rubric_ids=("fixture.missing_rubric.v1",),
+    )
+
+    with pytest.raises(ProfileValidationError, match="unknown active rubric"):
+        validate_compiler_profile(profile)
+
+
+def test_profile_validation_rejects_unknown_judge_policy_id():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(rules=(), judge_policies=(_judge_policy("fixture.judge_policy.v1"),)),
+        ),
+        judge_policy_id="fixture.missing_judge_policy.v1",
+    )
+
+    with pytest.raises(ProfileValidationError, match="unknown judge policy"):
+        validate_compiler_profile(profile)
+
+
+def test_rule_required_rubrics_must_be_active_in_profile():
+    rule = _rule(
+        "fixture.semantic_rule.v1",
+        rubric_ids=("fixture.semantic_rubric.v1",),
+    )
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(
+                rules=(rule,),
+                rubrics=(_rubric("fixture.semantic_rubric.v1"),),
+            ),
+        ),
+        active_rule_ids=("fixture.semantic_rule.v1",),
+        active_rubric_ids=(),
+    )
+
+    with pytest.raises(ProfileValidationError, match="inactive required rubric"):
+        validate_compiler_profile(profile)
+
+
+def test_domain_pack_cannot_disable_core_invariants():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(
+                rules=(),
+                disabled_core_invariants=("receipt_required_for_projection",),
+            ),
+        ),
+    )
+
+    with pytest.raises(ProfileValidationError, match="cannot disable core invariant"):
+        validate_compiler_profile(profile)
+
+
+def test_duplicate_rule_ids_are_rejected():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(
+                rules=(
+                    _rule("fixture.duplicate.v1"),
+                    _rule("fixture.duplicate.v1"),
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(ProfileValidationError, match="duplicate rule id"):
+        validate_compiler_profile(profile)


### PR DESCRIPTION
## Summary

- Add a compiler profile contract surface with `DomainPack`, `RuleFamily`, `SemanticRubric`, `JudgePolicy`, and `CompilerProfile`.
- Add profile validation that rejects unknown active rules, unknown active rubrics, unknown judge policies, duplicate rule ids, inactive required rubrics, and domain attempts to disable core invariants.
- Add `active_rule_families(...)` so installed domain rules are not automatically active; profile order controls active rule order.

## Why

This is the next implementation slice from the obligation-kernel working theory. It starts separating core protocol from domain behavior by making active rules/rubrics/judge policy explicit and version-lockable before adding real domain packs.

## Impact

- Adds profile/domain skeleton models under `comp.compiler_tool`.
- No rule execution integration yet.
- No ESG domain pack, reference DB, LLM, or projection behavior change.

## Validation

- `python -m pytest tests/test_compiler_profile_contract.py -q` -> 8 passed
- `python -m pytest -q` -> 83 passed in 4.40s
- `git diff --check origin/main..HEAD`