### PR TITLE
[codex] feat: add calculation obligation requirements

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -3,6 +3,7 @@
 from comp.compiler_tool.calculations import (
     CalculationFormula,
     CalculationInput,
+    CalculationRequirement,
     CalculationResult,
     CalculationStep,
     CalculationTrace,
@@ -72,6 +73,7 @@ __all__ = [
     "Hazard",
     "CalculationInput",
     "CalculationFormula",
+    "CalculationRequirement",
     "CalculationResult",
     "CalculationStep",
     "CalculationTrace",

--- a/comp/compiler_tool/calculation_report.py
+++ b/comp/compiler_tool/calculation_report.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from comp.compiler_tool.calculations import CalculationFormula, CalculationResult
+from comp.compiler_tool.calculations import (
+    CalculationFormula,
+    CalculationRequirement,
+    CalculationResult,
+)
 from comp.compiler_tool.models import CompileReport, ProofObligation
 
 
@@ -21,6 +25,11 @@ def apply_calculation_result(
         )
 
     reason = result.reason or "calculation_blocked"
+    requirement = result.requirement or CalculationRequirement(
+        reason=reason,
+        formula_id=formula.formula_id,
+        output_claim_id=output_claim_id,
+    )
     obligation = ProofObligation(
         kind="calculation_blocked",
         field=formula.output_field,
@@ -30,6 +39,7 @@ def apply_calculation_result(
         ),
         claim_id=output_claim_id,
         blocking=True,
+        calculation_requirement=requirement,
     )
     return replace(
         report,

--- a/comp/compiler_tool/calculations.py
+++ b/comp/compiler_tool/calculations.py
@@ -68,10 +68,26 @@ class CalculationFormula:
 
 
 @dataclass(frozen=True)
+class CalculationRequirement:
+    reason: str
+    formula_id: str
+    output_claim_id: str
+    input_claim_id: str | None = None
+    reference_binding_id: str | None = None
+    reference_id: str | None = None
+    expected_unit: str | None = None
+    actual_unit: str | None = None
+    expected_output_unit: str | None = None
+    actual_output_unit: str | None = None
+    missing_attribute: str | None = None
+
+
+@dataclass(frozen=True)
 class CalculationResult:
     status: str
     derived_claim: DerivedClaim | None = None
     reason: str | None = None
+    requirement: CalculationRequirement | None = None
 
 
 def calculate_derived_claim(
@@ -85,22 +101,67 @@ def calculate_derived_claim(
     try:
         reference = catalog.get(reference_binding.reference_id)
     except ReferenceLookupError:
-        return _blocked("unknown_reference")
+        return _blocked(
+            _requirement(
+                reason="unknown_reference",
+                output_claim_id=output_claim_id,
+                input_claim=input_claim,
+                reference_binding=reference_binding,
+                formula=formula,
+            )
+        )
 
     factor_value = reference.attribute(formula.factor_value_attribute)
     if factor_value is None:
-        return _blocked("missing_factor_value")
+        return _blocked(
+            _requirement(
+                reason="missing_factor_value",
+                output_claim_id=output_claim_id,
+                input_claim=input_claim,
+                reference_binding=reference_binding,
+                formula=formula,
+                missing_attribute=formula.factor_value_attribute,
+            )
+        )
 
     expected_input_unit = reference.attribute(formula.input_unit_attribute)
     if expected_input_unit is not None and input_claim.unit != expected_input_unit:
-        return _blocked("unit_mismatch")
+        return _blocked(
+            _requirement(
+                reason="unit_mismatch",
+                output_claim_id=output_claim_id,
+                input_claim=input_claim,
+                reference_binding=reference_binding,
+                formula=formula,
+                expected_unit=expected_input_unit,
+                actual_unit=input_claim.unit,
+            )
+        )
 
     expected_output_unit = reference.attribute(formula.output_unit_attribute)
     if expected_output_unit is not None and formula.output_unit != expected_output_unit:
-        return _blocked("output_unit_mismatch")
+        return _blocked(
+            _requirement(
+                reason="output_unit_mismatch",
+                output_claim_id=output_claim_id,
+                input_claim=input_claim,
+                reference_binding=reference_binding,
+                formula=formula,
+                expected_output_unit=expected_output_unit,
+                actual_output_unit=formula.output_unit,
+            )
+        )
 
     if not isinstance(input_claim.value, Number) or not isinstance(factor_value, Number):
-        return _blocked("non_numeric_input")
+        return _blocked(
+            _requirement(
+                reason="non_numeric_input",
+                output_claim_id=output_claim_id,
+                input_claim=input_claim,
+                reference_binding=reference_binding,
+                formula=formula,
+            )
+        )
 
     output_value = _multiply(input_claim.value, factor_value)
     trace = CalculationTrace(
@@ -130,8 +191,40 @@ def calculate_derived_claim(
     )
 
 
-def _blocked(reason: str) -> CalculationResult:
-    return CalculationResult(status="blocked", reason=reason)
+def _blocked(requirement: CalculationRequirement) -> CalculationResult:
+    return CalculationResult(
+        status="blocked",
+        reason=requirement.reason,
+        requirement=requirement,
+    )
+
+
+def _requirement(
+    *,
+    reason: str,
+    output_claim_id: str,
+    input_claim: CalculationInput,
+    reference_binding: ReferenceBinding,
+    formula: CalculationFormula,
+    expected_unit: str | None = None,
+    actual_unit: str | None = None,
+    expected_output_unit: str | None = None,
+    actual_output_unit: str | None = None,
+    missing_attribute: str | None = None,
+) -> CalculationRequirement:
+    return CalculationRequirement(
+        reason=reason,
+        formula_id=formula.formula_id,
+        output_claim_id=output_claim_id,
+        input_claim_id=input_claim.claim_id,
+        reference_binding_id=reference_binding.binding_id,
+        reference_id=reference_binding.reference_id,
+        expected_unit=expected_unit,
+        actual_unit=actual_unit,
+        expected_output_unit=expected_output_unit,
+        actual_output_unit=actual_output_unit,
+        missing_attribute=missing_attribute,
+    )
 
 
 def _multiply(left: Number, right: Number) -> int | float:
@@ -147,6 +240,7 @@ __all__ = [
     "DerivedClaim",
     "CalculationInput",
     "CalculationFormula",
+    "CalculationRequirement",
     "CalculationResult",
     "calculate_derived_claim",
 ]

--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -141,17 +141,26 @@ def _obligation_fact(
     *,
     section: str = "proof_obligation",
 ) -> Fact:
+    meta = [
+        ("kind", obligation.kind),
+        ("reason", obligation.reason),
+    ]
+    if obligation.calculation_requirement is not None:
+        meta.extend(
+            _calculation_requirement_meta(obligation.calculation_requirement)
+        )
+    meta.extend(
+        [
+            ("report_section", section),
+            ("report_status", status),
+        ]
+    )
     return Fact(
         tag=tag,
         subject=subject,
         key=f"proof_obligation:{obligation.field}",
         value=_obligation_id(obligation.kind, obligation.field, obligation.reason),
-        meta=(
-            ("kind", obligation.kind),
-            ("reason", obligation.reason),
-            ("report_section", section),
-            ("report_status", status),
-        ),
+        meta=tuple(meta),
     )
 
 
@@ -173,6 +182,25 @@ def _obligation_id(kind: str, field: str, reason: str) -> str:
 
 def _hazard_id(kind: str, field: str, severity: str) -> str:
     return _stable_id("hazard", kind, field, severity)
+
+
+def _calculation_requirement_meta(requirement) -> list[tuple[str, str]]:
+    return [
+        (key, value)
+        for key, value in (
+            ("actual_output_unit", requirement.actual_output_unit),
+            ("actual_unit", requirement.actual_unit),
+            ("expected_output_unit", requirement.expected_output_unit),
+            ("expected_unit", requirement.expected_unit),
+            ("formula_id", requirement.formula_id),
+            ("input_claim_id", requirement.input_claim_id),
+            ("missing_attribute", requirement.missing_attribute),
+            ("output_claim_id", requirement.output_claim_id),
+            ("reference_binding_id", requirement.reference_binding_id),
+            ("reference_id", requirement.reference_id),
+        )
+        if value is not None
+    ]
 
 
 def _stable_id(*parts: str) -> str:

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from comp.compiler_tool.calculations import DerivedClaim
+from comp.compiler_tool.calculations import CalculationRequirement, DerivedClaim
 from comp.compiler_tool.references import ReferenceBinding, ReferenceCandidate
 
 CompileStatus = Literal[
@@ -93,6 +93,7 @@ class ProofObligation:
     claim_id: str | None = None
     blocking: bool = True
     semantic_requirement: SemanticJudgmentRequirement | None = None
+    calculation_requirement: CalculationRequirement | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_calculation_obligation_requirements.py
+++ b/tests/test_calculation_obligation_requirements.py
@@ -1,0 +1,172 @@
+from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
+    CalculationRequirement,
+    CompileReport,
+    ReferenceBinding,
+    ReferenceCatalog,
+    ReferenceRecord,
+    apply_calculation_result,
+    calculate_derived_claim,
+    compile_report_to_facts,
+)
+from comp.judgment import Fact, SubjectRef
+
+
+def _catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                attributes=(
+                    ("factor_value", 0.0004),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+            ),
+        )
+    )
+
+
+def _binding(reference_id="factor.kr_grid.2024.location_based"):
+    return ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id=reference_id,
+        reference_type="emission_factor",
+    )
+
+
+def _formula(output_unit="tCO2e"):
+    return CalculationFormula(
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_field="co2e_emission",
+        output_unit=output_unit,
+    )
+
+
+def test_blocked_calculation_result_carries_structured_requirement():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=CalculationInput(
+            claim_id="hyp-1:amount",
+            field="amount",
+            value=1200,
+            unit="MWh",
+        ),
+        reference_binding=_binding(),
+        catalog=_catalog(),
+        formula=_formula(),
+    )
+
+    assert result.status == "blocked"
+    assert result.requirement == CalculationRequirement(
+        reason="unit_mismatch",
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim_id="hyp-1:amount",
+        reference_binding_id="bind-amount-factor",
+        reference_id="factor.kr_grid.2024.location_based",
+        expected_unit="kWh",
+        actual_unit="MWh",
+    )
+
+
+def test_blocked_calculation_report_obligation_carries_requirement_payload():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=CalculationInput(
+            claim_id="hyp-1:amount",
+            field="amount",
+            value=1200,
+            unit="MWh",
+        ),
+        reference_binding=_binding(),
+        catalog=_catalog(),
+        formula=_formula(),
+    )
+
+    report = apply_calculation_result(
+        CompileReport(status="accepted"),
+        result,
+        output_claim_id="hyp-1:co2e_emission",
+        formula=_formula(),
+    )
+
+    assert report.obligations[0].calculation_requirement == result.requirement
+
+
+def test_calculation_requirement_metadata_is_visible_to_judgment_facts():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=CalculationInput(
+            claim_id="hyp-1:amount",
+            field="amount",
+            value=1200,
+            unit="MWh",
+        ),
+        reference_binding=_binding(),
+        catalog=_catalog(),
+        formula=_formula(),
+    )
+    report = apply_calculation_result(
+        CompileReport(status="accepted"),
+        result,
+        output_claim_id="hyp-1:co2e_emission",
+        formula=_formula(),
+    )
+
+    facts = compile_report_to_facts(report, SubjectRef("claim", "hyp-1"))
+
+    assert Fact(
+        tag="hazard_open",
+        subject=SubjectRef("claim", "hyp-1"),
+        key="proof_obligation:co2e_emission",
+        value="proof_obligation:calculation_blocked:co2e_emission:unit_mismatch",
+        meta=(
+            ("kind", "calculation_blocked"),
+            ("reason", "unit_mismatch"),
+            ("actual_unit", "MWh"),
+            ("expected_unit", "kWh"),
+            ("formula_id", "ghg.electricity_factor_multiplication.v1"),
+            ("input_claim_id", "hyp-1:amount"),
+            ("output_claim_id", "hyp-1:co2e_emission"),
+            ("reference_binding_id", "bind-amount-factor"),
+            ("reference_id", "factor.kr_grid.2024.location_based"),
+            ("report_section", "proof_obligation"),
+            ("report_status", "blocked"),
+        ),
+    ) in facts
+
+
+def test_missing_factor_requirement_names_missing_attribute():
+    catalog = ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                attributes=(
+                    ("input_unit", "kWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+            ),
+        )
+    )
+
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=CalculationInput(
+            claim_id="hyp-1:amount",
+            field="amount",
+            value=1200,
+            unit="kWh",
+        ),
+        reference_binding=_binding(),
+        catalog=catalog,
+        formula=_formula(),
+    )
+
+    assert result.requirement is not None
+    assert result.requirement.reason == "missing_factor_value"
+    assert result.requirement.missing_attribute == "factor_value"

--- a/tests/test_calculation_report_integration.py
+++ b/tests/test_calculation_report_integration.py
@@ -1,6 +1,7 @@
 from comp.compiler_tool import (
     CalculationFormula,
     CalculationInput,
+    CalculationRequirement,
     CompileReport,
     ProofObligation,
     ReferenceBinding,
@@ -117,6 +118,16 @@ def test_blocked_calculation_opens_blocking_obligation_on_report():
             ),
             claim_id="hyp-1:co2e_emission",
             blocking=True,
+            calculation_requirement=CalculationRequirement(
+                reason="unit_mismatch",
+                formula_id="ghg.electricity_factor_multiplication.v1",
+                output_claim_id="hyp-1:co2e_emission",
+                input_claim_id="hyp-1:amount",
+                reference_binding_id="bind-amount-factor",
+                reference_id="factor.kr_grid.2024.location_based",
+                expected_unit="kWh",
+                actual_unit="MWh",
+            ),
         ),
     )
     assert updated.can_project_public_row is False
@@ -148,6 +159,13 @@ def test_calculation_obligation_maps_to_judgment_fact():
         meta=(
             ("kind", "calculation_blocked"),
             ("reason", "unit_mismatch"),
+            ("actual_unit", "MWh"),
+            ("expected_unit", "kWh"),
+            ("formula_id", "ghg.electricity_factor_multiplication.v1"),
+            ("input_claim_id", "hyp-1:amount"),
+            ("output_claim_id", "hyp-1:co2e_emission"),
+            ("reference_binding_id", "bind-amount-factor"),
+            ("reference_id", "factor.kr_grid.2024.location_based"),
             ("report_section", "proof_obligation"),
             ("report_status", "blocked"),
         ),


### PR DESCRIPTION
## Summary
- Add `CalculationRequirement` so blocked calculator results carry structured resolver context.
- Attach calculation requirements to `calculation_blocked` `ProofObligation` payloads.
- Expose calculation requirement metadata through judgment facts.

## Scope
- This does not resolve calculation obligations yet.
- This keeps the calculator deterministic and only enriches the artifacts emitted when calculation is blocked.

## Validation
- `python -m pytest tests/test_calculation_obligation_requirements.py -q` -> 4 passed
- `python -m pytest -q` -> 117 passed
- `git diff --check origin/main..HEAD`