### PR TITLE
[codex] fix: align publication kernel docs and obligation ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,116 +1,97 @@
 # comp
 
-`comp` is a rebuild branch for an evidence-preserving compiler.
+`comp` is a receipt-gated proof package compiler.
 
-This branch starts from the PR #14 judgment-core point. It does not continue the later package migration as the active direction.
+The active direction is no longer a domain-specific DSL-first compiler or a row generator.
+The core work is to preserve evidence, expose obligations, bind references,
+calculate derived claims, and only publish through receipt authority.
 
-The goal is to decide authority first, then move code.
-
----
-
-## Core claim
-
-`comp` is not primarily a row generator.
-
-It is a compiler that should explain whether a public output is justified.
-
-The intended flow is:
+## Current Flow
 
 ```text
-raw fragment
-→ evidence / claim
-→ judgment
-→ governance decision
-→ receipt
-→ public projection
+candidate / obligation / judgment / reference / calculation
+-> CommitPackage
+-> GovernanceDecision
+-> CommitReceipt
+-> Judgment Facts
+-> receipt-gated projection
 ```
 
-The table is not the source of truth. The judgment trail and receipt are the source of truth.
+Important authority boundaries:
 
----
+```text
+DerivedClaim != public output
+CommitPackage != public authority
+GovernanceDecision != public authority
+CommitReceipt == projection gate
+```
 
-## Active policy
+## Active Package Surface
+
+The top-level `comp` package exposes the judgment-core surface:
+
+```python
+from comp import Fact, JudgmentState, SubjectRef
+from comp import SelectionReceipt, CommitReceipt
+from comp import ProjectionSpec, project_public_row
+```
+
+The compiler-tool surface exposes the current deterministic kernel:
+
+```python
+from comp.compiler_tool import CompilerTool, CompileReport
+from comp.compiler_tool import prepare_commit, build_commit_receipt
+from comp.compiler_tool import compile_report_to_facts
+```
+
+Legacy pipeline runners, pass-pipeline modules, and compatibility facades are
+archive reference material, not active package source.
+
+## Compiler Tool Layers
+
+`comp.compiler_tool` is intentionally layered:
+
+```text
+semantic
+  semantic judgment obligations and submitted judgment validation
+
+reference
+  reference candidates, deterministic selection, and canonical bindings
+
+calculation
+  calculation requirements, calculation traces, and derived claims
+
+governance / commit
+  CommitPackage, GovernanceDecision, CommitReceipt builder, CommitPreparation
+
+judgment facts
+  adapters that publish compiler reports and commit preparation artifacts into
+  JudgmentState as evidence, hazards, discharges, and provenance edges
+```
+
+Extractors such as Lark are candidate producers. They should produce evidence
+and claim hypotheses for the compiler tool; they should not mint checked claims,
+commit receipts, or public projections.
+
+## Active Policy
 
 Read these first:
 
 ```text
 docs/architecture/authority-map.md
 docs/architecture/kill-list.md
+docs/architecture/obligation-kernel-working-theory.md
 docs/architecture/llm-orchestrated-compiler-tool-loop.md
-docs/architecture/active-surface-cutover.md
+docs/architecture/memory-assisted-compiler-loop.md
 ```
 
-These documents define what may own authority in the rebuild branch, how LLM-driven interpretation loops should treat the compiler as an obligation-producing tool rather than a public truth authority, and which package surface is active during the cutover.
+These documents define the authority boundaries, the obligation/receipt kernel,
+and how LLM or agent loops should interact with compiler diagnostics without
+becoming public truth authority.
 
----
+## Rebuild Rule
 
-## Active package surface
-
-The top-level `comp` package intentionally exposes the judgment-core surface only.
-
-```python
-from comp import Fact, JudgmentState, SubjectRef
-from comp import SelectionReceipt, CommitReceipt
-```
-
-Legacy pipeline runners, pass-pipeline modules, and compatibility facades are
-kept as archive reference material, not active package source.
-
----
-
-## Authoritative concepts
-
-Long-term authority belongs to:
-
-```text
-Evidence-backed Judgment
-Governance Decision
-Receipt Ledger
-```
-
-Derived outputs include:
-
-```text
-Public row
-CSV / JSON output
-DataFrame view
-Report-facing projection
-```
-
-Legacy transport includes:
-
-```text
-CompileArtifacts
-frame runtime metadata
-row status fields
-pipeline pass metadata
-legacy event and merge logs
-```
-
-Legacy transport may remain for compatibility, but it should not become the long-term source of truth.
-
----
-
-## What this branch is not
-
-This branch is not a continuation of relocation-first migration.
-
-It does not treat these as architecture success criteria:
-
-```text
-moving files into package paths
-making legacy and package imports point to the same object
-preserving behavior before deciding whether the behavior should survive
-keeping wrappers without an explicit reason
-```
-
-Those can be useful migration tools, but they are not the target architecture.
-
----
-
-## Rebuild rule
-
-Before moving a module, answer:
+Before moving or expanding a module, answer:
 
 ```text
 What authority does this module own today?
@@ -118,85 +99,4 @@ Should that authority stay here long term?
 If not, which layer should own it?
 ```
 
-If the answer is unclear, architecture correction comes before relocation.
-
----
-
-## Layer ownership
-
-Evidence answers:
-
-```text
-Where did this value come from?
-What source, claim, provenance, or conflict is attached?
-```
-
-Judgment answers:
-
-```text
-Which candidate is selected?
-Why was it selected?
-What derivation or justification exists?
-```
-
-Governance answers:
-
-```text
-Can this judgment be made public?
-Is the decision hold, commit, or reject?
-What receipt explains the decision?
-```
-
-Projection answers:
-
-```text
-How is a committed decision represented externally?
-```
-
-Runner/app code assembles these layers and may handle legacy adapters.
-
----
-
-## Preserved migration state
-
-The later migration state is preserved separately at:
-
-```text
-legacy/current-migration-state-20260429
-```
-
-Historical migration documents are reference material. They are not active policy for this rebuild branch.
-
-See:
-
-```text
-docs/archive/2026-migration/README.md
-```
-
----
-
-## Current status
-
-This branch is an architecture reset point.
-
-Current intent:
-
-```text
-1. keep the PR #14 judgment-core baseline
-2. define authority ownership
-3. prevent legacy transport from becoming the new source of truth
-4. build a small vertical slice before continuing relocation
-```
-
-Next useful slice:
-
-```text
-fragment
-→ claim
-→ judgment
-→ governance decision
-→ receipt
-→ projected row
-```
-
-That slice should work before broad migration continues.
+Architecture correction comes before broad relocation.

--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -279,7 +279,7 @@ def _obligation_fact(
         tag=tag,
         subject=subject,
         key=f"proof_obligation:{obligation.field}",
-        value=_obligation_id(obligation.kind, obligation.field, obligation.reason),
+        value=_obligation_id(obligation),
         meta=tuple(meta),
     )
 
@@ -296,8 +296,15 @@ def _unchecked_area_id(field: str, reason: str) -> str:
     return _stable_id("unchecked_area", field, reason)
 
 
-def _obligation_id(kind: str, field: str, reason: str) -> str:
-    return _stable_id("proof_obligation", kind, field, reason)
+def _obligation_id(obligation: ProofObligation) -> str:
+    if obligation.obligation_id is not None:
+        return obligation.obligation_id
+    return _stable_id(
+        "proof_obligation",
+        obligation.kind,
+        obligation.field,
+        obligation.reason,
+    )
 
 
 def _hazard_id(kind: str, field: str, severity: str) -> str:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,73 @@
 # docs
 
-This directory contains architecture notes for the rebuild branch.
+This directory tracks the active architecture for the `comp` rebuild.
 
-## Active policy
+## Current Architecture
 
-Start here:
+`comp` is now a receipt-gated proof package compiler:
+
+```text
+candidate / obligation / judgment / reference / calculation
+-> CommitPackage
+-> GovernanceDecision
+-> CommitReceipt
+-> Judgment Facts
+-> receipt-gated projection
+```
+
+The compiler does not create public truth directly. Public projection requires a
+`CommitReceipt`.
+
+## Active Map
+
+Read these first:
 
 1. `architecture/authority-map.md`
 2. `architecture/kill-list.md`
+3. `architecture/obligation-kernel-working-theory.md`
+4. `architecture/llm-orchestrated-compiler-tool-loop.md`
+5. `architecture/memory-assisted-compiler-loop.md`
 
-These documents decide ownership before relocation.
+`architecture/obligation-kernel-working-theory.md` is the broad working map for
+semantic obligations, reference-grounded calculation, commit packages,
+governance decisions, and receipt-gated projection.
 
-## Working theories
+## Compiler Tool Layers
 
-These documents describe current design hypotheses. They are not final policy.
+Use this layer map when adding code or reviewing PRs:
 
-1. `architecture/obligation-kernel-working-theory.md`
+```text
+semantic
+  ProofObligation(kind="semantic_judgment_required")
+  SemanticJudgment protocol validation
 
-## Historical reference
+reference
+  ReferenceCandidate
+  ReferenceBinding
+  deterministic reference selection
 
-Later migration documents are preserved outside this branch at:
+calculation
+  CalculationRequirement
+  CalculationTrace
+  DerivedClaim
+
+governance / commit
+  CommitPackage
+  GovernanceDecision
+  CommitReceipt builder
+  CommitPreparation
+
+judgment facts
+  CompileReport -> Fact
+  CommitPreparation -> Fact
+```
+
+Extractor work, including Lark, belongs before the compiler tool. Extractors
+produce evidence and claim hypotheses; they do not authorize projection.
+
+## Historical Reference
+
+Later migration documents are preserved outside the active surface at:
 
 ```text
 legacy/current-migration-state-20260429
@@ -28,11 +76,8 @@ legacy/current-migration-state-20260429
 Archive notes live at:
 
 ```text
-archive/2026-migration/README.md
+docs/archive/2026-migration/README.md
 ```
 
-Historical migration documents are reference material, not active policy for this branch.
-
-## Rule
-
-Do not continue relocation work until the authority map and kill list are accepted.
+Historical migration documents are reference material, not active policy for
+this branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comp"
 version = "0.1.0a0"
-description = "Experimental ESG evidence compiler driven by ESGDL"
+description = "Receipt-gated proof package compiler for obligation, reference, calculation, and commit workflows"
 readme = "README.md"
 requires-python = ">=3.11"
 

--- a/tests/test_calculation_obligation_requirements.py
+++ b/tests/test_calculation_obligation_requirements.py
@@ -123,7 +123,10 @@ def test_calculation_requirement_metadata_is_visible_to_judgment_facts():
         tag="hazard_open",
         subject=SubjectRef("claim", "hyp-1"),
         key="proof_obligation:co2e_emission",
-        value="proof_obligation:calculation_blocked:co2e_emission:unit_mismatch",
+        value=(
+            "calculation:ghg.electricity_factor_multiplication.v1:"
+            "hyp-1:co2e_emission:unit_mismatch"
+        ),
         meta=(
             ("kind", "calculation_blocked"),
             ("reason", "unit_mismatch"),

--- a/tests/test_calculation_report_integration.py
+++ b/tests/test_calculation_report_integration.py
@@ -155,7 +155,10 @@ def test_calculation_obligation_maps_to_judgment_fact():
         tag="hazard_open",
         subject=subject,
         key="proof_obligation:co2e_emission",
-        value="proof_obligation:calculation_blocked:co2e_emission:unit_mismatch",
+        value=(
+            "calculation:ghg.electricity_factor_multiplication.v1:"
+            "hyp-1:co2e_emission:unit_mismatch"
+        ),
         meta=(
             ("kind", "calculation_blocked"),
             ("reason", "unit_mismatch"),

--- a/tests/test_compile_report_to_judgment_facts.py
+++ b/tests/test_compile_report_to_judgment_facts.py
@@ -174,6 +174,56 @@ def test_resolved_obligations_discharge_matching_hazard_ids():
     )
 
 
+def test_obligation_facts_preserve_explicit_obligation_ids():
+    subject = SubjectRef("claim", "hyp-1")
+    report = CompileReport(
+        status="review_required",
+        obligations=(
+            ProofObligation(
+                kind="semantic_judgment_required",
+                field="scope2_method",
+                reason="support_required",
+                obligation_id="obl-custom-open",
+            ),
+        ),
+        resolved_obligations=(
+            ProofObligation(
+                kind="find_source_witness",
+                field="unit",
+                reason="unsupported_unit",
+                obligation_id="obl-custom-resolved",
+            ),
+        ),
+    )
+
+    facts = compile_report_to_facts(report, subject)
+
+    assert Fact(
+        tag="hazard_open",
+        subject=subject,
+        key="proof_obligation:scope2_method",
+        value="obl-custom-open",
+        meta=(
+            ("kind", "semantic_judgment_required"),
+            ("reason", "support_required"),
+            ("report_section", "proof_obligation"),
+            ("report_status", "review_required"),
+        ),
+    ) in facts
+    assert Fact(
+        tag="hazard_discharge",
+        subject=subject,
+        key="proof_obligation:unit",
+        value="obl-custom-resolved",
+        meta=(
+            ("kind", "find_source_witness"),
+            ("reason", "unsupported_unit"),
+            ("report_section", "resolved_obligation"),
+            ("report_status", "review_required"),
+        ),
+    ) in facts
+
+
 def test_add_compile_report_facts_is_append_only_and_idempotent():
     subject = SubjectRef("claim", "hyp-1")
     report = CompileReport(

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -73,6 +73,11 @@ def test_top_level_package_no_longer_exports_legacy_runner_surface():
 def test_pyproject_packages_comp_core_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
 
+    assert pyproject["project"]["description"] == (
+        "Receipt-gated proof package compiler for obligation, reference, "
+        "calculation, and commit workflows"
+    )
+
     setuptools_config = pyproject["tool"]["setuptools"]
     assert setuptools_config["packages"] == [
         "comp",


### PR DESCRIPTION
## Summary

- Respect explicit `ProofObligation.obligation_id` values when adapting open/resolved obligations into judgment facts, while keeping the existing fallback ID when no explicit ID exists.
- Refresh `README.md`, `docs/index.md`, and the package description around the current publication kernel flow.
- Update tests for explicit calculation obligation IDs and package description coverage.

## Verification

- `python -m pytest tests/test_calculation_obligation_requirements.py tests/test_calculation_report_integration.py -q`
- `python -m pytest tests/test_compile_report_to_judgment_facts.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`

## Notes

Typed receipt citation modeling is intentionally left for PR146.