### PR TITLE
[codex] test: add domain scenario pack registry

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -36,6 +36,20 @@ Scenario creation guidance lives in
 `docs/architecture/domain-scenario-pack-generation.md`. Treat larger scenarios
 as swappable Scenario Pack modules, not hard-coded golden fixtures.
 
+The shared test-support layer now exposes:
+
+```text
+ScenarioDefinition
+ScenarioContract
+SourceRef
+run_scenario()
+assert_scenario_contract()
+registered_scenarios()
+```
+
+New scenarios should enter through explicit registry registration instead of
+being auto-discovered from the filesystem.
+
 Strong assertions are encouraged for core invariants:
 
 ```text

--- a/tests/domain_scenarios/core.py
+++ b/tests/domain_scenarios/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -11,6 +12,45 @@ from comp.compiler_tool import (
     compile_report_to_facts,
 )
 from comp.judgment import Fact, SubjectRef
+
+
+@dataclass(frozen=True)
+class SourceRef:
+    repo: str
+    path: str
+    commit: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "repo": self.repo,
+            "commit": self.commit,
+            "path": self.path,
+        }
+
+
+@dataclass(frozen=True)
+class ScenarioContract:
+    must_commit: bool = False
+    required_projection: Mapping[str, Any] | None = None
+    required_resolved_obligation_kinds: tuple[str, ...] = ()
+    required_reference_candidate_ids: tuple[str, ...] = ()
+    required_reference_binding_ids: tuple[str, ...] = ()
+    required_derived_claim_ids: tuple[str, ...] = ()
+    required_receipt_reference_binding_ids: tuple[str, ...] = ()
+    required_receipt_derived_claim_ids: tuple[str, ...] = ()
+    required_receipt_calculation_trace_ids: tuple[str, ...] = ()
+    required_receipt_formula_ids: tuple[str, ...] = ()
+    required_open_obligation_ids: tuple[str, ...] | None = ()
+    required_hazard_ids: tuple[str, ...] | None = ()
+
+
+@dataclass(frozen=True)
+class ScenarioDefinition:
+    scenario_id: str
+    title: str
+    run: Callable[[], "DomainScenarioResult"]
+    contract: ScenarioContract
+    source_refs: tuple[SourceRef, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -117,6 +157,83 @@ def build_domain_scenario_result(
     )
 
 
+def run_scenario(scenario: ScenarioDefinition) -> DomainScenarioResult:
+    result = scenario.run()
+    if result.scenario_id != scenario.scenario_id:
+        raise AssertionError(
+            f"scenario result id {result.scenario_id!r} did not match "
+            f"definition id {scenario.scenario_id!r}"
+        )
+    return result
+
+
+def assert_scenario_contract(
+    result: DomainScenarioResult,
+    contract: ScenarioContract,
+) -> None:
+    if contract.must_commit:
+        assert result.preparation.package.complete is True
+        assert result.preparation.decision.status == "commit"
+        assert result.preparation.receipt is not None
+
+    if contract.required_projection is not None:
+        assert result.projection is not None
+        for key, expected in contract.required_projection.items():
+            assert result.projection[key] == expected
+
+    assert _contains_in_order(
+        tuple(item.kind for item in result.report.resolved_obligations),
+        contract.required_resolved_obligation_kinds,
+    )
+    assert _contains_in_order(
+        tuple(
+            candidate.reference_id
+            for candidate in result.report.reference_candidates
+        ),
+        contract.required_reference_candidate_ids,
+    )
+    assert _contains_in_order(
+        tuple(binding.binding_id for binding in result.report.reference_bindings),
+        contract.required_reference_binding_ids,
+    )
+    assert _contains_in_order(
+        tuple(claim.claim_id for claim in result.report.derived_claims),
+        contract.required_derived_claim_ids,
+    )
+
+    citations = (
+        result.preparation.receipt.citations
+        if result.preparation.receipt is not None
+        else None
+    )
+    if _requires_receipt_citations(contract):
+        assert citations is not None
+        assert _contains_in_order(
+            citations.reference_binding_ids,
+            contract.required_receipt_reference_binding_ids,
+        )
+        assert _contains_in_order(
+            citations.derived_claim_ids,
+            contract.required_receipt_derived_claim_ids,
+        )
+        assert _contains_in_order(
+            citations.calculation_trace_ids,
+            contract.required_receipt_calculation_trace_ids,
+        )
+        assert _contains_in_order(
+            citations.formula_ids,
+            contract.required_receipt_formula_ids,
+        )
+
+    if contract.required_open_obligation_ids is not None:
+        assert (
+            result.preparation.package.open_obligation_ids
+            == contract.required_open_obligation_ids
+        )
+    if contract.required_hazard_ids is not None:
+        assert result.preparation.package.hazard_ids == contract.required_hazard_ids
+
+
 def _obligation_view(obligation) -> dict[str, str | None]:
     return {
         "obligation_id": obligation.obligation_id,
@@ -136,4 +253,38 @@ def _json_ready(value):
     return value
 
 
-__all__ = ["DomainScenarioResult", "build_domain_scenario_result"]
+def _contains_in_order(
+    actual: tuple[Any, ...],
+    expected: tuple[Any, ...],
+) -> bool:
+    if not expected:
+        return True
+    cursor = 0
+    for item in actual:
+        if item == expected[cursor]:
+            cursor += 1
+            if cursor == len(expected):
+                return True
+    return False
+
+
+def _requires_receipt_citations(contract: ScenarioContract) -> bool:
+    return any(
+        (
+            contract.required_receipt_reference_binding_ids,
+            contract.required_receipt_derived_claim_ids,
+            contract.required_receipt_calculation_trace_ids,
+            contract.required_receipt_formula_ids,
+        )
+    )
+
+
+__all__ = [
+    "DomainScenarioResult",
+    "ScenarioContract",
+    "ScenarioDefinition",
+    "SourceRef",
+    "assert_scenario_contract",
+    "build_domain_scenario_result",
+    "run_scenario",
+]

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from tests.domain_scenarios.core import ScenarioDefinition
+from tests.domain_scenarios.tiny_pcf.scenario import SCENARIO as TINY_PCF_SCENARIO
+
+
+def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
+    return (TINY_PCF_SCENARIO,)
+
+
+__all__ = ["registered_scenarios"]

--- a/tests/domain_scenarios/tiny_pcf/scenario.py
+++ b/tests/domain_scenarios/tiny_pcf/scenario.py
@@ -4,7 +4,14 @@ from comp import ProjectionSpec, SubjectRef, project_public_row
 from comp.compiler_tool import prepare_commit, resolve_reference_grounded_calculation
 from tests.domain_scenarios.core import (
     DomainScenarioResult,
+    ScenarioContract,
+    ScenarioDefinition,
     build_domain_scenario_result,
+)
+from tests.domain_scenarios.tiny_pcf.expected import (
+    EXPECTED_PROJECTION,
+    EXPECTED_REFERENCE_CANDIDATE_IDS,
+    EXPECTED_RESOLVED_OBLIGATION_KINDS,
 )
 from tests.domain_scenarios.tiny_pcf.fixtures import (
     OUTPUT_CLAIM_ID,
@@ -27,6 +34,24 @@ RESOLVER_STEPS = (
     "retry_calculation",
     "prepare_commit",
     "receipt_gated_projection",
+)
+
+SCENARIO = ScenarioDefinition(
+    scenario_id=SCENARIO_ID,
+    title="Tiny PCF location-based electricity",
+    run=lambda: run_tiny_pcf_scenario(),
+    contract=ScenarioContract(
+        must_commit=True,
+        required_projection=EXPECTED_PROJECTION,
+        required_resolved_obligation_kinds=EXPECTED_RESOLVED_OBLIGATION_KINDS,
+        required_reference_candidate_ids=EXPECTED_REFERENCE_CANDIDATE_IDS,
+        required_reference_binding_ids=("bind-electricity-factor",),
+        required_derived_claim_ids=("tiny-pcf:co2e_kg",),
+        required_receipt_reference_binding_ids=("bind-electricity-factor",),
+        required_receipt_derived_claim_ids=("tiny-pcf:co2e_kg",),
+        required_receipt_calculation_trace_ids=("trace:tiny-pcf:co2e_kg",),
+        required_receipt_formula_ids=("pcf.electricity_factor_multiplication.v1",),
+    ),
 )
 
 
@@ -75,4 +100,4 @@ def _projection_source(report) -> dict[str, object]:
     return values
 
 
-__all__ = ["run_tiny_pcf_scenario"]
+__all__ = ["SCENARIO", "run_tiny_pcf_scenario"]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -1,10 +1,50 @@
-from tests.domain_scenarios.tiny_pcf.scenario import run_tiny_pcf_scenario
+from tests.domain_scenarios.core import (
+    ScenarioDefinition,
+    SourceRef,
+    assert_scenario_contract,
+    run_scenario,
+)
+from tests.domain_scenarios.registry import registered_scenarios
 from tests.domain_scenarios.tiny_pcf.expected import (
     EXPECTED_PROJECTION,
     EXPECTED_REFERENCE_CANDIDATE_IDS,
     EXPECTED_REJECTED_CANDIDATES,
     EXPECTED_RESOLVED_OBLIGATION_KINDS,
 )
+from tests.domain_scenarios.tiny_pcf.scenario import run_tiny_pcf_scenario
+
+
+def test_registered_scenarios_are_explicit_scenario_definitions():
+    scenarios = registered_scenarios()
+
+    assert tuple(scenario.scenario_id for scenario in scenarios) == (
+        "tiny_pcf.location_based_electricity.v1",
+    )
+    assert all(isinstance(scenario, ScenarioDefinition) for scenario in scenarios)
+    assert scenarios[0].contract.must_commit is True
+    assert scenarios[0].contract.required_projection == EXPECTED_PROJECTION
+
+
+def test_registered_scenarios_run_through_shared_contract_assertions():
+    for scenario in registered_scenarios():
+        result = run_scenario(scenario)
+
+        assert_scenario_contract(result, scenario.contract)
+        assert result.scenario_id == scenario.scenario_id
+
+
+def test_source_ref_serializes_external_scenario_trace_metadata():
+    source = SourceRef(
+        repo="minntcho/esg-platform",
+        commit="618c44dfcea1ee1e235550776acb78d8f20a7e0c",
+        path="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+    )
+
+    assert source.to_dict() == {
+        "repo": "minntcho/esg-platform",
+        "commit": "618c44dfcea1ee1e235550776acb78d8f20a7e0c",
+        "path": "tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+    }
 
 
 def test_tiny_pcf_scenario_runs_reference_to_receipt_flow():


### PR DESCRIPTION
## Summary

- Add test-support models for swappable Domain Scenario Lab packs: `ScenarioDefinition`, `ScenarioContract`, and `SourceRef`.
- Add shared `run_scenario()` and `assert_scenario_contract()` helpers.
- Add an explicit `registered_scenarios()` registry and migrate `tiny_pcf` to expose a registered `SCENARIO` definition.
- Keep existing tiny PCF direct tests while adding registry-based contract tests and source-ref metadata coverage.

## Why

Before adding the larger L-Energy PCF governance scenario from `minntcho/esg-platform`, the lab needs a reusable slot. This keeps scenarios modular and avoids turning them into hard-coded golden fixtures or auto-discovered filesystem blobs.

## Validation

- `python -m pytest tests/test_domain_scenario_lab.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`
