### PR TITLE
[codex] test: route canonical loop through retrieval bridge

### DIFF
--- a/docs/architecture/retrieval-fabric-north-star.md
+++ b/docs/architecture/retrieval-fabric-north-star.md
@@ -487,6 +487,23 @@ PublicProjection
 
 Those remain separate deterministic gates.
 
+Once the bridge exists, the canonical raw-input scenario should use it as the
+standard path:
+
+```text
+raw evidence
+-> deterministic extractor stub
+-> CompilerTool
+-> calculation_blocked
+-> reference_search_required
+-> retrieval bridge
+-> candidate-only ReferenceCandidate
+-> deterministic ReferenceBinding
+-> calculation retry
+-> CommitReceipt
+-> receipt-gated projection
+```
+
 These slices should not add:
 
 ```text

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -25,8 +25,10 @@ expected receipt/projection
 Start with `canonical_working_loop`, the raw-input harness for new contributors.
 It begins with a raw evidence sentence, uses a deterministic extractor stub,
 passes through `CompilerTool`, opens a calculation obligation, resolves a
-reference candidate into a canonical binding, calculates a derived claim, mints
-a commit receipt, and projects only through the receipt gate.
+reference search obligation through the retrieval bridge, turns candidate-only
+retrieval results into a canonical binding through deterministic selection,
+calculates a derived claim, mints a commit receipt, and projects only through
+the receipt gate.
 
 The smaller scenario `tiny_pcf` is a product-carbon-footprint slice that exercises
 reference search, near-miss rejection, canonical binding, calculation trace,

--- a/tests/domain_scenarios/canonical_working_loop/fixtures.py
+++ b/tests/domain_scenarios/canonical_working_loop/fixtures.py
@@ -9,9 +9,12 @@ from comp.compiler_tool import (
     CompileReport,
     CompilerTool,
     EvidenceWitness,
+    EmbeddingResolverStub,
     InterpretationHypothesis,
     ReferenceBinding,
     ReferenceCatalog,
+    ReferenceIndexEntry,
+    ReferenceQuery,
     ReferenceRecord,
     ReferenceSelectionCriteria,
     apply_calculation_result,
@@ -170,6 +173,47 @@ def catalog() -> ReferenceCatalog:
     )
 
 
+def reference_resolver() -> EmbeddingResolverStub:
+    return EmbeddingResolverStub(
+        entries=(
+            ReferenceIndexEntry(
+                entry_id="idx-canonical-kr-grid-2024",
+                reference_id="pcf.factor.kr_grid_2024.location_based",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea grid electricity factor 2024 location based",
+                reference_db_version="pcf-reference-catalog-v1",
+                index_version="canonical-embedding-stub-v1",
+                source="pcf-reference-catalog",
+                witness_ids=("factor-row-kr-grid-2024",),
+            ),
+            ReferenceIndexEntry(
+                entry_id="idx-canonical-kr-grid-2023",
+                reference_id="pcf.factor.kr_grid_2023.location_based",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea grid electricity factor 2023 location based",
+                reference_db_version="pcf-reference-catalog-v1",
+                index_version="canonical-embedding-stub-v1",
+                source="pcf-reference-catalog",
+                witness_ids=("factor-row-kr-grid-2023",),
+            ),
+        )
+    )
+
+
+def reference_query_for_obligation(obligation) -> ReferenceQuery | None:
+    if obligation.kind != "reference_search_required":
+        return None
+    return ReferenceQuery(
+        query_id=f"canonical-reference-query:{obligation.obligation_id}",
+        text="Korea grid electricity factor 2024",
+        lens="factor",
+        reference_type="emission_factor",
+        source_artifact_ids=(obligation.obligation_id or "reference_search_required",),
+    )
+
+
 def criteria() -> ReferenceSelectionCriteria:
     return ReferenceSelectionCriteria(
         binding_id="bind-canonical-electricity-factor",
@@ -233,4 +277,6 @@ __all__ = [
     "input_claim_from_report",
     "open_calculation_obligation",
     "projection_source",
+    "reference_query_for_obligation",
+    "reference_resolver",
 ]

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
 from comp import ProjectionSpec, SubjectRef, project_public_row
-from comp.compiler_tool import prepare_commit, resolve_reference_grounded_calculation
+from comp.compiler_tool import (
+    ReferenceBinding,
+    apply_reference_selection,
+    plan_calculation_resolution,
+    prepare_commit,
+    resolve_reference_retrieval_obligations,
+    retry_blocked_calculation,
+)
 from tests.domain_scenarios.canonical_working_loop.expected import (
     EXPECTED_PROJECTION,
     EXPECTED_REFERENCE_CANDIDATE_IDS,
@@ -21,6 +28,8 @@ from tests.domain_scenarios.canonical_working_loop.fixtures import (
     input_claim_from_report,
     open_calculation_obligation,
     projection_source,
+    reference_query_for_obligation,
+    reference_resolver,
 )
 from tests.domain_scenarios.core import (
     DomainScenarioResult,
@@ -37,7 +46,7 @@ RESOLVER_STEPS = (
     "compiler_tool.compile_interpretation",
     "open_calculation_obligation",
     "plan_calculation_resolution",
-    "reference_search:keyword",
+    "reference_retrieval:embedding_stub:factor",
     "deterministic_reference_selection",
     "retry_calculation",
     "prepare_commit",
@@ -73,19 +82,32 @@ SCENARIO = ScenarioDefinition(
 def run_canonical_working_loop_scenario() -> DomainScenarioResult:
     compiled_report = compile_raw_evidence(RAW_EVIDENCE)
     blocked_report = open_calculation_obligation(compiled_report)
-    resolved_report = resolve_reference_grounded_calculation(
-        blocked_report,
-        catalog(),
-        query_for_obligation=lambda obligation: (
-            "Korea grid electricity factor 2024"
-            if obligation.kind == "reference_search_required"
-            else None
-        ),
-        criteria=criteria(),
-        input_claim=input_claim_from_report(compiled_report),
-        formula=formula(),
-        output_claim_id=OUTPUT_CLAIM_ID,
+    planned_report = plan_calculation_resolution(blocked_report)
+    retrieval_report = resolve_reference_retrieval_obligations(
+        planned_report,
+        reference_resolver(),
+        query_for_obligation=reference_query_for_obligation,
     )
+    selected_report = apply_reference_selection(
+        retrieval_report,
+        catalog(),
+        criteria=criteria(),
+        field=formula().output_field,
+    )
+    binding = _binding_for(
+        selected_report.reference_bindings,
+        "bind-canonical-electricity-factor",
+    )
+    resolved_report = selected_report
+    if binding is not None:
+        resolved_report = retry_blocked_calculation(
+            selected_report,
+            catalog(),
+            input_claim=input_claim_from_report(compiled_report),
+            reference_binding=binding,
+            formula=formula(),
+            output_claim_id=OUTPUT_CLAIM_ID,
+        )
     preparation = prepare_commit(
         resolved_report,
         subject_id=SUBJECT_ID,
@@ -112,6 +134,16 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         subject=SubjectRef("claim", SUBJECT_ID),
         resolver_steps=RESOLVER_STEPS,
     )
+
+
+def _binding_for(
+    bindings: tuple[ReferenceBinding, ...],
+    binding_id: str,
+) -> ReferenceBinding | None:
+    for binding in reversed(bindings):
+        if binding.binding_id == binding_id:
+            return binding
+    return None
 
 
 __all__ = ["SCENARIO", "run_canonical_working_loop_scenario"]

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -62,13 +62,22 @@ def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
         "compiler_tool.compile_interpretation",
         "open_calculation_obligation",
         "plan_calculation_resolution",
-        "reference_search:keyword",
+        "reference_retrieval:embedding_stub:factor",
         "deterministic_reference_selection",
         "retry_calculation",
         "prepare_commit",
         "receipt_gated_projection",
     )
     assert_scenario_contract(result, SCENARIO.contract)
+    assert [
+        candidate.retrieval_method for candidate in result.report.reference_candidates
+    ] == [
+        "embedding_stub:factor",
+        "embedding_stub:factor",
+    ]
+    assert result.report.reference_bindings[0].selected_candidate_id == (
+        "embedding_stub:factor:idx-canonical-kr-grid-2024"
+    )
     assert result.projection == {
         "electricity_kwh": 1200,
         "reporting_year": 2024,


### PR DESCRIPTION
## Summary

- Route the `canonical_working_loop` Domain Scenario Lab path through `resolve_reference_retrieval_obligations` instead of keyword catalog search.
- Add canonical `ReferenceIndexEntry` fixtures and an `EmbeddingResolverStub` query builder so the scenario demonstrates `ReferenceQuery -> ReferenceResolver -> candidate_only ReferenceCandidate -> deterministic ReferenceBinding`.
- Update the canonical scenario assertions and docs to make retrieval bridge the standard raw-input path before selection, calculation retry, receipt, and projection.

## Authority Boundary

The canonical scenario now proves retrieval only adds `candidate_only` reference candidates. The deterministic selector still creates the `ReferenceBinding`, retry still creates the `DerivedClaim`, and projection still requires a `CommitReceipt`.

## Validation

- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest tests/test_retrieval_resolution.py tests/test_retrieval_lens_interface.py -q`
- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_domain_scenario_lab.py tests/test_retrieval_resolution.py tests/test_retrieval_lens_interface.py -q` (`19 passed`)
- `python -m pytest -q` (`209 passed`)
- `git diff --check HEAD~1..HEAD`