### PR TITLE
[codex] feat: add retrieval lens interface

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -80,6 +80,14 @@ from comp.compiler_tool.resolver_tasks import (
     resolver_task_from_obligation,
     resolver_tasks_from_report,
 )
+from comp.compiler_tool.retrieval import (
+    RETRIEVAL_LENSES,
+    EmbeddingResolverStub,
+    ReferenceIndexEntry,
+    ReferenceQuery,
+    ReferenceResolver,
+    RetrievalLens,
+)
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
@@ -142,6 +150,12 @@ __all__ = [
     "ResolverTask",
     "resolver_task_from_obligation",
     "resolver_tasks_from_report",
+    "RETRIEVAL_LENSES",
+    "RetrievalLens",
+    "ReferenceQuery",
+    "ReferenceIndexEntry",
+    "ReferenceResolver",
+    "EmbeddingResolverStub",
     "RuleFamily",
     "SemanticRubric",
     "JudgePolicy",

--- a/comp/compiler_tool/retrieval.py
+++ b/comp/compiler_tool/retrieval.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from comp.compiler_tool.references import ReferenceCandidate
+
+RetrievalLens = str
+
+RETRIEVAL_LENSES: tuple[str, ...] = (
+    "concept",
+    "metric",
+    "unit",
+    "factor",
+    "formula",
+    "rubric",
+    "rule",
+    "memory_skill",
+)
+
+
+@dataclass(frozen=True)
+class ReferenceQuery:
+    query_id: str
+    text: str
+    lens: RetrievalLens
+    reference_type: str | None = None
+    source_artifact_ids: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _validate_lens(self.lens)
+
+
+@dataclass(frozen=True)
+class ReferenceIndexEntry:
+    entry_id: str
+    reference_id: str
+    reference_type: str
+    lens: RetrievalLens
+    text: str
+    reference_db_version: str
+    index_version: str
+    embedding_model_id: str | None = None
+    source: str | None = None
+    witness_ids: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _validate_lens(self.lens)
+
+
+class ReferenceResolver(Protocol):
+    def search(
+        self,
+        query: ReferenceQuery,
+        *,
+        limit: int = 10,
+    ) -> tuple[ReferenceCandidate, ...]:
+        ...
+
+
+@dataclass(frozen=True)
+class EmbeddingResolverStub:
+    entries: tuple[ReferenceIndexEntry, ...] = field(default_factory=tuple)
+
+    def search(
+        self,
+        query: ReferenceQuery,
+        *,
+        limit: int = 10,
+    ) -> tuple[ReferenceCandidate, ...]:
+        scored: list[tuple[float, ReferenceIndexEntry]] = []
+        for entry in self.entries:
+            if entry.lens != query.lens:
+                continue
+            if query.reference_type is not None and (
+                entry.reference_type != query.reference_type
+            ):
+                continue
+
+            score = _match_score(query.text, entry.text)
+            if score > 0:
+                scored.append((score, entry))
+
+        scored.sort(key=lambda item: (-item[0], item[1].reference_id, item[1].entry_id))
+        return tuple(
+            _candidate_from_entry(query, entry, score)
+            for score, entry in scored[:limit]
+        )
+
+
+def _candidate_from_entry(
+    query: ReferenceQuery,
+    entry: ReferenceIndexEntry,
+    score: float,
+) -> ReferenceCandidate:
+    return ReferenceCandidate(
+        candidate_id=f"embedding_stub:{query.lens}:{entry.entry_id}",
+        reference_id=entry.reference_id,
+        reference_type=entry.reference_type,
+        retrieval_method=f"embedding_stub:{query.lens}",
+        retrieval_score=score,
+        source=entry.source,
+        witness_ids=entry.witness_ids,
+    )
+
+
+def _validate_lens(lens: str) -> None:
+    if lens not in RETRIEVAL_LENSES:
+        raise ValueError(f"unknown retrieval lens: {lens}")
+
+
+def _match_score(query: str, text: str) -> float:
+    query_tokens = set(_tokens(query))
+    if not query_tokens:
+        return 0.0
+
+    entry_tokens = set(_tokens(text))
+    overlap = query_tokens & entry_tokens
+    if not overlap:
+        return 0.0
+    return round(len(overlap) / len(query_tokens), 6)
+
+
+def _tokens(value: str) -> tuple[str, ...]:
+    return tuple(token for token in re.split(r"[^a-z0-9]+", value.lower()) if token)
+
+
+__all__ = [
+    "RETRIEVAL_LENSES",
+    "RetrievalLens",
+    "ReferenceQuery",
+    "ReferenceIndexEntry",
+    "ReferenceResolver",
+    "EmbeddingResolverStub",
+]

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -76,6 +76,10 @@ def test_readme_compiler_tool_import_surface_is_exported():
     from comp.compiler_tool import (
         CompileReport,
         CompilerTool,
+        EmbeddingResolverStub,
+        ReferenceIndexEntry,
+        ReferenceQuery,
+        ReferenceResolver,
         build_commit_receipt,
         compile_report_to_facts,
         prepare_commit,
@@ -88,6 +92,10 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert prepare_commit is not None
     assert build_commit_receipt is not None
     assert compile_report_to_facts is not None
+    assert ReferenceQuery is not None
+    assert ReferenceIndexEntry is not None
+    assert ReferenceResolver is not None
+    assert EmbeddingResolverStub is not None
 
 
 def test_working_theory_status_section_tracks_current_rebuild_state():

--- a/tests/test_retrieval_lens_interface.py
+++ b/tests/test_retrieval_lens_interface.py
@@ -1,0 +1,149 @@
+import pytest
+
+from comp.compiler_tool import (
+    EmbeddingResolverStub,
+    ReferenceCatalog,
+    ReferenceIndexEntry,
+    ReferenceQuery,
+    ReferenceRecord,
+    ReferenceSelectionCriteria,
+    select_reference_binding,
+)
+
+
+def _entries():
+    return (
+        ReferenceIndexEntry(
+            entry_id="idx-factor-kr-grid-2024",
+            reference_id="factor.kr_grid.2024.location_based",
+            reference_type="emission_factor",
+            lens="factor",
+            text="Korea grid electricity factor 2024 location based",
+            reference_db_version="refdb-fixture-v1",
+            index_version="embedding-stub-v1",
+            embedding_model_id="stub-embedding-model",
+            source="factor-catalog",
+            witness_ids=("factor-row-2024",),
+        ),
+        ReferenceIndexEntry(
+            entry_id="idx-rubric-scope2-method",
+            reference_id="rubric.scope2_method_support.v1",
+            reference_type="semantic_rubric",
+            lens="rubric",
+            text="Scope 2 market based method support rubric",
+            reference_db_version="refdb-fixture-v1",
+            index_version="embedding-stub-v1",
+        ),
+    )
+
+
+def test_embedding_resolver_stub_returns_candidate_only_reference_candidates():
+    resolver = EmbeddingResolverStub(entries=_entries())
+
+    candidates = resolver.search(
+        ReferenceQuery(
+            query_id="q-factor",
+            text="Korea electricity factor",
+            lens="factor",
+            reference_type="emission_factor",
+            source_artifact_ids=("obl-reference-search",),
+        )
+    )
+
+    assert [candidate.reference_id for candidate in candidates] == [
+        "factor.kr_grid.2024.location_based"
+    ]
+    assert candidates[0].candidate_id == (
+        "embedding_stub:factor:idx-factor-kr-grid-2024"
+    )
+    assert candidates[0].retrieval_method == "embedding_stub:factor"
+    assert candidates[0].retrieval_score is not None
+    assert candidates[0].authority == "candidate_only"
+    assert candidates[0].can_authorize_calculation is False
+    assert candidates[0].source == "factor-catalog"
+    assert candidates[0].witness_ids == ("factor-row-2024",)
+
+
+def test_retrieval_lens_and_reference_type_filter_candidate_space():
+    resolver = EmbeddingResolverStub(entries=_entries())
+
+    rubric_candidates = resolver.search(
+        ReferenceQuery(
+            query_id="q-rubric",
+            text="market based method support",
+            lens="rubric",
+        )
+    )
+    mismatched_type_candidates = resolver.search(
+        ReferenceQuery(
+            query_id="q-factor-as-rubric",
+            text="Korea electricity factor",
+            lens="factor",
+            reference_type="semantic_rubric",
+        )
+    )
+
+    assert [candidate.reference_id for candidate in rubric_candidates] == [
+        "rubric.scope2_method_support.v1"
+    ]
+    assert mismatched_type_candidates == ()
+
+
+def test_top_ranked_retrieval_candidate_still_requires_deterministic_selection():
+    resolver = EmbeddingResolverStub(
+        entries=(
+            ReferenceIndexEntry(
+                entry_id="idx-factor-kr-grid-2023",
+                reference_id="factor.kr_grid.2023.location_based",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea grid electricity factor 2023 location based",
+                reference_db_version="refdb-fixture-v1",
+                index_version="embedding-stub-v1",
+            ),
+        )
+    )
+    candidates = resolver.search(
+        ReferenceQuery(
+            query_id="q-factor",
+            text="Korea grid electricity factor",
+            lens="factor",
+            reference_type="emission_factor",
+        )
+    )
+    catalog = ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2023.location_based",
+                reference_type="emission_factor",
+                labels=("Korea grid electricity factor 2023",),
+                attributes=(("valid_period", "2023"),),
+            ),
+        )
+    )
+
+    result = select_reference_binding(
+        candidates=candidates,
+        catalog=catalog,
+        criteria=ReferenceSelectionCriteria(
+            binding_id="bind-factor",
+            claim_id="claim-electricity",
+            reference_type="emission_factor",
+            selector_rule_id="pcf.factor_selector.v1",
+            required_attributes=(("valid_period", "2024"),),
+        ),
+    )
+
+    assert candidates[0].can_authorize_calculation is False
+    assert result.status == "no_match"
+    assert result.binding is None
+    assert result.rejected_candidates[0].reason == "attribute_mismatch:valid_period"
+
+
+def test_reference_query_rejects_unknown_lens():
+    with pytest.raises(ValueError, match="unknown retrieval lens"):
+        ReferenceQuery(
+            query_id="q-unknown",
+            text="Korea electricity factor",
+            lens="everything",
+        )


### PR DESCRIPTION
## Summary
- Add `ReferenceQuery`, `ReferenceIndexEntry`, `ReferenceResolver`, and `EmbeddingResolverStub` to the compiler tool surface.
- Model retrieval lenses for concept, metric, unit, factor, formula, rubric, rule, and memory/skill candidate spaces.
- Keep embedding retrieval as candidate-only: the stub returns `ReferenceCandidate` artifacts with `authority='candidate_only'` and no calculation authority.
- Add tests proving lens/reference-type filtering and that top-ranked retrieval candidates still require deterministic selection before binding.

## Why
The canonical working loop now shows where reference search belongs. This PR adds the next narrow interface slice for obligation-indexed retrieval without introducing a real vector DB, embedding dependency, LLM call, or automatic binding behavior.

## Validation
- `python -m pytest tests/test_retrieval_lens_interface.py tests/test_reference_search_resolution.py tests/test_reference_grounded_calculation_flow.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`
