### PR TITLE
[codex] add in-memory persistence ledger

### DIFF
--- a/comp/persistence/__init__.py
+++ b/comp/persistence/__init__.py
@@ -2,8 +2,28 @@
 
 from comp.persistence.digest import artifact_digest
 from comp.persistence.envelope import ArtifactEnvelope
+from comp.persistence.ledger import (
+    ArtifactConflict,
+    ArtifactIntegrityError,
+    InMemoryArtifactStore,
+    InMemoryReceiptLedger,
+    PersistenceError,
+    ProjectionReplayBlocked,
+    ReceiptConflict,
+    ReceiptLedgerKey,
+    verify_materialized_public_projection,
+)
 
 __all__ = [
+    "ArtifactConflict",
     "ArtifactEnvelope",
+    "ArtifactIntegrityError",
+    "InMemoryArtifactStore",
+    "InMemoryReceiptLedger",
+    "PersistenceError",
+    "ProjectionReplayBlocked",
+    "ReceiptConflict",
+    "ReceiptLedgerKey",
     "artifact_digest",
+    "verify_materialized_public_projection",
 ]

--- a/comp/persistence/ledger.py
+++ b/comp/persistence/ledger.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from comp.judgment import (
+    CommitReceipt,
+    ProjectionBlocked,
+    ProjectionSpec,
+    project_public_row,
+)
+from comp.persistence.digest import artifact_digest
+from comp.persistence.envelope import ArtifactEnvelope
+
+
+class PersistenceError(RuntimeError):
+    """Base error for persistence boundary violations."""
+
+
+class ArtifactIntegrityError(PersistenceError):
+    """Raised when an artifact envelope digest does not match its body."""
+
+
+class ArtifactConflict(PersistenceError):
+    """Raised when an artifact id is recorded with conflicting content."""
+
+
+class ReceiptConflict(PersistenceError):
+    """Raised when a ledger receipt root is recorded with conflicting content."""
+
+
+class ProjectionReplayBlocked(PersistenceError):
+    """Raised when a materialized projection cannot be replayed from a receipt."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptLedgerKey:
+    public_row_id: str
+    projection_id: str
+    draft_id: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty("public_row_id", self.public_row_id)
+        _require_non_empty("projection_id", self.projection_id)
+        _require_non_empty("draft_id", self.draft_id)
+
+    @classmethod
+    def from_receipt(cls, receipt: CommitReceipt) -> "ReceiptLedgerKey":
+        return cls(
+            public_row_id=receipt.public_row_id,
+            projection_id=receipt.projection_id,
+            draft_id=receipt.draft_id,
+        )
+
+
+@dataclass
+class InMemoryArtifactStore:
+    _envelopes: dict[str, ArtifactEnvelope] = field(default_factory=dict)
+
+    def record(self, envelope: ArtifactEnvelope) -> ArtifactEnvelope:
+        _verify_envelope_digest(envelope)
+        existing = self._envelopes.get(envelope.artifact_id)
+        if existing is None:
+            self._envelopes[envelope.artifact_id] = envelope
+            return envelope
+        if (
+            existing.artifact_kind != envelope.artifact_kind
+            or existing.schema_version != envelope.schema_version
+            or existing.body_digest != envelope.body_digest
+        ):
+            raise ArtifactConflict(
+                f"Artifact already recorded with different content: "
+                f"{envelope.artifact_id}."
+            )
+        return existing
+
+    def get(self, artifact_id: str) -> ArtifactEnvelope:
+        return self._envelopes[artifact_id]
+
+    def envelopes(self) -> tuple[ArtifactEnvelope, ...]:
+        return tuple(self._envelopes.values())
+
+
+@dataclass
+class InMemoryReceiptLedger:
+    _receipts: dict[ReceiptLedgerKey, CommitReceipt] = field(default_factory=dict)
+
+    def record(self, receipt: CommitReceipt) -> CommitReceipt:
+        key = ReceiptLedgerKey.from_receipt(receipt)
+        existing = self._receipts.get(key)
+        if existing is None:
+            self._receipts[key] = receipt
+            return receipt
+        if existing != receipt:
+            raise ReceiptConflict(
+                f"CommitReceipt ledger root already recorded with different "
+                f"content: {key.public_row_id}."
+            )
+        return existing
+
+    def get(
+        self,
+        *,
+        public_row_id: str,
+        projection_id: str,
+        draft_id: str,
+    ) -> CommitReceipt:
+        return self._receipts[
+            ReceiptLedgerKey(
+                public_row_id=public_row_id,
+                projection_id=projection_id,
+                draft_id=draft_id,
+            )
+        ]
+
+    def receipts(self) -> tuple[CommitReceipt, ...]:
+        return tuple(self._receipts.values())
+
+
+def verify_materialized_public_projection(
+    row: Mapping[str, Any],
+    projection: ProjectionSpec,
+    *,
+    receipt: CommitReceipt,
+) -> dict[str, Any]:
+    try:
+        authorized_row = project_public_row(row, projection, receipt=receipt)
+    except ProjectionBlocked as exc:
+        raise ProjectionReplayBlocked(
+            "Materialized public projection cannot be replayed from receipt."
+        ) from exc
+    if dict(row) != authorized_row:
+        raise ProjectionReplayBlocked(
+            "Materialized public projection is not the receipt-authorized view."
+        )
+    return authorized_row
+
+
+def _verify_envelope_digest(envelope: ArtifactEnvelope) -> None:
+    expected_digest = artifact_digest(
+        artifact_kind=envelope.artifact_kind,
+        schema_version=envelope.schema_version,
+        body=envelope.body,
+    )
+    if envelope.body_digest != expected_digest:
+        raise ArtifactIntegrityError(
+            f"Artifact body digest mismatch: {envelope.artifact_id}."
+        )
+
+
+def _require_non_empty(field: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{field} is required.")
+
+
+__all__ = [
+    "PersistenceError",
+    "ArtifactIntegrityError",
+    "ArtifactConflict",
+    "ReceiptConflict",
+    "ProjectionReplayBlocked",
+    "ReceiptLedgerKey",
+    "InMemoryArtifactStore",
+    "InMemoryReceiptLedger",
+    "verify_materialized_public_projection",
+]

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -134,7 +134,13 @@ def test_domain_scenario_generation_guide_tracks_swappable_pack_contract():
 
 def test_pyproject_packages_comp_core_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
-    from comp.persistence import ArtifactEnvelope, artifact_digest
+    from comp.persistence import (
+        ArtifactEnvelope,
+        InMemoryArtifactStore,
+        InMemoryReceiptLedger,
+        artifact_digest,
+        verify_materialized_public_projection,
+    )
 
     assert pyproject["project"]["description"] == (
         "Receipt-gated proof package compiler for obligation, reference, "
@@ -157,7 +163,10 @@ def test_pyproject_packages_comp_core_and_agent_layer():
     dependencies = pyproject["project"].get("dependencies", [])
     assert not any(dependency.startswith("lark") for dependency in dependencies)
     assert ArtifactEnvelope is not None
+    assert InMemoryArtifactStore is not None
+    assert InMemoryReceiptLedger is not None
     assert artifact_digest is not None
+    assert verify_materialized_public_projection is not None
 
 
 def test_legacy_pipeline_sources_are_not_active_files():

--- a/tests/test_persistence_ledger_boundary.py
+++ b/tests/test_persistence_ledger_boundary.py
@@ -1,0 +1,182 @@
+from dataclasses import replace
+
+import pytest
+
+from comp import (
+    CommitReceipt,
+    CommitReceiptCitations,
+    ProjectionSpec,
+    ProjectionValueCommitment,
+)
+from comp.persistence import (
+    ArtifactConflict,
+    ArtifactEnvelope,
+    ArtifactIntegrityError,
+    InMemoryArtifactStore,
+    InMemoryReceiptLedger,
+    ProjectionReplayBlocked,
+    ReceiptConflict,
+    verify_materialized_public_projection,
+)
+
+
+def test_artifact_store_records_envelopes_by_id_idempotently():
+    store = InMemoryArtifactStore()
+    envelope = _claim_envelope(value=1200)
+
+    assert store.record(envelope) == envelope
+    assert store.record(envelope) == envelope
+
+    assert store.get("artifact:claim:1") == envelope
+    assert store.envelopes() == (envelope,)
+
+
+def test_artifact_store_rejects_same_id_with_different_body_digest():
+    store = InMemoryArtifactStore()
+    envelope = _claim_envelope(value=1200)
+    changed = _claim_envelope(value=1201)
+
+    store.record(envelope)
+
+    with pytest.raises(ArtifactConflict, match="artifact:claim:1"):
+        store.record(changed)
+
+    assert store.get("artifact:claim:1") == envelope
+
+
+def test_artifact_store_rejects_envelope_when_body_does_not_match_digest():
+    store = InMemoryArtifactStore()
+    envelope = _claim_envelope(value=1200)
+    tampered = ArtifactEnvelope(
+        artifact_id=envelope.artifact_id,
+        artifact_kind=envelope.artifact_kind,
+        schema_version=envelope.schema_version,
+        body_digest=envelope.body_digest,
+        body={"field": "electricity_kwh", "value": 999999},
+    )
+
+    with pytest.raises(ArtifactIntegrityError, match="body digest"):
+        store.record(tampered)
+
+
+def test_receipt_ledger_records_commit_receipt_as_append_only_root():
+    ledger = InMemoryReceiptLedger()
+    receipt = _receipt(amount=100)
+
+    assert ledger.record(receipt) == receipt
+    assert ledger.record(receipt) == receipt
+
+    assert ledger.get(
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        draft_id="draft-1",
+    ) == receipt
+    assert ledger.receipts() == (receipt,)
+
+
+def test_receipt_ledger_rejects_mutating_existing_receipt_root():
+    ledger = InMemoryReceiptLedger()
+    receipt = _receipt(amount=100)
+    changed = replace(
+        receipt,
+        authorized_fields=("site",),
+        barrier_snapshot=(("changed_after_commit", True),),
+    )
+
+    ledger.record(receipt)
+
+    with pytest.raises(ReceiptConflict, match="public-row-1"):
+        ledger.record(changed)
+
+    assert ledger.receipts() == (receipt,)
+
+
+def test_materialized_public_projection_is_a_receipt_verified_view():
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+    receipt = _receipt(amount=100)
+
+    row = verify_materialized_public_projection(
+        {"site": "plant-a", "amount": 100},
+        projection,
+        receipt=receipt,
+    )
+
+    assert row == {"site": "plant-a", "amount": 100}
+
+
+def test_materialized_public_projection_blocks_tampered_values_or_extra_fields():
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+    receipt = _receipt(amount=100)
+
+    with pytest.raises(ProjectionReplayBlocked, match="cannot be replayed"):
+        verify_materialized_public_projection(
+            {"site": "plant-a", "amount": 999999},
+            projection,
+            receipt=receipt,
+        )
+
+    with pytest.raises(ProjectionReplayBlocked, match="receipt-authorized view"):
+        verify_materialized_public_projection(
+            {"site": "plant-a", "amount": 100, "internal_note": "hidden"},
+            projection,
+            receipt=receipt,
+        )
+
+
+def _claim_envelope(*, value: int) -> ArtifactEnvelope:
+    return ArtifactEnvelope.from_body(
+        artifact_id="artifact:claim:1",
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={"field": "electricity_kwh", "value": value},
+    )
+
+
+def _receipt(*, amount: int) -> CommitReceipt:
+    commitments = (
+        ProjectionValueCommitment.from_value(
+            field="site",
+            source_kind="checked_claim",
+            source_id="checked_claim:site:span-site",
+            value="plant-a",
+        ),
+        ProjectionValueCommitment.from_value(
+            field="amount",
+            source_kind="checked_claim",
+            source_id="checked_claim:amount:span-amount",
+            value=amount,
+        ),
+    )
+    citations = CommitReceiptCitations(
+        governance_decision_id="decision-1",
+        governance_status="commit",
+        governance_reasons=("ready",),
+        commit_package_id="package-1",
+        commit_package_complete=True,
+        subject_id="facility-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        profile_id=None,
+        report_status="accepted",
+        checked_claim_fields=("site", "amount"),
+        checked_claim_witness_ids=("span-site", "span-amount"),
+        semantic_judgment_ids=(),
+        reference_binding_ids=(),
+        derived_claim_fields=(),
+        derived_claim_ids=(),
+        calculation_trace_ids=(),
+        formula_ids=(),
+        resolved_obligation_ids=(),
+        open_obligation_ids=(),
+        hazard_ids=(),
+        projection_value_commitments=commitments,
+    )
+    return CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("decision-1",),
+        barrier_snapshot=citations.to_barrier_snapshot(),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        citations=citations,
+    )


### PR DESCRIPTION
## Summary
- Add `comp.persistence.ledger` with an in-memory artifact store and append-only receipt ledger root.
- Verify artifact envelopes before storage so a body cannot drift from its recorded digest.
- Add a receipt-verified materialized projection helper so stored public rows remain views, not authority.
- Export the new persistence primitives and cover the package surface in smoke tests.

## Validation
- `python -m pytest tests\test_persistence_ledger_boundary.py tests\test_package_smoke.py -q` -> 15 passed
- `python -m pytest -q` -> 222 passed
- `git diff --check` -> exit 0, CRLF warnings only