### PR TITLE
[codex] feat: expose reference binding facts

### DIFF
--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -47,6 +47,35 @@ def compile_report_to_facts(report: CompileReport, subject: SubjectRef) -> set[F
             )
         )
 
+    for binding in report.reference_bindings:
+        facts.add(
+            Fact(
+                tag="prov_edge",
+                subject=subject,
+                key=f"reference_binding:{binding.binding_id}",
+                value=binding.reference_id,
+                witness=binding.selected_candidate_id,
+                weight=1.0,
+                meta=(
+                    ("authority", binding.authority),
+                    ("binding_id", binding.binding_id),
+                    ("claim_id", binding.claim_id),
+                    ("reference_type", binding.reference_type),
+                    (
+                        "rejected_candidates",
+                        tuple(
+                            (candidate.candidate_id, candidate.reason)
+                            for candidate in binding.rejected_candidates
+                        ),
+                    ),
+                    ("report_section", "reference_binding"),
+                    ("report_status", report.status),
+                    ("selector_rule_id", binding.selector_rule_id),
+                    ("source_witness_ids", binding.source_witness_ids),
+                ),
+            )
+        )
+
     for claim in report.failed_claims:
         facts.add(
             Fact(

--- a/tests/test_reference_binding_facts.py
+++ b/tests/test_reference_binding_facts.py
@@ -1,0 +1,52 @@
+from comp.compiler_tool import (
+    CompileReport,
+    ReferenceBinding,
+    RejectedReferenceCandidate,
+    compile_report_to_facts,
+)
+from comp.judgment import Fact, SubjectRef
+
+
+def test_compile_report_to_facts_maps_reference_binding_as_provenance_edge():
+    subject = SubjectRef("claim", "hyp-1")
+    rejected = RejectedReferenceCandidate(
+        candidate_id="cand-market",
+        reference_id="factor.kr_residual_mix.2024.market_based",
+        reason="attribute_mismatch:method",
+        selector_rule_id="ghg.factor_selector.v1",
+    )
+    binding = ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id="factor.kr_grid.2024.location_based",
+        reference_type="emission_factor",
+        selected_candidate_id="cand-location",
+        selector_rule_id="ghg.factor_selector.v1",
+        source_witness_ids=("span-amount", "ref-factor-row-17"),
+        rejected_candidates=(rejected,),
+    )
+    report = CompileReport(status="accepted", reference_bindings=(binding,))
+
+    facts = compile_report_to_facts(report, subject)
+
+    assert facts == {
+        Fact(
+            tag="prov_edge",
+            subject=subject,
+            key="reference_binding:bind-amount-factor",
+            value="factor.kr_grid.2024.location_based",
+            witness="cand-location",
+            weight=1.0,
+            meta=(
+                ("authority", "canonical_binding"),
+                ("binding_id", "bind-amount-factor"),
+                ("claim_id", "hyp-1:amount"),
+                ("reference_type", "emission_factor"),
+                ("rejected_candidates", (("cand-market", "attribute_mismatch:method"),)),
+                ("report_section", "reference_binding"),
+                ("report_status", "accepted"),
+                ("selector_rule_id", "ghg.factor_selector.v1"),
+                ("source_witness_ids", ("span-amount", "ref-factor-row-17")),
+            ),
+        )
+    }


### PR DESCRIPTION
## Summary
- Emit canonical `ReferenceBinding` artifacts as `prov_edge` facts from `compile_report_to_facts`.
- Preserve selector provenance, rejected candidate reasons, source witnesses, and binding authority in fact metadata.
- Add focused coverage so derived claim facts can be followed back to their canonical reference binding.

## Validation
- `python -m pytest tests/test_reference_binding_facts.py -q`
- `python -m pytest tests/test_reference_binding_facts.py tests/test_compile_report_to_judgment_facts.py tests/test_derived_claim_trace.py tests/test_reference_binding_model.py tests/test_calculation_report_integration.py tests/test_reference_grounded_calculation_flow.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`