### PR TITLE
[codex] feat: expose commit preparation facts

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -77,7 +77,9 @@ from comp.compiler_tool.report_status import (
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
+    add_commit_preparation_facts,
     add_compile_report_facts,
+    commit_preparation_to_facts,
     compile_report_to_facts,
 )
 
@@ -142,4 +144,6 @@ __all__ = [
     "apply_semantic_judgments",
     "compile_report_to_facts",
     "add_compile_report_facts",
+    "commit_preparation_to_facts",
+    "add_commit_preparation_facts",
 ]

--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from comp.compiler_tool.commit_flow import CommitPreparation
 from comp.compiler_tool.models import CompileReport, ProofObligation
 from comp.judgment import Fact, FactTag, JudgmentState, SubjectRef
 
@@ -162,6 +163,96 @@ def add_compile_report_facts(
     return state.add_facts(compile_report_to_facts(report, subject))
 
 
+def commit_preparation_to_facts(
+    preparation: CommitPreparation, subject: SubjectRef
+) -> set[Fact]:
+    package = preparation.package
+    decision = preparation.decision
+    facts = {
+        Fact(
+            tag="prov_edge",
+            subject=subject,
+            key="commit_package",
+            value=package.package_id,
+            meta=(
+                ("checked_claim_fields", package.checked_claim_fields),
+                ("checked_claim_witness_ids", package.checked_claim_witness_ids),
+                ("calculation_trace_ids", package.calculation_trace_ids),
+                ("complete", package.complete),
+                ("derived_claim_ids", package.derived_claim_ids),
+                ("formula_ids", package.formula_ids),
+                ("hazard_ids", package.hazard_ids),
+                ("open_obligation_ids", package.open_obligation_ids),
+                ("profile_id", package.profile_id),
+                ("reference_binding_ids", package.reference_binding_ids),
+                ("report_status", package.report_status),
+                ("resolved_obligation_ids", package.resolved_obligation_ids),
+                ("semantic_judgment_ids", package.semantic_judgment_ids),
+            ),
+        ),
+        Fact(
+            tag="prov_edge",
+            subject=subject,
+            key="governance_decision",
+            value=decision.decision_id,
+            meta=(
+                ("can_issue_commit_receipt", decision.can_issue_commit_receipt),
+                ("governance_reasons", decision.reasons),
+                ("governance_status", decision.status),
+                ("package_id", decision.package_id),
+                ("profile_id", decision.profile_id),
+            ),
+        ),
+    }
+
+    for obligation_id in package.open_obligation_ids:
+        facts.add(
+            Fact(
+                tag="hazard_open",
+                subject=subject,
+                key=f"commit_obligation:{obligation_id}",
+                value=obligation_id,
+                meta=(("report_section", "commit_package"),),
+            )
+        )
+
+    for hazard_id in package.hazard_ids:
+        facts.add(
+            Fact(
+                tag="hazard_open",
+                subject=subject,
+                key=f"commit_hazard:{hazard_id}",
+                value=hazard_id,
+                meta=(("report_section", "commit_package"),),
+            )
+        )
+
+    if preparation.receipt is not None:
+        facts.add(
+            Fact(
+                tag="prov_edge",
+                subject=subject,
+                key="commit_receipt",
+                value=preparation.receipt.public_row_id,
+                witness=decision.decision_id,
+                meta=(
+                    ("commit_package_id", package.package_id),
+                    ("receipt_snapshot", preparation.receipt.barrier_snapshot),
+                ),
+            )
+        )
+
+    return facts
+
+
+def add_commit_preparation_facts(
+    state: JudgmentState,
+    preparation: CommitPreparation,
+    subject: SubjectRef,
+) -> set[Fact]:
+    return state.add_facts(commit_preparation_to_facts(preparation, subject))
+
+
 def _obligation_fact(
     tag: FactTag,
     status: str,
@@ -239,4 +330,6 @@ def _stable_id(*parts: str) -> str:
 __all__ = [
     "compile_report_to_facts",
     "add_compile_report_facts",
+    "commit_preparation_to_facts",
+    "add_commit_preparation_facts",
 ]

--- a/tests/test_commit_preparation_facts.py
+++ b/tests/test_commit_preparation_facts.py
@@ -1,0 +1,115 @@
+from comp import JudgmentState, SubjectRef
+from comp.compiler_tool import (
+    CheckedClaim,
+    CompileReport,
+    ProofObligation,
+    add_commit_preparation_facts,
+    commit_preparation_to_facts,
+    prepare_commit,
+)
+
+
+def test_commit_preparation_to_facts_records_package_decision_and_receipt():
+    preparation = prepare_commit(
+        CompileReport(
+            status="accepted",
+            checked_claims=(
+                CheckedClaim(
+                    field="amount",
+                    value=1200,
+                    witness_id="span-amount",
+                    origin="source_text",
+                ),
+            ),
+        ),
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+        profile_id="esg-ghg-v1",
+        semantic_judgment_ids=("judgment-scope2",),
+    )
+
+    subject = SubjectRef("draft", "facility-1")
+    facts = commit_preparation_to_facts(preparation, subject)
+
+    package_fact = _one(facts, "prov_edge", "commit_package")
+    decision_fact = _one(facts, "prov_edge", "governance_decision")
+    receipt_fact = _one(facts, "prov_edge", "commit_receipt")
+
+    assert package_fact.value == "commit-package:facility-1"
+    assert ("complete", True) in package_fact.meta
+    assert ("checked_claim_fields", ("amount",)) in package_fact.meta
+    assert ("semantic_judgment_ids", ("judgment-scope2",)) in package_fact.meta
+    assert ("calculation_trace_ids", ()) in package_fact.meta
+    assert ("open_obligation_ids", ()) in package_fact.meta
+    assert ("hazard_ids", ()) in package_fact.meta
+
+    assert decision_fact.value == "governance-decision:commit-package:facility-1"
+    assert ("governance_status", "commit") in decision_fact.meta
+    assert ("can_issue_commit_receipt", True) in decision_fact.meta
+
+    assert receipt_fact.value == "public-row-1"
+    assert receipt_fact.witness == "governance-decision:commit-package:facility-1"
+    assert ("commit_package_id", "commit-package:facility-1") in receipt_fact.meta
+    assert ("receipt_snapshot", preparation.receipt.barrier_snapshot) in receipt_fact.meta
+
+
+def test_commit_preparation_to_facts_keeps_hold_visible_without_receipt_fact():
+    preparation = prepare_commit(
+        CompileReport(
+            status="accepted",
+            obligations=(
+                ProofObligation(
+                    kind="reference_selection_required",
+                    field="co2e_emission",
+                    reason="ambiguous",
+                    obligation_id="reference-selection:hyp-1:co2e_emission",
+                ),
+            ),
+        ),
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+    )
+
+    subject = SubjectRef("draft", "facility-1")
+    facts = commit_preparation_to_facts(preparation, subject)
+
+    decision_fact = _one(facts, "prov_edge", "governance_decision")
+    receipt_facts = [fact for fact in facts if fact.key == "commit_receipt"]
+    hazard_fact = _one(
+        facts,
+        "hazard_open",
+        "commit_obligation:reference-selection:hyp-1:co2e_emission",
+    )
+
+    assert decision_fact.value == "governance-decision:commit-package:facility-1"
+    assert ("governance_status", "hold") in decision_fact.meta
+    package_fact = _one(facts, "prov_edge", "commit_package")
+    assert (
+        "open_obligation_ids",
+        ("reference-selection:hyp-1:co2e_emission",),
+    ) in package_fact.meta
+    assert receipt_facts == []
+    assert hazard_fact.value == "reference-selection:hyp-1:co2e_emission"
+
+
+def test_add_commit_preparation_facts_updates_judgment_state_once():
+    preparation = prepare_commit(
+        CompileReport(status="accepted"),
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+    )
+    subject = SubjectRef("draft", "facility-1")
+    state = JudgmentState()
+
+    first_delta = add_commit_preparation_facts(state, preparation, subject)
+    second_delta = add_commit_preparation_facts(state, preparation, subject)
+
+    assert first_delta
+    assert second_delta == set()
+    assert state.version_of(subject) == 1
+
+
+def _one(facts, tag, key):
+    matches = [fact for fact in facts if fact.tag == tag and fact.key == key]
+    assert len(matches) == 1
+    return matches[0]


### PR DESCRIPTION
## Summary
- add `commit_preparation_to_facts()` to expose commit package, governance decision, and commit receipt provenance as judgment facts
- add `add_commit_preparation_facts()` for idempotently adding those facts to `JudgmentState`
- surface hold states as open commit obligation/hazard facts without creating a receipt fact

## Boundary
- commit package and governance decision are `prov_edge` facts
- commit receipt is a `prov_edge` fact only when a receipt exists
- hold/reject preparation remains observable without becoming projection authority

## Validation
- `python -m pytest tests/test_commit_preparation_facts.py -q`
- `python -m pytest tests/test_commit_preparation_facts.py tests/test_commit_preparation_flow.py tests/test_commit_receipt_builder.py tests/test_reference_binding_facts.py -q`
- `python -m pytest tests/test_judgment_core.py tests/test_minchoagnt_comp_adapter.py -q`
- `python -m pytest -q`