### PR TITLE
[codex] feat: add tiny reference catalog

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -30,6 +30,11 @@ from comp.compiler_tool.profiles import (
     validate_compiler_profile,
 )
 from comp.compiler_tool.profile_runner import compile_with_profile
+from comp.compiler_tool.reference_db import (
+    ReferenceCatalog,
+    ReferenceLookupError,
+    ReferenceRecord,
+)
 from comp.compiler_tool.references import (
     ReferenceBinding,
     ReferenceCandidate,
@@ -61,6 +66,9 @@ __all__ = [
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
     "ReferenceBinding",
+    "ReferenceLookupError",
+    "ReferenceRecord",
+    "ReferenceCatalog",
     "RuleFamily",
     "SemanticRubric",
     "JudgePolicy",

--- a/comp/compiler_tool/reference_db.py
+++ b/comp/compiler_tool/reference_db.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from comp.compiler_tool.references import ReferenceCandidate
+
+
+class ReferenceLookupError(KeyError):
+    """Raised when a requested canonical reference row is absent."""
+
+
+@dataclass(frozen=True)
+class ReferenceRecord:
+    reference_id: str
+    reference_type: str
+    labels: tuple[str, ...] = field(default_factory=tuple)
+    aliases: tuple[str, ...] = field(default_factory=tuple)
+    description: str = ""
+    attributes: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+    source: str | None = None
+    witness_ids: tuple[str, ...] = field(default_factory=tuple)
+
+    def attribute(self, name: str, default: Any = None) -> Any:
+        for key, value in self.attributes:
+            if key == name:
+                return value
+        return default
+
+    def to_candidate(
+        self,
+        *,
+        candidate_id: str,
+        retrieval_method: str,
+        retrieval_score: float | None = None,
+    ) -> ReferenceCandidate:
+        return ReferenceCandidate(
+            candidate_id=candidate_id,
+            reference_id=self.reference_id,
+            reference_type=self.reference_type,
+            retrieval_method=retrieval_method,
+            retrieval_score=retrieval_score,
+            source=self.source,
+            witness_ids=self.witness_ids,
+        )
+
+
+@dataclass(frozen=True)
+class ReferenceCatalog:
+    records: tuple[ReferenceRecord, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        seen: set[str] = set()
+        for record in self.records:
+            if record.reference_id in seen:
+                raise ValueError(f"duplicate reference id: {record.reference_id}")
+            seen.add(record.reference_id)
+
+    def get(self, reference_id: str) -> ReferenceRecord:
+        for record in self.records:
+            if record.reference_id == reference_id:
+                return record
+        raise ReferenceLookupError(f"unknown reference id: {reference_id}")
+
+    def search(
+        self,
+        query: str,
+        *,
+        reference_type: str | None = None,
+        limit: int = 10,
+        retrieval_method: str = "keyword",
+    ) -> tuple[ReferenceCandidate, ...]:
+        scored: list[tuple[float, ReferenceRecord]] = []
+        for record in self.records:
+            if reference_type is not None and record.reference_type != reference_type:
+                continue
+
+            score = _match_score(query, record)
+            if score > 0:
+                scored.append((score, record))
+
+        scored.sort(key=lambda item: (-item[0], item[1].reference_id))
+        return tuple(
+            record.to_candidate(
+                candidate_id=f"{retrieval_method}:{record.reference_id}",
+                retrieval_method=retrieval_method,
+                retrieval_score=score,
+            )
+            for score, record in scored[:limit]
+        )
+
+
+def _match_score(query: str, record: ReferenceRecord) -> float:
+    normalized_query = _normalize_text(query)
+    names = (*record.labels, *record.aliases)
+    if any(_normalize_text(name) == normalized_query for name in names):
+        return 1.0
+
+    query_tokens = set(_tokens(query))
+    if not query_tokens:
+        return 0.0
+
+    record_tokens = set(
+        _tokens(" ".join((*record.labels, *record.aliases, record.description)))
+    )
+    overlap = query_tokens & record_tokens
+    if not overlap:
+        return 0.0
+    return round(len(overlap) / len(query_tokens), 6)
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(_tokens(value))
+
+
+def _tokens(value: str) -> tuple[str, ...]:
+    return tuple(token for token in re.split(r"[^a-z0-9]+", value.lower()) if token)
+
+
+__all__ = [
+    "ReferenceLookupError",
+    "ReferenceRecord",
+    "ReferenceCatalog",
+]

--- a/tests/test_tiny_reference_db.py
+++ b/tests/test_tiny_reference_db.py
@@ -1,0 +1,123 @@
+import pytest
+
+from comp.compiler_tool import (
+    ReferenceCatalog,
+    ReferenceLookupError,
+    ReferenceRecord,
+)
+
+
+def _tiny_catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="concept.electricity_consumption",
+                reference_type="taxonomy_concept",
+                labels=("Electricity consumption",),
+                aliases=("purchased electricity", "scope 2 electricity"),
+                description="Purchased electricity consumption activity.",
+                attributes=(("claim_type", "activity_observation"),),
+                source="tiny-fixture",
+                witness_ids=("ref-concept-electricity",),
+            ),
+            ReferenceRecord(
+                reference_id="unit.kwh",
+                reference_type="unit",
+                labels=("kWh",),
+                aliases=("kilowatt hour", "kilowatt-hour"),
+                attributes=(("dimension", "energy"),),
+                source="tiny-fixture",
+                witness_ids=("ref-unit-kwh",),
+            ),
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                labels=("KR grid electricity factor 2024",),
+                aliases=("korea electricity grid factor",),
+                attributes=(
+                    ("concept_id", "concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "location_based"),
+                    ("unit_basis", "kgCO2e/kWh"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-17",),
+            ),
+        )
+    )
+
+
+def test_reference_catalog_retrieves_canonical_record_by_id():
+    catalog = _tiny_catalog()
+
+    factor = catalog.get("factor.kr_grid.2024.location_based")
+
+    assert factor.reference_type == "emission_factor"
+    assert factor.attribute("geography") == "KR"
+    assert factor.attribute("valid_period") == "2024"
+    assert factor.attribute("method") == "location_based"
+
+
+def test_reference_catalog_alias_search_returns_candidate_only_artifacts():
+    catalog = _tiny_catalog()
+
+    candidates = catalog.search(
+        "purchased electricity",
+        reference_type="taxonomy_concept",
+    )
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.reference_id == "concept.electricity_consumption"
+    assert candidate.reference_type == "taxonomy_concept"
+    assert candidate.retrieval_method == "keyword"
+    assert candidate.retrieval_score == 1.0
+    assert candidate.source == "tiny-fixture"
+    assert candidate.witness_ids == ("ref-concept-electricity",)
+    assert candidate.authority == "candidate_only"
+    assert candidate.can_authorize_calculation is False
+
+
+def test_reference_catalog_filters_by_reference_type():
+    catalog = _tiny_catalog()
+
+    candidates = catalog.search("electricity", reference_type="unit")
+
+    assert candidates == ()
+
+
+def test_reference_record_can_be_rendered_as_exact_candidate():
+    catalog = _tiny_catalog()
+    factor = catalog.get("factor.kr_grid.2024.location_based")
+
+    candidate = factor.to_candidate(
+        candidate_id="cand-factor-kr-grid-2024",
+        retrieval_method="fixture_exact",
+        retrieval_score=1.0,
+    )
+
+    assert candidate.reference_id == factor.reference_id
+    assert candidate.reference_type == "emission_factor"
+    assert candidate.source == "tiny-fixture"
+    assert candidate.witness_ids == ("ref-factor-row-17",)
+    assert candidate.authority == "candidate_only"
+
+
+def test_reference_catalog_rejects_duplicate_ids_and_missing_lookup():
+    with pytest.raises(ValueError, match="duplicate reference id"):
+        ReferenceCatalog(
+            records=(
+                ReferenceRecord(
+                    reference_id="unit.kwh",
+                    reference_type="unit",
+                ),
+                ReferenceRecord(
+                    reference_id="unit.kwh",
+                    reference_type="unit",
+                ),
+            )
+        )
+
+    with pytest.raises(ReferenceLookupError, match="unknown reference id"):
+        _tiny_catalog().get("missing.reference")


### PR DESCRIPTION
## Summary
- Add a generic in-memory `ReferenceCatalog` and canonical `ReferenceRecord` model.
- Support deterministic label/alias keyword lookup that emits `ReferenceCandidate(candidate_only)` artifacts.
- Cover a tiny test fixture with taxonomy concept, unit, and emission factor rows without baking ESG-specific rows into core code.

## Scope
- This does not add embeddings, a persistent DB, deterministic selector rules, `ReferenceBinding` creation, or calculation behavior.
- Search results remain candidate-only hints; they cannot authorize calculation or publication.

## Validation
- `python -m pytest tests/test_tiny_reference_db.py -q` -> 5 passed
- `python -m pytest -q` -> 100 passed
- `git diff --check origin/main..HEAD`