### PR TITLE
[codex] feat: add deterministic reference selector

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -35,6 +35,11 @@ from comp.compiler_tool.reference_db import (
     ReferenceLookupError,
     ReferenceRecord,
 )
+from comp.compiler_tool.reference_selector import (
+    ReferenceSelectionCriteria,
+    ReferenceSelectionResult,
+    select_reference_binding,
+)
 from comp.compiler_tool.references import (
     ReferenceBinding,
     ReferenceCandidate,
@@ -69,6 +74,9 @@ __all__ = [
     "ReferenceLookupError",
     "ReferenceRecord",
     "ReferenceCatalog",
+    "ReferenceSelectionCriteria",
+    "ReferenceSelectionResult",
+    "select_reference_binding",
     "RuleFamily",
     "SemanticRubric",
     "JudgePolicy",

--- a/comp/compiler_tool/reference_selector.py
+++ b/comp/compiler_tool/reference_selector.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from comp.compiler_tool.reference_db import ReferenceCatalog, ReferenceLookupError
+from comp.compiler_tool.references import (
+    ReferenceBinding,
+    ReferenceCandidate,
+    RejectedReferenceCandidate,
+)
+
+
+@dataclass(frozen=True)
+class ReferenceSelectionCriteria:
+    binding_id: str
+    claim_id: str
+    reference_type: str
+    selector_rule_id: str
+    required_attributes: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ReferenceSelectionResult:
+    status: str
+    binding: ReferenceBinding | None = None
+    accepted_candidate_ids: tuple[str, ...] = field(default_factory=tuple)
+    rejected_candidates: tuple[RejectedReferenceCandidate, ...] = field(
+        default_factory=tuple
+    )
+
+
+def select_reference_binding(
+    *,
+    candidates: tuple[ReferenceCandidate, ...],
+    catalog: ReferenceCatalog,
+    criteria: ReferenceSelectionCriteria,
+) -> ReferenceSelectionResult:
+    accepted: list[tuple[ReferenceCandidate, tuple[str, ...]]] = []
+    rejected: list[RejectedReferenceCandidate] = []
+
+    for candidate in candidates:
+        rejection = _rejection_reason(candidate, catalog, criteria)
+        if rejection is not None:
+            rejected.append(
+                RejectedReferenceCandidate(
+                    candidate_id=candidate.candidate_id,
+                    reference_id=candidate.reference_id,
+                    reason=rejection,
+                    selector_rule_id=criteria.selector_rule_id,
+                )
+            )
+            continue
+
+        record = catalog.get(candidate.reference_id)
+        accepted.append((candidate, record.witness_ids))
+
+    if len(accepted) != 1:
+        return ReferenceSelectionResult(
+            status="ambiguous" if accepted else "no_match",
+            accepted_candidate_ids=tuple(
+                candidate.candidate_id for candidate, _ in accepted
+            ),
+            rejected_candidates=tuple(rejected),
+        )
+
+    selected, witness_ids = accepted[0]
+    binding = ReferenceBinding(
+        binding_id=criteria.binding_id,
+        claim_id=criteria.claim_id,
+        reference_id=selected.reference_id,
+        reference_type=criteria.reference_type,
+        selected_candidate_id=selected.candidate_id,
+        selector_rule_id=criteria.selector_rule_id,
+        source_witness_ids=witness_ids,
+        rejected_candidates=tuple(rejected),
+    )
+    return ReferenceSelectionResult(
+        status="bound",
+        binding=binding,
+        accepted_candidate_ids=(selected.candidate_id,),
+        rejected_candidates=tuple(rejected),
+    )
+
+
+def _rejection_reason(
+    candidate: ReferenceCandidate,
+    catalog: ReferenceCatalog,
+    criteria: ReferenceSelectionCriteria,
+) -> str | None:
+    if candidate.reference_type != criteria.reference_type:
+        return "reference_type_mismatch"
+
+    try:
+        record = catalog.get(candidate.reference_id)
+    except ReferenceLookupError:
+        return "unknown_reference"
+
+    if record.reference_type != criteria.reference_type:
+        return "reference_type_mismatch"
+
+    for name, expected in criteria.required_attributes:
+        if record.attribute(name) != expected:
+            return f"attribute_mismatch:{name}"
+
+    return None
+
+
+__all__ = [
+    "ReferenceSelectionCriteria",
+    "ReferenceSelectionResult",
+    "select_reference_binding",
+]

--- a/tests/test_reference_selector.py
+++ b/tests/test_reference_selector.py
@@ -1,0 +1,168 @@
+from comp.compiler_tool import (
+    ReferenceCandidate,
+    ReferenceCatalog,
+    ReferenceRecord,
+    ReferenceSelectionCriteria,
+    ReferenceSelectionResult,
+    select_reference_binding,
+)
+
+
+def _catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                labels=("KR grid electricity factor 2024",),
+                attributes=(
+                    ("concept_id", "concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "location_based"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-17",),
+            ),
+            ReferenceRecord(
+                reference_id="factor.kr_residual_mix.2024.market_based",
+                reference_type="emission_factor",
+                labels=("KR residual mix electricity factor 2024",),
+                attributes=(
+                    ("concept_id", "concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "market_based"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-18",),
+            ),
+            ReferenceRecord(
+                reference_id="factor.us_grid.2024.location_based",
+                reference_type="emission_factor",
+                labels=("US grid electricity factor 2024",),
+                attributes=(
+                    ("concept_id", "concept.electricity_consumption"),
+                    ("geography", "US"),
+                    ("valid_period", "2024"),
+                    ("method", "location_based"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-19",),
+            ),
+        )
+    )
+
+
+def _candidate(candidate_id, reference_id, score):
+    return ReferenceCandidate(
+        candidate_id=candidate_id,
+        reference_id=reference_id,
+        reference_type="emission_factor",
+        retrieval_method="keyword",
+        retrieval_score=score,
+        source="tiny-fixture",
+    )
+
+
+def _criteria():
+    return ReferenceSelectionCriteria(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_type="emission_factor",
+        selector_rule_id="ghg.factor_selector.v1",
+        required_attributes=(
+            ("concept_id", "concept.electricity_consumption"),
+            ("geography", "KR"),
+            ("valid_period", "2024"),
+            ("method", "location_based"),
+        ),
+    )
+
+
+def test_reference_selector_binds_single_deterministic_match():
+    result = select_reference_binding(
+        candidates=(
+            _candidate("cand-market", "factor.kr_residual_mix.2024.market_based", 0.96),
+            _candidate("cand-location", "factor.kr_grid.2024.location_based", 0.82),
+            _candidate("cand-us", "factor.us_grid.2024.location_based", 0.73),
+        ),
+        catalog=_catalog(),
+        criteria=_criteria(),
+    )
+
+    assert isinstance(result, ReferenceSelectionResult)
+    assert result.status == "bound"
+    assert result.binding is not None
+    assert result.binding.reference_id == "factor.kr_grid.2024.location_based"
+    assert result.binding.selected_candidate_id == "cand-location"
+    assert result.binding.selector_rule_id == "ghg.factor_selector.v1"
+    assert result.binding.source_witness_ids == ("ref-factor-row-17",)
+    assert result.binding.rejected_candidates == result.rejected_candidates
+    assert result.binding.can_authorize_calculation is True
+    assert [(item.candidate_id, item.reason) for item in result.rejected_candidates] == [
+        ("cand-market", "attribute_mismatch:method"),
+        ("cand-us", "attribute_mismatch:geography"),
+    ]
+
+
+def test_reference_selector_does_not_auto_pick_top_score_when_ambiguous():
+    result = select_reference_binding(
+        candidates=(
+            _candidate("cand-a", "factor.kr_grid.2024.location_based", 0.99),
+            _candidate("cand-b", "factor.kr_grid.2024.location_based", 0.76),
+        ),
+        catalog=_catalog(),
+        criteria=_criteria(),
+    )
+
+    assert result.status == "ambiguous"
+    assert result.binding is None
+    assert result.accepted_candidate_ids == ("cand-a", "cand-b")
+    assert result.rejected_candidates == ()
+
+
+def test_reference_selector_reports_no_match_and_unknown_references():
+    result = select_reference_binding(
+        candidates=(
+            _candidate("cand-market", "factor.kr_residual_mix.2024.market_based", 0.96),
+            _candidate("cand-missing", "factor.missing", 0.95),
+        ),
+        catalog=_catalog(),
+        criteria=_criteria(),
+    )
+
+    assert result.status == "no_match"
+    assert result.binding is None
+    assert result.accepted_candidate_ids == ()
+    assert [(item.candidate_id, item.reason) for item in result.rejected_candidates] == [
+        ("cand-market", "attribute_mismatch:method"),
+        ("cand-missing", "unknown_reference"),
+    ]
+
+
+def test_reference_selector_rejects_reference_type_mismatch():
+    result = select_reference_binding(
+        candidates=(
+            ReferenceCandidate(
+                candidate_id="cand-unit",
+                reference_id="unit.kwh",
+                reference_type="unit",
+                retrieval_method="keyword",
+            ),
+        ),
+        catalog=ReferenceCatalog(
+            records=(
+                ReferenceRecord(
+                    reference_id="unit.kwh",
+                    reference_type="unit",
+                ),
+            )
+        ),
+        criteria=_criteria(),
+    )
+
+    assert result.status == "no_match"
+    assert [(item.candidate_id, item.reason) for item in result.rejected_candidates] == [
+        ("cand-unit", "reference_type_mismatch"),
+    ]


### PR DESCRIPTION
## Summary
- Add `ReferenceSelectionCriteria`, `ReferenceSelectionResult`, and `select_reference_binding`.
- Select a `ReferenceBinding` only when exactly one candidate passes deterministic reference type and attribute checks.
- Preserve rejected candidates with explicit reasons, and block ambiguous matches instead of choosing the highest retrieval score.

## Scope
- This does not add embeddings, semantic judgment fallback, obligations for unresolved selections, calculator wiring, or governance behavior.
- Retrieval scores remain hints only; the selector does not use them to authorize binding when multiple candidates satisfy the criteria.

## Validation
- `python -m pytest tests/test_reference_selector.py -q` -> 4 passed
- `python -m pytest -q` -> 104 passed
- `git diff --check origin/main..HEAD`