### PR TITLE
[codex] test: add L-Energy PCF governance scenario pack

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -26,6 +26,12 @@ The first scenario is `tiny_pcf`, a product-carbon-footprint slice that exercise
 reference search, near-miss rejection, canonical binding, calculation trace,
 commit preparation, and receipt-gated projection.
 
+The first larger source-referenced pack is `l_energy_pcf_governance`, based on
+`minntcho/esg-platform` case `001-l-energy-pcf-governance`. It uses
+fixture-derived claims from the platform expected receipt to test whether a
+realistic PCF governance case can be represented as `comp` authority artifacts
+without adding a full PCF workflow engine.
+
 ## Testing Philosophy
 
 Domain scenario tests should lock authority boundaries, not implementation shape.

--- a/tests/domain_scenarios/l_energy_pcf_governance/__init__.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/__init__.py
@@ -1,0 +1,8 @@
+"""L-Energy PCF governance scenario pack."""
+
+from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
+    SCENARIO,
+    run_l_energy_pcf_governance_scenario,
+)
+
+__all__ = ["SCENARIO", "run_l_energy_pcf_governance_scenario"]

--- a/tests/domain_scenarios/l_energy_pcf_governance/expected.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/expected.py
@@ -1,0 +1,75 @@
+from tests.domain_scenarios.core import SourceRef
+
+
+SCENARIO_ID = "l_energy_pcf_governance.v1"
+SOURCE_CASE_ID = "001-l-energy-pcf-governance"
+SOURCE_COMMIT = "618c44dfcea1ee1e235550776acb78d8f20a7e0c"
+
+EXPECTED_SOURCE_REFS = (
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/cases/001-l-energy-pcf-governance.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/dummy-data-mapping-l-energy-pcf.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="tests/e2e/expected/001-l-energy-pcf-governance.receipt.json",
+    ),
+)
+
+EXPECTED_PROJECTION = {
+    "case_id": SOURCE_CASE_ID,
+    "total_emission_tco2e": 199994,
+    "packs": 100000,
+    "total_energy_gwh": 7.5,
+    "kgco2e_per_pack": 1999.94,
+    "kgco2e_per_kwh": 26.66,
+}
+
+EXPECTED_REFERENCE_BINDING_IDS = (
+    "bind:pcf:electricity_factor",
+    "bind:pcf:lng_factor",
+    "bind:pcf:steel_proxy_factor",
+    "bind:pcf:carbon_tech_certificate_factor",
+    "bind:pcf:ncm811_factor",
+)
+
+EXPECTED_DERIVED_CLAIM_IDS = (
+    "l-energy:own_emission_tco2e",
+    "alpha-metal:final_emission_tco2e",
+    "steel-frame:final_emission_tco2e",
+    "carbon-tech:final_emission_tco2e",
+    "l-materials:final_emission_tco2e",
+    "c-pack:final_emission_tco2e",
+    "l-energy:total_emission_tco2e",
+    "l-energy:kgco2e_per_pack",
+    "l-energy:kgco2e_per_kwh",
+)
+
+EXPECTED_TRACE_IDS = tuple(
+    f"trace:{claim_id}" for claim_id in EXPECTED_DERIVED_CLAIM_IDS
+)
+
+EXPECTED_FORMULA_IDS = ("pcf-demo-2025.0",)
+
+__all__ = [
+    "EXPECTED_DERIVED_CLAIM_IDS",
+    "EXPECTED_FORMULA_IDS",
+    "EXPECTED_PROJECTION",
+    "EXPECTED_REFERENCE_BINDING_IDS",
+    "EXPECTED_SOURCE_REFS",
+    "EXPECTED_TRACE_IDS",
+    "SCENARIO_ID",
+    "SOURCE_CASE_ID",
+]

--- a/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from comp.compiler_tool import (
+    CalculationTrace,
+    CheckedClaim,
+    CompileReport,
+    DerivedClaim,
+    ReferenceBinding,
+)
+from tests.domain_scenarios.l_energy_pcf_governance.expected import (
+    SCENARIO_ID,
+    SOURCE_CASE_ID,
+)
+
+
+SUBJECT_ID = f"case:{SOURCE_CASE_ID}"
+PUBLIC_ROW_ID = f"public-row:{SOURCE_CASE_ID}"
+PROFILE_ID = "pcf-governance-platform-fixture-v1"
+FORMULA_ID = "pcf-demo-2025.0"
+
+
+def checked_claims() -> tuple[CheckedClaim, ...]:
+    return (
+        CheckedClaim(
+            field="case_id",
+            value=SOURCE_CASE_ID,
+            witness_id="source:e2e-case-yaml",
+            origin="source_ref",
+        ),
+        CheckedClaim(
+            field="packs",
+            value=100000,
+            witness_id="source:e2e-case-yaml",
+            origin="source_ref",
+        ),
+        CheckedClaim(
+            field="total_energy_gwh",
+            value=7.5,
+            witness_id="source:e2e-case-yaml",
+            origin="source_ref",
+        ),
+    )
+
+
+def reference_bindings() -> tuple[ReferenceBinding, ...]:
+    return (
+        ReferenceBinding(
+            binding_id="bind:pcf:electricity_factor",
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.electricity_mwh",
+            reference_type="emission_factor",
+            selector_rule_id="platform.expected_receipt.fixture",
+            source_witness_ids=("source:dummy-data-mapping",),
+        ),
+        ReferenceBinding(
+            binding_id="bind:pcf:lng_factor",
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.lng_nm3",
+            reference_type="emission_factor",
+            selector_rule_id="platform.expected_receipt.fixture",
+            source_witness_ids=("source:dummy-data-mapping",),
+        ),
+        ReferenceBinding(
+            binding_id="bind:pcf:steel_proxy_factor",
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.steel_proxy_per_ton",
+            reference_type="emission_factor",
+            selector_rule_id="platform.expected_receipt.fixture",
+            source_witness_ids=("source:dummy-data-mapping",),
+        ),
+        ReferenceBinding(
+            binding_id="bind:pcf:carbon_tech_certificate_factor",
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.carbon_tech_certificate_per_ton",
+            reference_type="certificate_factor",
+            selector_rule_id="platform.expected_receipt.fixture",
+            source_witness_ids=("source:expected-receipt",),
+        ),
+        ReferenceBinding(
+            binding_id="bind:pcf:ncm811_factor",
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.ncm811_composition",
+            reference_type="composition_factor",
+            selector_rule_id="platform.expected_receipt.fixture",
+            source_witness_ids=("source:expected-receipt",),
+        ),
+    )
+
+
+def derived_claims() -> tuple[DerivedClaim, ...]:
+    return (
+        _derived_claim(
+            claim_id="l-energy:own_emission_tco2e",
+            field="l_energy_own_emission_tco2e",
+            value=1695,
+            reference_binding_ids=(
+                "bind:pcf:electricity_factor",
+                "bind:pcf:lng_factor",
+            ),
+        ),
+        _derived_claim(
+            claim_id="alpha-metal:final_emission_tco2e",
+            field="alpha_metal_final_emission_tco2e",
+            value=5306,
+            reference_binding_ids=(
+                "bind:pcf:electricity_factor",
+                "bind:pcf:lng_factor",
+            ),
+        ),
+        _derived_claim(
+            claim_id="steel-frame:final_emission_tco2e",
+            field="steel_frame_final_emission_tco2e",
+            value=4750,
+            reference_binding_ids=("bind:pcf:steel_proxy_factor",),
+        ),
+        _derived_claim(
+            claim_id="carbon-tech:final_emission_tco2e",
+            field="carbon_tech_final_emission_tco2e",
+            value=13390,
+            reference_binding_ids=("bind:pcf:carbon_tech_certificate_factor",),
+        ),
+        _derived_claim(
+            claim_id="l-materials:final_emission_tco2e",
+            field="l_materials_final_emission_tco2e",
+            value=174375,
+            reference_binding_ids=("bind:pcf:ncm811_factor",),
+        ),
+        _derived_claim(
+            claim_id="c-pack:final_emission_tco2e",
+            field="c_pack_final_emission_tco2e",
+            value=10534,
+            input_claim_ids=(
+                "alpha-metal:final_emission_tco2e",
+                "steel-frame:final_emission_tco2e",
+            ),
+            reference_binding_ids=("bind:pcf:electricity_factor",),
+        ),
+        _derived_claim(
+            claim_id="l-energy:total_emission_tco2e",
+            field="total_emission_tco2e",
+            value=199994,
+            input_claim_ids=(
+                "l-energy:own_emission_tco2e",
+                "c-pack:final_emission_tco2e",
+                "carbon-tech:final_emission_tco2e",
+                "l-materials:final_emission_tco2e",
+            ),
+        ),
+        _derived_claim(
+            claim_id="l-energy:kgco2e_per_pack",
+            field="kgco2e_per_pack",
+            value=1999.94,
+            input_claim_ids=("l-energy:total_emission_tco2e",),
+        ),
+        _derived_claim(
+            claim_id="l-energy:kgco2e_per_kwh",
+            field="kgco2e_per_kwh",
+            value=26.66,
+            input_claim_ids=("l-energy:kgco2e_per_pack",),
+        ),
+    )
+
+
+def compile_report() -> CompileReport:
+    return CompileReport(
+        status="accepted",
+        checked_claims=checked_claims(),
+        reference_bindings=reference_bindings(),
+        derived_claims=derived_claims(),
+    )
+
+
+def _derived_claim(
+    *,
+    claim_id: str,
+    field: str,
+    value: float | int,
+    input_claim_ids: tuple[str, ...] = (),
+    reference_binding_ids: tuple[str, ...] = (),
+) -> DerivedClaim:
+    return DerivedClaim(
+        claim_id=claim_id,
+        field=field,
+        value=value,
+        unit="tCO2e" if field.endswith("_tco2e") else None,
+        origin="fixture_derived",
+        trace=CalculationTrace(
+            trace_id=f"trace:{claim_id}",
+            formula_id=FORMULA_ID,
+            input_claim_ids=input_claim_ids,
+            reference_binding_ids=reference_binding_ids,
+        ),
+    )
+
+
+__all__ = [
+    "FORMULA_ID",
+    "PROFILE_ID",
+    "PUBLIC_ROW_ID",
+    "SUBJECT_ID",
+    "checked_claims",
+    "compile_report",
+    "derived_claims",
+    "reference_bindings",
+]

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from comp import ProjectionSpec, SubjectRef, project_public_row
+from comp.compiler_tool import prepare_commit
+from tests.domain_scenarios.core import (
+    DomainScenarioResult,
+    ScenarioContract,
+    ScenarioDefinition,
+    build_domain_scenario_result,
+)
+from tests.domain_scenarios.l_energy_pcf_governance.expected import (
+    EXPECTED_DERIVED_CLAIM_IDS,
+    EXPECTED_FORMULA_IDS,
+    EXPECTED_PROJECTION,
+    EXPECTED_REFERENCE_BINDING_IDS,
+    EXPECTED_SOURCE_REFS,
+    EXPECTED_TRACE_IDS,
+    SCENARIO_ID,
+)
+from tests.domain_scenarios.l_energy_pcf_governance.fixtures import (
+    PROFILE_ID,
+    PUBLIC_ROW_ID,
+    SUBJECT_ID,
+    compile_report,
+)
+
+
+RESOLVER_STEPS = (
+    "load_platform_expected_receipt_fixture",
+    "create_fixture_reference_bindings",
+    "create_fixture_derived_claims",
+    "prepare_commit",
+    "receipt_gated_projection",
+)
+
+PROJECTION_FIELDS = (
+    "case_id",
+    "total_emission_tco2e",
+    "packs",
+    "total_energy_gwh",
+    "kgco2e_per_pack",
+    "kgco2e_per_kwh",
+)
+
+SCENARIO = ScenarioDefinition(
+    scenario_id=SCENARIO_ID,
+    title="L-Energy PCF Governance",
+    run=lambda: run_l_energy_pcf_governance_scenario(),
+    source_refs=EXPECTED_SOURCE_REFS,
+    contract=ScenarioContract(
+        must_commit=True,
+        required_projection=EXPECTED_PROJECTION,
+        required_reference_binding_ids=EXPECTED_REFERENCE_BINDING_IDS,
+        required_derived_claim_ids=EXPECTED_DERIVED_CLAIM_IDS,
+        required_receipt_reference_binding_ids=EXPECTED_REFERENCE_BINDING_IDS,
+        required_receipt_derived_claim_ids=EXPECTED_DERIVED_CLAIM_IDS,
+        required_receipt_calculation_trace_ids=EXPECTED_TRACE_IDS,
+        required_receipt_formula_ids=EXPECTED_FORMULA_IDS,
+    ),
+)
+
+
+def run_l_energy_pcf_governance_scenario() -> DomainScenarioResult:
+    report = compile_report()
+    preparation = prepare_commit(
+        report,
+        subject_id=SUBJECT_ID,
+        public_row_id=PUBLIC_ROW_ID,
+        profile_id=PROFILE_ID,
+    )
+    projection = None
+    if preparation.receipt is not None:
+        projection = project_public_row(
+            _projection_source(report),
+            ProjectionSpec("l-energy-pcf-public-row", PROJECTION_FIELDS),
+            receipt=preparation.receipt,
+        )
+
+    return build_domain_scenario_result(
+        scenario_id=SCENARIO_ID,
+        report=report,
+        preparation=preparation,
+        projection=projection,
+        subject=SubjectRef("claim", SUBJECT_ID),
+        resolver_steps=RESOLVER_STEPS,
+    )
+
+
+def _projection_source(report) -> dict[str, object]:
+    values = {claim.field: claim.value for claim in report.checked_claims}
+    values.update({claim.field: claim.value for claim in report.derived_claims})
+    return values
+
+
+__all__ = ["SCENARIO", "run_l_energy_pcf_governance_scenario"]

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from tests.domain_scenarios.core import ScenarioDefinition
+from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
+    SCENARIO as L_ENERGY_PCF_GOVERNANCE_SCENARIO,
+)
 from tests.domain_scenarios.tiny_pcf.scenario import SCENARIO as TINY_PCF_SCENARIO
 
 
 def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
-    return (TINY_PCF_SCENARIO,)
+    return (TINY_PCF_SCENARIO, L_ENERGY_PCF_GOVERNANCE_SCENARIO)
 
 
 __all__ = ["registered_scenarios"]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -19,6 +19,7 @@ def test_registered_scenarios_are_explicit_scenario_definitions():
 
     assert tuple(scenario.scenario_id for scenario in scenarios) == (
         "tiny_pcf.location_based_electricity.v1",
+        "l_energy_pcf_governance.v1",
     )
     assert all(isinstance(scenario, ScenarioDefinition) for scenario in scenarios)
     assert scenarios[0].contract.must_commit is True

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -1,0 +1,64 @@
+from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
+from tests.domain_scenarios.l_energy_pcf_governance.expected import (
+    EXPECTED_DERIVED_CLAIM_IDS,
+    EXPECTED_FORMULA_IDS,
+    EXPECTED_PROJECTION,
+    EXPECTED_SOURCE_REFS,
+    EXPECTED_TRACE_IDS,
+)
+from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
+    SCENARIO as L_ENERGY_SCENARIO,
+    run_l_energy_pcf_governance_scenario,
+)
+from tests.domain_scenarios.registry import registered_scenarios
+
+
+def test_l_energy_pcf_governance_scenario_is_registered_with_source_refs():
+    scenarios = registered_scenarios()
+
+    assert "l_energy_pcf_governance.v1" in tuple(
+        scenario.scenario_id for scenario in scenarios
+    )
+    assert L_ENERGY_SCENARIO.source_refs == EXPECTED_SOURCE_REFS
+    assert L_ENERGY_SCENARIO.contract.must_commit is True
+
+
+def test_l_energy_pcf_governance_scenario_reproduces_platform_summary():
+    result = run_l_energy_pcf_governance_scenario()
+
+    assert result.scenario_id == "l_energy_pcf_governance.v1"
+    assert result.report.status == "accepted"
+    assert result.preparation.decision.status == "commit"
+    assert result.preparation.receipt is not None
+    assert result.projection == EXPECTED_PROJECTION
+
+
+def test_l_energy_pcf_governance_scenario_preserves_actor_receipt_trace():
+    result = run_scenario(L_ENERGY_SCENARIO)
+
+    assert_scenario_contract(result, L_ENERGY_SCENARIO.contract)
+    assert result.preparation.package.open_obligation_ids == ()
+    assert result.preparation.package.hazard_ids == ()
+    assert tuple(claim.claim_id for claim in result.report.derived_claims) == (
+        EXPECTED_DERIVED_CLAIM_IDS
+    )
+    assert result.preparation.receipt is not None
+    assert result.preparation.receipt.citations is not None
+    assert result.preparation.receipt.citations.derived_claim_ids == (
+        EXPECTED_DERIVED_CLAIM_IDS
+    )
+    assert result.preparation.receipt.citations.calculation_trace_ids == (
+        EXPECTED_TRACE_IDS
+    )
+    assert result.preparation.receipt.citations.formula_ids == EXPECTED_FORMULA_IDS
+
+
+def test_l_energy_pcf_governance_scenario_exports_targeted_viewer_payload():
+    exported = run_l_energy_pcf_governance_scenario().to_dict()
+
+    assert exported["scenario_id"] == "l_energy_pcf_governance.v1"
+    assert exported["commit"]["governance_status"] == "commit"
+    assert exported["projection"] == EXPECTED_PROJECTION
+    assert len(exported["report"]["derived_claims"]) == len(
+        EXPECTED_DERIVED_CLAIM_IDS
+    )


### PR DESCRIPTION
## Summary

- Add `l_energy_pcf_governance` as a source-referenced Domain Scenario Lab pack based on `minntcho/esg-platform` case `001-l-energy-pcf-governance` at commit `618c44dfcea1ee1e235550776acb78d8f20a7e0c`.
- Preserve source refs to the platform case doc, dummy-data mapping, YAML fixture, and expected receipt JSON.
- Represent the platform case as fixture-derived `comp` authority artifacts: checked claims, reference bindings, derived claims, calculation traces, commit package, commit receipt, and receipt-gated projection.
- Register the new scenario pack and add targeted contract tests for summary projection, actor output claims, source refs, and receipt citations.

## Why

This is the first larger realistic scenario after `tiny_pcf`. It keeps the pack modular and does not add a PCF workflow engine, YAML parser dependency, RFI engine, LLM call, or runtime dependency on `esg-platform`.

## Validation

- `python -m pytest tests/test_l_energy_pcf_scenario.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check HEAD~1 HEAD`
