### PR TITLE
[codex] feat: add tiny domain fixture runner

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -24,6 +24,7 @@ from comp.compiler_tool.profiles import (
     active_rule_families,
     validate_compiler_profile,
 )
+from comp.compiler_tool.profile_runner import compile_with_profile
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
@@ -52,6 +53,7 @@ __all__ = [
     "ProfileValidationError",
     "validate_compiler_profile",
     "active_rule_families",
+    "compile_with_profile",
     "CompilerTool",
     "apply_semantic_judgments",
     "compile_report_to_facts",

--- a/comp/compiler_tool/profile_runner.py
+++ b/comp/compiler_tool/profile_runner.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from comp.compiler_tool.models import CompileReport, InterpretationHypothesis, ProofObligation
+from comp.compiler_tool.profiles import CompilerProfile, active_rule_families, validate_compiler_profile
+
+
+def compile_with_profile(
+    hypothesis: InterpretationHypothesis,
+    profile: CompilerProfile,
+) -> CompileReport:
+    validate_compiler_profile(profile)
+    obligations: list[ProofObligation] = []
+
+    for claim in hypothesis.claims:
+        for rule in active_rule_families(profile, validate=False):
+            if rule.evaluate is None:
+                continue
+            for result in rule.evaluate(claim, hypothesis, profile):
+                if isinstance(result, ProofObligation) and result not in obligations:
+                    obligations.append(result)
+
+    return CompileReport(
+        status=_status_for(obligations),
+        obligations=tuple(obligations),
+        can_project_public_row=False,
+    )
+
+
+def _status_for(obligations: list[ProofObligation]) -> str:
+    if any(
+        obligation.kind == "semantic_judgment_required" and obligation.blocking
+        for obligation in obligations
+    ):
+        return "review_required"
+    return "accepted"
+
+
+__all__ = ["compile_with_profile"]

--- a/comp/compiler_tool/profiles.py
+++ b/comp/compiler_tool/profiles.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TypeVar
+from typing import Any, Callable, TypeVar
+
+RuleEvaluator = Callable[[Any, Any, "CompilerProfile"], tuple[Any, ...]]
 
 
 class ProfileValidationError(ValueError):
@@ -13,6 +15,7 @@ class RuleFamily:
     rule_id: str
     required_rubric_ids: tuple[str, ...] = field(default_factory=tuple)
     description: str = ""
+    evaluate: RuleEvaluator | None = None
 
 
 @dataclass(frozen=True)
@@ -21,6 +24,26 @@ class SemanticRubric:
     acceptable_verdicts: tuple[str, ...]
     required_verdict: str = "supports"
     description: str = ""
+
+    def requirement(
+        self,
+        *,
+        question: str,
+        claim_id: str,
+        evidence_span_ids: tuple[str, ...] = (),
+        allowed_judges: tuple[str, ...] = (),
+    ):
+        from comp.compiler_tool.models import SemanticJudgmentRequirement
+
+        return SemanticJudgmentRequirement(
+            question=question,
+            claim_id=claim_id,
+            evidence_span_ids=evidence_span_ids,
+            rubric_id=self.rubric_id,
+            acceptable_verdicts=self.acceptable_verdicts,
+            required_verdict=self.required_verdict,
+            allowed_judges=allowed_judges,
+        )
 
 
 @dataclass(frozen=True)
@@ -49,6 +72,24 @@ class CompilerProfile:
     judge_policy_id: str | None = None
     projection_policy_id: str | None = None
     core_invariant_version: str = "core-invariants-v1"
+
+    def rubric(self, rubric_id: str) -> SemanticRubric:
+        _, rubrics, _ = _catalogs(self)
+        try:
+            return rubrics[rubric_id]
+        except KeyError as exc:
+            raise ProfileValidationError(f"unknown rubric id: {rubric_id}") from exc
+
+    def judge_policy(self) -> JudgePolicy:
+        if self.judge_policy_id is None:
+            return JudgePolicy(judge_policy_id="default-empty-judge-policy")
+        _, _, judge_policies = _catalogs(self)
+        try:
+            return judge_policies[self.judge_policy_id]
+        except KeyError as exc:
+            raise ProfileValidationError(
+                f"unknown judge policy id: {self.judge_policy_id}"
+            ) from exc
 
 
 def validate_compiler_profile(profile: CompilerProfile) -> None:

--- a/tests/test_tiny_domain_fixture.py
+++ b/tests/test_tiny_domain_fixture.py
@@ -1,0 +1,157 @@
+from comp.compiler_tool import (
+    ClaimHypothesis,
+    CompilerProfile,
+    DomainPack,
+    EvidenceWitness,
+    InterpretationHypothesis,
+    JudgePolicy,
+    ProofObligation,
+    RuleFamily,
+    SemanticJudgment,
+    SemanticRubric,
+    active_rule_families,
+    apply_semantic_judgments,
+    compile_with_profile,
+)
+
+
+SCOPE2_RUBRIC_ID = "fixture.ghg.scope2_method_support.v1"
+SCOPE2_RULE_ID = "fixture.ghg.scope2_method_support_rule.v1"
+JUDGE_POLICY_ID = "fixture.default_judge_policy.v1"
+
+
+def _scope2_method_rule(claim, hypothesis, profile):
+    if claim.field != "scope2_method":
+        return ()
+    rubric = profile.rubric(SCOPE2_RUBRIC_ID)
+    judge_policy = profile.judge_policy()
+    return (
+        ProofObligation(
+            kind="semantic_judgment_required",
+            field=claim.field,
+            reason="semantic_support_required",
+            obligation_id=f"semantic:{claim.field}:{claim.witness_id}",
+            claim_id=f"{hypothesis.hypothesis_id}:{claim.field}",
+            semantic_requirement=rubric.requirement(
+                question="Does the cited span support the claimed Scope 2 method?",
+                claim_id=f"{hypothesis.hypothesis_id}:{claim.field}",
+                evidence_span_ids=(claim.witness_id,),
+                allowed_judges=judge_policy.allowed_judges,
+            ),
+        ),
+    )
+
+
+def _tiny_domain():
+    return DomainPack(
+        domain_id="fixture-ghg",
+        version="2026.1",
+        rule_families=(
+            RuleFamily(
+                rule_id=SCOPE2_RULE_ID,
+                required_rubric_ids=(SCOPE2_RUBRIC_ID,),
+                evaluate=_scope2_method_rule,
+            ),
+            RuleFamily(rule_id="fixture.inactive_rule.v1"),
+        ),
+        rubrics=(
+            SemanticRubric(
+                rubric_id=SCOPE2_RUBRIC_ID,
+                acceptable_verdicts=("supports", "refutes", "ambiguous"),
+                required_verdict="supports",
+            ),
+        ),
+        judge_policies=(
+            JudgePolicy(
+                judge_policy_id=JUDGE_POLICY_ID,
+                allowed_judges=("human/reviewer", "llm/model@policy-v1"),
+            ),
+        ),
+    )
+
+
+def _profile(*, active_rule_ids=(SCOPE2_RULE_ID,)):
+    return CompilerProfile(
+        profile_id="fixture-ghg-profile",
+        domain_packs=(_tiny_domain(),),
+        active_rule_ids=active_rule_ids,
+        active_rubric_ids=(SCOPE2_RUBRIC_ID,),
+        judge_policy_id=JUDGE_POLICY_ID,
+    )
+
+
+def _hypothesis():
+    return InterpretationHypothesis(
+        hypothesis_id="hyp-scope2",
+        subject_id="claim-scope2",
+        claims=(
+            ClaimHypothesis(
+                field="scope2_method",
+                value="market_based",
+                witness_id="span-17",
+                origin="llm_inferred",
+            ),
+        ),
+        witnesses=(
+            EvidenceWitness(
+                witness_id="span-17",
+                field="scope2_method",
+                source="report.pdf",
+                span="p12",
+            ),
+        ),
+    )
+
+
+def _judgment(obligation_id):
+    return SemanticJudgment(
+        judgment_id="judgment-scope2",
+        obligation_id=obligation_id,
+        verdict="supports",
+        rubric_id=SCOPE2_RUBRIC_ID,
+        judge="llm/model@policy-v1",
+        cited_span_ids=("span-17",),
+        rationale="The cited span supports the claimed Scope 2 method.",
+    )
+
+
+def test_tiny_domain_profile_opens_scope2_semantic_obligation():
+    report = compile_with_profile(_hypothesis(), _profile())
+
+    assert report.status == "review_required"
+    assert len(report.obligations) == 1
+    obligation = report.obligations[0]
+    assert obligation.kind == "semantic_judgment_required"
+    assert obligation.field == "scope2_method"
+    assert obligation.semantic_requirement is not None
+    assert obligation.semantic_requirement.rubric_id == SCOPE2_RUBRIC_ID
+    assert obligation.semantic_requirement.allowed_judges == (
+        "human/reviewer",
+        "llm/model@policy-v1",
+    )
+    assert report.can_project_public_row is False
+
+
+def test_tiny_domain_semantic_judgment_discharges_obligation():
+    report = compile_with_profile(_hypothesis(), _profile())
+    obligation = report.obligations[0]
+
+    resolved = apply_semantic_judgments(
+        report,
+        (_judgment(obligation.obligation_id),),
+        available_span_ids=("span-17",),
+    )
+
+    assert resolved.status == "accepted"
+    assert resolved.obligations == ()
+    assert resolved.resolved_obligations == (obligation,)
+
+
+def test_inactive_tiny_domain_rule_does_not_open_obligation():
+    profile = _profile(active_rule_ids=())
+
+    report = compile_with_profile(_hypothesis(), profile)
+
+    assert active_rule_families(profile) == ()
+    assert report.status == "accepted"
+    assert report.obligations == ()


### PR DESCRIPTION
## Summary
- Add a tiny profile runner that evaluates active `RuleFamily` hooks and emits profile-scoped obligations.
- Extend profile models with optional rule evaluators plus rubric and judge-policy lookup helpers.
- Add a tiny fixture domain test showing `scope2_method` opening a semantic judgment obligation, then being discharged by a matching judgment.

## Scope
- This does not add a real ESG domain pack, reference DB, retrieval layer, governance policy, or public projection behavior.
- Embedding/LLM work remains outside this slice; this PR only proves the core/domain/profile loop can open obligations through declared rules.

## Validation
- `python -m pytest tests/test_tiny_domain_fixture.py -q` -> 3 passed
- `python -m pytest -q` -> 86 passed
- `git diff --check origin/main..HEAD`