### PR TITLE
[codex] feat: add governance decision model

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -15,6 +15,11 @@ from comp.compiler_tool.calculation_report import apply_calculation_result
 from comp.compiler_tool.calculation_resolution import plan_calculation_resolution
 from comp.compiler_tool.calculation_retry import retry_blocked_calculation
 from comp.compiler_tool.commit_package import CommitPackage, build_commit_package
+from comp.compiler_tool.governance import (
+    GovernanceDecision,
+    GovernanceStatus,
+    decide_governance,
+)
 from comp.compiler_tool.models import (
     CheckedClaim,
     ClaimHypothesis,
@@ -98,6 +103,9 @@ __all__ = [
     "retry_blocked_calculation",
     "CommitPackage",
     "build_commit_package",
+    "GovernanceDecision",
+    "GovernanceStatus",
+    "decide_governance",
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
     "ReferenceBinding",

--- a/comp/compiler_tool/governance.py
+++ b/comp/compiler_tool/governance.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from comp.compiler_tool.commit_package import CommitPackage
+
+GovernanceStatus = Literal["commit", "hold", "reject"]
+
+
+@dataclass(frozen=True)
+class GovernanceDecision:
+    decision_id: str
+    package_id: str
+    subject_id: str
+    status: GovernanceStatus
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+    profile_id: str | None = None
+
+    @property
+    def can_issue_commit_receipt(self) -> bool:
+        return self.status == "commit"
+
+    @property
+    def can_authorize_public_projection(self) -> bool:
+        return False
+
+
+def decide_governance(
+    package: CommitPackage,
+    *,
+    decision_id: str | None = None,
+) -> GovernanceDecision:
+    status, reasons = _evaluate_package(package)
+    return GovernanceDecision(
+        decision_id=decision_id or f"governance-decision:{package.package_id}",
+        package_id=package.package_id,
+        subject_id=package.subject_id,
+        status=status,
+        reasons=reasons,
+        profile_id=package.profile_id,
+    )
+
+
+def _evaluate_package(
+    package: CommitPackage,
+) -> tuple[GovernanceStatus, tuple[str, ...]]:
+    if package.complete:
+        return "commit", ("commit_package_complete",)
+
+    reasons = _incomplete_reasons(package)
+    if package.open_obligation_ids or package.hazard_ids:
+        return "hold", reasons
+    if package.report_status == "blocked":
+        return "reject", reasons
+    return "hold", reasons
+
+
+def _incomplete_reasons(package: CommitPackage) -> tuple[str, ...]:
+    reasons = []
+    if package.report_status != "accepted":
+        reasons.append(f"report_status:{package.report_status}")
+    reasons.extend(
+        f"open_obligation:{obligation_id}"
+        for obligation_id in package.open_obligation_ids
+    )
+    reasons.extend(package.hazard_ids)
+    if not reasons:
+        reasons.append("commit_package_incomplete")
+    return tuple(reasons)
+
+
+__all__ = ["GovernanceDecision", "GovernanceStatus", "decide_governance"]

--- a/tests/test_governance_decision.py
+++ b/tests/test_governance_decision.py
@@ -1,0 +1,88 @@
+from comp.compiler_tool import CommitPackage, decide_governance
+
+
+def test_governance_decision_commits_complete_package_without_projection_authority():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        checked_claim_fields=("amount",),
+        reference_binding_ids=("bind-amount-factor",),
+        derived_claim_ids=("hyp-1:co2e_emission",),
+        calculation_trace_ids=("trace:hyp-1:co2e_emission",),
+        complete=True,
+    )
+
+    decision = decide_governance(package)
+
+    assert decision.decision_id == "governance-decision:commit-package:facility-1"
+    assert decision.package_id == "commit-package:facility-1"
+    assert decision.subject_id == "facility-1"
+    assert decision.status == "commit"
+    assert decision.reasons == ("commit_package_complete",)
+    assert decision.can_issue_commit_receipt is True
+    assert decision.can_authorize_public_projection is False
+
+
+def test_governance_decision_holds_open_obligations():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="review_required",
+        open_obligation_ids=("reference-selection:hyp-1:co2e_emission",),
+        complete=False,
+    )
+
+    decision = decide_governance(package)
+
+    assert decision.status == "hold"
+    assert decision.reasons == (
+        "report_status:review_required",
+        "open_obligation:reference-selection:hyp-1:co2e_emission",
+    )
+    assert decision.can_issue_commit_receipt is False
+
+
+def test_governance_decision_holds_hazards_for_review():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="review_required",
+        hazard_ids=("hazard:conflict:scope2_method:review",),
+        complete=False,
+    )
+
+    decision = decide_governance(package)
+
+    assert decision.status == "hold"
+    assert decision.reasons == (
+        "report_status:review_required",
+        "hazard:conflict:scope2_method:review",
+    )
+
+
+def test_governance_decision_rejects_blocked_terminal_package():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="blocked",
+        complete=False,
+    )
+
+    decision = decide_governance(package)
+
+    assert decision.status == "reject"
+    assert decision.reasons == ("report_status:blocked",)
+
+
+def test_governance_decision_uses_explicit_decision_id():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        complete=True,
+    )
+
+    decision = decide_governance(package, decision_id="governance-custom")
+
+    assert decision.decision_id == "governance-custom"


### PR DESCRIPTION
## Summary
- add a compiler-tool `GovernanceDecision` artifact for the post-package governance boundary
- add `decide_governance()` to classify commit packages as `commit`, `hold`, or `reject`
- keep governance decisions non-authoritative for public projection while allowing commit decisions to become receipt inputs in a later PR

## Policy
- complete package -> `commit`
- open obligations or hazards -> `hold`
- blocked terminal package without open obligations -> `reject`

## Validation
- `python -m pytest tests/test_governance_decision.py -q`
- `python -m pytest tests/test_governance_decision.py tests/test_commit_package.py tests/test_report_status_policy.py -q`
- `python -m pytest tests/test_package_smoke.py tests/test_receipt_gated_projection.py tests/test_judgment_core.py -q`
- `python -m pytest -q`