### PR TITLE
[codex] harden receipt value integrity

### DIFF
--- a/comp/__init__.py
+++ b/comp/__init__.py
@@ -19,6 +19,7 @@ from comp.judgment import (
     JudgmentState,
     ProjectionBlocked,
     ProjectionSpec,
+    ProjectionValueCommitment,
     SelectionReceipt,
     SubjectKind,
     SubjectRef,
@@ -61,6 +62,7 @@ __all__ = [
     "committable",
     "project_public_row",
     "SelectionReceipt",
+    "ProjectionValueCommitment",
     "CommitReceipt",
     "CommitReceiptCitations",
 ]

--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -70,7 +70,7 @@ from comp.compiler_tool.receipt_builder import (
     ReceiptBuildBlocked,
     build_commit_receipt,
 )
-from comp.judgment.receipts import CommitReceiptCitations
+from comp.judgment.receipts import CommitReceiptCitations, ProjectionValueCommitment
 from comp.compiler_tool.report_status import (
     recompute_report_status,
     with_recomputed_status,
@@ -126,6 +126,7 @@ __all__ = [
     "ReferenceBinding",
     "ReceiptBuildBlocked",
     "CommitReceiptCitations",
+    "ProjectionValueCommitment",
     "build_commit_receipt",
     "ReferenceLookupError",
     "ReferenceRecord",

--- a/comp/compiler_tool/commit_package.py
+++ b/comp/compiler_tool/commit_package.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 
 from comp.compiler_tool.models import CompileReport, Hazard, ProofObligation
 from comp.compiler_tool.report_status import recompute_report_status
+from comp.judgment.receipts import ProjectionValueCommitment
 
 
 @dataclass(frozen=True)
@@ -20,6 +21,9 @@ class CommitPackage:
     derived_claim_ids: tuple[str, ...] = field(default_factory=tuple)
     calculation_trace_ids: tuple[str, ...] = field(default_factory=tuple)
     formula_ids: tuple[str, ...] = field(default_factory=tuple)
+    projection_value_commitments: tuple[ProjectionValueCommitment, ...] = field(
+        default_factory=tuple
+    )
     open_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
     resolved_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
     hazard_ids: tuple[str, ...] = field(default_factory=tuple)
@@ -66,6 +70,7 @@ def build_commit_package(
             claim.trace.trace_id for claim in report.derived_claims
         ),
         formula_ids=_unique(claim.formula_id for claim in report.derived_claims),
+        projection_value_commitments=_projection_value_commitments(report),
         open_obligation_ids=open_obligation_ids,
         resolved_obligation_ids=tuple(
             _obligation_id(obligation)
@@ -92,6 +97,34 @@ def _obligation_id(obligation: ProofObligation) -> str:
 
 def _hazard_id(hazard: Hazard) -> str:
     return _stable_id("hazard", hazard.kind, hazard.field, hazard.severity)
+
+
+def _projection_value_commitments(
+    report: CompileReport,
+) -> tuple[ProjectionValueCommitment, ...]:
+    checked = tuple(
+        ProjectionValueCommitment.from_value(
+            field=claim.field,
+            source_kind="checked_claim",
+            source_id=_checked_claim_source_id(claim.field, claim.witness_id),
+            value=claim.value,
+        )
+        for claim in report.checked_claims
+    )
+    derived = tuple(
+        ProjectionValueCommitment.from_value(
+            field=claim.field,
+            source_kind="derived_claim",
+            source_id=claim.claim_id,
+            value=claim.value,
+        )
+        for claim in report.derived_claims
+    )
+    return checked + derived
+
+
+def _checked_claim_source_id(field: str, witness_id: str) -> str:
+    return _stable_id("checked_claim", field, witness_id)
 
 
 def _stable_id(*parts: str) -> str:

--- a/comp/compiler_tool/receipt_builder.py
+++ b/comp/compiler_tool/receipt_builder.py
@@ -82,6 +82,7 @@ def _receipt_citations(
         resolved_obligation_ids=package.resolved_obligation_ids,
         open_obligation_ids=package.open_obligation_ids,
         hazard_ids=package.hazard_ids,
+        projection_value_commitments=package.projection_value_commitments,
     )
 
 

--- a/comp/judgment/__init__.py
+++ b/comp/judgment/__init__.py
@@ -29,6 +29,7 @@ from comp.judgment.program import (
 from comp.judgment.receipts import (
     CommitReceipt,
     CommitReceiptCitations,
+    ProjectionValueCommitment,
     SelectionReceipt,
 )
 
@@ -58,6 +59,7 @@ __all__ = [
     "committable",
     "project_public_row",
     "SelectionReceipt",
+    "ProjectionValueCommitment",
     "CommitReceipt",
     "CommitReceiptCitations",
 ]

--- a/comp/judgment/commit.py
+++ b/comp/judgment/commit.py
@@ -49,13 +49,14 @@ def project_public_row(
 ) -> dict[str, Any]:
     if receipt is None:
         raise ProjectionBlocked("Public projection requires a CommitReceipt.")
-    _validate_receipt_authorizes_projection(receipt, projection)
+    _validate_receipt_authorizes_projection(receipt, projection, field_values)
     return {field: field_values.get(field) for field in projection.output_fields}
 
 
 def _validate_receipt_authorizes_projection(
     receipt: CommitReceipt,
     projection: ProjectionSpec,
+    field_values: Mapping[str, Any],
 ) -> None:
     if receipt.projection_id != projection.projection_id:
         raise ProjectionBlocked(
@@ -88,6 +89,43 @@ def _validate_receipt_authorizes_projection(
 
     if citations.authorized_fields != receipt.authorized_fields:
         raise ProjectionBlocked("CommitReceipt citation field scope mismatch.")
+
+    _validate_projection_value_commitments(citations, projection, field_values)
+
+
+def _validate_projection_value_commitments(
+    citations,
+    projection: ProjectionSpec,
+    field_values: Mapping[str, Any],
+) -> None:
+    commitments_by_field = {}
+    for commitment in citations.projection_value_commitments:
+        if commitment.field in commitments_by_field:
+            raise ProjectionBlocked(
+                f"CommitReceipt has duplicate value commitment: {commitment.field}."
+            )
+        commitments_by_field[commitment.field] = commitment
+
+    for field in projection.output_fields:
+        if field not in field_values:
+            raise ProjectionBlocked(
+                f"Public projection missing committed value: {field}."
+            )
+        commitment = commitments_by_field.get(field)
+        if commitment is None:
+            raise ProjectionBlocked(
+                f"CommitReceipt lacks value commitment for field: {field}."
+            )
+        try:
+            matches = commitment.matches_value(field_values[field])
+        except (TypeError, ValueError) as exc:
+            raise ProjectionBlocked(
+                f"Public projection value commitment cannot be verified: {field}."
+            ) from exc
+        if not matches:
+            raise ProjectionBlocked(
+                f"Public projection value commitment mismatch: {field}."
+            )
 
 
 __all__ = [

--- a/comp/judgment/receipts.py
+++ b/comp/judgment/receipts.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from decimal import Decimal
 from typing import Any
 
 
@@ -11,6 +16,34 @@ class SelectionReceipt:
     winner_id: str | None
     bundle_version: int
     reason: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionValueCommitment:
+    field: str
+    source_kind: str
+    source_id: str
+    value_digest: str
+    digest_alg: str = "sha256"
+
+    @classmethod
+    def from_value(
+        cls,
+        *,
+        field: str,
+        source_kind: str,
+        source_id: str,
+        value: Any,
+    ) -> "ProjectionValueCommitment":
+        return cls(
+            field=field,
+            source_kind=source_kind,
+            source_id=source_id,
+            value_digest=_value_digest(value),
+        )
+
+    def matches_value(self, value: Any) -> bool:
+        return self.value_digest == _value_digest(value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +69,9 @@ class CommitReceiptCitations:
     resolved_obligation_ids: tuple[str, ...]
     open_obligation_ids: tuple[str, ...]
     hazard_ids: tuple[str, ...]
+    projection_value_commitments: tuple[ProjectionValueCommitment, ...] = field(
+        default_factory=tuple
+    )
 
     def to_barrier_snapshot(self) -> tuple[tuple[str, Any], ...]:
         return (
@@ -60,6 +96,10 @@ class CommitReceiptCitations:
             ("resolved_obligation_ids", self.resolved_obligation_ids),
             ("open_obligation_ids", self.open_obligation_ids),
             ("hazard_ids", self.hazard_ids),
+            (
+                "projection_value_commitments",
+                self.projection_value_commitments,
+            ),
         )
 
 
@@ -74,4 +114,61 @@ class CommitReceipt:
     citations: CommitReceiptCitations | None = None
 
 
-__all__ = ["SelectionReceipt", "CommitReceipt", "CommitReceiptCitations"]
+def _value_digest(value: Any) -> str:
+    canonical = json.dumps(
+        _canonical_value(value),
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _canonical_value(value: Any) -> Any:
+    if value is None:
+        return {"type": "none", "value": None}
+    if isinstance(value, bool):
+        return {"type": "bool", "value": value}
+    if isinstance(value, int):
+        return {"type": "int", "value": str(value)}
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Projection value commitment requires a finite float.")
+        return {"type": "float", "value": repr(value)}
+    if isinstance(value, str):
+        return {"type": "str", "value": value}
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError("Projection value commitment requires a finite decimal.")
+        return {"type": "decimal", "value": str(value)}
+    if isinstance(value, Mapping):
+        return {
+            "type": "mapping",
+            "value": tuple(
+                (str(key), _canonical_value(item))
+                for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            ),
+        }
+    if isinstance(value, tuple):
+        return {
+            "type": "tuple",
+            "value": tuple(_canonical_value(item) for item in value),
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return {
+            "type": "sequence",
+            "value": tuple(_canonical_value(item) for item in value),
+        }
+    raise TypeError(
+        f"Unsupported projection value for commitment: {type(value).__name__}"
+    )
+
+
+__all__ = [
+    "SelectionReceipt",
+    "ProjectionValueCommitment",
+    "CommitReceipt",
+    "CommitReceiptCitations",
+]

--- a/tests/test_commit_receipt_builder.py
+++ b/tests/test_commit_receipt_builder.py
@@ -2,9 +2,15 @@ import pytest
 
 from comp import ProjectionBlocked, ProjectionSpec, project_public_row
 from comp.compiler_tool import (
+    CalculationTrace,
+    CheckedClaim,
     CommitPackage,
     CommitReceiptCitations,
+    CompileReport,
+    DerivedClaim,
+    ProjectionValueCommitment,
     ReceiptBuildBlocked,
+    build_commit_package,
     build_commit_receipt,
     decide_governance,
 )
@@ -109,14 +115,148 @@ def test_commit_receipt_builder_exposes_typed_citations():
     assert receipt.citations.to_barrier_snapshot() == receipt.barrier_snapshot
 
 
-def test_generated_commit_receipt_can_authorize_existing_projection_gate():
-    package = CommitPackage(
-        package_id="commit-package:facility-1",
-        subject_id="facility-1",
-        report_status="accepted",
-        checked_claim_fields=("site", "amount"),
-        complete=True,
+def test_commit_receipt_builder_commits_checked_and_derived_projection_values():
+    report = CompileReport(
+        status="accepted",
+        checked_claims=(
+            CheckedClaim(
+                field="amount",
+                value=1200,
+                witness_id="span-amount",
+                origin="source_text",
+            ),
+        ),
+        derived_claims=(
+            DerivedClaim(
+                claim_id="hyp-1:co2e_emission",
+                field="co2e_emission",
+                value=0.48,
+                unit="tCO2e",
+                trace=CalculationTrace(
+                    trace_id="trace:hyp-1:co2e_emission",
+                    formula_id="ghg.electricity_factor_multiplication.v1",
+                ),
+            ),
+        ),
     )
+    package = build_commit_package(
+        report,
+        subject_id="facility-1",
+        profile_id="esg-ghg-v1",
+    )
+
+    receipt = build_commit_receipt(
+        package,
+        decide_governance(package),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+    )
+
+    commitments = receipt.citations.projection_value_commitments
+    assert commitments == (
+        ProjectionValueCommitment.from_value(
+            field="amount",
+            source_kind="checked_claim",
+            source_id="checked_claim:amount:span-amount",
+            value=1200,
+        ),
+        ProjectionValueCommitment.from_value(
+            field="co2e_emission",
+            source_kind="derived_claim",
+            source_id="hyp-1:co2e_emission",
+            value=0.48,
+        ),
+    )
+
+    snapshot = dict(receipt.barrier_snapshot)
+    assert snapshot["projection_value_commitments"] == commitments
+    assert tuple(ProjectionValueCommitment.__dataclass_fields__) == (
+        "field",
+        "source_kind",
+        "source_id",
+        "value_digest",
+        "digest_alg",
+    )
+    assert all(commitment.value_digest.startswith("sha256:") for commitment in commitments)
+
+
+def test_commit_receipt_value_digests_preserve_value_type():
+    report = CompileReport(
+        status="accepted",
+        checked_claims=(
+            CheckedClaim(
+                field="amount_int",
+                value=1200,
+                witness_id="span-int",
+                origin="source_text",
+            ),
+            CheckedClaim(
+                field="amount_int_again",
+                value=1200,
+                witness_id="span-int-again",
+                origin="source_text",
+            ),
+            CheckedClaim(
+                field="amount_str",
+                value="1200",
+                witness_id="span-str",
+                origin="source_text",
+            ),
+            CheckedClaim(
+                field="amount_float",
+                value=1200.0,
+                witness_id="span-float",
+                origin="source_text",
+            ),
+        ),
+    )
+    package = build_commit_package(report, subject_id="facility-1")
+    receipt = build_commit_receipt(
+        package,
+        decide_governance(package),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+    )
+
+    commitments = {
+        commitment.field: commitment
+        for commitment in receipt.citations.projection_value_commitments
+    }
+
+    assert commitments["amount_int"].value_digest.startswith("sha256:")
+    assert (
+        commitments["amount_int"].value_digest
+        == commitments["amount_int_again"].value_digest
+    )
+    assert (
+        commitments["amount_int"].value_digest
+        != commitments["amount_str"].value_digest
+    )
+    assert (
+        commitments["amount_int"].value_digest
+        != commitments["amount_float"].value_digest
+    )
+
+
+def test_generated_commit_receipt_can_authorize_existing_projection_gate():
+    report = CompileReport(
+        status="accepted",
+        checked_claims=(
+            CheckedClaim(
+                field="site",
+                value="plant-a",
+                witness_id="span-site",
+                origin="source_text",
+            ),
+            CheckedClaim(
+                field="amount",
+                value=100,
+                witness_id="span-amount",
+                origin="source_text",
+            ),
+        ),
+    )
+    package = build_commit_package(report, subject_id="facility-1")
     receipt = build_commit_receipt(
         package,
         decide_governance(package),

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -1,3 +1,6 @@
+import pytest
+
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
 from tests.domain_scenarios.core import (
     ScenarioDefinition,
     SourceRef,
@@ -56,6 +59,18 @@ def test_tiny_pcf_scenario_runs_reference_to_receipt_flow():
     assert result.preparation.decision.status == "commit"
     assert result.preparation.receipt is not None
     assert result.projection == EXPECTED_PROJECTION
+
+
+def test_tiny_pcf_scenario_rejects_tampered_projection_value():
+    result = run_tiny_pcf_scenario()
+
+    assert result.preparation.receipt is not None
+    with pytest.raises(ProjectionBlocked, match="value commitment"):
+        project_public_row(
+            {"electricity_kwh": 1200, "co2e_kg": 999999},
+            ProjectionSpec("pcf-public-row", ("electricity_kwh", "co2e_kg")),
+            receipt=result.preparation.receipt,
+        )
 
 
 def test_tiny_pcf_scenario_preserves_traceable_domain_artifacts():

--- a/tests/test_receipt_gated_projection.py
+++ b/tests/test_receipt_gated_projection.py
@@ -1,7 +1,13 @@
 import pytest
 
 import comp
-from comp import CommitReceipt, ProjectionBlocked, ProjectionSpec, project_public_row
+from comp import (
+    CommitReceipt,
+    ProjectionBlocked,
+    ProjectionSpec,
+    ProjectionValueCommitment,
+    project_public_row,
+)
 from comp.compiler_tool import CompileReport
 
 
@@ -16,6 +22,20 @@ def test_accepted_compile_report_without_commit_receipt_cannot_project_public_ro
 
 def test_commit_receipt_allows_public_projection():
     projection = ProjectionSpec("public-row", ("site", "amount"))
+    commitments = (
+        ProjectionValueCommitment.from_value(
+            field="site",
+            source_kind="checked_claim",
+            source_id="checked_claim:site:span-site",
+            value="plant-a",
+        ),
+        ProjectionValueCommitment.from_value(
+            field="amount",
+            source_kind="checked_claim",
+            source_id="checked_claim:amount:span-amount",
+            value=100,
+        ),
+    )
     receipt = CommitReceipt(
         draft_id="draft-1",
         winner_receipt_ids=("selection-1",),
@@ -27,6 +47,7 @@ def test_commit_receipt_allows_public_projection():
             projection_id="public-row",
             authorized_fields=("site", "amount"),
             checked_claim_fields=("site", "amount"),
+            projection_value_commitments=commitments,
         ),
     )
 
@@ -37,6 +58,126 @@ def test_commit_receipt_allows_public_projection():
     )
 
     assert row == {"site": "plant-a", "amount": 100}
+
+
+def test_projection_rejects_tampered_committed_value():
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+    receipt = CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("selection-1",),
+        barrier_snapshot=(("active_hazards", ()),),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        citations=_clean_citations(
+            projection_id="public-row",
+            authorized_fields=("site", "amount"),
+            checked_claim_fields=("site", "amount"),
+            projection_value_commitments=(
+                ProjectionValueCommitment.from_value(
+                    field="site",
+                    source_kind="checked_claim",
+                    source_id="checked_claim:site:span-site",
+                    value="plant-a",
+                ),
+                ProjectionValueCommitment.from_value(
+                    field="amount",
+                    source_kind="checked_claim",
+                    source_id="checked_claim:amount:span-amount",
+                    value=100,
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(ProjectionBlocked, match="value commitment"):
+        project_public_row(
+            {"site": "plant-a", "amount": 999999},
+            projection,
+            receipt=receipt,
+        )
+
+
+def test_projection_rejects_missing_committed_source_value():
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+    receipt = CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("selection-1",),
+        barrier_snapshot=(("active_hazards", ()),),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        citations=_clean_citations(
+            projection_id="public-row",
+            authorized_fields=("site", "amount"),
+            checked_claim_fields=("site", "amount"),
+            projection_value_commitments=(
+                ProjectionValueCommitment.from_value(
+                    field="site",
+                    source_kind="checked_claim",
+                    source_id="checked_claim:site:span-site",
+                    value="plant-a",
+                ),
+                ProjectionValueCommitment.from_value(
+                    field="amount",
+                    source_kind="checked_claim",
+                    source_id="checked_claim:amount:span-amount",
+                    value=100,
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(ProjectionBlocked, match="missing committed value"):
+        project_public_row({"site": "plant-a"}, projection, receipt=receipt)
+
+
+def test_projection_rejects_missing_value_commitment():
+    projection = ProjectionSpec("public-row", ("site",))
+    receipt = CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("selection-1",),
+        barrier_snapshot=(("active_hazards", ()),),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site",),
+        citations=_clean_citations(
+            projection_id="public-row",
+            authorized_fields=("site",),
+            checked_claim_fields=("site",),
+            projection_value_commitments=(),
+        ),
+    )
+
+    with pytest.raises(ProjectionBlocked, match="value commitment"):
+        project_public_row({"site": "plant-a"}, projection, receipt=receipt)
+
+
+def test_projection_rejects_duplicate_value_commitments():
+    projection = ProjectionSpec("public-row", ("site",))
+    duplicate = ProjectionValueCommitment.from_value(
+        field="site",
+        source_kind="checked_claim",
+        source_id="checked_claim:site:span-site",
+        value="plant-a",
+    )
+    receipt = CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("selection-1",),
+        barrier_snapshot=(("active_hazards", ()),),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site",),
+        citations=_clean_citations(
+            projection_id="public-row",
+            authorized_fields=("site",),
+            checked_claim_fields=("site",),
+            projection_value_commitments=(duplicate, duplicate),
+        ),
+    )
+
+    with pytest.raises(ProjectionBlocked, match="duplicate value commitment"):
+        project_public_row({"site": "plant-a"}, projection, receipt=receipt)
 
 
 def test_top_level_projection_surface_is_receipt_gated():
@@ -104,6 +245,7 @@ def _clean_citations(
     projection_id,
     authorized_fields,
     checked_claim_fields,
+    projection_value_commitments=(),
 ):
     return comp.CommitReceiptCitations(
         governance_decision_id="decision-1",
@@ -127,4 +269,5 @@ def _clean_citations(
         resolved_obligation_ids=(),
         open_obligation_ids=(),
         hazard_ids=(),
+        projection_value_commitments=projection_value_commitments,
     )


### PR DESCRIPTION
## Summary
- Add typed `ProjectionValueCommitment` records that commit public projection fields to canonical SHA-256 value digests.
- Have `CommitPackage` derive commitments from checked claims and derived claims, then carry them into `CommitReceiptCitations` and the receipt barrier snapshot.
- Harden `project_public_row()` so authorized fields still block when the source value is missing, the receipt lacks a value commitment, commitments are duplicated, or the supplied value digest mismatches.
- Add scenario coverage showing the tiny PCF receipt rejects a tampered projection value.

## Why
PR #158 locked the projection gate at the field level. This PR adds value-level integrity so a receipt that authorizes `co2e_kg` cannot be reused with a modified `co2e_kg` value.

## Validation
- `python -m pytest tests/test_receipt_gated_projection.py tests/test_commit_receipt_builder.py -q`
- `python -m pytest tests/test_domain_scenario_lab.py tests/test_l_energy_pcf_scenario.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`
