### PR TITLE
[codex] feat: add commit package model

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -14,6 +14,7 @@ from comp.compiler_tool.calculation_flow import resolve_reference_grounded_calcu
 from comp.compiler_tool.calculation_report import apply_calculation_result
 from comp.compiler_tool.calculation_resolution import plan_calculation_resolution
 from comp.compiler_tool.calculation_retry import retry_blocked_calculation
+from comp.compiler_tool.commit_package import CommitPackage, build_commit_package
 from comp.compiler_tool.models import (
     CheckedClaim,
     ClaimHypothesis,
@@ -95,6 +96,8 @@ __all__ = [
     "apply_calculation_result",
     "plan_calculation_resolution",
     "retry_blocked_calculation",
+    "CommitPackage",
+    "build_commit_package",
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
     "ReferenceBinding",

--- a/comp/compiler_tool/commit_package.py
+++ b/comp/compiler_tool/commit_package.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from comp.compiler_tool.models import CompileReport, Hazard, ProofObligation
+from comp.compiler_tool.report_status import recompute_report_status
+
+
+@dataclass(frozen=True)
+class CommitPackage:
+    package_id: str
+    subject_id: str
+    report_status: str
+    checked_claim_fields: tuple[str, ...] = field(default_factory=tuple)
+    semantic_judgment_ids: tuple[str, ...] = field(default_factory=tuple)
+    reference_binding_ids: tuple[str, ...] = field(default_factory=tuple)
+    derived_claim_ids: tuple[str, ...] = field(default_factory=tuple)
+    calculation_trace_ids: tuple[str, ...] = field(default_factory=tuple)
+    open_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
+    resolved_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
+    hazard_ids: tuple[str, ...] = field(default_factory=tuple)
+    profile_id: str | None = None
+    complete: bool = False
+
+    @property
+    def can_authorize_public_projection(self) -> bool:
+        return False
+
+
+def build_commit_package(
+    report: CompileReport,
+    *,
+    subject_id: str,
+    package_id: str | None = None,
+    profile_id: str | None = None,
+    semantic_judgment_ids: Iterable[str] = (),
+) -> CommitPackage:
+    report_status = recompute_report_status(report)
+    open_obligation_ids = tuple(
+        _obligation_id(obligation) for obligation in report.obligations
+    )
+    has_open_blocking_obligation = any(
+        obligation.blocking for obligation in report.obligations
+    )
+    hazard_ids = tuple(_hazard_id(hazard) for hazard in report.hazards)
+
+    return CommitPackage(
+        package_id=package_id or f"commit-package:{subject_id}",
+        subject_id=subject_id,
+        report_status=report_status,
+        checked_claim_fields=tuple(claim.field for claim in report.checked_claims),
+        semantic_judgment_ids=tuple(semantic_judgment_ids),
+        reference_binding_ids=tuple(
+            binding.binding_id for binding in report.reference_bindings
+        ),
+        derived_claim_ids=tuple(claim.claim_id for claim in report.derived_claims),
+        calculation_trace_ids=tuple(
+            claim.trace.trace_id for claim in report.derived_claims
+        ),
+        open_obligation_ids=open_obligation_ids,
+        resolved_obligation_ids=tuple(
+            _obligation_id(obligation)
+            for obligation in report.resolved_obligations
+        ),
+        hazard_ids=hazard_ids,
+        profile_id=profile_id,
+        complete=report_status == "accepted"
+        and not has_open_blocking_obligation
+        and not hazard_ids,
+    )
+
+
+def _obligation_id(obligation: ProofObligation) -> str:
+    if obligation.obligation_id is not None:
+        return obligation.obligation_id
+    return _stable_id(
+        "proof_obligation",
+        obligation.kind,
+        obligation.field,
+        obligation.reason,
+    )
+
+
+def _hazard_id(hazard: Hazard) -> str:
+    return _stable_id("hazard", hazard.kind, hazard.field, hazard.severity)
+
+
+def _stable_id(*parts: str) -> str:
+    return ":".join(str(part) for part in parts)
+
+
+__all__ = ["CommitPackage", "build_commit_package"]

--- a/tests/test_commit_package.py
+++ b/tests/test_commit_package.py
@@ -1,0 +1,137 @@
+from comp.compiler_tool import (
+    CalculationTrace,
+    CheckedClaim,
+    CompileReport,
+    DerivedClaim,
+    Hazard,
+    ProofObligation,
+    ReferenceBinding,
+    build_commit_package,
+)
+
+
+def test_commit_package_collects_report_artifacts_without_receipt_authority():
+    report = CompileReport(
+        status="accepted",
+        checked_claims=(
+            CheckedClaim(
+                field="amount",
+                value=1200,
+                witness_id="span-amount",
+                origin="source_text",
+            ),
+        ),
+        resolved_obligations=(
+            ProofObligation(
+                kind="calculation_blocked",
+                field="co2e_emission",
+                reason="unknown_reference",
+                obligation_id="calculation:hyp-1:co2e_emission",
+            ),
+        ),
+        reference_bindings=(
+            ReferenceBinding(
+                binding_id="bind-amount-factor",
+                claim_id="hyp-1:amount",
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+            ),
+        ),
+        derived_claims=(
+            DerivedClaim(
+                claim_id="hyp-1:co2e_emission",
+                field="co2e_emission",
+                value=0.48,
+                unit="tCO2e",
+                trace=CalculationTrace(
+                    trace_id="trace:hyp-1:co2e_emission",
+                    formula_id="ghg.electricity_factor_multiplication.v1",
+                    input_claim_ids=("hyp-1:amount",),
+                    reference_binding_ids=("bind-amount-factor",),
+                ),
+            ),
+        ),
+    )
+
+    package = build_commit_package(
+        report,
+        subject_id="facility-1",
+        profile_id="esg-ghg-v1",
+        semantic_judgment_ids=("judgment-scope2",),
+    )
+
+    assert package.package_id == "commit-package:facility-1"
+    assert package.subject_id == "facility-1"
+    assert package.profile_id == "esg-ghg-v1"
+    assert package.report_status == "accepted"
+    assert package.checked_claim_fields == ("amount",)
+    assert package.semantic_judgment_ids == ("judgment-scope2",)
+    assert package.reference_binding_ids == ("bind-amount-factor",)
+    assert package.derived_claim_ids == ("hyp-1:co2e_emission",)
+    assert package.calculation_trace_ids == ("trace:hyp-1:co2e_emission",)
+    assert package.open_obligation_ids == ()
+    assert package.resolved_obligation_ids == ("calculation:hyp-1:co2e_emission",)
+    assert package.hazard_ids == ()
+    assert package.complete is True
+    assert package.can_authorize_public_projection is False
+
+
+def test_commit_package_is_incomplete_with_open_blocking_obligation():
+    report = CompileReport(
+        status="accepted",
+        obligations=(
+            ProofObligation(
+                kind="reference_selection_required",
+                field="co2e_emission",
+                reason="ambiguous",
+                obligation_id="reference-selection:hyp-1:co2e_emission",
+            ),
+        ),
+    )
+
+    package = build_commit_package(report, subject_id="facility-1")
+
+    assert package.report_status == "review_required"
+    assert package.open_obligation_ids == (
+        "reference-selection:hyp-1:co2e_emission",
+    )
+    assert package.complete is False
+
+
+def test_commit_package_cites_nonblocking_obligations_without_blocking_completion():
+    report = CompileReport(
+        status="review_required",
+        obligations=(
+            ProofObligation(
+                kind="nonblocking_hint",
+                field="co2e_emission",
+                reason="candidate_available",
+                obligation_id="hint:hyp-1:co2e_emission",
+                blocking=False,
+            ),
+        ),
+    )
+
+    package = build_commit_package(report, subject_id="facility-1")
+
+    assert package.report_status == "accepted"
+    assert package.open_obligation_ids == ("hint:hyp-1:co2e_emission",)
+    assert package.complete is True
+
+
+def test_commit_package_is_incomplete_with_hazards():
+    report = CompileReport(
+        status="accepted",
+        hazards=(Hazard(kind="conflict", field="scope2_method", severity="review"),),
+    )
+
+    package = build_commit_package(
+        report,
+        subject_id="facility-1",
+        package_id="package-custom",
+    )
+
+    assert package.package_id == "package-custom"
+    assert package.report_status == "review_required"
+    assert package.hazard_ids == ("hazard:conflict:scope2_method:review",)
+    assert package.complete is False


### PR DESCRIPTION
## Summary
- add a compiler-tool `CommitPackage` artifact that bundles report citations before governance/receipt authority
- add `build_commit_package()` to collect checked fields, semantic judgment ids, reference bindings, derived claims, calculation traces, obligations, hazards, and profile id
- keep the package explicitly non-authoritative for public projection while using the central report status policy for completeness

## Validation
- `python -m pytest tests/test_commit_package.py -q`
- `python -m pytest tests/test_commit_package.py tests/test_report_status_policy.py -q`
- `python -m pytest tests/test_reference_grounded_calculation_flow.py tests/test_reference_binding_facts.py tests/test_derived_claim_trace.py -q`
- `python -m pytest tests/test_package_smoke.py tests/test_receipt_gated_projection.py -q`
- `python -m pytest -q`