### PR TITLE
[codex] feat: add reference binding artifacts

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -25,6 +25,11 @@ from comp.compiler_tool.profiles import (
     validate_compiler_profile,
 )
 from comp.compiler_tool.profile_runner import compile_with_profile
+from comp.compiler_tool.references import (
+    ReferenceBinding,
+    ReferenceCandidate,
+    RejectedReferenceCandidate,
+)
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
@@ -45,6 +50,9 @@ __all__ = [
     "SemanticJudgmentRequirement",
     "SemanticJudgment",
     "Hazard",
+    "ReferenceCandidate",
+    "RejectedReferenceCandidate",
+    "ReferenceBinding",
     "RuleFamily",
     "SemanticRubric",
     "JudgePolicy",

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from comp.compiler_tool.references import ReferenceBinding, ReferenceCandidate
+
 CompileStatus = Literal[
     "accepted",
     "blocked",
@@ -121,4 +123,6 @@ class CompileReport:
     obligations: tuple[ProofObligation, ...] = field(default_factory=tuple)
     resolved_obligations: tuple[ProofObligation, ...] = field(default_factory=tuple)
     hazards: tuple[Hazard, ...] = field(default_factory=tuple)
+    reference_candidates: tuple[ReferenceCandidate, ...] = field(default_factory=tuple)
+    reference_bindings: tuple[ReferenceBinding, ...] = field(default_factory=tuple)
     can_project_public_row: bool = False

--- a/comp/compiler_tool/references.py
+++ b/comp/compiler_tool/references.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ReferenceCandidate:
+    candidate_id: str
+    reference_id: str
+    reference_type: str
+    retrieval_method: str
+    retrieval_score: float | None = None
+    source: str | None = None
+    witness_ids: tuple[str, ...] = field(default_factory=tuple)
+    authority: str = "candidate_only"
+
+    def __post_init__(self) -> None:
+        _require_authority(
+            actual=self.authority,
+            expected="candidate_only",
+            artifact="ReferenceCandidate",
+        )
+
+    @property
+    def can_authorize_calculation(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class RejectedReferenceCandidate:
+    candidate_id: str
+    reference_id: str
+    reason: str
+    selector_rule_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ReferenceBinding:
+    binding_id: str
+    claim_id: str
+    reference_id: str
+    reference_type: str
+    selected_candidate_id: str | None = None
+    selector_rule_id: str | None = None
+    source_witness_ids: tuple[str, ...] = field(default_factory=tuple)
+    rejected_candidates: tuple[RejectedReferenceCandidate, ...] = field(
+        default_factory=tuple
+    )
+    authority: str = "canonical_binding"
+
+    def __post_init__(self) -> None:
+        _require_authority(
+            actual=self.authority,
+            expected="canonical_binding",
+            artifact="ReferenceBinding",
+        )
+
+    @property
+    def can_authorize_calculation(self) -> bool:
+        return True
+
+
+def _require_authority(*, actual: str, expected: str, artifact: str) -> None:
+    if actual != expected:
+        raise ValueError(f"{artifact} authority must be {expected!r}")
+
+
+__all__ = [
+    "ReferenceCandidate",
+    "RejectedReferenceCandidate",
+    "ReferenceBinding",
+]

--- a/comp/compiler_tool/semantic.py
+++ b/comp/compiler_tool/semantic.py
@@ -83,6 +83,8 @@ def apply_semantic_judgments(
             *tuple(newly_resolved),
         ),
         hazards=tuple(hazards),
+        reference_candidates=report.reference_candidates,
+        reference_bindings=report.reference_bindings,
         can_project_public_row=report.can_project_public_row,
     )
 

--- a/tests/test_reference_binding_model.py
+++ b/tests/test_reference_binding_model.py
@@ -1,0 +1,140 @@
+import pytest
+
+from comp.compiler_tool import (
+    CompileReport,
+    ProofObligation,
+    ReferenceBinding,
+    ReferenceCandidate,
+    RejectedReferenceCandidate,
+    SemanticJudgment,
+    SemanticJudgmentRequirement,
+    apply_semantic_judgments,
+)
+
+
+def test_reference_candidate_is_candidate_only_authority():
+    candidate = ReferenceCandidate(
+        candidate_id="cand-kr-grid-2024",
+        reference_id="factor.kr_grid.2024",
+        reference_type="emission_factor",
+        retrieval_method="embedding",
+        retrieval_score=0.91,
+        source="reference_db",
+        witness_ids=("span-amount",),
+    )
+
+    assert candidate.authority == "candidate_only"
+    assert candidate.can_authorize_calculation is False
+
+    report = CompileReport(
+        status="review_required",
+        reference_candidates=(candidate,),
+    )
+
+    assert report.reference_candidates == (candidate,)
+    assert report.reference_bindings == ()
+
+
+def test_reference_candidate_cannot_claim_binding_authority():
+    with pytest.raises(ValueError, match="candidate_only"):
+        ReferenceCandidate(
+            candidate_id="cand-1",
+            reference_id="factor.kr_grid.2024",
+            reference_type="emission_factor",
+            retrieval_method="embedding",
+            authority="canonical_binding",
+        )
+
+
+def test_reference_binding_records_selector_and_rejected_candidates():
+    rejected = RejectedReferenceCandidate(
+        candidate_id="cand-residual-mix",
+        reference_id="factor.kr_residual_mix.2024",
+        reason="method_mismatch",
+        selector_rule_id="ghg.factor_selector.v1",
+    )
+    binding = ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id="factor.kr_grid.2024",
+        reference_type="emission_factor",
+        selected_candidate_id="cand-kr-grid-2024",
+        selector_rule_id="ghg.factor_selector.v1",
+        source_witness_ids=("span-amount", "factor-row-17"),
+        rejected_candidates=(rejected,),
+    )
+
+    assert binding.authority == "canonical_binding"
+    assert binding.can_authorize_calculation is True
+    assert binding.rejected_candidates == (rejected,)
+
+    report = CompileReport(status="accepted", reference_bindings=(binding,))
+
+    assert report.reference_bindings == (binding,)
+    assert report.reference_candidates == ()
+
+
+def test_reference_binding_cannot_be_downgraded_to_candidate_authority():
+    with pytest.raises(ValueError, match="canonical_binding"):
+        ReferenceBinding(
+            binding_id="bind-1",
+            claim_id="hyp-1:amount",
+            reference_id="factor.kr_grid.2024",
+            reference_type="emission_factor",
+            authority="candidate_only",
+        )
+
+
+def test_semantic_judgment_application_preserves_reference_artifacts():
+    candidate = ReferenceCandidate(
+        candidate_id="cand-kr-grid-2024",
+        reference_id="factor.kr_grid.2024",
+        reference_type="emission_factor",
+        retrieval_method="embedding",
+    )
+    binding = ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id="factor.kr_grid.2024",
+        reference_type="emission_factor",
+        selected_candidate_id=candidate.candidate_id,
+        selector_rule_id="ghg.factor_selector.v1",
+    )
+    obligation = ProofObligation(
+        kind="semantic_judgment_required",
+        field="scope2_method",
+        reason="semantic_support_required",
+        obligation_id="obl-scope2",
+        semantic_requirement=SemanticJudgmentRequirement(
+            question="Does the span support market-based Scope 2?",
+            claim_id="hyp-1:scope2_method",
+            evidence_span_ids=("span-17",),
+            rubric_id="ghg.scope2_method.v1",
+            acceptable_verdicts=("supports", "refutes", "ambiguous"),
+        ),
+    )
+    report = CompileReport(
+        status="review_required",
+        obligations=(obligation,),
+        reference_candidates=(candidate,),
+        reference_bindings=(binding,),
+    )
+
+    updated = apply_semantic_judgments(
+        report,
+        [
+            SemanticJudgment(
+                judgment_id="judgment-1",
+                obligation_id="obl-scope2",
+                verdict="supports",
+                rubric_id="ghg.scope2_method.v1",
+                judge="llm/test",
+                cited_span_ids=("span-17",),
+                rationale="Fixture judgment.",
+            )
+        ],
+        available_span_ids=("span-17",),
+    )
+
+    assert updated.reference_candidates == (candidate,)
+    assert updated.reference_bindings == (binding,)


### PR DESCRIPTION
## Summary
- Add `ReferenceCandidate`, `RejectedReferenceCandidate`, and `ReferenceBinding` artifacts.
- Keep retrieval candidates explicitly `candidate_only` and bindings explicitly `canonical_binding`, so embedding/search scores cannot masquerade as calculation authority.
- Add `CompileReport.reference_candidates` and `CompileReport.reference_bindings` slots, and preserve them through semantic judgment application.

## Scope
- This does not add a real reference database, retrieval implementation, deterministic selector, factor binding rules, or calculator.
- The slice only establishes the core artifacts that later DB-backed selector/calculator work can emit and validate.

## Validation
- `python -m pytest tests/test_reference_binding_model.py -q` -> 5 passed
- `python -m pytest -q` -> 91 passed
- `git diff --check origin/main..HEAD`