### PR TITLE
[codex] document domain scenario testing philosophy

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -25,3 +25,37 @@ expected receipt/projection
 The first scenario is `tiny_pcf`, a product-carbon-footprint slice that exercises
 reference search, near-miss rejection, canonical binding, calculation trace,
 commit preparation, and receipt-gated projection.
+
+## Testing Philosophy
+
+Domain scenario tests should lock authority boundaries, not implementation shape.
+They are pressure tests for the compiler contract, not golden snapshots of a
+final LCA, DPP, UI, or reference database schema.
+
+Strong assertions are encouraged for core invariants:
+
+```text
+ReferenceCandidate remains candidate_only
+retrieval_score never authorizes truth
+ReferenceBinding is required for calculation authority
+DerivedClaim cannot authorize public projection
+CommitReceipt is required for projection
+open obligations prevent receipt issuance
+receipt traces binding, formula, calculation, and derived-claim evidence
+```
+
+Weak assertions are preferred for surfaces that are still exploratory:
+
+```text
+exact viewer JSON shape
+resolver function names
+file or module layout
+fixture factor values as real-world PCF truth
+final LCA/DPP domain-pack schema
+UI viewer layout
+the exact function where profile-aware gating is enforced
+```
+
+Scenario payloads should stay stable enough for a viewer to explain the run, but
+tests should avoid asserting one huge exported JSON blob. Prefer targeted checks
+that prove the authority boundary and traceability story still hold.


### PR DESCRIPTION
## Summary

- Document the Domain Scenario Lab testing philosophy in `tests/domain_scenarios/README.md`
- Clarify that scenario tests should lock authority boundaries rather than implementation shape
- Separate strong invariant assertions from exploratory surfaces that should stay loosely asserted

## Why

The Domain Scenario Lab is becoming an architecture pressure-test surface for LCA/DPP-style flows. This documentation gives future tests a clear rule of thumb: protect authority boundaries and traceability without freezing viewer payloads, module layout, or domain schemas too early.

## Validation

- `python -m pytest tests/test_domain_scenario_lab.py -q`