### PR TITLE
[codex] feat: add deterministic derived claim calculator

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -1,9 +1,13 @@
 """Deterministic compiler-tool contract surface."""
 
 from comp.compiler_tool.calculations import (
+    CalculationFormula,
+    CalculationInput,
+    CalculationResult,
     CalculationStep,
     CalculationTrace,
     DerivedClaim,
+    calculate_derived_claim,
 )
 from comp.compiler_tool.models import (
     CheckedClaim,
@@ -65,9 +69,13 @@ __all__ = [
     "SemanticJudgmentRequirement",
     "SemanticJudgment",
     "Hazard",
+    "CalculationInput",
+    "CalculationFormula",
+    "CalculationResult",
     "CalculationStep",
     "CalculationTrace",
     "DerivedClaim",
+    "calculate_derived_claim",
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
     "ReferenceBinding",

--- a/comp/compiler_tool/calculations.py
+++ b/comp/compiler_tool/calculations.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from decimal import Decimal
+from numbers import Number
 from typing import Any
+
+from comp.compiler_tool.reference_db import ReferenceCatalog, ReferenceLookupError
+from comp.compiler_tool.references import ReferenceBinding
 
 
 @dataclass(frozen=True)
@@ -44,8 +49,104 @@ class DerivedClaim:
         return False
 
 
+@dataclass(frozen=True)
+class CalculationInput:
+    claim_id: str
+    field: str
+    value: Any
+    unit: str | None = None
+
+
+@dataclass(frozen=True)
+class CalculationFormula:
+    formula_id: str
+    output_field: str
+    output_unit: str
+    factor_value_attribute: str = "factor_value"
+    input_unit_attribute: str = "input_unit"
+    output_unit_attribute: str = "output_unit"
+
+
+@dataclass(frozen=True)
+class CalculationResult:
+    status: str
+    derived_claim: DerivedClaim | None = None
+    reason: str | None = None
+
+
+def calculate_derived_claim(
+    *,
+    output_claim_id: str,
+    input_claim: CalculationInput,
+    reference_binding: ReferenceBinding,
+    catalog: ReferenceCatalog,
+    formula: CalculationFormula,
+) -> CalculationResult:
+    try:
+        reference = catalog.get(reference_binding.reference_id)
+    except ReferenceLookupError:
+        return _blocked("unknown_reference")
+
+    factor_value = reference.attribute(formula.factor_value_attribute)
+    if factor_value is None:
+        return _blocked("missing_factor_value")
+
+    expected_input_unit = reference.attribute(formula.input_unit_attribute)
+    if expected_input_unit is not None and input_claim.unit != expected_input_unit:
+        return _blocked("unit_mismatch")
+
+    expected_output_unit = reference.attribute(formula.output_unit_attribute)
+    if expected_output_unit is not None and formula.output_unit != expected_output_unit:
+        return _blocked("output_unit_mismatch")
+
+    if not isinstance(input_claim.value, Number) or not isinstance(factor_value, Number):
+        return _blocked("non_numeric_input")
+
+    output_value = _multiply(input_claim.value, factor_value)
+    trace = CalculationTrace(
+        trace_id=f"trace:{output_claim_id}",
+        formula_id=formula.formula_id,
+        input_claim_ids=(input_claim.claim_id,),
+        reference_binding_ids=(reference_binding.binding_id,),
+        steps=(
+            CalculationStep(
+                step_id="multiply-input-by-factor",
+                operation="multiply",
+                input_ids=(input_claim.claim_id, reference_binding.binding_id),
+                output_value=output_value,
+                output_unit=formula.output_unit,
+            ),
+        ),
+    )
+    return CalculationResult(
+        status="calculated",
+        derived_claim=DerivedClaim(
+            claim_id=output_claim_id,
+            field=formula.output_field,
+            value=output_value,
+            unit=formula.output_unit,
+            trace=trace,
+        ),
+    )
+
+
+def _blocked(reason: str) -> CalculationResult:
+    return CalculationResult(status="blocked", reason=reason)
+
+
+def _multiply(left: Number, right: Number) -> int | float:
+    value = Decimal(str(left)) * Decimal(str(right))
+    if value == value.to_integral_value():
+        return int(value)
+    return float(value)
+
+
 __all__ = [
     "CalculationStep",
     "CalculationTrace",
     "DerivedClaim",
+    "CalculationInput",
+    "CalculationFormula",
+    "CalculationResult",
+    "calculate_derived_claim",
 ]

--- a/tests/test_deterministic_calculator.py
+++ b/tests/test_deterministic_calculator.py
@@ -1,0 +1,162 @@
+from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
+    CalculationResult,
+    ReferenceBinding,
+    ReferenceCatalog,
+    ReferenceRecord,
+    calculate_derived_claim,
+)
+
+
+def _catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                labels=("KR grid electricity factor 2024",),
+                attributes=(
+                    ("factor_value", 0.0004),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-17",),
+            ),
+        )
+    )
+
+
+def _binding(reference_id="factor.kr_grid.2024.location_based"):
+    return ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id=reference_id,
+        reference_type="emission_factor",
+        selected_candidate_id="cand-factor",
+        selector_rule_id="ghg.factor_selector.v1",
+        source_witness_ids=("ref-factor-row-17",),
+    )
+
+
+def _input(value=1200, unit="kWh"):
+    return CalculationInput(
+        claim_id="hyp-1:amount",
+        field="amount",
+        value=value,
+        unit=unit,
+    )
+
+
+def _formula():
+    return CalculationFormula(
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_field="co2e_emission",
+        output_unit="tCO2e",
+    )
+
+
+def test_calculator_generates_derived_claim_from_binding_and_formula():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(),
+        reference_binding=_binding(),
+        catalog=_catalog(),
+        formula=_formula(),
+    )
+
+    assert isinstance(result, CalculationResult)
+    assert result.status == "calculated"
+    assert result.reason is None
+    assert result.derived_claim is not None
+    assert result.derived_claim.claim_id == "hyp-1:co2e_emission"
+    assert result.derived_claim.field == "co2e_emission"
+    assert result.derived_claim.value == 0.48
+    assert result.derived_claim.unit == "tCO2e"
+    assert result.derived_claim.formula_id == "ghg.electricity_factor_multiplication.v1"
+    assert result.derived_claim.can_authorize_public_projection is False
+    assert result.derived_claim.trace.input_claim_ids == ("hyp-1:amount",)
+    assert result.derived_claim.trace.reference_binding_ids == ("bind-amount-factor",)
+    assert result.derived_claim.trace.steps[0].operation == "multiply"
+    assert result.derived_claim.trace.steps[0].input_ids == (
+        "hyp-1:amount",
+        "bind-amount-factor",
+    )
+    assert result.derived_claim.trace.steps[0].output_value == 0.48
+    assert result.derived_claim.trace.steps[0].output_unit == "tCO2e"
+
+
+def test_calculator_blocks_unit_mismatch():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(unit="MWh"),
+        reference_binding=_binding(),
+        catalog=_catalog(),
+        formula=_formula(),
+    )
+
+    assert result.status == "blocked"
+    assert result.reason == "unit_mismatch"
+    assert result.derived_claim is None
+
+
+def test_calculator_blocks_missing_factor_value():
+    catalog = ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                attributes=(
+                    ("input_unit", "kWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+            ),
+        )
+    )
+
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(),
+        reference_binding=_binding(),
+        catalog=catalog,
+        formula=_formula(),
+    )
+
+    assert result.status == "blocked"
+    assert result.reason == "missing_factor_value"
+    assert result.derived_claim is None
+
+
+def test_calculator_blocks_output_unit_mismatch():
+    formula = CalculationFormula(
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_field="co2e_emission",
+        output_unit="kgCO2e",
+    )
+
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(),
+        reference_binding=_binding(),
+        catalog=_catalog(),
+        formula=formula,
+    )
+
+    assert result.status == "blocked"
+    assert result.reason == "output_unit_mismatch"
+    assert result.derived_claim is None
+
+
+def test_calculator_blocks_unknown_binding_reference():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(),
+        reference_binding=_binding(reference_id="factor.missing"),
+        catalog=_catalog(),
+        formula=_formula(),
+    )
+
+    assert result.status == "blocked"
+    assert result.reason == "unknown_reference"
+    assert result.derived_claim is None


### PR DESCRIPTION
## Summary
- Add `CalculationInput`, `CalculationFormula`, `CalculationResult`, and `calculate_derived_claim`.
- Generate a `DerivedClaim` with `CalculationTrace` from an input claim, canonical `ReferenceBinding`, reference catalog row, and formula.
- Block deterministic calculation when the factor is missing, input/output units mismatch, reference lookup fails, or numeric inputs are invalid.

## Scope
- This does not add formula registries, automatic obligation emission, governance/public projection behavior, or LLM/embedding involvement.
- The calculator output remains a derived claim artifact, not publication authority.

## Validation
- `python -m pytest tests/test_deterministic_calculator.py -q` -> 5 passed
- `python -m pytest -q` -> 109 passed
- `git diff --check origin/main..HEAD`