### PR TITLE
[codex] feat: apply reference selection to reports

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -46,6 +46,7 @@ from comp.compiler_tool.reference_resolution import (
     ReferenceSearchQuery,
     resolve_reference_search_obligations,
 )
+from comp.compiler_tool.reference_selection_report import apply_reference_selection
 from comp.compiler_tool.reference_selector import (
     ReferenceSelectionCriteria,
     ReferenceSelectionResult,
@@ -94,6 +95,7 @@ __all__ = [
     "ReferenceCatalog",
     "ReferenceSearchQuery",
     "resolve_reference_search_obligations",
+    "apply_reference_selection",
     "ReferenceSelectionCriteria",
     "ReferenceSelectionResult",
     "select_reference_binding",

--- a/comp/compiler_tool/reference_selection_report.py
+++ b/comp/compiler_tool/reference_selection_report.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from comp.compiler_tool.models import CompileReport, Hazard, ProofObligation
+from comp.compiler_tool.reference_db import ReferenceCatalog
+from comp.compiler_tool.reference_selector import (
+    ReferenceSelectionCriteria,
+    select_reference_binding,
+)
+from comp.compiler_tool.references import ReferenceBinding
+
+
+def apply_reference_selection(
+    report: CompileReport,
+    catalog: ReferenceCatalog,
+    *,
+    criteria: ReferenceSelectionCriteria,
+    field: str,
+) -> CompileReport:
+    result = select_reference_binding(
+        candidates=report.reference_candidates,
+        catalog=catalog,
+        criteria=criteria,
+    )
+    obligation_id = _selection_obligation_id(criteria)
+
+    if result.status == "bound" and result.binding is not None:
+        open_obligations = tuple(
+            obligation
+            for obligation in report.obligations
+            if not _matches_selection_obligation(obligation, obligation_id)
+        )
+        resolved = tuple(
+            obligation
+            for obligation in report.obligations
+            if _matches_selection_obligation(obligation, obligation_id)
+        )
+        return replace(
+            report,
+            status=_status_for(
+                report=report,
+                open_obligations=open_obligations,
+                hazards=report.hazards,
+            ),
+            obligations=open_obligations,
+            resolved_obligations=_append_unique_obligations(
+                report.resolved_obligations,
+                resolved,
+            ),
+            reference_bindings=_append_unique_bindings(
+                report.reference_bindings,
+                (result.binding,),
+            ),
+            can_project_public_row=False,
+        )
+
+    obligation = ProofObligation(
+        kind="reference_selection_required",
+        field=field,
+        reason=result.status,
+        obligation_id=obligation_id,
+        claim_id=criteria.claim_id,
+        blocking=True,
+    )
+    return replace(
+        report,
+        status="blocked",
+        obligations=_append_unique_obligation_by_id(report.obligations, obligation),
+        can_project_public_row=False,
+    )
+
+
+def _selection_obligation_id(criteria: ReferenceSelectionCriteria) -> str:
+    return f"reference_selection:{criteria.selector_rule_id}:{criteria.claim_id}"
+
+
+def _matches_selection_obligation(
+    obligation: ProofObligation,
+    obligation_id: str,
+) -> bool:
+    return (
+        obligation.kind == "reference_selection_required"
+        and obligation.obligation_id == obligation_id
+    )
+
+
+def _append_unique_bindings(
+    existing: tuple[ReferenceBinding, ...],
+    additions: tuple[ReferenceBinding, ...],
+) -> tuple[ReferenceBinding, ...]:
+    result = existing
+    for binding in additions:
+        if binding not in result:
+            result = (*result, binding)
+    return result
+
+
+def _append_unique_obligations(
+    existing: tuple[ProofObligation, ...],
+    additions: tuple[ProofObligation, ...],
+) -> tuple[ProofObligation, ...]:
+    result = existing
+    for obligation in additions:
+        if obligation not in result:
+            result = (*result, obligation)
+    return result
+
+
+def _append_unique_obligation_by_id(
+    existing: tuple[ProofObligation, ...],
+    addition: ProofObligation,
+) -> tuple[ProofObligation, ...]:
+    if addition.obligation_id is not None and any(
+        obligation.obligation_id == addition.obligation_id
+        for obligation in existing
+    ):
+        return existing
+    if addition in existing:
+        return existing
+    return (*existing, addition)
+
+
+def _status_for(
+    *,
+    report: CompileReport,
+    open_obligations: tuple[ProofObligation, ...],
+    hazards: tuple[Hazard, ...],
+) -> str:
+    if report.failed_claims:
+        return "blocked"
+    if any(
+        obligation.kind == "calculation_blocked" and obligation.blocking
+        for obligation in open_obligations
+    ):
+        return "blocked"
+    if hazards:
+        return "review_required"
+    if report.unchecked_areas:
+        return "unchecked"
+    if report.unknowns:
+        return "underconstrained"
+    if any(obligation.blocking for obligation in open_obligations):
+        return "review_required"
+    return "accepted"
+
+
+__all__ = ["apply_reference_selection"]

--- a/tests/test_reference_selection_report.py
+++ b/tests/test_reference_selection_report.py
@@ -1,0 +1,189 @@
+from comp.compiler_tool import (
+    CompileReport,
+    ProofObligation,
+    ReferenceCandidate,
+    ReferenceCatalog,
+    ReferenceRecord,
+    ReferenceSelectionCriteria,
+    apply_reference_selection,
+)
+
+
+def _catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                attributes=(
+                    ("concept_id", "concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "location_based"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-17",),
+            ),
+            ReferenceRecord(
+                reference_id="factor.kr_residual_mix.2024.market_based",
+                reference_type="emission_factor",
+                attributes=(
+                    ("concept_id", "concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "market_based"),
+                ),
+                source="tiny-fixture",
+                witness_ids=("ref-factor-row-18",),
+            ),
+        )
+    )
+
+
+def _candidate(candidate_id, reference_id, score):
+    return ReferenceCandidate(
+        candidate_id=candidate_id,
+        reference_id=reference_id,
+        reference_type="emission_factor",
+        retrieval_method="keyword",
+        retrieval_score=score,
+        source="tiny-fixture",
+    )
+
+
+def _criteria():
+    return ReferenceSelectionCriteria(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_type="emission_factor",
+        selector_rule_id="ghg.factor_selector.v1",
+        required_attributes=(
+            ("concept_id", "concept.electricity_consumption"),
+            ("geography", "KR"),
+            ("valid_period", "2024"),
+            ("method", "location_based"),
+        ),
+    )
+
+
+def _selection_obligation(reason="ambiguous"):
+    return ProofObligation(
+        kind="reference_selection_required",
+        field="co2e_emission",
+        reason=reason,
+        obligation_id="reference_selection:ghg.factor_selector.v1:hyp-1:amount",
+        claim_id="hyp-1:amount",
+        blocking=True,
+    )
+
+
+def test_reference_selection_adds_binding_and_resolves_matching_obligation():
+    obligation = _selection_obligation()
+    report = CompileReport(
+        status="blocked",
+        obligations=(obligation,),
+        reference_candidates=(
+            _candidate(
+                "cand-market",
+                "factor.kr_residual_mix.2024.market_based",
+                0.96,
+            ),
+            _candidate(
+                "cand-location",
+                "factor.kr_grid.2024.location_based",
+                0.82,
+            ),
+        ),
+    )
+
+    updated = apply_reference_selection(
+        report,
+        _catalog(),
+        criteria=_criteria(),
+        field="co2e_emission",
+    )
+
+    assert updated.status == "accepted"
+    assert updated.can_project_public_row is False
+    assert updated.obligations == ()
+    assert updated.resolved_obligations == (obligation,)
+    assert len(updated.reference_bindings) == 1
+    binding = updated.reference_bindings[0]
+    assert binding.reference_id == "factor.kr_grid.2024.location_based"
+    assert binding.selected_candidate_id == "cand-location"
+    assert binding.selector_rule_id == "ghg.factor_selector.v1"
+    assert binding.source_witness_ids == ("ref-factor-row-17",)
+    assert [(item.candidate_id, item.reason) for item in binding.rejected_candidates] == [
+        ("cand-market", "attribute_mismatch:method")
+    ]
+
+
+def test_reference_selection_opens_obligation_when_candidates_are_ambiguous():
+    report = CompileReport(
+        status="accepted",
+        reference_candidates=(
+            _candidate("cand-a", "factor.kr_grid.2024.location_based", 0.99),
+            _candidate("cand-b", "factor.kr_grid.2024.location_based", 0.76),
+        ),
+    )
+
+    updated = apply_reference_selection(
+        report,
+        _catalog(),
+        criteria=_criteria(),
+        field="co2e_emission",
+    )
+
+    assert updated.status == "blocked"
+    assert updated.reference_bindings == ()
+    assert updated.obligations == (_selection_obligation(reason="ambiguous"),)
+
+
+def test_reference_selection_opens_obligation_when_no_candidate_matches():
+    report = CompileReport(
+        status="accepted",
+        reference_candidates=(
+            _candidate(
+                "cand-market",
+                "factor.kr_residual_mix.2024.market_based",
+                0.96,
+            ),
+        ),
+    )
+
+    updated = apply_reference_selection(
+        report,
+        _catalog(),
+        criteria=_criteria(),
+        field="co2e_emission",
+    )
+
+    assert updated.status == "blocked"
+    assert updated.reference_bindings == ()
+    assert updated.obligations == (_selection_obligation(reason="no_match"),)
+
+
+def test_reference_selection_report_application_is_idempotent():
+    report = CompileReport(
+        status="accepted",
+        reference_candidates=(
+            _candidate("cand-a", "factor.kr_grid.2024.location_based", 0.99),
+            _candidate("cand-b", "factor.kr_grid.2024.location_based", 0.76),
+        ),
+    )
+
+    once = apply_reference_selection(
+        report,
+        _catalog(),
+        criteria=_criteria(),
+        field="co2e_emission",
+    )
+    twice = apply_reference_selection(
+        once,
+        _catalog(),
+        criteria=_criteria(),
+        field="co2e_emission",
+    )
+
+    assert twice.obligations == once.obligations
+    assert twice.reference_bindings == once.reference_bindings


### PR DESCRIPTION
## Summary
- Add `apply_reference_selection` to run deterministic reference selection against report candidates and append canonical `ReferenceBinding` artifacts.
- Resolve matching `reference_selection_required` obligations when a binding is selected.
- Open a blocking `reference_selection_required` obligation when selection is ambiguous or no candidate matches, without treating retrieval scores as authority.

## Validation
- `python -m pytest tests/test_reference_selection_report.py -q`
- `python -m pytest tests/test_reference_selection_report.py tests/test_reference_selector.py tests/test_reference_search_resolution.py tests/test_calculation_resolution_planner.py tests/test_calculation_report_integration.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`