### PR TITLE
[codex] test: add canonical working loop scenario

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -22,7 +22,13 @@ expected derived claims
 expected receipt/projection
 ```
 
-The first scenario is `tiny_pcf`, a product-carbon-footprint slice that exercises
+Start with `canonical_working_loop`, the raw-input harness for new contributors.
+It begins with a raw evidence sentence, uses a deterministic extractor stub,
+passes through `CompilerTool`, opens a calculation obligation, resolves a
+reference candidate into a canonical binding, calculates a derived claim, mints
+a commit receipt, and projects only through the receipt gate.
+
+The smaller scenario `tiny_pcf` is a product-carbon-footprint slice that exercises
 reference search, near-miss rejection, canonical binding, calculation trace,
 commit preparation, and receipt-gated projection.
 

--- a/tests/domain_scenarios/canonical_working_loop/__init__.py
+++ b/tests/domain_scenarios/canonical_working_loop/__init__.py
@@ -1,0 +1,2 @@
+"""Canonical raw-input working-loop scenario pack."""
+

--- a/tests/domain_scenarios/canonical_working_loop/expected.py
+++ b/tests/domain_scenarios/canonical_working_loop/expected.py
@@ -1,0 +1,16 @@
+EXPECTED_PROJECTION = {
+    "electricity_kwh": 1200,
+    "reporting_year": 2024,
+    "co2e_kg": 504.0,
+}
+
+EXPECTED_REFERENCE_CANDIDATE_IDS = (
+    "pcf.factor.kr_grid_2024.location_based",
+    "pcf.factor.kr_grid_2023.location_based",
+)
+
+EXPECTED_RESOLVED_OBLIGATION_KINDS = (
+    "reference_search_required",
+    "calculation_blocked",
+)
+

--- a/tests/domain_scenarios/canonical_working_loop/fixtures.py
+++ b/tests/domain_scenarios/canonical_working_loop/fixtures.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import re
+
+from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
+    ClaimHypothesis,
+    CompileReport,
+    CompilerTool,
+    EvidenceWitness,
+    InterpretationHypothesis,
+    ReferenceBinding,
+    ReferenceCatalog,
+    ReferenceRecord,
+    ReferenceSelectionCriteria,
+    apply_calculation_result,
+    calculate_derived_claim,
+)
+
+
+SCENARIO_ID = "canonical_working_loop.raw_text_pcf.v1"
+SUBJECT_ID = "product:canonical-raw-pcf-1"
+PUBLIC_ROW_ID = "public-row:canonical-raw-pcf-1"
+PROFILE_ID = "pcf-canonical-loop-v1"
+INPUT_CLAIM_ID = "canonical-raw:electricity_kwh"
+OUTPUT_CLAIM_ID = "canonical-raw:co2e_kg"
+RAW_EVIDENCE = "Seoul office used 1200kWh electricity in Jan 2024."
+
+
+def extract_raw_evidence(raw_text: str) -> InterpretationHypothesis:
+    amount = _required_int(raw_text, r"(\d+)\s*kwh")
+    year = _required_int(raw_text, r"(20\d{2})")
+    source = "raw-evidence:canonical-working-loop"
+
+    return InterpretationHypothesis(
+        hypothesis_id="hyp:canonical-raw-pcf",
+        subject_id=SUBJECT_ID,
+        claims=(
+            ClaimHypothesis("activity", "electricity", witness_id="w-activity"),
+            ClaimHypothesis(
+                "electricity_kwh",
+                amount,
+                witness_id="w-electricity-kwh",
+                origin="deterministic_extractor",
+            ),
+            ClaimHypothesis("unit", "kWh", witness_id="w-unit"),
+            ClaimHypothesis("reporting_year", year, witness_id="w-reporting-year"),
+            ClaimHypothesis("geography", "KR", witness_id="w-geography"),
+        ),
+        witnesses=(
+            EvidenceWitness(
+                "w-activity",
+                "activity",
+                source=source,
+                span="electricity",
+                text=raw_text,
+            ),
+            EvidenceWitness(
+                "w-electricity-kwh",
+                "electricity_kwh",
+                source=source,
+                span="1200kWh",
+                text=raw_text,
+            ),
+            EvidenceWitness(
+                "w-unit",
+                "unit",
+                source=source,
+                span="kWh",
+                text=raw_text,
+            ),
+            EvidenceWitness(
+                "w-reporting-year",
+                "reporting_year",
+                source=source,
+                span="2024",
+                text=raw_text,
+            ),
+            EvidenceWitness(
+                "w-geography",
+                "geography",
+                source=source,
+                span="Seoul",
+                text=raw_text,
+            ),
+        ),
+    )
+
+
+def compile_raw_evidence(raw_text: str) -> CompileReport:
+    return CompilerTool(
+        known_fields=frozenset(
+            {
+                "activity",
+                "electricity_kwh",
+                "unit",
+                "reporting_year",
+                "geography",
+            }
+        )
+    ).compile_interpretation(extract_raw_evidence(raw_text))
+
+
+def open_calculation_obligation(report: CompileReport) -> CompileReport:
+    result = calculate_derived_claim(
+        output_claim_id=OUTPUT_CLAIM_ID,
+        input_claim=input_claim_from_report(report),
+        reference_binding=ReferenceBinding(
+            binding_id="bind-canonical-electricity-factor",
+            claim_id=INPUT_CLAIM_ID,
+            reference_id="pcf.factor.unknown",
+            reference_type="emission_factor",
+        ),
+        catalog=ReferenceCatalog(records=()),
+        formula=formula(),
+    )
+    return apply_calculation_result(
+        report,
+        result,
+        output_claim_id=OUTPUT_CLAIM_ID,
+        formula=formula(),
+    )
+
+
+def catalog() -> ReferenceCatalog:
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="pcf.factor.kr_grid_2024.location_based",
+                reference_type="emission_factor",
+                labels=("Korea grid electricity factor 2024",),
+                aliases=("KR electricity grid factor",),
+                description=(
+                    "Location-based electricity emission factor for Korea in 2024."
+                ),
+                attributes=(
+                    ("concept_id", "pcf.concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "location_based"),
+                    ("factor_value", 0.42),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "kgCO2e"),
+                ),
+                source="pcf-reference-catalog",
+                witness_ids=("factor-row-kr-grid-2024",),
+            ),
+            ReferenceRecord(
+                reference_id="pcf.factor.kr_grid_2023.location_based",
+                reference_type="emission_factor",
+                labels=("Korea grid electricity factor 2023",),
+                aliases=("KR electricity grid factor historical",),
+                description=(
+                    "Location-based electricity emission factor for Korea in 2023."
+                ),
+                attributes=(
+                    ("concept_id", "pcf.concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2023"),
+                    ("method", "location_based"),
+                    ("factor_value", 0.41),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "kgCO2e"),
+                ),
+                source="pcf-reference-catalog",
+                witness_ids=("factor-row-kr-grid-2023",),
+            ),
+        )
+    )
+
+
+def criteria() -> ReferenceSelectionCriteria:
+    return ReferenceSelectionCriteria(
+        binding_id="bind-canonical-electricity-factor",
+        claim_id=INPUT_CLAIM_ID,
+        reference_type="emission_factor",
+        selector_rule_id="pcf.factor_selector.v1",
+        required_attributes=(
+            ("concept_id", "pcf.concept.electricity_consumption"),
+            ("geography", "KR"),
+            ("valid_period", "2024"),
+            ("method", "location_based"),
+        ),
+    )
+
+
+def formula() -> CalculationFormula:
+    return CalculationFormula(
+        formula_id="pcf.electricity_factor_multiplication.v1",
+        output_field="co2e_kg",
+        output_unit="kgCO2e",
+    )
+
+
+def input_claim_from_report(report: CompileReport) -> CalculationInput:
+    values = {claim.field: claim.value for claim in report.checked_claims}
+    return CalculationInput(
+        claim_id=INPUT_CLAIM_ID,
+        field="electricity_kwh",
+        value=values["electricity_kwh"],
+        unit=values["unit"],
+    )
+
+
+def projection_source(report: CompileReport) -> dict[str, object]:
+    values: dict[str, object] = {
+        claim.field: claim.value for claim in report.checked_claims
+    }
+    values.update({claim.field: claim.value for claim in report.derived_claims})
+    return values
+
+
+def _required_int(text: str, pattern: str) -> int:
+    match = re.search(pattern, text, flags=re.IGNORECASE)
+    if match is None:
+        raise ValueError(f"raw evidence did not match {pattern!r}")
+    return int(match.group(1))
+
+
+__all__ = [
+    "OUTPUT_CLAIM_ID",
+    "PROFILE_ID",
+    "PUBLIC_ROW_ID",
+    "RAW_EVIDENCE",
+    "SCENARIO_ID",
+    "SUBJECT_ID",
+    "catalog",
+    "compile_raw_evidence",
+    "criteria",
+    "extract_raw_evidence",
+    "formula",
+    "input_claim_from_report",
+    "open_calculation_obligation",
+    "projection_source",
+]

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from comp import ProjectionSpec, SubjectRef, project_public_row
+from comp.compiler_tool import prepare_commit, resolve_reference_grounded_calculation
+from tests.domain_scenarios.canonical_working_loop.expected import (
+    EXPECTED_PROJECTION,
+    EXPECTED_REFERENCE_CANDIDATE_IDS,
+    EXPECTED_RESOLVED_OBLIGATION_KINDS,
+)
+from tests.domain_scenarios.canonical_working_loop.fixtures import (
+    OUTPUT_CLAIM_ID,
+    PROFILE_ID,
+    PUBLIC_ROW_ID,
+    RAW_EVIDENCE,
+    SCENARIO_ID,
+    SUBJECT_ID,
+    catalog,
+    compile_raw_evidence,
+    criteria,
+    formula,
+    input_claim_from_report,
+    open_calculation_obligation,
+    projection_source,
+)
+from tests.domain_scenarios.core import (
+    DomainScenarioResult,
+    ScenarioContract,
+    ScenarioDefinition,
+    SourceRef,
+    build_domain_scenario_result,
+)
+
+
+RESOLVER_STEPS = (
+    "raw_text_fixture",
+    "deterministic_extractor_stub",
+    "compiler_tool.compile_interpretation",
+    "open_calculation_obligation",
+    "plan_calculation_resolution",
+    "reference_search:keyword",
+    "deterministic_reference_selection",
+    "retry_calculation",
+    "prepare_commit",
+    "receipt_gated_projection",
+)
+
+
+SCENARIO = ScenarioDefinition(
+    scenario_id=SCENARIO_ID,
+    title="Canonical raw text PCF working loop",
+    run=lambda: run_canonical_working_loop_scenario(),
+    contract=ScenarioContract(
+        must_commit=True,
+        required_projection=EXPECTED_PROJECTION,
+        required_resolved_obligation_kinds=EXPECTED_RESOLVED_OBLIGATION_KINDS,
+        required_reference_candidate_ids=EXPECTED_REFERENCE_CANDIDATE_IDS,
+        required_reference_binding_ids=("bind-canonical-electricity-factor",),
+        required_derived_claim_ids=("canonical-raw:co2e_kg",),
+        required_receipt_reference_binding_ids=("bind-canonical-electricity-factor",),
+        required_receipt_derived_claim_ids=("canonical-raw:co2e_kg",),
+        required_receipt_calculation_trace_ids=("trace:canonical-raw:co2e_kg",),
+        required_receipt_formula_ids=("pcf.electricity_factor_multiplication.v1",),
+    ),
+    source_refs=(
+        SourceRef(
+            repo="minntcho/comp",
+            path="tests/domain_scenarios/canonical_working_loop/fixtures.py",
+        ),
+    ),
+)
+
+
+def run_canonical_working_loop_scenario() -> DomainScenarioResult:
+    compiled_report = compile_raw_evidence(RAW_EVIDENCE)
+    blocked_report = open_calculation_obligation(compiled_report)
+    resolved_report = resolve_reference_grounded_calculation(
+        blocked_report,
+        catalog(),
+        query_for_obligation=lambda obligation: (
+            "Korea grid electricity factor 2024"
+            if obligation.kind == "reference_search_required"
+            else None
+        ),
+        criteria=criteria(),
+        input_claim=input_claim_from_report(compiled_report),
+        formula=formula(),
+        output_claim_id=OUTPUT_CLAIM_ID,
+    )
+    preparation = prepare_commit(
+        resolved_report,
+        subject_id=SUBJECT_ID,
+        public_row_id=PUBLIC_ROW_ID,
+        projection_id="canonical-pcf-public-row",
+        profile_id=PROFILE_ID,
+    )
+    projection = None
+    if preparation.receipt is not None:
+        projection = project_public_row(
+            projection_source(resolved_report),
+            ProjectionSpec(
+                "canonical-pcf-public-row",
+                ("electricity_kwh", "reporting_year", "co2e_kg"),
+            ),
+            receipt=preparation.receipt,
+        )
+
+    return build_domain_scenario_result(
+        scenario_id=SCENARIO_ID,
+        report=resolved_report,
+        preparation=preparation,
+        projection=projection,
+        subject=SubjectRef("claim", SUBJECT_ID),
+        resolver_steps=RESOLVER_STEPS,
+    )
+
+
+__all__ = ["SCENARIO", "run_canonical_working_loop_scenario"]

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from tests.domain_scenarios.core import ScenarioDefinition
+from tests.domain_scenarios.canonical_working_loop.scenario import (
+    SCENARIO as CANONICAL_WORKING_LOOP_SCENARIO,
+)
 from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
     SCENARIO as L_ENERGY_PCF_GOVERNANCE_SCENARIO,
 )
@@ -8,7 +11,11 @@ from tests.domain_scenarios.tiny_pcf.scenario import SCENARIO as TINY_PCF_SCENAR
 
 
 def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
-    return (TINY_PCF_SCENARIO, L_ENERGY_PCF_GOVERNANCE_SCENARIO)
+    return (
+        CANONICAL_WORKING_LOOP_SCENARIO,
+        TINY_PCF_SCENARIO,
+        L_ENERGY_PCF_GOVERNANCE_SCENARIO,
+    )
 
 
 __all__ = ["registered_scenarios"]

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -1,0 +1,95 @@
+import pytest
+
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from tests.domain_scenarios.canonical_working_loop.fixtures import (
+    RAW_EVIDENCE,
+    compile_raw_evidence,
+    extract_raw_evidence,
+    open_calculation_obligation,
+)
+from tests.domain_scenarios.canonical_working_loop.scenario import (
+    SCENARIO,
+    run_canonical_working_loop_scenario,
+)
+from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
+
+
+def test_canonical_working_loop_extracts_and_compiles_raw_text():
+    hypothesis = extract_raw_evidence(RAW_EVIDENCE)
+
+    assert hypothesis.subject_id == "product:canonical-raw-pcf-1"
+    assert [(claim.field, claim.value) for claim in hypothesis.claims] == [
+        ("activity", "electricity"),
+        ("electricity_kwh", 1200),
+        ("unit", "kWh"),
+        ("reporting_year", 2024),
+        ("geography", "KR"),
+    ]
+    assert all(witness.grounded for witness in hypothesis.witnesses)
+
+    report = compile_raw_evidence(RAW_EVIDENCE)
+
+    assert report.status == "accepted"
+    assert [claim.field for claim in report.checked_claims] == [
+        "activity",
+        "electricity_kwh",
+        "unit",
+        "reporting_year",
+        "geography",
+    ]
+    assert report.obligations == ()
+    assert report.can_project_public_row is False
+
+
+def test_canonical_working_loop_opens_calculation_obligation_after_compile():
+    report = open_calculation_obligation(compile_raw_evidence(RAW_EVIDENCE))
+
+    assert report.status == "blocked"
+    assert [obligation.kind for obligation in report.obligations] == [
+        "calculation_blocked",
+    ]
+    assert report.obligations[0].reason == "unknown_reference"
+    assert report.derived_claims == ()
+
+
+def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
+    result = run_scenario(SCENARIO)
+
+    assert result.scenario_id == "canonical_working_loop.raw_text_pcf.v1"
+    assert result.resolver_steps == (
+        "raw_text_fixture",
+        "deterministic_extractor_stub",
+        "compiler_tool.compile_interpretation",
+        "open_calculation_obligation",
+        "plan_calculation_resolution",
+        "reference_search:keyword",
+        "deterministic_reference_selection",
+        "retry_calculation",
+        "prepare_commit",
+        "receipt_gated_projection",
+    )
+    assert_scenario_contract(result, SCENARIO.contract)
+    assert result.projection == {
+        "electricity_kwh": 1200,
+        "reporting_year": 2024,
+        "co2e_kg": 504.0,
+    }
+
+
+def test_canonical_working_loop_receipt_rejects_tampered_projection_value():
+    result = run_canonical_working_loop_scenario()
+
+    assert result.preparation.receipt is not None
+    with pytest.raises(ProjectionBlocked, match="value commitment"):
+        project_public_row(
+            {
+                "electricity_kwh": 1200,
+                "reporting_year": 2024,
+                "co2e_kg": 999999,
+            },
+            ProjectionSpec(
+                "canonical-pcf-public-row",
+                ("electricity_kwh", "reporting_year", "co2e_kg"),
+            ),
+            receipt=result.preparation.receipt,
+        )

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -21,12 +21,13 @@ def test_registered_scenarios_are_explicit_scenario_definitions():
     scenarios = registered_scenarios()
 
     assert tuple(scenario.scenario_id for scenario in scenarios) == (
+        "canonical_working_loop.raw_text_pcf.v1",
         "tiny_pcf.location_based_electricity.v1",
         "l_energy_pcf_governance.v1",
     )
     assert all(isinstance(scenario, ScenarioDefinition) for scenario in scenarios)
-    assert scenarios[0].contract.must_commit is True
-    assert scenarios[0].contract.required_projection == EXPECTED_PROJECTION
+    assert scenarios[1].contract.must_commit is True
+    assert scenarios[1].contract.required_projection == EXPECTED_PROJECTION
 
 
 def test_registered_scenarios_run_through_shared_contract_assertions():


### PR DESCRIPTION
## Summary
- Add `canonical_working_loop.raw_text_pcf.v1`, a Domain Scenario Lab pack that starts from raw evidence text.
- Include a deterministic extractor stub that produces an `InterpretationHypothesis`, runs `CompilerTool.compile_interpretation`, opens a calculation obligation, resolves reference search/selection, retries calculation, prepares commit, and projects through the receipt gate.
- Register the scenario ahead of the existing `tiny_pcf` and `l_energy_pcf_governance` packs so it becomes the first contributor-facing harness.
- Document the canonical scenario in the Domain Scenario Lab README.

## Why
The architecture now has receipt value integrity. This PR adds the next missing proof point: one canonical path that shows the whole wheel moving from raw input to receipt-gated public projection without adding LLM, retrieval lens, parser, or production API surface.

## Validation
- `python -m pytest tests/test_canonical_working_loop_scenario.py -q`
- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest tests/test_l_energy_pcf_scenario.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`
