### PR TITLE
[codex] feat: centralize report status policy

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -59,6 +59,10 @@ from comp.compiler_tool.references import (
     ReferenceCandidate,
     RejectedReferenceCandidate,
 )
+from comp.compiler_tool.report_status import (
+    recompute_report_status,
+    with_recomputed_status,
+)
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
@@ -103,6 +107,8 @@ __all__ = [
     "ReferenceSelectionCriteria",
     "ReferenceSelectionResult",
     "select_reference_binding",
+    "recompute_report_status",
+    "with_recomputed_status",
     "RuleFamily",
     "SemanticRubric",
     "JudgePolicy",

--- a/comp/compiler_tool/calculation_report.py
+++ b/comp/compiler_tool/calculation_report.py
@@ -8,6 +8,7 @@ from comp.compiler_tool.calculations import (
     CalculationResult,
 )
 from comp.compiler_tool.models import CompileReport, ProofObligation
+from comp.compiler_tool.report_status import with_recomputed_status
 
 
 def apply_calculation_result(
@@ -18,10 +19,12 @@ def apply_calculation_result(
     formula: CalculationFormula,
 ) -> CompileReport:
     if result.status == "calculated" and result.derived_claim is not None:
-        return replace(
-            report,
-            derived_claims=(*report.derived_claims, result.derived_claim),
-            can_project_public_row=False,
+        return with_recomputed_status(
+            replace(
+                report,
+                derived_claims=(*report.derived_claims, result.derived_claim),
+                can_project_public_row=False,
+            )
         )
 
     reason = result.reason or "calculation_blocked"
@@ -41,11 +44,12 @@ def apply_calculation_result(
         blocking=True,
         calculation_requirement=requirement,
     )
-    return replace(
-        report,
-        status="blocked",
-        obligations=_append_unique(report.obligations, obligation),
-        can_project_public_row=False,
+    return with_recomputed_status(
+        replace(
+            report,
+            obligations=_append_unique(report.obligations, obligation),
+            can_project_public_row=False,
+        )
     )
 
 

--- a/comp/compiler_tool/calculation_retry.py
+++ b/comp/compiler_tool/calculation_retry.py
@@ -9,9 +9,10 @@ from comp.compiler_tool.calculations import (
     DerivedClaim,
     calculate_derived_claim,
 )
-from comp.compiler_tool.models import CompileReport, Hazard, ProofObligation
+from comp.compiler_tool.models import CompileReport, ProofObligation
 from comp.compiler_tool.reference_db import ReferenceCatalog
 from comp.compiler_tool.references import ReferenceBinding
+from comp.compiler_tool.report_status import with_recomputed_status
 
 
 def retry_blocked_calculation(
@@ -45,18 +46,15 @@ def retry_blocked_calculation(
             ),
             can_project_public_row=False,
         )
-        return replace(
-            base_report,
-            status=_status_for(
-                report=base_report,
-                open_obligations=base_report.obligations,
-                hazards=base_report.hazards,
-            ),
-            derived_claims=_append_unique_derived_claim(
-                base_report.derived_claims,
-                result.derived_claim,
-            ),
-            can_project_public_row=False,
+        return with_recomputed_status(
+            replace(
+                base_report,
+                derived_claims=_append_unique_derived_claim(
+                    base_report.derived_claims,
+                    result.derived_claim,
+                ),
+                can_project_public_row=False,
+            )
         )
 
     return apply_calculation_result(
@@ -127,30 +125,6 @@ def _append_unique_derived_claim(
     if any(claim.claim_id == addition.claim_id for claim in existing):
         return existing
     return (*existing, addition)
-
-
-def _status_for(
-    *,
-    report: CompileReport,
-    open_obligations: tuple[ProofObligation, ...],
-    hazards: tuple[Hazard, ...],
-) -> str:
-    if report.failed_claims:
-        return "blocked"
-    if any(
-        obligation.kind == "calculation_blocked" and obligation.blocking
-        for obligation in open_obligations
-    ):
-        return "blocked"
-    if hazards:
-        return "review_required"
-    if report.unchecked_areas:
-        return "unchecked"
-    if report.unknowns:
-        return "underconstrained"
-    if any(obligation.blocking for obligation in open_obligations):
-        return "review_required"
-    return "accepted"
 
 
 __all__ = ["retry_blocked_calculation"]

--- a/comp/compiler_tool/profile_runner.py
+++ b/comp/compiler_tool/profile_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from comp.compiler_tool.models import CompileReport, InterpretationHypothesis, ProofObligation
 from comp.compiler_tool.profiles import CompilerProfile, active_rule_families, validate_compiler_profile
+from comp.compiler_tool.report_status import with_recomputed_status
 
 
 def compile_with_profile(
@@ -19,20 +20,13 @@ def compile_with_profile(
                 if isinstance(result, ProofObligation) and result not in obligations:
                     obligations.append(result)
 
-    return CompileReport(
-        status=_status_for(obligations),
-        obligations=tuple(obligations),
-        can_project_public_row=False,
+    return with_recomputed_status(
+        CompileReport(
+            status="accepted",
+            obligations=tuple(obligations),
+            can_project_public_row=False,
+        )
     )
-
-
-def _status_for(obligations: list[ProofObligation]) -> str:
-    if any(
-        obligation.kind == "semantic_judgment_required" and obligation.blocking
-        for obligation in obligations
-    ):
-        return "review_required"
-    return "accepted"
 
 
 __all__ = ["compile_with_profile"]

--- a/comp/compiler_tool/reference_selection_report.py
+++ b/comp/compiler_tool/reference_selection_report.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from comp.compiler_tool.models import CompileReport, Hazard, ProofObligation
+from comp.compiler_tool.models import CompileReport, ProofObligation
 from comp.compiler_tool.reference_db import ReferenceCatalog
 from comp.compiler_tool.reference_selector import (
     ReferenceSelectionCriteria,
     select_reference_binding,
 )
 from comp.compiler_tool.references import ReferenceBinding
+from comp.compiler_tool.report_status import with_recomputed_status
 
 
 def apply_reference_selection(
@@ -36,23 +37,20 @@ def apply_reference_selection(
             for obligation in report.obligations
             if _matches_selection_obligation(obligation, obligation_id)
         )
-        return replace(
-            report,
-            status=_status_for(
-                report=report,
-                open_obligations=open_obligations,
-                hazards=report.hazards,
-            ),
-            obligations=open_obligations,
-            resolved_obligations=_append_unique_obligations(
-                report.resolved_obligations,
-                resolved,
-            ),
-            reference_bindings=_append_unique_bindings(
-                report.reference_bindings,
-                (result.binding,),
-            ),
-            can_project_public_row=False,
+        return with_recomputed_status(
+            replace(
+                report,
+                obligations=open_obligations,
+                resolved_obligations=_append_unique_obligations(
+                    report.resolved_obligations,
+                    resolved,
+                ),
+                reference_bindings=_append_unique_bindings(
+                    report.reference_bindings,
+                    (result.binding,),
+                ),
+                can_project_public_row=False,
+            )
         )
 
     obligation = ProofObligation(
@@ -63,11 +61,12 @@ def apply_reference_selection(
         claim_id=criteria.claim_id,
         blocking=True,
     )
-    return replace(
-        report,
-        status="blocked",
-        obligations=_append_unique_obligation_by_id(report.obligations, obligation),
-        can_project_public_row=False,
+    return with_recomputed_status(
+        replace(
+            report,
+            obligations=_append_unique_obligation_by_id(report.obligations, obligation),
+            can_project_public_row=False,
+        )
     )
 
 
@@ -119,30 +118,6 @@ def _append_unique_obligation_by_id(
     if addition in existing:
         return existing
     return (*existing, addition)
-
-
-def _status_for(
-    *,
-    report: CompileReport,
-    open_obligations: tuple[ProofObligation, ...],
-    hazards: tuple[Hazard, ...],
-) -> str:
-    if report.failed_claims:
-        return "blocked"
-    if any(
-        obligation.kind == "calculation_blocked" and obligation.blocking
-        for obligation in open_obligations
-    ):
-        return "blocked"
-    if hazards:
-        return "review_required"
-    if report.unchecked_areas:
-        return "unchecked"
-    if report.unknowns:
-        return "underconstrained"
-    if any(obligation.blocking for obligation in open_obligations):
-        return "review_required"
-    return "accepted"
 
 
 __all__ = ["apply_reference_selection"]

--- a/comp/compiler_tool/report_status.py
+++ b/comp/compiler_tool/report_status.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from comp.compiler_tool.models import CompileReport, CompileStatus
+
+
+def recompute_report_status(report: CompileReport) -> CompileStatus:
+    if report.failed_claims:
+        return "blocked"
+    if any(
+        obligation.kind == "calculation_blocked" and obligation.blocking
+        for obligation in report.obligations
+    ):
+        return "blocked"
+    if report.hazards:
+        return "review_required"
+    if any(
+        obligation.kind == "semantic_judgment_required" and obligation.blocking
+        for obligation in report.obligations
+    ):
+        return "review_required"
+    if report.unchecked_areas:
+        return "unchecked"
+    if report.unknowns:
+        return "underconstrained"
+    if any(obligation.blocking for obligation in report.obligations):
+        return "review_required"
+    return "accepted"
+
+
+def with_recomputed_status(report: CompileReport) -> CompileReport:
+    return replace(report, status=recompute_report_status(report))
+
+
+__all__ = ["recompute_report_status", "with_recomputed_status"]

--- a/comp/compiler_tool/semantic.py
+++ b/comp/compiler_tool/semantic.py
@@ -8,6 +8,7 @@ from comp.compiler_tool.models import (
     ProofObligation,
     SemanticJudgment,
 )
+from comp.compiler_tool.report_status import with_recomputed_status
 
 
 def apply_semantic_judgments(
@@ -67,26 +68,24 @@ def apply_semantic_judgments(
 
         open_obligations.append(obligation)
 
-    return CompileReport(
-        status=_status_for(
-            report=report,
-            open_obligations=tuple(open_obligations),
+    return with_recomputed_status(
+        CompileReport(
+            status=report.status,
+            checked_claims=report.checked_claims,
+            failed_claims=report.failed_claims,
+            unknowns=report.unknowns,
+            unchecked_areas=report.unchecked_areas,
+            obligations=tuple(open_obligations),
+            resolved_obligations=(
+                *report.resolved_obligations,
+                *tuple(newly_resolved),
+            ),
             hazards=tuple(hazards),
-        ),
-        checked_claims=report.checked_claims,
-        failed_claims=report.failed_claims,
-        unknowns=report.unknowns,
-        unchecked_areas=report.unchecked_areas,
-        obligations=tuple(open_obligations),
-        resolved_obligations=(
-            *report.resolved_obligations,
-            *tuple(newly_resolved),
-        ),
-        hazards=tuple(hazards),
-        reference_candidates=report.reference_candidates,
-        reference_bindings=report.reference_bindings,
-        derived_claims=report.derived_claims,
-        can_project_public_row=report.can_project_public_row,
+            reference_candidates=report.reference_candidates,
+            reference_bindings=report.reference_bindings,
+            derived_claims=report.derived_claims,
+            can_project_public_row=report.can_project_public_row,
+        )
     )
 
 
@@ -117,35 +116,6 @@ def _judgment_satisfies_protocol(
         return False
 
     return True
-
-
-def _status_for(
-    *,
-    report: CompileReport,
-    open_obligations: tuple[ProofObligation, ...],
-    hazards: tuple[Hazard, ...],
-) -> str:
-    if report.failed_claims:
-        return "blocked"
-    if any(
-        obligation.kind == "calculation_blocked" and obligation.blocking
-        for obligation in open_obligations
-    ):
-        return "blocked"
-    if hazards:
-        return "review_required"
-    if any(
-        obligation.kind == "semantic_judgment_required" and obligation.blocking
-        for obligation in open_obligations
-    ):
-        return "review_required"
-    if report.unchecked_areas:
-        return "unchecked"
-    if report.unknowns:
-        return "underconstrained"
-    if any(obligation.blocking for obligation in open_obligations):
-        return "review_required"
-    return "accepted"
 
 
 def _obligation_id(obligation: ProofObligation) -> str:

--- a/comp/compiler_tool/tool.py
+++ b/comp/compiler_tool/tool.py
@@ -12,6 +12,7 @@ from comp.compiler_tool.models import (
     UncheckedArea,
     UnknownClaim,
 )
+from comp.compiler_tool.report_status import with_recomputed_status
 
 
 class CompilerTool:
@@ -106,15 +107,17 @@ class CompilerTool:
             hazards.append(Hazard(kind="missing_unit", field="unit", severity="review"))
             self._add_find_source_witness(obligations, "unit", "missing_unit")
 
-        return CompileReport(
-            status=self._status_for(failed, hazards, unchecked, unknowns),
-            checked_claims=tuple(checked),
-            failed_claims=tuple(failed),
-            unknowns=tuple(unknowns),
-            unchecked_areas=tuple(unchecked),
-            obligations=tuple(obligations),
-            hazards=tuple(hazards),
-            can_project_public_row=False,
+        return with_recomputed_status(
+            CompileReport(
+                status="accepted",
+                checked_claims=tuple(checked),
+                failed_claims=tuple(failed),
+                unknowns=tuple(unknowns),
+                unchecked_areas=tuple(unchecked),
+                obligations=tuple(obligations),
+                hazards=tuple(hazards),
+                can_project_public_row=False,
+            )
         )
 
     @staticmethod
@@ -160,23 +163,6 @@ class CompilerTool:
             )
 
         return None
-
-    @staticmethod
-    def _status_for(
-        failed: list[FailedClaim],
-        hazards: list[Hazard],
-        unchecked: list[UncheckedArea],
-        unknowns: list[UnknownClaim],
-    ) -> str:
-        if failed:
-            return "blocked"
-        if hazards:
-            return "review_required"
-        if unchecked:
-            return "unchecked"
-        if unknowns:
-            return "underconstrained"
-        return "accepted"
 
     @staticmethod
     def _add_find_source_witness(

--- a/tests/test_reference_selection_report.py
+++ b/tests/test_reference_selection_report.py
@@ -134,7 +134,7 @@ def test_reference_selection_opens_obligation_when_candidates_are_ambiguous():
         field="co2e_emission",
     )
 
-    assert updated.status == "blocked"
+    assert updated.status == "review_required"
     assert updated.reference_bindings == ()
     assert updated.obligations == (_selection_obligation(reason="ambiguous"),)
 
@@ -158,7 +158,7 @@ def test_reference_selection_opens_obligation_when_no_candidate_matches():
         field="co2e_emission",
     )
 
-    assert updated.status == "blocked"
+    assert updated.status == "review_required"
     assert updated.reference_bindings == ()
     assert updated.obligations == (_selection_obligation(reason="no_match"),)
 

--- a/tests/test_report_status_policy.py
+++ b/tests/test_report_status_policy.py
@@ -1,0 +1,125 @@
+import pytest
+
+from comp.compiler_tool import (
+    CompileReport,
+    FailedClaim,
+    Hazard,
+    ProofObligation,
+    UncheckedArea,
+    UnknownClaim,
+    recompute_report_status,
+    with_recomputed_status,
+)
+
+
+@pytest.mark.parametrize(
+    ("report", "expected_status"),
+    (
+        (
+            CompileReport(
+                status="accepted",
+                failed_claims=(
+                    FailedClaim(
+                        field="amount",
+                        value="not a number",
+                        reason="invalid_number",
+                        origin="llm_inferred",
+                    ),
+                ),
+            ),
+            "blocked",
+        ),
+        (
+            CompileReport(
+                status="accepted",
+                obligations=(
+                    ProofObligation(
+                        kind="calculation_blocked",
+                        field="co2e_emission",
+                        reason="unit_mismatch",
+                    ),
+                ),
+            ),
+            "blocked",
+        ),
+        (
+            CompileReport(
+                status="accepted",
+                hazards=(Hazard(kind="conflict", field="scope2_method", severity="review"),),
+            ),
+            "review_required",
+        ),
+        (
+            CompileReport(
+                status="accepted",
+                obligations=(
+                    ProofObligation(
+                        kind="semantic_judgment_required",
+                        field="scope2_method",
+                        reason="semantic_support_required",
+                    ),
+                ),
+            ),
+            "review_required",
+        ),
+        (
+            CompileReport(
+                status="accepted",
+                unchecked_areas=(
+                    UncheckedArea(field="factor_policy", reason="missing_rule_family"),
+                ),
+            ),
+            "unchecked",
+        ),
+        (
+            CompileReport(
+                status="accepted",
+                unknowns=(UnknownClaim(field="period", reason="context_required"),),
+            ),
+            "underconstrained",
+        ),
+        (
+            CompileReport(
+                status="accepted",
+                obligations=(
+                    ProofObligation(
+                        kind="reference_selection_required",
+                        field="co2e_emission",
+                        reason="ambiguous",
+                    ),
+                ),
+            ),
+            "review_required",
+        ),
+        (
+            CompileReport(
+                status="review_required",
+                obligations=(
+                    ProofObligation(
+                        kind="nonblocking_hint",
+                        field="co2e_emission",
+                        reason="candidate_available",
+                        blocking=False,
+                    ),
+                ),
+            ),
+            "accepted",
+        ),
+    ),
+)
+def test_recompute_report_status_uses_single_priority_policy(report, expected_status):
+    assert recompute_report_status(report) == expected_status
+
+
+def test_with_recomputed_status_preserves_report_payload():
+    report = CompileReport(
+        status="accepted",
+        hazards=(Hazard(kind="conflict", field="scope2_method", severity="review"),),
+        can_project_public_row=True,
+    )
+
+    updated = with_recomputed_status(report)
+
+    assert updated.status == "review_required"
+    assert updated.hazards == report.hazards
+    assert updated.can_project_public_row is True


### PR DESCRIPTION
## Summary
- Add `report_status.py` with a single `recompute_report_status` / `with_recomputed_status` policy for `CompileReport`.
- Route semantic judgment application, reference selection, calculation result application, calculation retry, profile runner, and compiler tool reports through the central policy.
- Update reference-selection-only failures to be `review_required` under the shared “other blocking obligation” rule, while `calculation_blocked` remains `blocked`.
- Remove duplicated `_status_for` helpers from compiler-tool adapters.

## Validation
- `python -m pytest tests/test_report_status_policy.py -q`
- `python -m pytest tests/test_compiler_tool_contract.py tests/test_report_status_policy.py tests/test_semantic_judgment_obligations.py tests/test_reference_selection_report.py tests/test_calculation_retry_report.py tests/test_calculation_report_integration.py tests/test_tiny_domain_fixture.py -q`
- `python -m pytest tests/test_reference_grounded_calculation_flow.py tests/test_compile_report_to_judgment_facts.py tests/test_receipt_gated_projection.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`
- `rg "def _status_for|_status_for\(" -n comp/compiler_tool` returned no matches