### PR TITLE
[codex] feat: add derived claim calculation traces

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -1,5 +1,10 @@
 """Deterministic compiler-tool contract surface."""
 
+from comp.compiler_tool.calculations import (
+    CalculationStep,
+    CalculationTrace,
+    DerivedClaim,
+)
 from comp.compiler_tool.models import (
     CheckedClaim,
     ClaimHypothesis,
@@ -50,6 +55,9 @@ __all__ = [
     "SemanticJudgmentRequirement",
     "SemanticJudgment",
     "Hazard",
+    "CalculationStep",
+    "CalculationTrace",
+    "DerivedClaim",
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
     "ReferenceBinding",

--- a/comp/compiler_tool/calculations.py
+++ b/comp/compiler_tool/calculations.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CalculationStep:
+    step_id: str
+    operation: str
+    input_ids: tuple[str, ...] = field(default_factory=tuple)
+    output_value: Any = None
+    output_unit: str | None = None
+
+
+@dataclass(frozen=True)
+class CalculationTrace:
+    trace_id: str
+    formula_id: str
+    input_claim_ids: tuple[str, ...] = field(default_factory=tuple)
+    reference_binding_ids: tuple[str, ...] = field(default_factory=tuple)
+    steps: tuple[CalculationStep, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.formula_id:
+            raise ValueError("CalculationTrace formula_id is required")
+
+
+@dataclass(frozen=True)
+class DerivedClaim:
+    claim_id: str
+    field: str
+    value: Any
+    unit: str | None
+    trace: CalculationTrace
+    origin: str = "calculated"
+
+    @property
+    def formula_id(self) -> str:
+        return self.trace.formula_id
+
+    @property
+    def can_authorize_public_projection(self) -> bool:
+        return False
+
+
+__all__ = [
+    "CalculationStep",
+    "CalculationTrace",
+    "DerivedClaim",
+]

--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -24,6 +24,29 @@ def compile_report_to_facts(report: CompileReport, subject: SubjectRef) -> set[F
             )
         )
 
+    for claim in report.derived_claims:
+        facts.add(
+            Fact(
+                tag="evidence",
+                subject=subject,
+                key=claim.field,
+                value=claim.value,
+                witness=claim.trace.trace_id,
+                weight=1.0,
+                meta=(
+                    ("claim_id", claim.claim_id),
+                    ("formula_id", claim.formula_id),
+                    ("input_claim_ids", claim.trace.input_claim_ids),
+                    ("origin", claim.origin),
+                    ("reference_binding_ids", claim.trace.reference_binding_ids),
+                    ("report_section", "derived_claim"),
+                    ("report_status", report.status),
+                    ("trace_id", claim.trace.trace_id),
+                    ("unit", claim.unit),
+                ),
+            )
+        )
+
     for claim in report.failed_claims:
         facts.add(
             Fact(

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from comp.compiler_tool.calculations import DerivedClaim
 from comp.compiler_tool.references import ReferenceBinding, ReferenceCandidate
 
 CompileStatus = Literal[
@@ -125,4 +126,5 @@ class CompileReport:
     hazards: tuple[Hazard, ...] = field(default_factory=tuple)
     reference_candidates: tuple[ReferenceCandidate, ...] = field(default_factory=tuple)
     reference_bindings: tuple[ReferenceBinding, ...] = field(default_factory=tuple)
+    derived_claims: tuple[DerivedClaim, ...] = field(default_factory=tuple)
     can_project_public_row: bool = False

--- a/comp/compiler_tool/semantic.py
+++ b/comp/compiler_tool/semantic.py
@@ -85,6 +85,7 @@ def apply_semantic_judgments(
         hazards=tuple(hazards),
         reference_candidates=report.reference_candidates,
         reference_bindings=report.reference_bindings,
+        derived_claims=report.derived_claims,
         can_project_public_row=report.can_project_public_row,
     )
 

--- a/tests/test_derived_claim_trace.py
+++ b/tests/test_derived_claim_trace.py
@@ -1,0 +1,132 @@
+import pytest
+
+from comp.compiler_tool import (
+    CalculationStep,
+    CalculationTrace,
+    CompileReport,
+    DerivedClaim,
+    ProofObligation,
+    SemanticJudgment,
+    SemanticJudgmentRequirement,
+    apply_semantic_judgments,
+    compile_report_to_facts,
+)
+from comp.judgment import Fact, SubjectRef
+
+
+def _trace():
+    return CalculationTrace(
+        trace_id="trace-electricity-co2e",
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        input_claim_ids=("hyp-1:amount",),
+        reference_binding_ids=("bind-amount-factor",),
+        steps=(
+            CalculationStep(
+                step_id="multiply-activity-by-factor",
+                operation="multiply",
+                input_ids=("hyp-1:amount", "bind-amount-factor"),
+                output_value=0.48,
+                output_unit="tCO2e",
+            ),
+        ),
+    )
+
+
+def _derived_claim():
+    return DerivedClaim(
+        claim_id="hyp-1:co2e_emission",
+        field="co2e_emission",
+        value=0.48,
+        unit="tCO2e",
+        trace=_trace(),
+    )
+
+
+def test_derived_claim_is_calculated_claim_not_public_authority():
+    claim = _derived_claim()
+
+    assert claim.origin == "calculated"
+    assert claim.formula_id == "ghg.electricity_factor_multiplication.v1"
+    assert claim.can_authorize_public_projection is False
+
+    report = CompileReport(status="accepted", derived_claims=(claim,))
+
+    assert report.derived_claims == (claim,)
+    assert report.can_project_public_row is False
+
+
+def test_calculation_trace_requires_formula_id():
+    with pytest.raises(ValueError, match="formula_id"):
+        CalculationTrace(
+            trace_id="trace-1",
+            formula_id="",
+            input_claim_ids=("hyp-1:amount",),
+        )
+
+
+def test_semantic_judgment_application_preserves_derived_claims():
+    claim = _derived_claim()
+    obligation = ProofObligation(
+        kind="semantic_judgment_required",
+        field="scope2_method",
+        reason="semantic_support_required",
+        obligation_id="obl-scope2",
+        semantic_requirement=SemanticJudgmentRequirement(
+            question="Does the span support market-based Scope 2?",
+            claim_id="hyp-1:scope2_method",
+            evidence_span_ids=("span-17",),
+            rubric_id="ghg.scope2_method.v1",
+            acceptable_verdicts=("supports", "refutes", "ambiguous"),
+        ),
+    )
+    report = CompileReport(
+        status="review_required",
+        obligations=(obligation,),
+        derived_claims=(claim,),
+    )
+
+    updated = apply_semantic_judgments(
+        report,
+        [
+            SemanticJudgment(
+                judgment_id="judgment-1",
+                obligation_id="obl-scope2",
+                verdict="supports",
+                rubric_id="ghg.scope2_method.v1",
+                judge="llm/test",
+                cited_span_ids=("span-17",),
+                rationale="Fixture judgment.",
+            )
+        ],
+        available_span_ids=("span-17",),
+    )
+
+    assert updated.derived_claims == (claim,)
+
+
+def test_compile_report_to_facts_maps_derived_claim_with_trace_metadata():
+    subject = SubjectRef("claim", "hyp-1")
+    claim = _derived_claim()
+    report = CompileReport(status="accepted", derived_claims=(claim,))
+
+    facts = compile_report_to_facts(report, subject)
+
+    assert Fact(
+        tag="evidence",
+        subject=subject,
+        key="co2e_emission",
+        value=0.48,
+        witness="trace-electricity-co2e",
+        weight=1.0,
+        meta=(
+            ("claim_id", "hyp-1:co2e_emission"),
+            ("formula_id", "ghg.electricity_factor_multiplication.v1"),
+            ("input_claim_ids", ("hyp-1:amount",)),
+            ("origin", "calculated"),
+            ("reference_binding_ids", ("bind-amount-factor",)),
+            ("report_section", "derived_claim"),
+            ("report_status", "accepted"),
+            ("trace_id", "trace-electricity-co2e"),
+            ("unit", "tCO2e"),
+        ),
+    ) in facts


### PR DESCRIPTION
## Summary
- Add `CalculationStep`, `CalculationTrace`, and `DerivedClaim` artifacts for calculated outputs.
- Add `CompileReport.derived_claims` and preserve derived claims through semantic judgment application.
- Map derived claims into judgment facts with calculation trace, formula, input claim, reference binding, and unit metadata.

## Scope
- This does not add a real calculator, formula registry, reference DB, selector, or governance/public projection behavior.
- Derived claims remain non-public-authorizing artifacts; receipt-gated projection is still a later slice.

## Validation
- `python -m pytest tests/test_derived_claim_trace.py -q` -> 4 passed
- `python -m pytest -q` -> 95 passed
- `git diff --check origin/main..HEAD`