### PR TITLE
[codex] feat: add resolver task model

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -75,6 +75,11 @@ from comp.compiler_tool.report_status import (
     recompute_report_status,
     with_recomputed_status,
 )
+from comp.compiler_tool.resolver_tasks import (
+    ResolverTask,
+    resolver_task_from_obligation,
+    resolver_tasks_from_report,
+)
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
@@ -133,6 +138,9 @@ __all__ = [
     "select_reference_binding",
     "recompute_report_status",
     "with_recomputed_status",
+    "ResolverTask",
+    "resolver_task_from_obligation",
+    "resolver_tasks_from_report",
     "RuleFamily",
     "SemanticRubric",
     "JudgePolicy",

--- a/comp/compiler_tool/resolver_tasks.py
+++ b/comp/compiler_tool/resolver_tasks.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from comp.compiler_tool.calculations import CalculationRequirement
+from comp.compiler_tool.models import (
+    CompileReport,
+    ProofObligation,
+    SemanticJudgmentRequirement,
+)
+
+
+@dataclass(frozen=True)
+class ResolverTask:
+    task_id: str
+    obligation_id: str
+    task_type: str
+    required_artifact: str
+    obligation_kind: str
+    field: str
+    reason: str
+    claim_id: str | None = None
+    blocking: bool = True
+    payload: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+
+def resolver_tasks_from_report(report: CompileReport) -> tuple[ResolverTask, ...]:
+    return tuple(
+        resolver_task_from_obligation(obligation)
+        for obligation in report.obligations
+    )
+
+
+def resolver_task_from_obligation(obligation: ProofObligation) -> ResolverTask:
+    obligation_id = _obligation_id(obligation)
+    return ResolverTask(
+        task_id=f"resolver-task:{obligation_id}",
+        obligation_id=obligation_id,
+        task_type=_task_type(obligation.kind),
+        required_artifact=_required_artifact(obligation.kind),
+        obligation_kind=obligation.kind,
+        field=obligation.field,
+        reason=obligation.reason,
+        claim_id=obligation.claim_id,
+        blocking=obligation.blocking,
+        payload=_payload(obligation),
+    )
+
+
+def _task_type(obligation_kind: str) -> str:
+    return {
+        "semantic_judgment_required": "semantic_judgment",
+        "reference_search_required": "reference_search",
+        "reference_selection_required": "reference_selection",
+        "reference_context_required": "reference_context",
+        "find_context": "context",
+        "find_source_witness": "evidence_search",
+        "calculation_blocked": "calculation_resolution",
+    }.get(obligation_kind, "obligation_resolution")
+
+
+def _required_artifact(obligation_kind: str) -> str:
+    return {
+        "semantic_judgment_required": "semantic_judgment",
+        "reference_search_required": "reference_candidates",
+        "reference_selection_required": "reference_binding",
+        "reference_context_required": "context_attachment",
+        "find_context": "context_attachment",
+        "find_source_witness": "evidence_witness",
+        "calculation_blocked": "calculation_result",
+    }.get(obligation_kind, "resolver_artifact")
+
+
+def _payload(obligation: ProofObligation) -> tuple[tuple[str, Any], ...]:
+    if obligation.semantic_requirement is not None:
+        return _semantic_payload(obligation.semantic_requirement)
+    if obligation.calculation_requirement is not None:
+        return _calculation_payload(obligation.calculation_requirement)
+    return ()
+
+
+def _semantic_payload(
+    requirement: SemanticJudgmentRequirement,
+) -> tuple[tuple[str, Any], ...]:
+    return (
+        ("question", requirement.question),
+        ("rubric_id", requirement.rubric_id),
+        ("acceptable_verdicts", requirement.acceptable_verdicts),
+        ("required_verdict", requirement.required_verdict),
+        ("allowed_judges", requirement.allowed_judges),
+        ("evidence_span_ids", requirement.evidence_span_ids),
+    )
+
+
+def _calculation_payload(
+    requirement: CalculationRequirement,
+) -> tuple[tuple[str, Any], ...]:
+    items: list[tuple[str, Any]] = [
+        ("calculation_reason", requirement.reason),
+        ("formula_id", requirement.formula_id),
+        ("output_claim_id", requirement.output_claim_id),
+    ]
+    items.extend(
+        _present_items(
+            (
+                ("input_claim_id", requirement.input_claim_id),
+                ("reference_binding_id", requirement.reference_binding_id),
+                ("reference_id", requirement.reference_id),
+                ("expected_unit", requirement.expected_unit),
+                ("actual_unit", requirement.actual_unit),
+                ("expected_output_unit", requirement.expected_output_unit),
+                ("actual_output_unit", requirement.actual_output_unit),
+                ("missing_attribute", requirement.missing_attribute),
+            )
+        )
+    )
+    return tuple(items)
+
+
+def _present_items(
+    items: tuple[tuple[str, Any], ...],
+) -> tuple[tuple[str, Any], ...]:
+    return tuple((key, value) for key, value in items if value is not None)
+
+
+def _obligation_id(obligation: ProofObligation) -> str:
+    if obligation.obligation_id is not None:
+        return obligation.obligation_id
+    return _stable_id(
+        "proof_obligation",
+        obligation.kind,
+        obligation.field,
+        obligation.reason,
+    )
+
+
+def _stable_id(*parts: str) -> str:
+    return ":".join(str(part) for part in parts)
+
+
+__all__ = [
+    "ResolverTask",
+    "resolver_task_from_obligation",
+    "resolver_tasks_from_report",
+]

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,10 @@ calculation
   CalculationTrace
   DerivedClaim
 
+resolver tasks
+  ProofObligation -> ResolverTask
+  resolver-facing task type, required artifact, and payload
+
 governance / commit
   CommitPackage
   GovernanceDecision

--- a/tests/test_resolver_tasks.py
+++ b/tests/test_resolver_tasks.py
@@ -1,0 +1,137 @@
+from comp.compiler_tool import (
+    CalculationRequirement,
+    CompileReport,
+    ProofObligation,
+    ResolverTask,
+    SemanticJudgmentRequirement,
+    resolver_tasks_from_report,
+)
+
+
+def test_semantic_obligation_becomes_resolver_task_with_rubric_payload():
+    report = CompileReport(
+        status="review_required",
+        obligations=(
+            ProofObligation(
+                kind="semantic_judgment_required",
+                field="scope2_method",
+                reason="support_required",
+                obligation_id="obl-scope2",
+                claim_id="claim-scope2",
+                semantic_requirement=SemanticJudgmentRequirement(
+                    question="Does this span support market-based Scope 2?",
+                    claim_id="claim-scope2",
+                    evidence_span_ids=("span-17",),
+                    rubric_id="ghg-protocol-scope2-method-v1",
+                    acceptable_verdicts=("supports", "refutes", "ambiguous"),
+                    required_verdict="supports",
+                    allowed_judges=("llm/scope2-fixture",),
+                ),
+            ),
+        ),
+    )
+
+    tasks = resolver_tasks_from_report(report)
+
+    assert tasks == (
+        ResolverTask(
+            task_id="resolver-task:obl-scope2",
+            obligation_id="obl-scope2",
+            task_type="semantic_judgment",
+            required_artifact="semantic_judgment",
+            obligation_kind="semantic_judgment_required",
+            field="scope2_method",
+            reason="support_required",
+            claim_id="claim-scope2",
+            blocking=True,
+            payload=(
+                ("question", "Does this span support market-based Scope 2?"),
+                ("rubric_id", "ghg-protocol-scope2-method-v1"),
+                ("acceptable_verdicts", ("supports", "refutes", "ambiguous")),
+                ("required_verdict", "supports"),
+                ("allowed_judges", ("llm/scope2-fixture",)),
+                ("evidence_span_ids", ("span-17",)),
+            ),
+        ),
+    )
+
+
+def test_calculation_reference_search_obligation_preserves_requirement_payload():
+    requirement = CalculationRequirement(
+        reason="unknown_reference",
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim_id="hyp-1:amount",
+        reference_binding_id="bind-amount-factor",
+        reference_id="factor.kr_grid.2024.location_based",
+    )
+    report = CompileReport(
+        status="blocked",
+        obligations=(
+            ProofObligation(
+                kind="reference_search_required",
+                field="co2e_emission",
+                reason="unknown_reference",
+                obligation_id="resolve:ghg.electricity_factor_multiplication.v1:"
+                "hyp-1:co2e_emission:reference_search_required",
+                claim_id="hyp-1:co2e_emission",
+                calculation_requirement=requirement,
+            ),
+        ),
+    )
+
+    task = resolver_tasks_from_report(report)[0]
+
+    assert task.task_type == "reference_search"
+    assert task.required_artifact == "reference_candidates"
+    assert task.obligation_id == (
+        "resolve:ghg.electricity_factor_multiplication.v1:"
+        "hyp-1:co2e_emission:reference_search_required"
+    )
+    assert task.payload == (
+        ("calculation_reason", "unknown_reference"),
+        ("formula_id", "ghg.electricity_factor_multiplication.v1"),
+        ("output_claim_id", "hyp-1:co2e_emission"),
+        ("input_claim_id", "hyp-1:amount"),
+        ("reference_binding_id", "bind-amount-factor"),
+        ("reference_id", "factor.kr_grid.2024.location_based"),
+    )
+
+
+def test_resolver_tasks_use_fallback_obligation_ids_and_ignore_resolved_items():
+    report = CompileReport(
+        status="review_required",
+        obligations=(
+            ProofObligation(
+                kind="find_source_witness",
+                field="unit",
+                reason="missing_unit",
+                blocking=True,
+            ),
+        ),
+        resolved_obligations=(
+            ProofObligation(
+                kind="find_source_witness",
+                field="amount",
+                reason="missing_amount",
+            ),
+        ),
+    )
+
+    tasks = resolver_tasks_from_report(report)
+
+    assert tasks == (
+        ResolverTask(
+            task_id="resolver-task:proof_obligation:find_source_witness:unit:"
+            "missing_unit",
+            obligation_id="proof_obligation:find_source_witness:unit:missing_unit",
+            task_type="evidence_search",
+            required_artifact="evidence_witness",
+            obligation_kind="find_source_witness",
+            field="unit",
+            reason="missing_unit",
+            claim_id=None,
+            blocking=True,
+            payload=(),
+        ),
+    )


### PR DESCRIPTION
## Summary

- Add a `ResolverTask` model that normalizes open `ProofObligation` items into resolver-facing work units.
- Preserve explicit obligation IDs, provide stable fallback IDs, and map obligation kinds to task types plus required artifact names.
- Carry semantic judgment requirements and calculation requirements as structured task payloads.
- Update the docs layer map to include the resolver task bridge.

## Verification

- `python -m pytest tests/test_resolver_tasks.py -q`
- `python -m pytest tests/test_semantic_judgment_obligations.py tests/test_calculation_resolution_planner.py tests/test_commit_preparation_flow.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`