### PR TITLE
[codex] feat: build commit receipts from governance

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -65,6 +65,10 @@ from comp.compiler_tool.references import (
     ReferenceCandidate,
     RejectedReferenceCandidate,
 )
+from comp.compiler_tool.receipt_builder import (
+    ReceiptBuildBlocked,
+    build_commit_receipt,
+)
 from comp.compiler_tool.report_status import (
     recompute_report_status,
     with_recomputed_status,
@@ -109,6 +113,8 @@ __all__ = [
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
     "ReferenceBinding",
+    "ReceiptBuildBlocked",
+    "build_commit_receipt",
     "ReferenceLookupError",
     "ReferenceRecord",
     "ReferenceCatalog",

--- a/comp/compiler_tool/commit_package.py
+++ b/comp/compiler_tool/commit_package.py
@@ -13,10 +13,12 @@ class CommitPackage:
     subject_id: str
     report_status: str
     checked_claim_fields: tuple[str, ...] = field(default_factory=tuple)
+    checked_claim_witness_ids: tuple[str, ...] = field(default_factory=tuple)
     semantic_judgment_ids: tuple[str, ...] = field(default_factory=tuple)
     reference_binding_ids: tuple[str, ...] = field(default_factory=tuple)
     derived_claim_ids: tuple[str, ...] = field(default_factory=tuple)
     calculation_trace_ids: tuple[str, ...] = field(default_factory=tuple)
+    formula_ids: tuple[str, ...] = field(default_factory=tuple)
     open_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
     resolved_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
     hazard_ids: tuple[str, ...] = field(default_factory=tuple)
@@ -50,6 +52,9 @@ def build_commit_package(
         subject_id=subject_id,
         report_status=report_status,
         checked_claim_fields=tuple(claim.field for claim in report.checked_claims),
+        checked_claim_witness_ids=tuple(
+            claim.witness_id for claim in report.checked_claims
+        ),
         semantic_judgment_ids=tuple(semantic_judgment_ids),
         reference_binding_ids=tuple(
             binding.binding_id for binding in report.reference_bindings
@@ -58,6 +63,7 @@ def build_commit_package(
         calculation_trace_ids=tuple(
             claim.trace.trace_id for claim in report.derived_claims
         ),
+        formula_ids=_unique(claim.formula_id for claim in report.derived_claims),
         open_obligation_ids=open_obligation_ids,
         resolved_obligation_ids=tuple(
             _obligation_id(obligation)
@@ -88,6 +94,17 @@ def _hazard_id(hazard: Hazard) -> str:
 
 def _stable_id(*parts: str) -> str:
     return ":".join(str(part) for part in parts)
+
+
+def _unique(values: Iterable[str]) -> tuple[str, ...]:
+    seen = set()
+    unique_values = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        unique_values.append(value)
+    return tuple(unique_values)
 
 
 __all__ = ["CommitPackage", "build_commit_package"]

--- a/comp/compiler_tool/receipt_builder.py
+++ b/comp/compiler_tool/receipt_builder.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from comp.compiler_tool.commit_package import CommitPackage
+from comp.compiler_tool.governance import GovernanceDecision
+from comp.judgment.receipts import CommitReceipt
+
+
+class ReceiptBuildBlocked(RuntimeError):
+    """Raised when a governance decision cannot mint a commit receipt."""
+
+
+def build_commit_receipt(
+    package: CommitPackage,
+    decision: GovernanceDecision,
+    *,
+    public_row_id: str,
+) -> CommitReceipt:
+    _validate_receipt_inputs(package, decision)
+    return CommitReceipt(
+        draft_id=package.package_id,
+        winner_receipt_ids=(decision.decision_id,),
+        barrier_snapshot=_barrier_snapshot(package, decision),
+        public_row_id=public_row_id,
+    )
+
+
+def _validate_receipt_inputs(
+    package: CommitPackage,
+    decision: GovernanceDecision,
+) -> None:
+    if decision.package_id != package.package_id:
+        raise ReceiptBuildBlocked("Commit receipt package mismatch.")
+    if decision.subject_id != package.subject_id:
+        raise ReceiptBuildBlocked("Commit receipt subject mismatch.")
+    if not decision.can_issue_commit_receipt:
+        raise ReceiptBuildBlocked("Commit receipt requires a commit decision.")
+    if not package.complete:
+        raise ReceiptBuildBlocked("Commit receipt requires a complete package.")
+
+
+def _barrier_snapshot(
+    package: CommitPackage,
+    decision: GovernanceDecision,
+) -> tuple[tuple[str, object], ...]:
+    return (
+        ("governance_decision_id", decision.decision_id),
+        ("governance_status", decision.status),
+        ("governance_reasons", decision.reasons),
+        ("commit_package_id", package.package_id),
+        ("commit_package_complete", package.complete),
+        ("subject_id", package.subject_id),
+        ("profile_id", package.profile_id),
+        ("report_status", package.report_status),
+        ("checked_claim_fields", package.checked_claim_fields),
+        ("checked_claim_witness_ids", package.checked_claim_witness_ids),
+        ("semantic_judgment_ids", package.semantic_judgment_ids),
+        ("reference_binding_ids", package.reference_binding_ids),
+        ("derived_claim_ids", package.derived_claim_ids),
+        ("calculation_trace_ids", package.calculation_trace_ids),
+        ("formula_ids", package.formula_ids),
+        ("resolved_obligation_ids", package.resolved_obligation_ids),
+        ("open_obligation_ids", package.open_obligation_ids),
+        ("hazard_ids", package.hazard_ids),
+    )
+
+
+__all__ = ["ReceiptBuildBlocked", "build_commit_receipt"]

--- a/tests/test_commit_package.py
+++ b/tests/test_commit_package.py
@@ -65,10 +65,12 @@ def test_commit_package_collects_report_artifacts_without_receipt_authority():
     assert package.profile_id == "esg-ghg-v1"
     assert package.report_status == "accepted"
     assert package.checked_claim_fields == ("amount",)
+    assert package.checked_claim_witness_ids == ("span-amount",)
     assert package.semantic_judgment_ids == ("judgment-scope2",)
     assert package.reference_binding_ids == ("bind-amount-factor",)
     assert package.derived_claim_ids == ("hyp-1:co2e_emission",)
     assert package.calculation_trace_ids == ("trace:hyp-1:co2e_emission",)
+    assert package.formula_ids == ("ghg.electricity_factor_multiplication.v1",)
     assert package.open_obligation_ids == ()
     assert package.resolved_obligation_ids == ("calculation:hyp-1:co2e_emission",)
     assert package.hazard_ids == ()

--- a/tests/test_commit_receipt_builder.py
+++ b/tests/test_commit_receipt_builder.py
@@ -1,0 +1,119 @@
+import pytest
+
+from comp import ProjectionSpec, project_public_row
+from comp.compiler_tool import (
+    CommitPackage,
+    ReceiptBuildBlocked,
+    build_commit_receipt,
+    decide_governance,
+)
+
+
+def test_commit_receipt_builder_cites_package_and_governance_artifacts():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        checked_claim_fields=("amount",),
+        checked_claim_witness_ids=("span-amount",),
+        semantic_judgment_ids=("judgment-scope2",),
+        reference_binding_ids=("bind-amount-factor",),
+        derived_claim_ids=("hyp-1:co2e_emission",),
+        calculation_trace_ids=("trace:hyp-1:co2e_emission",),
+        formula_ids=("ghg.electricity_factor_multiplication.v1",),
+        resolved_obligation_ids=("calculation:hyp-1:co2e_emission",),
+        profile_id="esg-ghg-v1",
+        complete=True,
+    )
+    decision = decide_governance(package)
+
+    receipt = build_commit_receipt(
+        package,
+        decision,
+        public_row_id="public-row-1",
+    )
+
+    snapshot = dict(receipt.barrier_snapshot)
+    assert receipt.draft_id == "commit-package:facility-1"
+    assert receipt.winner_receipt_ids == (
+        "governance-decision:commit-package:facility-1",
+    )
+    assert receipt.public_row_id == "public-row-1"
+    assert snapshot["governance_decision_id"] == decision.decision_id
+    assert snapshot["governance_status"] == "commit"
+    assert snapshot["commit_package_id"] == "commit-package:facility-1"
+    assert snapshot["subject_id"] == "facility-1"
+    assert snapshot["profile_id"] == "esg-ghg-v1"
+    assert snapshot["checked_claim_fields"] == ("amount",)
+    assert snapshot["checked_claim_witness_ids"] == ("span-amount",)
+    assert snapshot["semantic_judgment_ids"] == ("judgment-scope2",)
+    assert snapshot["reference_binding_ids"] == ("bind-amount-factor",)
+    assert snapshot["derived_claim_ids"] == ("hyp-1:co2e_emission",)
+    assert snapshot["calculation_trace_ids"] == ("trace:hyp-1:co2e_emission",)
+    assert snapshot["formula_ids"] == ("ghg.electricity_factor_multiplication.v1",)
+    assert snapshot["resolved_obligation_ids"] == (
+        "calculation:hyp-1:co2e_emission",
+    )
+    assert snapshot["open_obligation_ids"] == ()
+    assert snapshot["hazard_ids"] == ()
+
+
+def test_generated_commit_receipt_can_authorize_existing_projection_gate():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        complete=True,
+    )
+    receipt = build_commit_receipt(
+        package,
+        decide_governance(package),
+        public_row_id="public-row-1",
+    )
+
+    row = project_public_row(
+        {"site": "plant-a", "amount": 100, "internal_note": "hidden"},
+        ProjectionSpec("public-row", ("site", "amount")),
+        receipt=receipt,
+    )
+
+    assert row == {"site": "plant-a", "amount": 100}
+
+
+def test_commit_receipt_builder_blocks_hold_decision():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="review_required",
+        open_obligation_ids=("reference-selection:hyp-1:co2e_emission",),
+        complete=False,
+    )
+
+    with pytest.raises(ReceiptBuildBlocked, match="commit decision"):
+        build_commit_receipt(
+            package,
+            decide_governance(package),
+            public_row_id="public-row-1",
+        )
+
+
+def test_commit_receipt_builder_blocks_package_mismatch():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        complete=True,
+    )
+    other_package = CommitPackage(
+        package_id="commit-package:facility-2",
+        subject_id="facility-2",
+        report_status="accepted",
+        complete=True,
+    )
+
+    with pytest.raises(ReceiptBuildBlocked, match="package mismatch"):
+        build_commit_receipt(
+            package,
+            decide_governance(other_package),
+            public_row_id="public-row-1",
+        )


### PR DESCRIPTION
## Summary
- add `build_commit_receipt()` to mint existing `CommitReceipt` artifacts from a committed `GovernanceDecision` and matching `CommitPackage`
- add `ReceiptBuildBlocked` for hold/reject decisions, incomplete packages, and package/subject mismatches
- expand `CommitPackage` citations with checked claim witness ids and formula ids so receipts can cite evidence and calculation authority

## Boundary
- `CommitPackage` is still not projection authority
- `GovernanceDecision` is still not projection authority
- only the generated `CommitReceipt` can pass the existing receipt-gated projection API

## Validation
- `python -m pytest tests/test_commit_package.py -q`
- `python -m pytest tests/test_commit_receipt_builder.py -q`
- `python -m pytest tests/test_commit_receipt_builder.py tests/test_commit_package.py tests/test_governance_decision.py tests/test_receipt_gated_projection.py -q`
- `python -m pytest tests/test_reference_grounded_calculation_flow.py tests/test_derived_claim_trace.py tests/test_reference_binding_facts.py -q`
- `python -m pytest -q`