### PR TITLE
[codex] add artifact envelope digest

### DIFF
--- a/comp/persistence/__init__.py
+++ b/comp/persistence/__init__.py
@@ -1,0 +1,9 @@
+"""Persistence boundary primitives for replayable artifact records."""
+
+from comp.persistence.digest import artifact_digest
+from comp.persistence.envelope import ArtifactEnvelope
+
+__all__ = [
+    "ArtifactEnvelope",
+    "artifact_digest",
+]

--- a/comp/persistence/digest.py
+++ b/comp/persistence/digest.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from typing import Any
+
+
+def artifact_digest(
+    *,
+    artifact_kind: str,
+    schema_version: str,
+    body: Mapping[str, Any],
+) -> str:
+    _require_non_empty("artifact_kind", artifact_kind)
+    _require_non_empty("schema_version", schema_version)
+    canonical = json.dumps(
+        {
+            "artifact_kind": artifact_kind,
+            "schema_version": schema_version,
+            "body": _canonical_value(body),
+        },
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _canonical_value(value: Any) -> Any:
+    if value is None:
+        return {"type": "none", "value": None}
+    if isinstance(value, bool):
+        return {"type": "bool", "value": value}
+    if isinstance(value, int):
+        return {"type": "int", "value": str(value)}
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Artifact digest requires a finite float.")
+        return {"type": "float", "value": repr(value)}
+    if isinstance(value, str):
+        return {"type": "str", "value": value}
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError("Artifact digest requires a finite decimal.")
+        return {"type": "decimal", "value": str(value)}
+    if isinstance(value, Mapping):
+        return {
+            "type": "mapping",
+            "value": tuple(
+                (key, _canonical_value(item))
+                for key, item in sorted(
+                    _string_key_items(value),
+                    key=lambda pair: pair[0],
+                )
+            ),
+        }
+    if isinstance(value, tuple):
+        return {
+            "type": "tuple",
+            "value": tuple(_canonical_value(item) for item in value),
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return {
+            "type": "sequence",
+            "value": tuple(_canonical_value(item) for item in value),
+        }
+    raise TypeError(f"Unsupported artifact digest value: {type(value).__name__}")
+
+
+def _string_key_items(value: Mapping[Any, Any]) -> tuple[tuple[str, Any], ...]:
+    items: list[tuple[str, Any]] = []
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise TypeError("Artifact digest mappings require string keys.")
+        items.append((key, item))
+    return tuple(items)
+
+
+def _require_non_empty(field: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{field} is required.")
+
+
+__all__ = ["artifact_digest"]

--- a/comp/persistence/envelope.py
+++ b/comp/persistence/envelope.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from comp.persistence.digest import artifact_digest
+
+
+@dataclass(frozen=True)
+class ArtifactEnvelope:
+    artifact_id: str
+    artifact_kind: str
+    schema_version: str
+    body_digest: str
+    body: Mapping[str, Any]
+    source_refs: tuple[str, ...] = field(default_factory=tuple)
+    meta: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("artifact_id", self.artifact_id)
+        _require_non_empty("artifact_kind", self.artifact_kind)
+        _require_non_empty("schema_version", self.schema_version)
+
+    @classmethod
+    def from_body(
+        cls,
+        *,
+        artifact_id: str,
+        artifact_kind: str,
+        schema_version: str,
+        body: Mapping[str, Any],
+        source_refs: tuple[str, ...] = (),
+        meta: tuple[tuple[str, Any], ...] = (),
+    ) -> "ArtifactEnvelope":
+        return cls(
+            artifact_id=artifact_id,
+            artifact_kind=artifact_kind,
+            schema_version=schema_version,
+            body_digest=artifact_digest(
+                artifact_kind=artifact_kind,
+                schema_version=schema_version,
+                body=body,
+            ),
+            body=body,
+            source_refs=tuple(source_refs),
+            meta=tuple(meta),
+        )
+
+
+def _require_non_empty(field: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{field} is required.")
+
+
+__all__ = ["ArtifactEnvelope"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
   "comp",
   "comp.compiler_tool",
   "comp.judgment",
+  "comp.persistence",
   "minchoagnt",
 ]
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -134,6 +134,7 @@ def test_domain_scenario_generation_guide_tracks_swappable_pack_contract():
 
 def test_pyproject_packages_comp_core_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    from comp.persistence import ArtifactEnvelope, artifact_digest
 
     assert pyproject["project"]["description"] == (
         "Receipt-gated proof package compiler for obligation, reference, "
@@ -145,6 +146,7 @@ def test_pyproject_packages_comp_core_and_agent_layer():
         "comp",
         "comp.compiler_tool",
         "comp.judgment",
+        "comp.persistence",
         "minchoagnt",
     ]
     assert "py-modules" not in setuptools_config
@@ -154,6 +156,8 @@ def test_pyproject_packages_comp_core_and_agent_layer():
 
     dependencies = pyproject["project"].get("dependencies", [])
     assert not any(dependency.startswith("lark") for dependency in dependencies)
+    assert ArtifactEnvelope is not None
+    assert artifact_digest is not None
 
 
 def test_legacy_pipeline_sources_are_not_active_files():

--- a/tests/test_persistence_envelope.py
+++ b/tests/test_persistence_envelope.py
@@ -1,0 +1,140 @@
+from decimal import Decimal
+
+import pytest
+
+from comp.persistence import ArtifactEnvelope, artifact_digest
+
+
+def test_artifact_envelope_body_digest_is_stable_for_canonical_body():
+    first = ArtifactEnvelope.from_body(
+        artifact_id="artifact:claim:1",
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={
+            "field": "electricity_kwh",
+            "value": 1200,
+            "meta": {"unit": "kWh", "source": "span-1"},
+        },
+    )
+    second = ArtifactEnvelope.from_body(
+        artifact_id="artifact:claim:1",
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={
+            "meta": {"source": "span-1", "unit": "kWh"},
+            "value": 1200,
+            "field": "electricity_kwh",
+        },
+    )
+
+    assert first.body_digest == second.body_digest
+    assert first.body_digest.startswith("sha256:")
+
+
+def test_artifact_digest_changes_when_body_kind_or_schema_changes():
+    base = artifact_digest(
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={"field": "electricity_kwh", "value": 1200},
+    )
+
+    assert artifact_digest(
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={"field": "electricity_kwh", "value": 1201},
+    ) != base
+    assert artifact_digest(
+        artifact_kind="derived_claim",
+        schema_version="v1",
+        body={"field": "electricity_kwh", "value": 1200},
+    ) != base
+    assert artifact_digest(
+        artifact_kind="checked_claim",
+        schema_version="v2",
+        body={"field": "electricity_kwh", "value": 1200},
+    ) != base
+
+
+def test_artifact_envelope_metadata_is_outside_body_digest():
+    first = ArtifactEnvelope.from_body(
+        artifact_id="artifact:claim:1",
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={"field": "electricity_kwh", "value": 1200},
+        source_refs=("span-1",),
+        meta=(("stored_at", "2026-05-20T00:00:00Z"),),
+    )
+    second = ArtifactEnvelope.from_body(
+        artifact_id="artifact:claim:1",
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={"field": "electricity_kwh", "value": 1200},
+        source_refs=("span-2",),
+        meta=(("stored_at", "2026-05-21T00:00:00Z"),),
+    )
+
+    assert first.body_digest == second.body_digest
+    assert first.source_refs != second.source_refs
+    assert first.meta != second.meta
+
+
+def test_artifact_digest_preserves_scalar_types():
+    digests = {
+        artifact_digest(
+            artifact_kind="projection_value",
+            schema_version="v1",
+            body={"value": value},
+        )
+        for value in (1200, 1200.0, "1200", Decimal("1200.0"), True)
+    }
+
+    assert len(digests) == 5
+
+
+def test_artifact_digest_rejects_non_finite_numbers_and_non_string_keys():
+    with pytest.raises(ValueError, match="finite float"):
+        artifact_digest(
+            artifact_kind="projection_value",
+            schema_version="v1",
+            body={"value": float("nan")},
+        )
+
+    with pytest.raises(ValueError, match="finite decimal"):
+        artifact_digest(
+            artifact_kind="projection_value",
+            schema_version="v1",
+            body={"value": Decimal("NaN")},
+        )
+
+    with pytest.raises(TypeError, match="string keys"):
+        artifact_digest(
+            artifact_kind="projection_value",
+            schema_version="v1",
+            body={1: "numeric key"},
+        )
+
+
+def test_artifact_envelope_requires_stable_identity_fields():
+    with pytest.raises(ValueError, match="artifact_id"):
+        ArtifactEnvelope.from_body(
+            artifact_id="",
+            artifact_kind="checked_claim",
+            schema_version="v1",
+            body={"field": "electricity_kwh"},
+        )
+
+    with pytest.raises(ValueError, match="artifact_kind"):
+        ArtifactEnvelope.from_body(
+            artifact_id="artifact:claim:1",
+            artifact_kind="",
+            schema_version="v1",
+            body={"field": "electricity_kwh"},
+        )
+
+    with pytest.raises(ValueError, match="schema_version"):
+        ArtifactEnvelope.from_body(
+            artifact_id="artifact:claim:1",
+            artifact_kind="checked_claim",
+            schema_version="",
+            body={"field": "electricity_kwh"},
+        )


### PR DESCRIPTION
## Summary

This PR adds the first persistence primitive from the persistence ledger boundary: a stable artifact envelope with canonical body digests.

## Changes

- Add `comp.persistence` package.
- Add `artifact_digest(...)` for type-preserving canonical JSON body digests.
- Add `ArtifactEnvelope.from_body(...)` so persisted artifacts can carry a stable `body_digest` while keeping `source_refs` and `meta` outside the digest.
- Package `comp.persistence` in `pyproject.toml`.
- Add focused tests for digest stability, body/kind/schema changes, metadata exclusion, scalar type preservation, invalid values, and required identity fields.

## Why

The persistence ledger boundary defines artifact envelopes as the replay substrate. This PR implements only that narrow base layer before adding ledger storage, replay, or profile/reference fingerprints.

## Validation

- `python -m pytest tests\test_persistence_envelope.py tests\test_package_smoke.py -q` -> `14 passed in 0.24s`
- `python -m pytest -q` -> `215 passed in 4.97s`
- `git diff --check` -> exit 0; only CRLF conversion warnings from Git on Windows