### PR TITLE
[codex] feat: add commit preparation flow

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -14,6 +14,7 @@ from comp.compiler_tool.calculation_flow import resolve_reference_grounded_calcu
 from comp.compiler_tool.calculation_report import apply_calculation_result
 from comp.compiler_tool.calculation_resolution import plan_calculation_resolution
 from comp.compiler_tool.calculation_retry import retry_blocked_calculation
+from comp.compiler_tool.commit_flow import CommitPreparation, prepare_commit
 from comp.compiler_tool.commit_package import CommitPackage, build_commit_package
 from comp.compiler_tool.governance import (
     GovernanceDecision,
@@ -105,6 +106,8 @@ __all__ = [
     "apply_calculation_result",
     "plan_calculation_resolution",
     "retry_blocked_calculation",
+    "CommitPreparation",
+    "prepare_commit",
     "CommitPackage",
     "build_commit_package",
     "GovernanceDecision",

--- a/comp/compiler_tool/commit_flow.py
+++ b/comp/compiler_tool/commit_flow.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from comp.compiler_tool.commit_package import CommitPackage, build_commit_package
+from comp.compiler_tool.governance import GovernanceDecision, decide_governance
+from comp.compiler_tool.models import CompileReport
+from comp.compiler_tool.receipt_builder import build_commit_receipt
+from comp.judgment.receipts import CommitReceipt
+
+
+@dataclass(frozen=True)
+class CommitPreparation:
+    package: CommitPackage
+    decision: GovernanceDecision
+    receipt: CommitReceipt | None = None
+
+    @property
+    def can_project_public_row(self) -> bool:
+        return self.receipt is not None
+
+
+def prepare_commit(
+    report: CompileReport,
+    *,
+    subject_id: str,
+    public_row_id: str,
+    package_id: str | None = None,
+    decision_id: str | None = None,
+    profile_id: str | None = None,
+    semantic_judgment_ids: Iterable[str] = (),
+) -> CommitPreparation:
+    package = build_commit_package(
+        report,
+        subject_id=subject_id,
+        package_id=package_id,
+        profile_id=profile_id,
+        semantic_judgment_ids=semantic_judgment_ids,
+    )
+    decision = decide_governance(package, decision_id=decision_id)
+    receipt = None
+    if decision.can_issue_commit_receipt and package.complete:
+        receipt = build_commit_receipt(
+            package,
+            decision,
+            public_row_id=public_row_id,
+        )
+    return CommitPreparation(package=package, decision=decision, receipt=receipt)
+
+
+__all__ = ["CommitPreparation", "prepare_commit"]

--- a/tests/test_commit_preparation_flow.py
+++ b/tests/test_commit_preparation_flow.py
@@ -1,0 +1,132 @@
+import pytest
+
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from comp.compiler_tool import (
+    CalculationTrace,
+    CheckedClaim,
+    CompileReport,
+    DerivedClaim,
+    FailedClaim,
+    ProofObligation,
+    ReferenceBinding,
+    prepare_commit,
+)
+
+
+def test_prepare_commit_builds_package_decision_and_receipt_for_accepted_report():
+    report = CompileReport(
+        status="accepted",
+        checked_claims=(
+            CheckedClaim(
+                field="amount",
+                value=1200,
+                witness_id="span-amount",
+                origin="source_text",
+            ),
+        ),
+        reference_bindings=(
+            ReferenceBinding(
+                binding_id="bind-amount-factor",
+                claim_id="hyp-1:amount",
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+            ),
+        ),
+        derived_claims=(
+            DerivedClaim(
+                claim_id="hyp-1:co2e_emission",
+                field="co2e_emission",
+                value=0.48,
+                unit="tCO2e",
+                trace=CalculationTrace(
+                    trace_id="trace:hyp-1:co2e_emission",
+                    formula_id="ghg.electricity_factor_multiplication.v1",
+                    input_claim_ids=("hyp-1:amount",),
+                    reference_binding_ids=("bind-amount-factor",),
+                ),
+            ),
+        ),
+    )
+
+    preparation = prepare_commit(
+        report,
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+        profile_id="esg-ghg-v1",
+        semantic_judgment_ids=("judgment-scope2",),
+    )
+
+    assert preparation.package.complete is True
+    assert preparation.decision.status == "commit"
+    assert preparation.receipt is not None
+    assert preparation.can_project_public_row is True
+
+    snapshot = dict(preparation.receipt.barrier_snapshot)
+    assert snapshot["checked_claim_witness_ids"] == ("span-amount",)
+    assert snapshot["semantic_judgment_ids"] == ("judgment-scope2",)
+    assert snapshot["reference_binding_ids"] == ("bind-amount-factor",)
+    assert snapshot["formula_ids"] == ("ghg.electricity_factor_multiplication.v1",)
+
+    row = project_public_row(
+        {"amount": 1200, "co2e_emission": 0.48, "internal_note": "hidden"},
+        ProjectionSpec("public-row", ("amount", "co2e_emission")),
+        receipt=preparation.receipt,
+    )
+    assert row == {"amount": 1200, "co2e_emission": 0.48}
+
+
+def test_prepare_commit_returns_hold_without_receipt_for_open_obligations():
+    report = CompileReport(
+        status="accepted",
+        obligations=(
+            ProofObligation(
+                kind="reference_selection_required",
+                field="co2e_emission",
+                reason="ambiguous",
+                obligation_id="reference-selection:hyp-1:co2e_emission",
+            ),
+        ),
+    )
+
+    preparation = prepare_commit(
+        report,
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+    )
+
+    assert preparation.package.open_obligation_ids == (
+        "reference-selection:hyp-1:co2e_emission",
+    )
+    assert preparation.decision.status == "hold"
+    assert preparation.receipt is None
+    assert preparation.can_project_public_row is False
+    with pytest.raises(ProjectionBlocked):
+        project_public_row(
+            {"co2e_emission": 0.48},
+            ProjectionSpec("public-row", ("co2e_emission",)),
+            receipt=preparation.receipt,
+        )
+
+
+def test_prepare_commit_returns_reject_without_receipt_for_terminal_failures():
+    report = CompileReport(
+        status="accepted",
+        failed_claims=(
+            FailedClaim(
+                field="amount",
+                value="not a number",
+                reason="invalid_number",
+                origin="llm_inferred",
+            ),
+        ),
+    )
+
+    preparation = prepare_commit(
+        report,
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+    )
+
+    assert preparation.package.report_status == "blocked"
+    assert preparation.decision.status == "reject"
+    assert preparation.receipt is None


### PR DESCRIPTION
## Summary
- add `CommitPreparation` as an end-to-end compiler-tool publication boundary result
- add `prepare_commit()` to build a commit package, decide governance, and mint a `CommitReceipt` only for committed packages
- keep hold/reject outcomes observable with `receipt=None` so agent loops can inspect obligations/hazards instead of treating normal review states as exceptions

## Boundary
- accepted/complete report -> package + commit decision + receipt
- open obligation -> package + hold decision + no receipt
- terminal failed report -> package + reject decision + no receipt
- public projection still requires the generated `CommitReceipt`

## Validation
- `python -m pytest tests/test_commit_preparation_flow.py -q`
- `python -m pytest tests/test_commit_preparation_flow.py tests/test_commit_receipt_builder.py tests/test_commit_package.py tests/test_governance_decision.py tests/test_receipt_gated_projection.py -q`
- `python -m pytest tests/test_reference_grounded_calculation_flow.py tests/test_calculation_retry_report.py tests/test_reference_binding_facts.py -q`
- `python -m pytest -q`