### PR TITLE
[codex] feat: resolve reference search obligations

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -42,6 +42,10 @@ from comp.compiler_tool.reference_db import (
     ReferenceLookupError,
     ReferenceRecord,
 )
+from comp.compiler_tool.reference_resolution import (
+    ReferenceSearchQuery,
+    resolve_reference_search_obligations,
+)
 from comp.compiler_tool.reference_selector import (
     ReferenceSelectionCriteria,
     ReferenceSelectionResult,
@@ -88,6 +92,8 @@ __all__ = [
     "ReferenceLookupError",
     "ReferenceRecord",
     "ReferenceCatalog",
+    "ReferenceSearchQuery",
+    "resolve_reference_search_obligations",
     "ReferenceSelectionCriteria",
     "ReferenceSelectionResult",
     "select_reference_binding",

--- a/comp/compiler_tool/reference_resolution.py
+++ b/comp/compiler_tool/reference_resolution.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+
+from comp.compiler_tool.models import CompileReport, ProofObligation
+from comp.compiler_tool.reference_db import ReferenceCatalog
+from comp.compiler_tool.references import ReferenceCandidate
+
+ReferenceSearchQuery = Callable[[ProofObligation], str | None]
+
+
+def resolve_reference_search_obligations(
+    report: CompileReport,
+    catalog: ReferenceCatalog,
+    *,
+    query_for_obligation: ReferenceSearchQuery,
+    reference_type: str | None = None,
+    limit: int = 10,
+    retrieval_method: str = "keyword",
+) -> CompileReport:
+    obligations: list[ProofObligation] = []
+    candidates = report.reference_candidates
+    resolved_obligations = report.resolved_obligations
+    changed = False
+
+    for obligation in report.obligations:
+        if not _is_reference_search_obligation(obligation):
+            obligations.append(obligation)
+            continue
+
+        query = query_for_obligation(obligation)
+        if not query:
+            obligations.append(obligation)
+            continue
+
+        found = catalog.search(
+            query,
+            reference_type=reference_type,
+            limit=limit,
+            retrieval_method=retrieval_method,
+        )
+        if not found:
+            obligations.append(obligation)
+            continue
+
+        candidates = _append_unique_candidates(candidates, found)
+        resolved_obligations = _append_unique_obligations(
+            resolved_obligations,
+            (obligation,),
+        )
+        changed = True
+
+    if not changed:
+        return report
+
+    return replace(
+        report,
+        obligations=tuple(obligations),
+        resolved_obligations=resolved_obligations,
+        reference_candidates=candidates,
+        can_project_public_row=False,
+    )
+
+
+def _is_reference_search_obligation(obligation: ProofObligation) -> bool:
+    return (
+        obligation.kind == "reference_search_required"
+        and obligation.calculation_requirement is not None
+    )
+
+
+def _append_unique_candidates(
+    existing: tuple[ReferenceCandidate, ...],
+    additions: tuple[ReferenceCandidate, ...],
+) -> tuple[ReferenceCandidate, ...]:
+    result = existing
+    for candidate in additions:
+        if candidate not in result:
+            result = (*result, candidate)
+    return result
+
+
+def _append_unique_obligations(
+    existing: tuple[ProofObligation, ...],
+    additions: tuple[ProofObligation, ...],
+) -> tuple[ProofObligation, ...]:
+    result = existing
+    for obligation in additions:
+        if obligation not in result:
+            result = (*result, obligation)
+    return result
+
+
+__all__ = ["ReferenceSearchQuery", "resolve_reference_search_obligations"]

--- a/tests/test_reference_search_resolution.py
+++ b/tests/test_reference_search_resolution.py
@@ -1,0 +1,152 @@
+from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
+    CompileReport,
+    ReferenceBinding,
+    ReferenceCatalog,
+    ReferenceRecord,
+    apply_calculation_result,
+    calculate_derived_claim,
+    plan_calculation_resolution,
+    resolve_reference_search_obligations,
+)
+
+
+def _formula():
+    return CalculationFormula(
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_field="co2e_emission",
+        output_unit="tCO2e",
+    )
+
+
+def _input():
+    return CalculationInput(
+        claim_id="hyp-1:amount",
+        field="amount",
+        value=1200,
+        unit="kWh",
+    )
+
+
+def _binding(reference_id="factor.missing"):
+    return ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id=reference_id,
+        reference_type="emission_factor",
+    )
+
+
+def _empty_catalog():
+    return ReferenceCatalog(records=())
+
+
+def _catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                labels=("KR grid electricity factor 2024",),
+                aliases=("korea electricity grid factor",),
+                attributes=(
+                    ("factor_value", 0.0004),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-17",),
+            ),
+        )
+    )
+
+
+def _planned_unknown_reference_report():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(),
+        reference_binding=_binding(),
+        catalog=_empty_catalog(),
+        formula=_formula(),
+    )
+    blocked = apply_calculation_result(
+        CompileReport(status="accepted"),
+        result,
+        output_claim_id="hyp-1:co2e_emission",
+        formula=_formula(),
+    )
+    return plan_calculation_resolution(blocked)
+
+
+def test_reference_search_resolution_adds_candidates_and_resolves_followup():
+    planned = _planned_unknown_reference_report()
+
+    resolved = resolve_reference_search_obligations(
+        planned,
+        _catalog(),
+        query_for_obligation=lambda obligation: "korea electricity grid factor",
+        reference_type="emission_factor",
+    )
+
+    assert resolved.status == "blocked"
+    assert resolved.can_project_public_row is False
+    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+        "factor.kr_grid.2024.location_based"
+    ]
+    assert resolved.reference_candidates[0].authority == "candidate_only"
+    assert resolved.reference_candidates[0].source == "tiny-fixture"
+    assert resolved.reference_candidates[0].witness_ids == ("ref-factor-row-17",)
+    assert [obligation.kind for obligation in resolved.obligations] == [
+        "calculation_blocked"
+    ]
+    assert [obligation.kind for obligation in resolved.resolved_obligations] == [
+        "reference_search_required"
+    ]
+
+
+def test_reference_search_resolution_leaves_followup_open_without_query():
+    planned = _planned_unknown_reference_report()
+
+    resolved = resolve_reference_search_obligations(
+        planned,
+        _catalog(),
+        query_for_obligation=lambda obligation: None,
+        reference_type="emission_factor",
+    )
+
+    assert resolved == planned
+
+
+def test_reference_search_resolution_leaves_followup_open_without_candidates():
+    planned = _planned_unknown_reference_report()
+
+    resolved = resolve_reference_search_obligations(
+        planned,
+        _catalog(),
+        query_for_obligation=lambda obligation: "diesel combustion",
+        reference_type="emission_factor",
+    )
+
+    assert resolved == planned
+
+
+def test_reference_search_resolution_is_idempotent():
+    planned = _planned_unknown_reference_report()
+
+    once = resolve_reference_search_obligations(
+        planned,
+        _catalog(),
+        query_for_obligation=lambda obligation: "korea electricity grid factor",
+        reference_type="emission_factor",
+    )
+    twice = resolve_reference_search_obligations(
+        once,
+        _catalog(),
+        query_for_obligation=lambda obligation: "korea electricity grid factor",
+        reference_type="emission_factor",
+    )
+
+    assert twice.reference_candidates == once.reference_candidates
+    assert twice.resolved_obligations == once.resolved_obligations
+    assert twice.obligations == once.obligations


### PR DESCRIPTION
## Summary
- Add a reference-search resolver that turns `reference_search_required` obligations into candidate-only `ReferenceCandidate` artifacts via `ReferenceCatalog.search`.
- Resolve only the follow-up search obligation; the original `calculation_blocked` obligation remains open until binding/calculation is retried.
- Export the resolver and cover no-query, no-candidate, successful, and idempotent paths.

## Validation
- `python -m pytest tests/test_reference_search_resolution.py -q`
- `python -m pytest tests/test_reference_search_resolution.py tests/test_calculation_resolution_planner.py tests/test_calculation_obligation_requirements.py tests/test_tiny_reference_db.py tests/test_reference_selector.py tests/test_reference_binding_model.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`