### PR TITLE
[codex] feat: add retrieval resolver bridge

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -88,6 +88,10 @@ from comp.compiler_tool.retrieval import (
     ReferenceResolver,
     RetrievalLens,
 )
+from comp.compiler_tool.retrieval_resolution import (
+    ReferenceRetrievalQuery,
+    resolve_reference_retrieval_obligations,
+)
 from comp.compiler_tool.semantic import apply_semantic_judgments
 from comp.compiler_tool.tool import CompilerTool
 from comp.compiler_tool.judgment_adapter import (
@@ -156,6 +160,8 @@ __all__ = [
     "ReferenceIndexEntry",
     "ReferenceResolver",
     "EmbeddingResolverStub",
+    "ReferenceRetrievalQuery",
+    "resolve_reference_retrieval_obligations",
     "RuleFamily",
     "SemanticRubric",
     "JudgePolicy",

--- a/comp/compiler_tool/retrieval_resolution.py
+++ b/comp/compiler_tool/retrieval_resolution.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+
+from comp.compiler_tool.models import CompileReport, ProofObligation
+from comp.compiler_tool.references import ReferenceCandidate
+from comp.compiler_tool.retrieval import ReferenceQuery, ReferenceResolver
+
+ReferenceRetrievalQuery = Callable[[ProofObligation], ReferenceQuery | None]
+
+
+def resolve_reference_retrieval_obligations(
+    report: CompileReport,
+    resolver: ReferenceResolver,
+    *,
+    query_for_obligation: ReferenceRetrievalQuery,
+    limit: int = 10,
+) -> CompileReport:
+    obligations: list[ProofObligation] = []
+    candidates = report.reference_candidates
+    resolved_obligations = report.resolved_obligations
+    changed = False
+
+    for obligation in report.obligations:
+        if not _is_reference_search_obligation(obligation):
+            obligations.append(obligation)
+            continue
+
+        query = query_for_obligation(obligation)
+        if query is None:
+            obligations.append(obligation)
+            continue
+
+        found = resolver.search(query, limit=limit)
+        if not found:
+            obligations.append(obligation)
+            continue
+
+        candidates = _append_unique_candidates(candidates, found)
+        resolved_obligations = _append_unique_obligations(
+            resolved_obligations,
+            (obligation,),
+        )
+        changed = True
+
+    if not changed:
+        return report
+
+    return replace(
+        report,
+        obligations=tuple(obligations),
+        resolved_obligations=resolved_obligations,
+        reference_candidates=candidates,
+        can_project_public_row=False,
+    )
+
+
+def _is_reference_search_obligation(obligation: ProofObligation) -> bool:
+    return (
+        obligation.kind == "reference_search_required"
+        and obligation.calculation_requirement is not None
+    )
+
+
+def _append_unique_candidates(
+    existing: tuple[ReferenceCandidate, ...],
+    additions: tuple[ReferenceCandidate, ...],
+) -> tuple[ReferenceCandidate, ...]:
+    result = existing
+    for candidate in additions:
+        if candidate not in result:
+            result = (*result, candidate)
+    return result
+
+
+def _append_unique_obligations(
+    existing: tuple[ProofObligation, ...],
+    additions: tuple[ProofObligation, ...],
+) -> tuple[ProofObligation, ...]:
+    result = existing
+    for obligation in additions:
+        if obligation not in result:
+            result = (*result, obligation)
+    return result
+
+
+__all__ = [
+    "ReferenceRetrievalQuery",
+    "resolve_reference_retrieval_obligations",
+]

--- a/docs/architecture/obligation-kernel-working-theory.md
+++ b/docs/architecture/obligation-kernel-working-theory.md
@@ -923,9 +923,10 @@ domain scenarios
 
 ---
 
-## 14. Next Implementation Slice
+## 14. Retrieval Implementation Slice
 
-Recommended next implementation direction:
+The retrieval north star should enter the codebase in small slices. The first
+slice is:
 
 ```text
 feat: add retrieval lens interface and embedding resolver stub
@@ -965,7 +966,37 @@ Retrieval lens interface can return candidate_only artifacts.
 EmbeddingResolverStub can produce deterministic candidates for tests.
 Retrieval score is never enough to create ReferenceBinding.
 Top-1 retrieval cannot authorize calculation.
-Obligation-indexed retrieval can feed the existing reference search / selection loop.
+No vector DB dependency is introduced.
+No real LLM call is introduced.
+```
+
+The bridge slice is:
+
+```text
+feat: add retrieval resolver bridge
+```
+
+Purpose:
+
+```text
+Connect reference_search_required obligations to ReferenceResolver.search.
+Add candidate_only ReferenceCandidate artifacts to CompileReport.
+Resolve only the search obligation, not calculation or publication authority.
+Leave ReferenceBinding to deterministic reference selection.
+Leave DerivedClaim to deterministic calculation retry.
+```
+
+Acceptance criteria:
+
+```text
+ProofObligation(reference_search_required)
+-> ReferenceQuery
+-> ReferenceResolver.search(...)
+-> CompileReport.reference_candidates
+
+No ReferenceBinding is created by retrieval.
+No DerivedClaim is created by retrieval.
+No public projection authority is created by retrieval.
 No vector DB dependency is introduced.
 No real LLM call is introduced.
 ```

--- a/docs/architecture/retrieval-fabric-north-star.md
+++ b/docs/architecture/retrieval-fabric-north-star.md
@@ -437,11 +437,11 @@ cited_by_receipt
 ```
 
 This is useful for audit and debugging, but it should not be implemented before
-the retrieval lens contract exists.
+the candidate-only retrieval path is stable.
 
-## Next Implementation Slice
+## Near-Term Implementation Slices
 
-The next code PR should be small:
+The first code slice should stay small:
 
 ```text
 feat: add retrieval lens interface and embedding resolver stub
@@ -458,7 +458,36 @@ EmbeddingResolverStub
 candidate-only invariant tests
 ```
 
-It should not add:
+The bridge slice is also intentionally narrow:
+
+```text
+feat: add retrieval resolver bridge
+```
+
+It connects an open retrieval obligation to the resolver interface without
+creating authority:
+
+```text
+ProofObligation(kind="reference_search_required")
+-> ReferenceQuery
+-> ReferenceResolver.search(...)
+-> ReferenceCandidate[]
+-> CompileReport.reference_candidates
+```
+
+The bridge may discharge the search obligation, but it must not create:
+
+```text
+ReferenceBinding
+DerivedClaim
+GovernanceDecision
+CommitReceipt
+PublicProjection
+```
+
+Those remain separate deterministic gates.
+
+These slices should not add:
 
 ```text
 real embedding providers

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,9 @@ semantic
   SemanticJudgment protocol validation
 
 reference
+  ReferenceQuery
+  ReferenceResolver / EmbeddingResolverStub
+  reference_search_required -> candidate-only ReferenceCandidate
   ReferenceCandidate
   ReferenceBinding
   deterministic reference selection

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -80,6 +80,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
         ReferenceIndexEntry,
         ReferenceQuery,
         ReferenceResolver,
+        resolve_reference_retrieval_obligations,
         build_commit_receipt,
         compile_report_to_facts,
         prepare_commit,
@@ -96,6 +97,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert ReferenceIndexEntry is not None
     assert ReferenceResolver is not None
     assert EmbeddingResolverStub is not None
+    assert resolve_reference_retrieval_obligations is not None
 
 
 def test_working_theory_status_section_tracks_current_rebuild_state():
@@ -110,6 +112,8 @@ def test_working_theory_status_section_tracks_current_rebuild_state():
     assert "Domain Scenario Lab" in working_theory
     assert "Retrieval lens interface" in working_theory
     assert "EmbeddingResolverStub" in working_theory
+    assert "retrieval resolver bridge" in working_theory
+    assert "resolve only the search obligation" in working_theory.lower()
     assert "PR8: Core / Domain Boundary Working Theory" not in working_theory
     assert "PR9: SemanticJudgmentObligation Minimal Slice" not in working_theory
 

--- a/tests/test_retrieval_resolution.py
+++ b/tests/test_retrieval_resolution.py
@@ -1,0 +1,217 @@
+from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
+    CompileReport,
+    EmbeddingResolverStub,
+    ReferenceBinding,
+    ReferenceCatalog,
+    ReferenceIndexEntry,
+    ReferenceQuery,
+    ReferenceRecord,
+    ReferenceSelectionCriteria,
+    apply_calculation_result,
+    apply_reference_selection,
+    calculate_derived_claim,
+    plan_calculation_resolution,
+    resolve_reference_retrieval_obligations,
+    retry_blocked_calculation,
+)
+
+
+def _formula():
+    return CalculationFormula(
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_field="co2e_emission",
+        output_unit="tCO2e",
+    )
+
+
+def _input():
+    return CalculationInput(
+        claim_id="hyp-1:amount",
+        field="amount",
+        value=1200,
+        unit="kWh",
+    )
+
+
+def _missing_binding():
+    return ReferenceBinding(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_id="factor.missing",
+        reference_type="emission_factor",
+    )
+
+
+def _catalog():
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                labels=("KR grid electricity factor 2024",),
+                attributes=(
+                    ("concept_id", "concept.electricity_consumption"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "location_based"),
+                    ("factor_value", 0.0004),
+                    ("input_unit", "kWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="factor-catalog",
+                witness_ids=("factor-row-2024",),
+            ),
+        )
+    )
+
+
+def _resolver():
+    return EmbeddingResolverStub(
+        entries=(
+            ReferenceIndexEntry(
+                entry_id="idx-factor-kr-grid-2024",
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea grid electricity factor 2024 location based",
+                reference_db_version="refdb-fixture-v1",
+                index_version="embedding-stub-v1",
+                source="factor-catalog",
+                witness_ids=("factor-row-2024",),
+            ),
+        )
+    )
+
+
+def _criteria():
+    return ReferenceSelectionCriteria(
+        binding_id="bind-amount-factor",
+        claim_id="hyp-1:amount",
+        reference_type="emission_factor",
+        selector_rule_id="ghg.factor_selector.v1",
+        required_attributes=(
+            ("concept_id", "concept.electricity_consumption"),
+            ("geography", "KR"),
+            ("valid_period", "2024"),
+            ("method", "location_based"),
+        ),
+    )
+
+
+def _planned_unknown_reference_report():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(),
+        reference_binding=_missing_binding(),
+        catalog=ReferenceCatalog(records=()),
+        formula=_formula(),
+    )
+    blocked = apply_calculation_result(
+        CompileReport(status="accepted"),
+        result,
+        output_claim_id="hyp-1:co2e_emission",
+        formula=_formula(),
+    )
+    return plan_calculation_resolution(blocked)
+
+
+def _query_for_obligation(obligation):
+    return ReferenceQuery(
+        query_id=f"query:{obligation.obligation_id}",
+        text="Korea grid electricity factor",
+        lens="factor",
+        reference_type="emission_factor",
+        source_artifact_ids=(obligation.obligation_id or "reference_search_required",),
+    )
+
+
+def test_retrieval_resolution_adds_candidate_only_candidates_and_resolves_search_obligation():
+    planned = _planned_unknown_reference_report()
+
+    resolved = resolve_reference_retrieval_obligations(
+        planned,
+        _resolver(),
+        query_for_obligation=_query_for_obligation,
+    )
+
+    assert resolved.status == "blocked"
+    assert resolved.can_project_public_row is False
+    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+        "factor.kr_grid.2024.location_based"
+    ]
+    assert resolved.reference_candidates[0].retrieval_method == "embedding_stub:factor"
+    assert resolved.reference_candidates[0].authority == "candidate_only"
+    assert resolved.reference_candidates[0].can_authorize_calculation is False
+    assert resolved.reference_candidates[0].source == "factor-catalog"
+    assert resolved.reference_candidates[0].witness_ids == ("factor-row-2024",)
+    assert [obligation.kind for obligation in resolved.obligations] == [
+        "calculation_blocked"
+    ]
+    assert [obligation.kind for obligation in resolved.resolved_obligations] == [
+        "reference_search_required"
+    ]
+    assert resolved.reference_bindings == ()
+    assert resolved.derived_claims == ()
+
+
+def test_retrieval_resolution_leaves_followup_open_without_query():
+    planned = _planned_unknown_reference_report()
+
+    resolved = resolve_reference_retrieval_obligations(
+        planned,
+        _resolver(),
+        query_for_obligation=lambda obligation: None,
+    )
+
+    assert resolved == planned
+
+
+def test_retrieval_resolution_leaves_followup_open_without_candidates():
+    planned = _planned_unknown_reference_report()
+
+    resolved = resolve_reference_retrieval_obligations(
+        planned,
+        _resolver(),
+        query_for_obligation=lambda obligation: ReferenceQuery(
+            query_id="q-diesel",
+            text="diesel combustion",
+            lens="factor",
+            reference_type="emission_factor",
+        ),
+    )
+
+    assert resolved == planned
+
+
+def test_retrieval_resolution_candidates_can_continue_through_selection_and_retry():
+    resolved = resolve_reference_retrieval_obligations(
+        _planned_unknown_reference_report(),
+        _resolver(),
+        query_for_obligation=_query_for_obligation,
+    )
+
+    selected = apply_reference_selection(
+        resolved,
+        _catalog(),
+        criteria=_criteria(),
+        field="co2e_emission",
+    )
+    retried = retry_blocked_calculation(
+        selected,
+        _catalog(),
+        input_claim=_input(),
+        reference_binding=selected.reference_bindings[0],
+        formula=_formula(),
+        output_claim_id="hyp-1:co2e_emission",
+    )
+
+    assert [binding.reference_id for binding in selected.reference_bindings] == [
+        "factor.kr_grid.2024.location_based"
+    ]
+    assert selected.derived_claims == ()
+    assert retried.status == "accepted"
+    assert retried.obligations == ()
+    assert retried.derived_claims[0].value == 0.48
+    assert retried.can_project_public_row is False


### PR DESCRIPTION
## Summary

- Add a `resolve_reference_retrieval_obligations` bridge from `reference_search_required` obligations to the `ReferenceResolver` / `ReferenceQuery` retrieval interface.
- Keep retrieval strictly candidate-only: the bridge appends `ReferenceCandidate` artifacts and resolves only the search obligation.
- Update architecture docs to place the bridge after the retrieval lens interface and before deterministic selection/calculation authority.

## Authority Boundary

Retrieval can now feed the existing reference selection loop, but it does not create `ReferenceBinding`, `DerivedClaim`, `GovernanceDecision`, `CommitReceipt`, or public projection authority.

## Validation

- `python -m pytest tests/test_retrieval_resolution.py tests/test_retrieval_lens_interface.py -q`
- `python -m pytest tests/test_reference_search_resolution.py tests/test_reference_grounded_calculation_flow.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q` (`209 passed`)
- `git diff --check`