### PR TITLE
[codex] harden receipt projection gate

### DIFF
--- a/comp/compiler_tool/commit_flow.py
+++ b/comp/compiler_tool/commit_flow.py
@@ -26,6 +26,7 @@ def prepare_commit(
     *,
     subject_id: str,
     public_row_id: str,
+    projection_id: str,
     package_id: str | None = None,
     decision_id: str | None = None,
     profile_id: str | None = None,
@@ -45,6 +46,7 @@ def prepare_commit(
             package,
             decision,
             public_row_id=public_row_id,
+            projection_id=projection_id,
         )
     return CommitPreparation(package=package, decision=decision, receipt=receipt)
 

--- a/comp/compiler_tool/commit_package.py
+++ b/comp/compiler_tool/commit_package.py
@@ -16,6 +16,7 @@ class CommitPackage:
     checked_claim_witness_ids: tuple[str, ...] = field(default_factory=tuple)
     semantic_judgment_ids: tuple[str, ...] = field(default_factory=tuple)
     reference_binding_ids: tuple[str, ...] = field(default_factory=tuple)
+    derived_claim_fields: tuple[str, ...] = field(default_factory=tuple)
     derived_claim_ids: tuple[str, ...] = field(default_factory=tuple)
     calculation_trace_ids: tuple[str, ...] = field(default_factory=tuple)
     formula_ids: tuple[str, ...] = field(default_factory=tuple)
@@ -59,6 +60,7 @@ def build_commit_package(
         reference_binding_ids=tuple(
             binding.binding_id for binding in report.reference_bindings
         ),
+        derived_claim_fields=tuple(claim.field for claim in report.derived_claims),
         derived_claim_ids=tuple(claim.claim_id for claim in report.derived_claims),
         calculation_trace_ids=tuple(
             claim.trace.trace_id for claim in report.derived_claims

--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -179,6 +179,7 @@ def commit_preparation_to_facts(
                 ("checked_claim_witness_ids", package.checked_claim_witness_ids),
                 ("calculation_trace_ids", package.calculation_trace_ids),
                 ("complete", package.complete),
+                ("derived_claim_fields", package.derived_claim_fields),
                 ("derived_claim_ids", package.derived_claim_ids),
                 ("formula_ids", package.formula_ids),
                 ("hazard_ids", package.hazard_ids),
@@ -237,6 +238,8 @@ def commit_preparation_to_facts(
                 witness=decision.decision_id,
                 meta=(
                     ("commit_package_id", package.package_id),
+                    ("projection_id", preparation.receipt.projection_id),
+                    ("authorized_fields", preparation.receipt.authorized_fields),
                     ("receipt_snapshot", preparation.receipt.barrier_snapshot),
                 ),
             )

--- a/comp/compiler_tool/receipt_builder.py
+++ b/comp/compiler_tool/receipt_builder.py
@@ -14,14 +14,23 @@ def build_commit_receipt(
     decision: GovernanceDecision,
     *,
     public_row_id: str,
+    projection_id: str,
 ) -> CommitReceipt:
-    _validate_receipt_inputs(package, decision)
-    citations = _receipt_citations(package, decision)
+    _validate_receipt_inputs(package, decision, projection_id=projection_id)
+    authorized_fields = _authorized_fields(package)
+    citations = _receipt_citations(
+        package,
+        decision,
+        projection_id=projection_id,
+        authorized_fields=authorized_fields,
+    )
     return CommitReceipt(
         draft_id=package.package_id,
         winner_receipt_ids=(decision.decision_id,),
         barrier_snapshot=citations.to_barrier_snapshot(),
         public_row_id=public_row_id,
+        projection_id=projection_id,
+        authorized_fields=authorized_fields,
         citations=citations,
     )
 
@@ -29,7 +38,11 @@ def build_commit_receipt(
 def _validate_receipt_inputs(
     package: CommitPackage,
     decision: GovernanceDecision,
+    *,
+    projection_id: str,
 ) -> None:
+    if not projection_id:
+        raise ReceiptBuildBlocked("Commit receipt requires a projection id.")
     if decision.package_id != package.package_id:
         raise ReceiptBuildBlocked("Commit receipt package mismatch.")
     if decision.subject_id != package.subject_id:
@@ -43,6 +56,9 @@ def _validate_receipt_inputs(
 def _receipt_citations(
     package: CommitPackage,
     decision: GovernanceDecision,
+    *,
+    projection_id: str,
+    authorized_fields: tuple[str, ...],
 ) -> CommitReceiptCitations:
     return CommitReceiptCitations(
         governance_decision_id=decision.decision_id,
@@ -51,12 +67,15 @@ def _receipt_citations(
         commit_package_id=package.package_id,
         commit_package_complete=package.complete,
         subject_id=package.subject_id,
+        projection_id=projection_id,
+        authorized_fields=authorized_fields,
         profile_id=package.profile_id,
         report_status=package.report_status,
         checked_claim_fields=package.checked_claim_fields,
         checked_claim_witness_ids=package.checked_claim_witness_ids,
         semantic_judgment_ids=package.semantic_judgment_ids,
         reference_binding_ids=package.reference_binding_ids,
+        derived_claim_fields=package.derived_claim_fields,
         derived_claim_ids=package.derived_claim_ids,
         calculation_trace_ids=package.calculation_trace_ids,
         formula_ids=package.formula_ids,
@@ -64,6 +83,21 @@ def _receipt_citations(
         open_obligation_ids=package.open_obligation_ids,
         hazard_ids=package.hazard_ids,
     )
+
+
+def _authorized_fields(package: CommitPackage) -> tuple[str, ...]:
+    return _unique((*package.checked_claim_fields, *package.derived_claim_fields))
+
+
+def _unique(values: tuple[str, ...]) -> tuple[str, ...]:
+    seen = set()
+    unique_values = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        unique_values.append(value)
+    return tuple(unique_values)
 
 
 __all__ = ["ReceiptBuildBlocked", "build_commit_receipt"]

--- a/comp/judgment/commit.py
+++ b/comp/judgment/commit.py
@@ -49,7 +49,45 @@ def project_public_row(
 ) -> dict[str, Any]:
     if receipt is None:
         raise ProjectionBlocked("Public projection requires a CommitReceipt.")
+    _validate_receipt_authorizes_projection(receipt, projection)
     return {field: field_values.get(field) for field in projection.output_fields}
+
+
+def _validate_receipt_authorizes_projection(
+    receipt: CommitReceipt,
+    projection: ProjectionSpec,
+) -> None:
+    if receipt.projection_id != projection.projection_id:
+        raise ProjectionBlocked(
+            "CommitReceipt does not authorize this projection."
+        )
+
+    unauthorized_fields = tuple(
+        field
+        for field in projection.output_fields
+        if field not in receipt.authorized_fields
+    )
+    if unauthorized_fields:
+        fields = ", ".join(unauthorized_fields)
+        raise ProjectionBlocked(f"CommitReceipt has unauthorized field(s): {fields}.")
+
+    if receipt.citations is None:
+        raise ProjectionBlocked("Public projection requires a clean commit receipt.")
+
+    citations = receipt.citations
+    if (
+        citations.governance_status != "commit"
+        or not citations.commit_package_complete
+        or citations.open_obligation_ids
+        or citations.hazard_ids
+    ):
+        raise ProjectionBlocked("Public projection requires a clean commit receipt.")
+
+    if citations.projection_id != receipt.projection_id:
+        raise ProjectionBlocked("CommitReceipt citation projection mismatch.")
+
+    if citations.authorized_fields != receipt.authorized_fields:
+        raise ProjectionBlocked("CommitReceipt citation field scope mismatch.")
 
 
 __all__ = [

--- a/comp/judgment/receipts.py
+++ b/comp/judgment/receipts.py
@@ -21,12 +21,15 @@ class CommitReceiptCitations:
     commit_package_id: str
     commit_package_complete: bool
     subject_id: str
+    projection_id: str
+    authorized_fields: tuple[str, ...]
     profile_id: str | None
     report_status: str
     checked_claim_fields: tuple[str, ...]
     checked_claim_witness_ids: tuple[str, ...]
     semantic_judgment_ids: tuple[str, ...]
     reference_binding_ids: tuple[str, ...]
+    derived_claim_fields: tuple[str, ...]
     derived_claim_ids: tuple[str, ...]
     calculation_trace_ids: tuple[str, ...]
     formula_ids: tuple[str, ...]
@@ -42,12 +45,15 @@ class CommitReceiptCitations:
             ("commit_package_id", self.commit_package_id),
             ("commit_package_complete", self.commit_package_complete),
             ("subject_id", self.subject_id),
+            ("projection_id", self.projection_id),
+            ("authorized_fields", self.authorized_fields),
             ("profile_id", self.profile_id),
             ("report_status", self.report_status),
             ("checked_claim_fields", self.checked_claim_fields),
             ("checked_claim_witness_ids", self.checked_claim_witness_ids),
             ("semantic_judgment_ids", self.semantic_judgment_ids),
             ("reference_binding_ids", self.reference_binding_ids),
+            ("derived_claim_fields", self.derived_claim_fields),
             ("derived_claim_ids", self.derived_claim_ids),
             ("calculation_trace_ids", self.calculation_trace_ids),
             ("formula_ids", self.formula_ids),
@@ -63,6 +69,8 @@ class CommitReceipt:
     winner_receipt_ids: tuple[str, ...]
     barrier_snapshot: tuple[tuple[str, Any], ...]
     public_row_id: str
+    projection_id: str
+    authorized_fields: tuple[str, ...]
     citations: CommitReceiptCitations | None = None
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -41,6 +41,7 @@ PROJECTION_FIELDS = (
     "kgco2e_per_pack",
     "kgco2e_per_kwh",
 )
+PROJECTION_ID = "l-energy-pcf-public-row"
 
 SCENARIO = ScenarioDefinition(
     scenario_id=SCENARIO_ID,
@@ -66,13 +67,14 @@ def run_l_energy_pcf_governance_scenario() -> DomainScenarioResult:
         report,
         subject_id=SUBJECT_ID,
         public_row_id=PUBLIC_ROW_ID,
+        projection_id=PROJECTION_ID,
         profile_id=PROFILE_ID,
     )
     projection = None
     if preparation.receipt is not None:
         projection = project_public_row(
             _projection_source(report),
-            ProjectionSpec("l-energy-pcf-public-row", PROJECTION_FIELDS),
+            ProjectionSpec(PROJECTION_ID, PROJECTION_FIELDS),
             receipt=preparation.receipt,
         )
 

--- a/tests/domain_scenarios/tiny_pcf/scenario.py
+++ b/tests/domain_scenarios/tiny_pcf/scenario.py
@@ -74,6 +74,7 @@ def run_tiny_pcf_scenario() -> DomainScenarioResult:
         resolved_report,
         subject_id=SUBJECT_ID,
         public_row_id=PUBLIC_ROW_ID,
+        projection_id="pcf-public-row",
         profile_id=scenario_profile.profile_id,
     )
     projection = None

--- a/tests/test_commit_preparation_facts.py
+++ b/tests/test_commit_preparation_facts.py
@@ -24,6 +24,7 @@ def test_commit_preparation_to_facts_records_package_decision_and_receipt():
         ),
         subject_id="facility-1",
         public_row_id="public-row-1",
+        projection_id="public-row",
         profile_id="esg-ghg-v1",
         semantic_judgment_ids=("judgment-scope2",),
     )
@@ -68,6 +69,7 @@ def test_commit_preparation_to_facts_keeps_hold_visible_without_receipt_fact():
         ),
         subject_id="facility-1",
         public_row_id="public-row-1",
+        projection_id="public-row",
     )
 
     subject = SubjectRef("draft", "facility-1")
@@ -97,6 +99,7 @@ def test_add_commit_preparation_facts_updates_judgment_state_once():
         CompileReport(status="accepted"),
         subject_id="facility-1",
         public_row_id="public-row-1",
+        projection_id="public-row",
     )
     subject = SubjectRef("draft", "facility-1")
     state = JudgmentState()

--- a/tests/test_commit_preparation_flow.py
+++ b/tests/test_commit_preparation_flow.py
@@ -52,6 +52,7 @@ def test_prepare_commit_builds_package_decision_and_receipt_for_accepted_report(
         report,
         subject_id="facility-1",
         public_row_id="public-row-1",
+        projection_id="public-row",
         profile_id="esg-ghg-v1",
         semantic_judgment_ids=("judgment-scope2",),
     )
@@ -65,7 +66,10 @@ def test_prepare_commit_builds_package_decision_and_receipt_for_accepted_report(
     assert snapshot["checked_claim_witness_ids"] == ("span-amount",)
     assert snapshot["semantic_judgment_ids"] == ("judgment-scope2",)
     assert snapshot["reference_binding_ids"] == ("bind-amount-factor",)
+    assert snapshot["derived_claim_fields"] == ("co2e_emission",)
     assert snapshot["formula_ids"] == ("ghg.electricity_factor_multiplication.v1",)
+    assert preparation.receipt.projection_id == "public-row"
+    assert preparation.receipt.authorized_fields == ("amount", "co2e_emission")
 
     row = project_public_row(
         {"amount": 1200, "co2e_emission": 0.48, "internal_note": "hidden"},
@@ -92,6 +96,7 @@ def test_prepare_commit_returns_hold_without_receipt_for_open_obligations():
         report,
         subject_id="facility-1",
         public_row_id="public-row-1",
+        projection_id="public-row",
     )
 
     assert preparation.package.open_obligation_ids == (
@@ -125,6 +130,7 @@ def test_prepare_commit_returns_reject_without_receipt_for_terminal_failures():
         report,
         subject_id="facility-1",
         public_row_id="public-row-1",
+        projection_id="public-row",
     )
 
     assert preparation.package.report_status == "blocked"

--- a/tests/test_commit_receipt_builder.py
+++ b/tests/test_commit_receipt_builder.py
@@ -1,6 +1,6 @@
 import pytest
 
-from comp import ProjectionSpec, project_public_row
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
 from comp.compiler_tool import (
     CommitPackage,
     CommitReceiptCitations,
@@ -19,6 +19,7 @@ def test_commit_receipt_builder_cites_package_and_governance_artifacts():
         checked_claim_witness_ids=("span-amount",),
         semantic_judgment_ids=("judgment-scope2",),
         reference_binding_ids=("bind-amount-factor",),
+        derived_claim_fields=("co2e_emission",),
         derived_claim_ids=("hyp-1:co2e_emission",),
         calculation_trace_ids=("trace:hyp-1:co2e_emission",),
         formula_ids=("ghg.electricity_factor_multiplication.v1",),
@@ -32,6 +33,7 @@ def test_commit_receipt_builder_cites_package_and_governance_artifacts():
         package,
         decision,
         public_row_id="public-row-1",
+        projection_id="public-row",
     )
 
     snapshot = dict(receipt.barrier_snapshot)
@@ -40,6 +42,8 @@ def test_commit_receipt_builder_cites_package_and_governance_artifacts():
         "governance-decision:commit-package:facility-1",
     )
     assert receipt.public_row_id == "public-row-1"
+    assert receipt.projection_id == "public-row"
+    assert receipt.authorized_fields == ("amount", "co2e_emission")
     assert snapshot["governance_decision_id"] == decision.decision_id
     assert snapshot["governance_status"] == "commit"
     assert snapshot["commit_package_id"] == "commit-package:facility-1"
@@ -49,6 +53,7 @@ def test_commit_receipt_builder_cites_package_and_governance_artifacts():
     assert snapshot["checked_claim_witness_ids"] == ("span-amount",)
     assert snapshot["semantic_judgment_ids"] == ("judgment-scope2",)
     assert snapshot["reference_binding_ids"] == ("bind-amount-factor",)
+    assert snapshot["derived_claim_fields"] == ("co2e_emission",)
     assert snapshot["derived_claim_ids"] == ("hyp-1:co2e_emission",)
     assert snapshot["calculation_trace_ids"] == ("trace:hyp-1:co2e_emission",)
     assert snapshot["formula_ids"] == ("ghg.electricity_factor_multiplication.v1",)
@@ -68,6 +73,7 @@ def test_commit_receipt_builder_exposes_typed_citations():
         checked_claim_witness_ids=("span-amount",),
         semantic_judgment_ids=("judgment-scope2",),
         reference_binding_ids=("bind-amount-factor",),
+        derived_claim_fields=("co2e_emission",),
         derived_claim_ids=("hyp-1:co2e_emission",),
         calculation_trace_ids=("trace:hyp-1:co2e_emission",),
         formula_ids=("ghg.electricity_factor_multiplication.v1",),
@@ -81,6 +87,7 @@ def test_commit_receipt_builder_exposes_typed_citations():
         package,
         decision,
         public_row_id="public-row-1",
+        projection_id="public-row",
     )
 
     assert isinstance(receipt.citations, CommitReceiptCitations)
@@ -91,6 +98,7 @@ def test_commit_receipt_builder_exposes_typed_citations():
     assert receipt.citations.checked_claim_witness_ids == ("span-amount",)
     assert receipt.citations.semantic_judgment_ids == ("judgment-scope2",)
     assert receipt.citations.reference_binding_ids == ("bind-amount-factor",)
+    assert receipt.citations.derived_claim_fields == ("co2e_emission",)
     assert receipt.citations.derived_claim_ids == ("hyp-1:co2e_emission",)
     assert receipt.citations.calculation_trace_ids == (
         "trace:hyp-1:co2e_emission",
@@ -106,12 +114,14 @@ def test_generated_commit_receipt_can_authorize_existing_projection_gate():
         package_id="commit-package:facility-1",
         subject_id="facility-1",
         report_status="accepted",
+        checked_claim_fields=("site", "amount"),
         complete=True,
     )
     receipt = build_commit_receipt(
         package,
         decide_governance(package),
         public_row_id="public-row-1",
+        projection_id="public-row",
     )
 
     row = project_public_row(
@@ -121,6 +131,52 @@ def test_generated_commit_receipt_can_authorize_existing_projection_gate():
     )
 
     assert row == {"site": "plant-a", "amount": 100}
+
+
+def test_commit_receipt_cannot_authorize_different_projection():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        checked_claim_fields=("site", "amount"),
+        complete=True,
+    )
+    receipt = build_commit_receipt(
+        package,
+        decide_governance(package),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+    )
+
+    with pytest.raises(ProjectionBlocked, match="authorize this projection"):
+        project_public_row(
+            {"site": "plant-a", "amount": 100},
+            ProjectionSpec("audit-row", ("site", "amount")),
+            receipt=receipt,
+        )
+
+
+def test_commit_receipt_cannot_authorize_unscoped_projection_fields():
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        checked_claim_fields=("site", "amount"),
+        complete=True,
+    )
+    receipt = build_commit_receipt(
+        package,
+        decide_governance(package),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+    )
+
+    with pytest.raises(ProjectionBlocked, match="unauthorized field"):
+        project_public_row(
+            {"site": "plant-a", "amount": 100, "internal_note": "hidden"},
+            ProjectionSpec("public-row", ("site", "internal_note")),
+            receipt=receipt,
+        )
 
 
 def test_commit_receipt_builder_blocks_hold_decision():
@@ -137,6 +193,7 @@ def test_commit_receipt_builder_blocks_hold_decision():
             package,
             decide_governance(package),
             public_row_id="public-row-1",
+            projection_id="public-row",
         )
 
 
@@ -159,4 +216,5 @@ def test_commit_receipt_builder_blocks_package_mismatch():
             package,
             decide_governance(other_package),
             public_row_id="public-row-1",
+            projection_id="public-row",
         )

--- a/tests/test_receipt_gated_projection.py
+++ b/tests/test_receipt_gated_projection.py
@@ -21,6 +21,13 @@ def test_commit_receipt_allows_public_projection():
         winner_receipt_ids=("selection-1",),
         barrier_snapshot=(("active_hazards", ()),),
         public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        citations=_clean_citations(
+            projection_id="public-row",
+            authorized_fields=("site", "amount"),
+            checked_claim_fields=("site", "amount"),
+        ),
     )
 
     row = project_public_row(
@@ -37,3 +44,87 @@ def test_top_level_projection_surface_is_receipt_gated():
 
     with pytest.raises(ProjectionBlocked):
         comp.project_public_row({"site": "plant-a"}, projection)
+
+
+def test_projection_rejects_receipt_without_citations():
+    projection = ProjectionSpec("public-row", ("site",))
+    receipt = CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("selection-1",),
+        barrier_snapshot=(("active_hazards", ()),),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site",),
+    )
+
+    with pytest.raises(ProjectionBlocked, match="clean commit receipt"):
+        project_public_row({"site": "plant-a"}, projection, receipt=receipt)
+
+
+def test_projection_rejects_receipt_with_unclean_citations():
+    projection = ProjectionSpec("public-row", ("site",))
+    receipt = CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("selection-1",),
+        barrier_snapshot=(("active_hazards", ()),),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site",),
+        citations=comp.CommitReceiptCitations(
+            governance_decision_id="decision-1",
+            governance_status="hold",
+            governance_reasons=("open_obligation:obl-1",),
+            commit_package_id="package-1",
+            commit_package_complete=False,
+            subject_id="facility-1",
+            projection_id="public-row",
+            authorized_fields=("site",),
+            profile_id=None,
+            report_status="review_required",
+            checked_claim_fields=("site",),
+            checked_claim_witness_ids=("span-site",),
+            semantic_judgment_ids=(),
+            reference_binding_ids=(),
+            derived_claim_fields=(),
+            derived_claim_ids=(),
+            calculation_trace_ids=(),
+            formula_ids=(),
+            resolved_obligation_ids=(),
+            open_obligation_ids=("obl-1",),
+            hazard_ids=(),
+        ),
+    )
+
+    with pytest.raises(ProjectionBlocked, match="clean commit receipt"):
+        project_public_row({"site": "plant-a"}, projection, receipt=receipt)
+
+
+def _clean_citations(
+    *,
+    projection_id,
+    authorized_fields,
+    checked_claim_fields,
+):
+    return comp.CommitReceiptCitations(
+        governance_decision_id="decision-1",
+        governance_status="commit",
+        governance_reasons=("commit_package_complete",),
+        commit_package_id="package-1",
+        commit_package_complete=True,
+        subject_id="facility-1",
+        projection_id=projection_id,
+        authorized_fields=authorized_fields,
+        profile_id=None,
+        report_status="accepted",
+        checked_claim_fields=checked_claim_fields,
+        checked_claim_witness_ids=tuple(f"span-{field}" for field in checked_claim_fields),
+        semantic_judgment_ids=(),
+        reference_binding_ids=(),
+        derived_claim_fields=(),
+        derived_claim_ids=(),
+        calculation_trace_ids=(),
+        formula_ids=(),
+        resolved_obligation_ids=(),
+        open_obligation_ids=(),
+        hazard_ids=(),
+    )


### PR DESCRIPTION
## Summary

This PR tightens the receipt-gated projection boundary so a `CommitReceipt` must explicitly authorize the projection being rendered.

## Changes

- Add `projection_id`, `authorized_fields`, and derived-claim field scope to commit receipts and citations.
- Require `prepare_commit` / `build_commit_receipt` callers to provide the projection id being authorized.
- Validate projection id, field scope, citation presence, commit status, package completeness, open obligations, and hazards before rendering a public row.
- Extend commit preparation facts and domain scenario fixtures to preserve the new receipt scope.
- Add regression tests for mismatched projections, unauthorized fields, missing citations, and unclean citations.

## Why

Previously, `project_public_row` only required a non-null receipt object. That left the architecture's most important boundary too broad: a receipt could be reused for a different projection or field set. This change makes the receipt projection-specific, field-scoped, and citation-checked.

## Validation

- `python -m pytest -q` -> `190 passed in 4.48s`
- `git diff --cached --check` before commit produced no output.