### PR TITLE
[codex] feat: add typed commit receipt citations

### DIFF
--- a/comp/__init__.py
+++ b/comp/__init__.py
@@ -9,6 +9,7 @@ from comp.judgment import (
     BundleSpec,
     CandidateSummary,
     CommitReceipt,
+    CommitReceiptCitations,
     CommitSpec,
     CompiledJudgmentProgram,
     DraftSnapshot,
@@ -61,4 +62,5 @@ __all__ = [
     "project_public_row",
     "SelectionReceipt",
     "CommitReceipt",
+    "CommitReceiptCitations",
 ]

--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -70,6 +70,7 @@ from comp.compiler_tool.receipt_builder import (
     ReceiptBuildBlocked,
     build_commit_receipt,
 )
+from comp.judgment.receipts import CommitReceiptCitations
 from comp.compiler_tool.report_status import (
     recompute_report_status,
     with_recomputed_status,
@@ -119,6 +120,7 @@ __all__ = [
     "RejectedReferenceCandidate",
     "ReferenceBinding",
     "ReceiptBuildBlocked",
+    "CommitReceiptCitations",
     "build_commit_receipt",
     "ReferenceLookupError",
     "ReferenceRecord",

--- a/comp/compiler_tool/receipt_builder.py
+++ b/comp/compiler_tool/receipt_builder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from comp.compiler_tool.commit_package import CommitPackage
 from comp.compiler_tool.governance import GovernanceDecision
-from comp.judgment.receipts import CommitReceipt
+from comp.judgment.receipts import CommitReceipt, CommitReceiptCitations
 
 
 class ReceiptBuildBlocked(RuntimeError):
@@ -16,11 +16,13 @@ def build_commit_receipt(
     public_row_id: str,
 ) -> CommitReceipt:
     _validate_receipt_inputs(package, decision)
+    citations = _receipt_citations(package, decision)
     return CommitReceipt(
         draft_id=package.package_id,
         winner_receipt_ids=(decision.decision_id,),
-        barrier_snapshot=_barrier_snapshot(package, decision),
+        barrier_snapshot=citations.to_barrier_snapshot(),
         public_row_id=public_row_id,
+        citations=citations,
     )
 
 
@@ -38,29 +40,29 @@ def _validate_receipt_inputs(
         raise ReceiptBuildBlocked("Commit receipt requires a complete package.")
 
 
-def _barrier_snapshot(
+def _receipt_citations(
     package: CommitPackage,
     decision: GovernanceDecision,
-) -> tuple[tuple[str, object], ...]:
-    return (
-        ("governance_decision_id", decision.decision_id),
-        ("governance_status", decision.status),
-        ("governance_reasons", decision.reasons),
-        ("commit_package_id", package.package_id),
-        ("commit_package_complete", package.complete),
-        ("subject_id", package.subject_id),
-        ("profile_id", package.profile_id),
-        ("report_status", package.report_status),
-        ("checked_claim_fields", package.checked_claim_fields),
-        ("checked_claim_witness_ids", package.checked_claim_witness_ids),
-        ("semantic_judgment_ids", package.semantic_judgment_ids),
-        ("reference_binding_ids", package.reference_binding_ids),
-        ("derived_claim_ids", package.derived_claim_ids),
-        ("calculation_trace_ids", package.calculation_trace_ids),
-        ("formula_ids", package.formula_ids),
-        ("resolved_obligation_ids", package.resolved_obligation_ids),
-        ("open_obligation_ids", package.open_obligation_ids),
-        ("hazard_ids", package.hazard_ids),
+) -> CommitReceiptCitations:
+    return CommitReceiptCitations(
+        governance_decision_id=decision.decision_id,
+        governance_status=decision.status,
+        governance_reasons=decision.reasons,
+        commit_package_id=package.package_id,
+        commit_package_complete=package.complete,
+        subject_id=package.subject_id,
+        profile_id=package.profile_id,
+        report_status=package.report_status,
+        checked_claim_fields=package.checked_claim_fields,
+        checked_claim_witness_ids=package.checked_claim_witness_ids,
+        semantic_judgment_ids=package.semantic_judgment_ids,
+        reference_binding_ids=package.reference_binding_ids,
+        derived_claim_ids=package.derived_claim_ids,
+        calculation_trace_ids=package.calculation_trace_ids,
+        formula_ids=package.formula_ids,
+        resolved_obligation_ids=package.resolved_obligation_ids,
+        open_obligation_ids=package.open_obligation_ids,
+        hazard_ids=package.hazard_ids,
     )
 
 

--- a/comp/judgment/__init__.py
+++ b/comp/judgment/__init__.py
@@ -26,7 +26,11 @@ from comp.judgment.program import (
     TransferEmitter,
     TransferRule,
 )
-from comp.judgment.receipts import CommitReceipt, SelectionReceipt
+from comp.judgment.receipts import (
+    CommitReceipt,
+    CommitReceiptCitations,
+    SelectionReceipt,
+)
 
 __all__ = [
     "SubjectKind",
@@ -55,4 +59,5 @@ __all__ = [
     "project_public_row",
     "SelectionReceipt",
     "CommitReceipt",
+    "CommitReceiptCitations",
 ]

--- a/comp/judgment/receipts.py
+++ b/comp/judgment/receipts.py
@@ -14,11 +14,56 @@ class SelectionReceipt:
 
 
 @dataclass(frozen=True, slots=True)
+class CommitReceiptCitations:
+    governance_decision_id: str
+    governance_status: str
+    governance_reasons: tuple[str, ...]
+    commit_package_id: str
+    commit_package_complete: bool
+    subject_id: str
+    profile_id: str | None
+    report_status: str
+    checked_claim_fields: tuple[str, ...]
+    checked_claim_witness_ids: tuple[str, ...]
+    semantic_judgment_ids: tuple[str, ...]
+    reference_binding_ids: tuple[str, ...]
+    derived_claim_ids: tuple[str, ...]
+    calculation_trace_ids: tuple[str, ...]
+    formula_ids: tuple[str, ...]
+    resolved_obligation_ids: tuple[str, ...]
+    open_obligation_ids: tuple[str, ...]
+    hazard_ids: tuple[str, ...]
+
+    def to_barrier_snapshot(self) -> tuple[tuple[str, Any], ...]:
+        return (
+            ("governance_decision_id", self.governance_decision_id),
+            ("governance_status", self.governance_status),
+            ("governance_reasons", self.governance_reasons),
+            ("commit_package_id", self.commit_package_id),
+            ("commit_package_complete", self.commit_package_complete),
+            ("subject_id", self.subject_id),
+            ("profile_id", self.profile_id),
+            ("report_status", self.report_status),
+            ("checked_claim_fields", self.checked_claim_fields),
+            ("checked_claim_witness_ids", self.checked_claim_witness_ids),
+            ("semantic_judgment_ids", self.semantic_judgment_ids),
+            ("reference_binding_ids", self.reference_binding_ids),
+            ("derived_claim_ids", self.derived_claim_ids),
+            ("calculation_trace_ids", self.calculation_trace_ids),
+            ("formula_ids", self.formula_ids),
+            ("resolved_obligation_ids", self.resolved_obligation_ids),
+            ("open_obligation_ids", self.open_obligation_ids),
+            ("hazard_ids", self.hazard_ids),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class CommitReceipt:
     draft_id: str
     winner_receipt_ids: tuple[str, ...]
     barrier_snapshot: tuple[tuple[str, Any], ...]
     public_row_id: str
+    citations: CommitReceiptCitations | None = None
 
 
-__all__ = ["SelectionReceipt", "CommitReceipt"]
+__all__ = ["SelectionReceipt", "CommitReceipt", "CommitReceiptCitations"]

--- a/tests/test_commit_receipt_builder.py
+++ b/tests/test_commit_receipt_builder.py
@@ -3,6 +3,7 @@ import pytest
 from comp import ProjectionSpec, project_public_row
 from comp.compiler_tool import (
     CommitPackage,
+    CommitReceiptCitations,
     ReceiptBuildBlocked,
     build_commit_receipt,
     decide_governance,
@@ -56,6 +57,48 @@ def test_commit_receipt_builder_cites_package_and_governance_artifacts():
     )
     assert snapshot["open_obligation_ids"] == ()
     assert snapshot["hazard_ids"] == ()
+
+
+def test_commit_receipt_builder_exposes_typed_citations():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        checked_claim_fields=("amount",),
+        checked_claim_witness_ids=("span-amount",),
+        semantic_judgment_ids=("judgment-scope2",),
+        reference_binding_ids=("bind-amount-factor",),
+        derived_claim_ids=("hyp-1:co2e_emission",),
+        calculation_trace_ids=("trace:hyp-1:co2e_emission",),
+        formula_ids=("ghg.electricity_factor_multiplication.v1",),
+        resolved_obligation_ids=("calculation:hyp-1:co2e_emission",),
+        profile_id="esg-ghg-v1",
+        complete=True,
+    )
+    decision = decide_governance(package)
+
+    receipt = build_commit_receipt(
+        package,
+        decision,
+        public_row_id="public-row-1",
+    )
+
+    assert isinstance(receipt.citations, CommitReceiptCitations)
+    assert receipt.citations.governance_decision_id == decision.decision_id
+    assert receipt.citations.commit_package_id == "commit-package:facility-1"
+    assert receipt.citations.subject_id == "facility-1"
+    assert receipt.citations.profile_id == "esg-ghg-v1"
+    assert receipt.citations.checked_claim_witness_ids == ("span-amount",)
+    assert receipt.citations.semantic_judgment_ids == ("judgment-scope2",)
+    assert receipt.citations.reference_binding_ids == ("bind-amount-factor",)
+    assert receipt.citations.derived_claim_ids == ("hyp-1:co2e_emission",)
+    assert receipt.citations.calculation_trace_ids == (
+        "trace:hyp-1:co2e_emission",
+    )
+    assert receipt.citations.formula_ids == (
+        "ghg.electricity_factor_multiplication.v1",
+    )
+    assert receipt.citations.to_barrier_snapshot() == receipt.barrier_snapshot
 
 
 def test_generated_commit_receipt_can_authorize_existing_projection_gate():

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -4,6 +4,7 @@ import tomllib
 import comp
 from comp import (
     CommitReceipt,
+    CommitReceiptCitations,
     Fact,
     FixpointEngine,
     JudgmentState,
@@ -61,6 +62,7 @@ def test_top_level_package_exposes_active_judgment_surface():
     assert FixpointEngine is not None
     assert SelectionReceipt is not None
     assert CommitReceipt is not None
+    assert CommitReceiptCitations is not None
 
 
 def test_top_level_package_no_longer_exports_legacy_runner_surface():


### PR DESCRIPTION
## Summary

- Add a typed `CommitReceiptCitations` model for the citation set currently carried in receipt barrier snapshots.
- Build generated commit receipts from typed citations, while preserving the existing `barrier_snapshot` contract and backward-compatible manual `CommitReceipt` construction.
- Export the citation model through the active judgment and compiler-tool package surfaces.

## Verification

- `python -m pytest tests/test_commit_receipt_builder.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest tests/test_receipt_gated_projection.py tests/test_commit_preparation_flow.py tests/test_commit_preparation_facts.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`