### PR TITLE
[codex] feat: retry blocked calculations

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -12,6 +12,7 @@ from comp.compiler_tool.calculations import (
 )
 from comp.compiler_tool.calculation_report import apply_calculation_result
 from comp.compiler_tool.calculation_resolution import plan_calculation_resolution
+from comp.compiler_tool.calculation_retry import retry_blocked_calculation
 from comp.compiler_tool.models import (
     CheckedClaim,
     ClaimHypothesis,
@@ -87,6 +88,7 @@ __all__ = [
     "calculate_derived_claim",
     "apply_calculation_result",
     "plan_calculation_resolution",
+    "retry_blocked_calculation",
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
     "ReferenceBinding",

--- a/comp/compiler_tool/calculation_retry.py
+++ b/comp/compiler_tool/calculation_retry.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from comp.compiler_tool.calculation_report import apply_calculation_result
+from comp.compiler_tool.calculations import (
+    CalculationFormula,
+    CalculationInput,
+    DerivedClaim,
+    calculate_derived_claim,
+)
+from comp.compiler_tool.models import CompileReport, Hazard, ProofObligation
+from comp.compiler_tool.reference_db import ReferenceCatalog
+from comp.compiler_tool.references import ReferenceBinding
+
+
+def retry_blocked_calculation(
+    report: CompileReport,
+    catalog: ReferenceCatalog,
+    *,
+    input_claim: CalculationInput,
+    reference_binding: ReferenceBinding,
+    formula: CalculationFormula,
+    output_claim_id: str,
+) -> CompileReport:
+    result = calculate_derived_claim(
+        output_claim_id=output_claim_id,
+        input_claim=input_claim,
+        reference_binding=reference_binding,
+        catalog=catalog,
+        formula=formula,
+    )
+    if result.status == "calculated" and result.derived_claim is not None:
+        open_obligations, resolved = _split_matching_calculation_obligations(
+            report.obligations,
+            formula=formula,
+            output_claim_id=output_claim_id,
+        )
+        base_report = replace(
+            report,
+            obligations=open_obligations,
+            resolved_obligations=_append_unique_obligations(
+                report.resolved_obligations,
+                resolved,
+            ),
+            can_project_public_row=False,
+        )
+        return replace(
+            base_report,
+            status=_status_for(
+                report=base_report,
+                open_obligations=base_report.obligations,
+                hazards=base_report.hazards,
+            ),
+            derived_claims=_append_unique_derived_claim(
+                base_report.derived_claims,
+                result.derived_claim,
+            ),
+            can_project_public_row=False,
+        )
+
+    return apply_calculation_result(
+        report,
+        result,
+        output_claim_id=output_claim_id,
+        formula=formula,
+    )
+
+
+def _split_matching_calculation_obligations(
+    obligations: tuple[ProofObligation, ...],
+    *,
+    formula: CalculationFormula,
+    output_claim_id: str,
+) -> tuple[tuple[ProofObligation, ...], tuple[ProofObligation, ...]]:
+    open_obligations: list[ProofObligation] = []
+    resolved: list[ProofObligation] = []
+    for obligation in obligations:
+        if _matches_calculation_obligation(
+            obligation,
+            formula=formula,
+            output_claim_id=output_claim_id,
+        ):
+            resolved.append(obligation)
+        else:
+            open_obligations.append(obligation)
+    return tuple(open_obligations), tuple(resolved)
+
+
+def _matches_calculation_obligation(
+    obligation: ProofObligation,
+    *,
+    formula: CalculationFormula,
+    output_claim_id: str,
+) -> bool:
+    if obligation.kind != "calculation_blocked":
+        return False
+
+    requirement = obligation.calculation_requirement
+    if requirement is not None:
+        return (
+            requirement.formula_id == formula.formula_id
+            and requirement.output_claim_id == output_claim_id
+        )
+
+    return (
+        obligation.field == formula.output_field
+        and obligation.claim_id == output_claim_id
+    )
+
+
+def _append_unique_obligations(
+    existing: tuple[ProofObligation, ...],
+    additions: tuple[ProofObligation, ...],
+) -> tuple[ProofObligation, ...]:
+    result = existing
+    for obligation in additions:
+        if obligation not in result:
+            result = (*result, obligation)
+    return result
+
+
+def _append_unique_derived_claim(
+    existing: tuple[DerivedClaim, ...],
+    addition: DerivedClaim,
+) -> tuple[DerivedClaim, ...]:
+    if any(claim.claim_id == addition.claim_id for claim in existing):
+        return existing
+    return (*existing, addition)
+
+
+def _status_for(
+    *,
+    report: CompileReport,
+    open_obligations: tuple[ProofObligation, ...],
+    hazards: tuple[Hazard, ...],
+) -> str:
+    if report.failed_claims:
+        return "blocked"
+    if any(
+        obligation.kind == "calculation_blocked" and obligation.blocking
+        for obligation in open_obligations
+    ):
+        return "blocked"
+    if hazards:
+        return "review_required"
+    if report.unchecked_areas:
+        return "unchecked"
+    if report.unknowns:
+        return "underconstrained"
+    if any(obligation.blocking for obligation in open_obligations):
+        return "review_required"
+    return "accepted"
+
+
+__all__ = ["retry_blocked_calculation"]

--- a/tests/test_calculation_retry_report.py
+++ b/tests/test_calculation_retry_report.py
@@ -1,0 +1,143 @@
+from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
+    CompileReport,
+    ReferenceBinding,
+    ReferenceCatalog,
+    ReferenceRecord,
+    apply_calculation_result,
+    calculate_derived_claim,
+    retry_blocked_calculation,
+)
+
+
+def _formula():
+    return CalculationFormula(
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_field="co2e_emission",
+        output_unit="tCO2e",
+    )
+
+
+def _input():
+    return CalculationInput(
+        claim_id="hyp-1:amount",
+        field="amount",
+        value=1200,
+        unit="kWh",
+    )
+
+
+def _binding(reference_id):
+    return ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id=reference_id,
+        reference_type="emission_factor",
+        selected_candidate_id="cand-factor",
+        selector_rule_id="ghg.factor_selector.v1",
+    )
+
+
+def _empty_catalog():
+    return ReferenceCatalog(records=())
+
+
+def _catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                attributes=(
+                    ("factor_value", 0.0004),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                witness_ids=("ref-factor-row-17",),
+            ),
+        )
+    )
+
+
+def _blocked_unknown_reference_report():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(),
+        reference_binding=_binding("factor.missing"),
+        catalog=_empty_catalog(),
+        formula=_formula(),
+    )
+    return apply_calculation_result(
+        CompileReport(status="accepted"),
+        result,
+        output_claim_id="hyp-1:co2e_emission",
+        formula=_formula(),
+    )
+
+
+def test_retry_blocked_calculation_resolves_old_obligation_and_adds_derived_claim():
+    report = _blocked_unknown_reference_report()
+    old_obligation = report.obligations[0]
+
+    updated = retry_blocked_calculation(
+        report,
+        _catalog(),
+        input_claim=_input(),
+        reference_binding=_binding("factor.kr_grid.2024.location_based"),
+        formula=_formula(),
+        output_claim_id="hyp-1:co2e_emission",
+    )
+
+    assert updated.status == "accepted"
+    assert updated.obligations == ()
+    assert updated.resolved_obligations == (old_obligation,)
+    assert len(updated.derived_claims) == 1
+    derived = updated.derived_claims[0]
+    assert derived.claim_id == "hyp-1:co2e_emission"
+    assert derived.value == 0.48
+    assert derived.unit == "tCO2e"
+    assert derived.trace.reference_binding_ids == ("bind-amount-factor",)
+    assert updated.can_project_public_row is False
+
+
+def test_retry_blocked_calculation_is_idempotent_after_success():
+    report = _blocked_unknown_reference_report()
+
+    once = retry_blocked_calculation(
+        report,
+        _catalog(),
+        input_claim=_input(),
+        reference_binding=_binding("factor.kr_grid.2024.location_based"),
+        formula=_formula(),
+        output_claim_id="hyp-1:co2e_emission",
+    )
+    twice = retry_blocked_calculation(
+        once,
+        _catalog(),
+        input_claim=_input(),
+        reference_binding=_binding("factor.kr_grid.2024.location_based"),
+        formula=_formula(),
+        output_claim_id="hyp-1:co2e_emission",
+    )
+
+    assert twice.derived_claims == once.derived_claims
+    assert twice.resolved_obligations == once.resolved_obligations
+    assert twice.obligations == once.obligations
+
+
+def test_retry_blocked_calculation_keeps_obligation_open_when_still_blocked():
+    report = _blocked_unknown_reference_report()
+
+    updated = retry_blocked_calculation(
+        report,
+        _empty_catalog(),
+        input_claim=_input(),
+        reference_binding=_binding("factor.missing"),
+        formula=_formula(),
+        output_claim_id="hyp-1:co2e_emission",
+    )
+
+    assert updated.derived_claims == ()
+    assert updated.resolved_obligations == ()
+    assert updated.obligations == report.obligations


### PR DESCRIPTION
## Summary
- Add `retry_blocked_calculation` to re-run the deterministic calculator after a new reference binding is available.
- When retry succeeds, move matching `calculation_blocked` obligations into `resolved_obligations` and append the resulting `DerivedClaim` without duplicating repeated retries.
- Keep the original calculation obligation open when the retry is still blocked, so open/resolved trails do not contradict each other.

## Validation
- `python -m pytest tests/test_calculation_retry_report.py -q`
- `python -m pytest tests/test_calculation_retry_report.py tests/test_calculation_report_integration.py tests/test_deterministic_calculator.py tests/test_reference_selection_report.py tests/test_calculation_resolution_planner.py tests/test_reference_search_resolution.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`