### PR TITLE
[codex] feat: add deterministic comp resolver bridge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,10 @@ judgment facts
 Extractor work, including Lark, belongs before the compiler tool. Extractors
 produce evidence and claim hypotheses; they do not authorize projection.
 
+Agent work, including `minchoagnt`, belongs outside the compiler core. Agents may
+consume `ResolverTask` items and submit resolver artifacts such as semantic
+judgments or reference queries, but they do not mint commit receipts.
+
 ## Historical Reference
 
 Later migration documents are preserved outside the active surface at:

--- a/minchoagnt/__init__.py
+++ b/minchoagnt/__init__.py
@@ -1,7 +1,12 @@
 """A tiny Hermes-style memory, skills, and review loop."""
 
 from minchoagnt.agent import ChatResult, MiniAgent, ReviewSummary
-from minchoagnt.comp_adapter import CompCompileResult, CompCompilerAdapter
+from minchoagnt.comp_adapter import (
+    CompCompileResult,
+    CompCompilerAdapter,
+    CompResolutionResult,
+    DeterministicCompResolver,
+)
 from minchoagnt.memory import MemoryStore
 from minchoagnt.ollama import OllamaHTTPClient, OllamaReviewEngine
 from minchoagnt.review import (
@@ -17,6 +22,8 @@ __all__ = [
     "ChatResult",
     "CompCompileResult",
     "CompCompilerAdapter",
+    "CompResolutionResult",
+    "DeterministicCompResolver",
     "MemoryStore",
     "MiniAgent",
     "OllamaHTTPClient",

--- a/minchoagnt/comp_adapter.py
+++ b/minchoagnt/comp_adapter.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, replace
 
 from comp.compiler_tool import (
     CompileReport,
     CompilerTool,
     InterpretationHypothesis,
+    ProofObligation,
+    ReferenceCatalog,
+    ResolverTask,
+    SemanticJudgment,
+    apply_semantic_judgments,
     compile_report_to_facts,
+    resolve_reference_search_obligations,
+    resolver_task_from_obligation,
+    resolver_tasks_from_report,
 )
 from comp.judgment import CommitReceipt, Fact, JudgmentState, SubjectRef
 
@@ -18,6 +27,15 @@ class CompCompileResult:
     report: CompileReport
     judgment: JudgmentState = field(default_factory=JudgmentState)
     receipt: CommitReceipt | None = None
+
+
+@dataclass(frozen=True)
+class CompResolutionResult:
+    source: CompCompileResult
+    result: CompCompileResult
+    tasks: tuple[ResolverTask, ...] = field(default_factory=tuple)
+    semantic_judgment_ids: tuple[str, ...] = field(default_factory=tuple)
+    reference_query_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
 
 
 class CompCompilerAdapter:
@@ -54,5 +72,100 @@ class CompCompilerAdapter:
         facts = compile_report_to_facts(result.report, result.subject)
         return result.judgment.add_facts(facts)
 
+    def resolver_tasks(self, result: CompCompileResult) -> tuple[ResolverTask, ...]:
+        return resolver_tasks_from_report(result.report)
 
-__all__ = ["CompCompileResult", "CompCompilerAdapter"]
+
+class DeterministicCompResolver:
+    """Fixture resolver for agent-side comp loops without LLM authority."""
+
+    def __init__(
+        self,
+        *,
+        semantic_judgments: Iterable[SemanticJudgment] = (),
+        available_span_ids: Iterable[str] | None = None,
+        reference_catalog: ReferenceCatalog | None = None,
+        reference_queries: Mapping[str, str] | None = None,
+        reference_type: str | None = None,
+        reference_limit: int = 10,
+        retrieval_method: str = "keyword",
+    ):
+        self.semantic_judgments = tuple(semantic_judgments)
+        self.available_span_ids = (
+            None if available_span_ids is None else tuple(available_span_ids)
+        )
+        self.reference_catalog = reference_catalog
+        self.reference_queries = dict(reference_queries or {})
+        self.reference_type = reference_type
+        self.reference_limit = reference_limit
+        self.retrieval_method = retrieval_method
+
+    def resolve(self, result: CompCompileResult) -> CompResolutionResult:
+        tasks = resolver_tasks_from_report(result.report)
+        report = result.report
+
+        semantic_judgments = self._semantic_judgments_for(tasks)
+        if semantic_judgments:
+            report = apply_semantic_judgments(
+                report,
+                semantic_judgments,
+                available_span_ids=self.available_span_ids,
+            )
+
+        reference_query_obligation_ids = self._reference_query_obligation_ids(tasks)
+        if self.reference_catalog is not None and reference_query_obligation_ids:
+            report = resolve_reference_search_obligations(
+                report,
+                self.reference_catalog,
+                query_for_obligation=self._query_for_obligation,
+                reference_type=self.reference_type,
+                limit=self.reference_limit,
+                retrieval_method=self.retrieval_method,
+            )
+
+        resolved = replace(result, report=report, receipt=None)
+        return CompResolutionResult(
+            source=result,
+            result=resolved,
+            tasks=tasks,
+            semantic_judgment_ids=tuple(
+                judgment.judgment_id for judgment in semantic_judgments
+            ),
+            reference_query_obligation_ids=reference_query_obligation_ids,
+        )
+
+    def _semantic_judgments_for(
+        self, tasks: tuple[ResolverTask, ...]
+    ) -> tuple[SemanticJudgment, ...]:
+        semantic_obligation_ids = {
+            task.obligation_id
+            for task in tasks
+            if task.task_type == "semantic_judgment"
+        }
+        return tuple(
+            judgment
+            for judgment in self.semantic_judgments
+            if judgment.obligation_id in semantic_obligation_ids
+        )
+
+    def _reference_query_obligation_ids(
+        self, tasks: tuple[ResolverTask, ...]
+    ) -> tuple[str, ...]:
+        return tuple(
+            task.obligation_id
+            for task in tasks
+            if task.task_type == "reference_search"
+            and task.obligation_id in self.reference_queries
+        )
+
+    def _query_for_obligation(self, obligation: ProofObligation) -> str | None:
+        task = resolver_task_from_obligation(obligation)
+        return self.reference_queries.get(task.obligation_id)
+
+
+__all__ = [
+    "CompCompileResult",
+    "CompResolutionResult",
+    "CompCompilerAdapter",
+    "DeterministicCompResolver",
+]

--- a/tests/test_minchoagnt_comp_adapter.py
+++ b/tests/test_minchoagnt_comp_adapter.py
@@ -3,12 +3,27 @@ import pytest
 import comp
 from comp import ProjectionBlocked, ProjectionSpec, project_public_row
 from comp.compiler_tool import (
+    CalculationRequirement,
     ClaimHypothesis,
+    CompileReport,
     EvidenceWitness,
     InterpretationHypothesis,
+    ProofObligation,
+    ReferenceCatalog,
+    ReferenceRecord,
+    SemanticJudgment,
+    SemanticJudgmentRequirement,
 )
-from minchoagnt import MemoryStore, MiniAgent, ReviewWorkbench, SkillStore
-from minchoagnt.comp_adapter import CompCompilerAdapter
+from comp.judgment import SubjectRef
+from minchoagnt import (
+    CompCompileResult,
+    CompCompilerAdapter,
+    DeterministicCompResolver,
+    MemoryStore,
+    MiniAgent,
+    ReviewWorkbench,
+    SkillStore,
+)
 
 
 def test_minchoagnt_layer_is_available_without_expanding_comp_surface():
@@ -71,3 +86,122 @@ def test_comp_adapter_can_append_report_facts_without_minting_receipts():
     assert result.receipt is None
     assert any(fact.tag == "hazard_open" for fact in delta)
     assert result.judgment.active_hazard_ids(result.subject)
+
+
+def test_comp_adapter_exposes_resolver_tasks_for_agent_loop():
+    adapter = CompCompilerAdapter(allowed_units=frozenset({"kwh"}))
+    result = adapter.compile(
+        InterpretationHypothesis(
+            hypothesis_id="hyp-3",
+            subject_id="claim-3",
+            claims=(ClaimHypothesis("unit", "mwh", witness_id="w-unit"),),
+            witnesses=(EvidenceWitness("w-unit", "unit", source="fragment-1"),),
+        )
+    )
+
+    tasks = adapter.resolver_tasks(result)
+
+    assert len(tasks) == 1
+    assert tasks[0].task_type == "evidence_search"
+    assert tasks[0].required_artifact == "evidence_witness"
+    assert tasks[0].obligation_kind == "find_source_witness"
+    assert tasks[0].field == "unit"
+
+
+def test_deterministic_comp_resolver_applies_semantic_judgment_without_receipt():
+    obligation = ProofObligation(
+        kind="semantic_judgment_required",
+        field="scope2_method",
+        reason="support_required",
+        obligation_id="obl-scope2",
+        semantic_requirement=SemanticJudgmentRequirement(
+            question="Does this span support market-based Scope 2?",
+            claim_id="claim-scope2",
+            evidence_span_ids=("span-17",),
+            rubric_id="ghg-protocol-scope2-method-v1",
+            acceptable_verdicts=("supports", "refutes", "ambiguous"),
+            allowed_judges=("llm/scope2-fixture",),
+        ),
+    )
+    compile_result = CompCompileResult(
+        hypothesis=InterpretationHypothesis("hyp-sem", "facility-1"),
+        subject=SubjectRef("claim", "hyp-sem"),
+        report=CompileReport(status="review_required", obligations=(obligation,)),
+    )
+    resolver = DeterministicCompResolver(
+        semantic_judgments=(
+            SemanticJudgment(
+                judgment_id="judgment-scope2",
+                obligation_id="obl-scope2",
+                verdict="supports",
+                rubric_id="ghg-protocol-scope2-method-v1",
+                judge="llm/scope2-fixture",
+                cited_span_ids=("span-17",),
+                rationale="fixture judgment",
+            ),
+        ),
+        available_span_ids=("span-17",),
+    )
+
+    resolution = resolver.resolve(compile_result)
+
+    assert [task.obligation_id for task in resolution.tasks] == ["obl-scope2"]
+    assert resolution.semantic_judgment_ids == ("judgment-scope2",)
+    assert resolution.result.report.status == "accepted"
+    assert resolution.result.report.obligations == ()
+    assert resolution.result.report.resolved_obligations == (obligation,)
+    assert resolution.result.receipt is None
+
+
+def test_deterministic_comp_resolver_runs_reference_search_from_task_query():
+    obligation_id = (
+        "resolve:ghg.electricity_factor_multiplication.v1:"
+        "hyp-1:co2e_emission:reference_search_required"
+    )
+    requirement = CalculationRequirement(
+        reason="unknown_reference",
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim_id="hyp-1:amount",
+        reference_binding_id="bind-amount-factor",
+        reference_id="factor.missing",
+    )
+    obligation = ProofObligation(
+        kind="reference_search_required",
+        field="co2e_emission",
+        reason="unknown_reference",
+        obligation_id=obligation_id,
+        claim_id="hyp-1:co2e_emission",
+        calculation_requirement=requirement,
+    )
+    compile_result = CompCompileResult(
+        hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
+        subject=SubjectRef("claim", "hyp-ref"),
+        report=CompileReport(status="blocked", obligations=(obligation,)),
+    )
+    catalog = ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                aliases=("korea electricity grid factor",),
+            ),
+        )
+    )
+    resolver = DeterministicCompResolver(
+        reference_catalog=catalog,
+        reference_queries={obligation_id: "korea electricity grid factor"},
+        reference_type="emission_factor",
+    )
+
+    resolution = resolver.resolve(compile_result)
+
+    assert resolution.reference_query_obligation_ids == (obligation_id,)
+    reference_ids = [
+        candidate.reference_id
+        for candidate in resolution.result.report.reference_candidates
+    ]
+    assert reference_ids == ["factor.kr_grid.2024.location_based"]
+    assert resolution.result.report.obligations == ()
+    assert resolution.result.report.resolved_obligations == (obligation,)
+    assert resolution.result.receipt is None


### PR DESCRIPTION
## Summary

- Add an agent-side deterministic resolver bridge in `minchoagnt` for consuming comp `ResolverTask` items.
- Expose resolver tasks from `CompCompilerAdapter` without granting projection or receipt authority.
- Allow fixture semantic judgments to be applied through comp validation and reference-search tasks to submit deterministic catalog queries.
- Return `CompResolutionResult` with the source result, resolved result, observed tasks, submitted judgment IDs, and queried obligation IDs.
- Document that agent resolver work stays outside compiler core and does not mint commit receipts.

## Verification

- `python -m pytest tests/test_minchoagnt_comp_adapter.py -q`
- `python -m pytest tests/test_resolver_tasks.py tests/test_reference_search_resolution.py tests/test_semantic_judgment_obligations.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`