### PR TITLE
[codex] test: add domain scenario lab skeleton

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -1,0 +1,27 @@
+# Domain Scenario Lab
+
+Domain scenarios are empirical fixtures for checking whether `comp` can survive
+small real-domain flows without giving UI or LLM code authority.
+
+```text
+pytest/assertion = verdict
+scenario result = trace artifact
+UI/viewer = observation
+```
+
+Each scenario should keep these pieces close together:
+
+```text
+input evidence
+domain pack/profile
+reference catalog
+resolver steps
+expected obligations
+expected bindings
+expected derived claims
+expected receipt/projection
+```
+
+The first scenario is `tiny_pcf`, a product-carbon-footprint slice that exercises
+reference search, near-miss rejection, canonical binding, calculation trace,
+commit preparation, and receipt-gated projection.

--- a/tests/domain_scenarios/__init__.py
+++ b/tests/domain_scenarios/__init__.py
@@ -1,0 +1,1 @@
+"""Domain Scenario Lab test fixtures."""

--- a/tests/domain_scenarios/core.py
+++ b/tests/domain_scenarios/core.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from comp.compiler_tool import (
+    CommitPreparation,
+    CompileReport,
+    commit_preparation_to_facts,
+    compile_report_to_facts,
+)
+from comp.judgment import Fact, SubjectRef
+
+
+@dataclass(frozen=True)
+class DomainScenarioResult:
+    scenario_id: str
+    report: CompileReport
+    preparation: CommitPreparation
+    projection: dict[str, Any] | None
+    report_facts: frozenset[Fact]
+    commit_facts: frozenset[Fact]
+    resolver_steps: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "resolver_steps": self.resolver_steps,
+            "report": {
+                "status": self.report.status,
+                "open_obligations": [
+                    _obligation_view(obligation)
+                    for obligation in self.report.obligations
+                ],
+                "resolved_obligations": [
+                    _obligation_view(obligation)
+                    for obligation in self.report.resolved_obligations
+                ],
+                "reference_candidates": [
+                    {
+                        "candidate_id": candidate.candidate_id,
+                        "reference_id": candidate.reference_id,
+                        "reference_type": candidate.reference_type,
+                        "retrieval_method": candidate.retrieval_method,
+                        "retrieval_score": candidate.retrieval_score,
+                        "authority": candidate.authority,
+                    }
+                    for candidate in self.report.reference_candidates
+                ],
+                "reference_bindings": [
+                    {
+                        "binding_id": binding.binding_id,
+                        "reference_id": binding.reference_id,
+                        "selected_candidate_id": binding.selected_candidate_id,
+                        "rejected_candidates": [
+                            {
+                                "reference_id": rejected.reference_id,
+                                "reason": rejected.reason,
+                            }
+                            for rejected in binding.rejected_candidates
+                        ],
+                    }
+                    for binding in self.report.reference_bindings
+                ],
+                "derived_claims": [
+                    {
+                        "claim_id": claim.claim_id,
+                        "field": claim.field,
+                        "value": claim.value,
+                        "unit": claim.unit,
+                        "trace_id": claim.trace.trace_id,
+                        "formula_id": claim.formula_id,
+                        "reference_binding_ids": claim.trace.reference_binding_ids,
+                    }
+                    for claim in self.report.derived_claims
+                ],
+            },
+            "commit": {
+                "package_id": self.preparation.package.package_id,
+                "package_complete": self.preparation.package.complete,
+                "governance_status": self.preparation.decision.status,
+                "receipt_id": (
+                    self.preparation.receipt.public_row_id
+                    if self.preparation.receipt is not None
+                    else None
+                ),
+            },
+            "facts": {
+                "report_count": len(self.report_facts),
+                "commit_count": len(self.commit_facts),
+            },
+            "projection": self.projection,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(_json_ready(self.to_dict()), indent=2, sort_keys=True)
+
+
+def build_domain_scenario_result(
+    *,
+    scenario_id: str,
+    report: CompileReport,
+    preparation: CommitPreparation,
+    projection: dict[str, Any] | None,
+    subject: SubjectRef,
+    resolver_steps: tuple[str, ...],
+) -> DomainScenarioResult:
+    return DomainScenarioResult(
+        scenario_id=scenario_id,
+        report=report,
+        preparation=preparation,
+        projection=projection,
+        report_facts=frozenset(compile_report_to_facts(report, subject)),
+        commit_facts=frozenset(commit_preparation_to_facts(preparation, subject)),
+        resolver_steps=resolver_steps,
+    )
+
+
+def _obligation_view(obligation) -> dict[str, str | None]:
+    return {
+        "obligation_id": obligation.obligation_id,
+        "kind": obligation.kind,
+        "field": obligation.field,
+        "reason": obligation.reason,
+    }
+
+
+def _json_ready(value):
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _json_ready(item) for key, item in value.items()}
+    return value
+
+
+__all__ = ["DomainScenarioResult", "build_domain_scenario_result"]

--- a/tests/domain_scenarios/tiny_pcf/__init__.py
+++ b/tests/domain_scenarios/tiny_pcf/__init__.py
@@ -1,0 +1,5 @@
+"""Tiny product-carbon-footprint scenario."""
+
+from tests.domain_scenarios.tiny_pcf.scenario import run_tiny_pcf_scenario
+
+__all__ = ["run_tiny_pcf_scenario"]

--- a/tests/domain_scenarios/tiny_pcf/expected.py
+++ b/tests/domain_scenarios/tiny_pcf/expected.py
@@ -1,0 +1,29 @@
+EXPECTED_RESOLVED_OBLIGATION_KINDS = (
+    "reference_search_required",
+    "calculation_blocked",
+)
+
+EXPECTED_REFERENCE_CANDIDATE_IDS = (
+    "pcf.factor.kr_grid_2024.location_based",
+    "pcf.factor.kr_grid_2023.location_based",
+)
+
+EXPECTED_REJECTED_CANDIDATES = (
+    (
+        "pcf.factor.kr_grid_2023.location_based",
+        "attribute_mismatch:valid_period",
+    ),
+)
+
+EXPECTED_PROJECTION = {
+    "electricity_kwh": 1200,
+    "co2e_kg": 504.0,
+}
+
+
+__all__ = [
+    "EXPECTED_PROJECTION",
+    "EXPECTED_REFERENCE_CANDIDATE_IDS",
+    "EXPECTED_REJECTED_CANDIDATES",
+    "EXPECTED_RESOLVED_OBLIGATION_KINDS",
+]

--- a/tests/domain_scenarios/tiny_pcf/fixtures.py
+++ b/tests/domain_scenarios/tiny_pcf/fixtures.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
+    CheckedClaim,
+    CompileReport,
+    CompilerProfile,
+    DomainPack,
+    ReferenceBinding,
+    ReferenceCatalog,
+    ReferenceRecord,
+    ReferenceSelectionCriteria,
+    RuleFamily,
+    apply_calculation_result,
+    calculate_derived_claim,
+)
+
+
+SCENARIO_ID = "tiny_pcf.location_based_electricity.v1"
+SUBJECT_ID = "product:tiny-pcf-1"
+PUBLIC_ROW_ID = "public-row:tiny-pcf-1"
+PROFILE_ID = "pcf-lca-lab-v1"
+INPUT_CLAIM_ID = "tiny-pcf:electricity_kwh"
+OUTPUT_CLAIM_ID = "tiny-pcf:co2e_kg"
+
+
+def profile() -> CompilerProfile:
+    return CompilerProfile(
+        profile_id=PROFILE_ID,
+        domain_packs=(
+            DomainPack(
+                domain_id="pcf-lca-lab",
+                version="2026.1",
+                rule_families=(
+                    RuleFamily(
+                        rule_id="pcf.factor_selector.v1",
+                        description=(
+                            "Select a location-based electricity factor by "
+                            "concept, geography, period, and method."
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        active_rule_ids=("pcf.factor_selector.v1",),
+        projection_policy_id="pcf.public-row.v1",
+    )
+
+
+def catalog() -> ReferenceCatalog:
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="pcf.factor.kr_grid_2024.location_based",
+                reference_type="emission_factor",
+                labels=("Korea grid electricity factor 2024",),
+                aliases=("KR electricity grid factor",),
+                description=(
+                    "Location-based electricity emission factor for Korea in 2024."
+                ),
+                attributes=(
+                    ("concept_id", "pcf.concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "location_based"),
+                    ("factor_value", 0.42),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "kgCO2e"),
+                ),
+                source="pcf-reference-catalog",
+                witness_ids=("factor-row-kr-grid-2024",),
+            ),
+            ReferenceRecord(
+                reference_id="pcf.factor.kr_grid_2023.location_based",
+                reference_type="emission_factor",
+                labels=("Korea grid electricity factor 2023",),
+                aliases=("KR electricity grid factor historical",),
+                description=(
+                    "Location-based electricity emission factor for Korea in 2023."
+                ),
+                attributes=(
+                    ("concept_id", "pcf.concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2023"),
+                    ("method", "location_based"),
+                    ("factor_value", 0.41),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "kgCO2e"),
+                ),
+                source="pcf-reference-catalog",
+                witness_ids=("factor-row-kr-grid-2023",),
+            ),
+        )
+    )
+
+
+def input_claim() -> CalculationInput:
+    return CalculationInput(
+        claim_id=INPUT_CLAIM_ID,
+        field="electricity_kwh",
+        value=1200,
+        unit="kWh",
+    )
+
+
+def formula() -> CalculationFormula:
+    return CalculationFormula(
+        formula_id="pcf.electricity_factor_multiplication.v1",
+        output_field="co2e_kg",
+        output_unit="kgCO2e",
+    )
+
+
+def criteria() -> ReferenceSelectionCriteria:
+    return ReferenceSelectionCriteria(
+        binding_id="bind-electricity-factor",
+        claim_id=INPUT_CLAIM_ID,
+        reference_type="emission_factor",
+        selector_rule_id="pcf.factor_selector.v1",
+        required_attributes=(
+            ("concept_id", "pcf.concept.electricity_consumption"),
+            ("geography", "KR"),
+            ("valid_period", "2024"),
+            ("method", "location_based"),
+        ),
+    )
+
+
+def blocked_report() -> CompileReport:
+    result = calculate_derived_claim(
+        output_claim_id=OUTPUT_CLAIM_ID,
+        input_claim=input_claim(),
+        reference_binding=ReferenceBinding(
+            binding_id="bind-electricity-factor",
+            claim_id=INPUT_CLAIM_ID,
+            reference_id="pcf.factor.unknown",
+            reference_type="emission_factor",
+        ),
+        catalog=ReferenceCatalog(records=()),
+        formula=formula(),
+    )
+    return apply_calculation_result(
+        CompileReport(
+            status="accepted",
+            checked_claims=(
+                CheckedClaim(
+                    field="electricity_kwh",
+                    value=1200,
+                    witness_id="span-electricity-amount",
+                    origin="source_text",
+                ),
+            ),
+        ),
+        result,
+        output_claim_id=OUTPUT_CLAIM_ID,
+        formula=formula(),
+    )
+
+
+__all__ = [
+    "OUTPUT_CLAIM_ID",
+    "PROFILE_ID",
+    "PUBLIC_ROW_ID",
+    "SCENARIO_ID",
+    "SUBJECT_ID",
+    "blocked_report",
+    "catalog",
+    "criteria",
+    "formula",
+    "input_claim",
+    "profile",
+]

--- a/tests/domain_scenarios/tiny_pcf/scenario.py
+++ b/tests/domain_scenarios/tiny_pcf/scenario.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from comp import ProjectionSpec, SubjectRef, project_public_row
+from comp.compiler_tool import prepare_commit, resolve_reference_grounded_calculation
+from tests.domain_scenarios.core import (
+    DomainScenarioResult,
+    build_domain_scenario_result,
+)
+from tests.domain_scenarios.tiny_pcf.fixtures import (
+    OUTPUT_CLAIM_ID,
+    PUBLIC_ROW_ID,
+    SCENARIO_ID,
+    SUBJECT_ID,
+    blocked_report,
+    catalog,
+    criteria,
+    formula,
+    input_claim,
+    profile,
+)
+
+
+RESOLVER_STEPS = (
+    "plan_calculation_resolution",
+    "reference_search:keyword",
+    "deterministic_reference_selection",
+    "retry_calculation",
+    "prepare_commit",
+    "receipt_gated_projection",
+)
+
+
+def run_tiny_pcf_scenario() -> DomainScenarioResult:
+    scenario_profile = profile()
+    resolved_report = resolve_reference_grounded_calculation(
+        blocked_report(),
+        catalog(),
+        query_for_obligation=lambda obligation: (
+            "Korea grid electricity factor 2024"
+            if obligation.kind == "reference_search_required"
+            else None
+        ),
+        criteria=criteria(),
+        input_claim=input_claim(),
+        formula=formula(),
+        output_claim_id=OUTPUT_CLAIM_ID,
+    )
+    preparation = prepare_commit(
+        resolved_report,
+        subject_id=SUBJECT_ID,
+        public_row_id=PUBLIC_ROW_ID,
+        profile_id=scenario_profile.profile_id,
+    )
+    projection = None
+    if preparation.receipt is not None:
+        projection = project_public_row(
+            _projection_source(resolved_report),
+            ProjectionSpec("pcf-public-row", ("electricity_kwh", "co2e_kg")),
+            receipt=preparation.receipt,
+        )
+
+    return build_domain_scenario_result(
+        scenario_id=SCENARIO_ID,
+        report=resolved_report,
+        preparation=preparation,
+        projection=projection,
+        subject=SubjectRef("claim", SUBJECT_ID),
+        resolver_steps=RESOLVER_STEPS,
+    )
+
+
+def _projection_source(report) -> dict[str, object]:
+    values = {claim.field: claim.value for claim in report.checked_claims}
+    values.update({claim.field: claim.value for claim in report.derived_claims})
+    return values
+
+
+__all__ = ["run_tiny_pcf_scenario"]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -1,0 +1,65 @@
+from tests.domain_scenarios.tiny_pcf.scenario import run_tiny_pcf_scenario
+from tests.domain_scenarios.tiny_pcf.expected import (
+    EXPECTED_PROJECTION,
+    EXPECTED_REFERENCE_CANDIDATE_IDS,
+    EXPECTED_REJECTED_CANDIDATES,
+    EXPECTED_RESOLVED_OBLIGATION_KINDS,
+)
+
+
+def test_tiny_pcf_scenario_runs_reference_to_receipt_flow():
+    result = run_tiny_pcf_scenario()
+
+    assert result.scenario_id == "tiny_pcf.location_based_electricity.v1"
+    assert result.report.status == "accepted"
+    assert result.preparation.decision.status == "commit"
+    assert result.preparation.receipt is not None
+    assert result.projection == EXPECTED_PROJECTION
+
+
+def test_tiny_pcf_scenario_preserves_traceable_domain_artifacts():
+    result = run_tiny_pcf_scenario()
+
+    assert tuple(item.kind for item in result.report.resolved_obligations) == (
+        EXPECTED_RESOLVED_OBLIGATION_KINDS
+    )
+    assert tuple(
+        candidate.reference_id for candidate in result.report.reference_candidates
+    ) == EXPECTED_REFERENCE_CANDIDATE_IDS
+
+    binding = result.report.reference_bindings[0]
+    assert binding.reference_id == "pcf.factor.kr_grid_2024.location_based"
+    assert binding.selected_candidate_id == (
+        "keyword:pcf.factor.kr_grid_2024.location_based"
+    )
+    assert tuple(
+        (item.reference_id, item.reason) for item in binding.rejected_candidates
+    ) == EXPECTED_REJECTED_CANDIDATES
+
+    derived = result.report.derived_claims[0]
+    assert derived.claim_id == "tiny-pcf:co2e_kg"
+    assert derived.value == 504.0
+    assert derived.trace.reference_binding_ids == ("bind-electricity-factor",)
+
+
+def test_tiny_pcf_scenario_exports_json_ready_viewer_payload():
+    exported = run_tiny_pcf_scenario().to_dict()
+
+    assert exported["scenario_id"] == "tiny_pcf.location_based_electricity.v1"
+    assert exported["report"]["status"] == "accepted"
+    assert exported["report"]["reference_bindings"] == [
+        {
+            "binding_id": "bind-electricity-factor",
+            "reference_id": "pcf.factor.kr_grid_2024.location_based",
+            "selected_candidate_id": "keyword:pcf.factor.kr_grid_2024.location_based",
+            "rejected_candidates": [
+                {
+                    "reference_id": "pcf.factor.kr_grid_2023.location_based",
+                    "reason": "attribute_mismatch:valid_period",
+                }
+            ],
+        }
+    ]
+    assert exported["commit"]["governance_status"] == "commit"
+    assert exported["commit"]["receipt_id"] == "public-row:tiny-pcf-1"
+    assert exported["projection"] == EXPECTED_PROJECTION


### PR DESCRIPTION
## Summary

- Add a `tests/domain_scenarios` lab scaffold for empirical domain fixtures.
- Add a `tiny_pcf` product-carbon-footprint scenario that exercises reference search, deterministic factor selection, near-miss rejection, calculation retry, commit preparation, receipt-gated projection, and JSON-ready result export.
- Add pytest contracts that keep pass/fail authority in assertions while scenario output remains a trace/viewer artifact.

## Why

LCA/DPP-style behavior needs more than isolated unit tests. This gives the project a small deterministic Domain Scenario Lab slice without adding real UI, LLM calls, vector DB dependencies, or production API surface.

## Validation

- `python -m pytest tests/test_domain_scenario_lab.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`
