### PR TITLE
[codex] feat: build reference queries from resolver tasks

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -80,6 +80,10 @@ from comp.compiler_tool.resolver_tasks import (
     resolver_task_from_obligation,
     resolver_tasks_from_report,
 )
+from comp.compiler_tool.resolver_retrieval import (
+    reference_query_for_obligation_from_resolver_tasks,
+    reference_query_from_resolver_task,
+)
 from comp.compiler_tool.retrieval import (
     RETRIEVAL_LENSES,
     EmbeddingResolverStub,
@@ -154,6 +158,8 @@ __all__ = [
     "ResolverTask",
     "resolver_task_from_obligation",
     "resolver_tasks_from_report",
+    "reference_query_for_obligation_from_resolver_tasks",
+    "reference_query_from_resolver_task",
     "RETRIEVAL_LENSES",
     "RetrievalLens",
     "ReferenceQuery",

--- a/comp/compiler_tool/resolver_retrieval.py
+++ b/comp/compiler_tool/resolver_retrieval.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from comp.compiler_tool.models import ProofObligation
+from comp.compiler_tool.resolver_tasks import ResolverTask, resolver_task_from_obligation
+from comp.compiler_tool.retrieval import ReferenceQuery, RetrievalLens
+
+
+def reference_query_from_resolver_task(
+    task: ResolverTask,
+    *,
+    text: str,
+    lens: RetrievalLens,
+    reference_type: str | None = None,
+) -> ReferenceQuery:
+    if task.task_type != "reference_search":
+        raise ValueError(
+            "reference_query_from_resolver_task requires a reference_search task"
+        )
+
+    return ReferenceQuery(
+        query_id=f"reference-query:{task.obligation_id}",
+        text=text,
+        lens=lens,
+        reference_type=reference_type,
+        source_artifact_ids=(task.task_id, task.obligation_id),
+    )
+
+
+def reference_query_for_obligation_from_resolver_tasks(
+    tasks: tuple[ResolverTask, ...],
+    *,
+    query_texts: Mapping[str, str],
+    lens: RetrievalLens,
+    reference_type: str | None = None,
+) -> Callable[[ProofObligation], ReferenceQuery | None]:
+    queries_by_obligation_id = {
+        task.obligation_id: reference_query_from_resolver_task(
+            task,
+            text=query_texts[task.obligation_id],
+            lens=lens,
+            reference_type=reference_type,
+        )
+        for task in tasks
+        if task.task_type == "reference_search" and task.obligation_id in query_texts
+    }
+
+    def query_for_obligation(obligation: ProofObligation) -> ReferenceQuery | None:
+        obligation_id = resolver_task_from_obligation(obligation).obligation_id
+        return queries_by_obligation_id.get(obligation_id)
+
+    return query_for_obligation
+
+
+__all__ = [
+    "reference_query_for_obligation_from_resolver_tasks",
+    "reference_query_from_resolver_task",
+]

--- a/docs/architecture/retrieval-fabric-north-star.md
+++ b/docs/architecture/retrieval-fabric-north-star.md
@@ -496,6 +496,8 @@ raw evidence
 -> CompilerTool
 -> calculation_blocked
 -> reference_search_required
+-> ResolverTask
+-> ReferenceQuery
 -> retrieval bridge
 -> candidate-only ReferenceCandidate
 -> deterministic ReferenceBinding

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ calculation
 
 resolver tasks
   ProofObligation -> ResolverTask
+  ResolverTask -> ReferenceQuery
   resolver-facing task type, required artifact, and payload
 
 governance / commit

--- a/minchoagnt/comp_adapter.py
+++ b/minchoagnt/comp_adapter.py
@@ -9,11 +9,14 @@ from comp.compiler_tool import (
     InterpretationHypothesis,
     ProofObligation,
     ReferenceCatalog,
+    ReferenceResolver,
     ResolverTask,
     SemanticJudgment,
     apply_semantic_judgments,
     compile_report_to_facts,
+    reference_query_for_obligation_from_resolver_tasks,
     resolve_reference_search_obligations,
+    resolve_reference_retrieval_obligations,
     resolver_task_from_obligation,
     resolver_tasks_from_report,
 )
@@ -85,7 +88,9 @@ class DeterministicCompResolver:
         semantic_judgments: Iterable[SemanticJudgment] = (),
         available_span_ids: Iterable[str] | None = None,
         reference_catalog: ReferenceCatalog | None = None,
+        reference_resolver: ReferenceResolver | None = None,
         reference_queries: Mapping[str, str] | None = None,
+        reference_lens: str = "factor",
         reference_type: str | None = None,
         reference_limit: int = 10,
         retrieval_method: str = "keyword",
@@ -95,7 +100,9 @@ class DeterministicCompResolver:
             None if available_span_ids is None else tuple(available_span_ids)
         )
         self.reference_catalog = reference_catalog
+        self.reference_resolver = reference_resolver
         self.reference_queries = dict(reference_queries or {})
+        self.reference_lens = reference_lens
         self.reference_type = reference_type
         self.reference_limit = reference_limit
         self.retrieval_method = retrieval_method
@@ -113,7 +120,19 @@ class DeterministicCompResolver:
             )
 
         reference_query_obligation_ids = self._reference_query_obligation_ids(tasks)
-        if self.reference_catalog is not None and reference_query_obligation_ids:
+        if self.reference_resolver is not None and reference_query_obligation_ids:
+            report = resolve_reference_retrieval_obligations(
+                report,
+                self.reference_resolver,
+                query_for_obligation=reference_query_for_obligation_from_resolver_tasks(
+                    tasks,
+                    query_texts=self.reference_queries,
+                    lens=self.reference_lens,
+                    reference_type=self.reference_type,
+                ),
+                limit=self.reference_limit,
+            )
+        elif self.reference_catalog is not None and reference_query_obligation_ids:
             report = resolve_reference_search_obligations(
                 report,
                 self.reference_catalog,

--- a/tests/domain_scenarios/canonical_working_loop/fixtures.py
+++ b/tests/domain_scenarios/canonical_working_loop/fixtures.py
@@ -14,7 +14,6 @@ from comp.compiler_tool import (
     ReferenceBinding,
     ReferenceCatalog,
     ReferenceIndexEntry,
-    ReferenceQuery,
     ReferenceRecord,
     ReferenceSelectionCriteria,
     apply_calculation_result,
@@ -202,18 +201,6 @@ def reference_resolver() -> EmbeddingResolverStub:
     )
 
 
-def reference_query_for_obligation(obligation) -> ReferenceQuery | None:
-    if obligation.kind != "reference_search_required":
-        return None
-    return ReferenceQuery(
-        query_id=f"canonical-reference-query:{obligation.obligation_id}",
-        text="Korea grid electricity factor 2024",
-        lens="factor",
-        reference_type="emission_factor",
-        source_artifact_ids=(obligation.obligation_id or "reference_search_required",),
-    )
-
-
 def criteria() -> ReferenceSelectionCriteria:
     return ReferenceSelectionCriteria(
         binding_id="bind-canonical-electricity-factor",
@@ -277,6 +264,5 @@ __all__ = [
     "input_claim_from_report",
     "open_calculation_obligation",
     "projection_source",
-    "reference_query_for_obligation",
     "reference_resolver",
 ]

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -6,7 +6,9 @@ from comp.compiler_tool import (
     apply_reference_selection,
     plan_calculation_resolution,
     prepare_commit,
+    reference_query_for_obligation_from_resolver_tasks,
     resolve_reference_retrieval_obligations,
+    resolver_tasks_from_report,
     retry_blocked_calculation,
 )
 from tests.domain_scenarios.canonical_working_loop.expected import (
@@ -28,7 +30,6 @@ from tests.domain_scenarios.canonical_working_loop.fixtures import (
     input_claim_from_report,
     open_calculation_obligation,
     projection_source,
-    reference_query_for_obligation,
     reference_resolver,
 )
 from tests.domain_scenarios.core import (
@@ -46,6 +47,8 @@ RESOLVER_STEPS = (
     "compiler_tool.compile_interpretation",
     "open_calculation_obligation",
     "plan_calculation_resolution",
+    "resolver_tasks_from_report",
+    "resolver_task_to_reference_query",
     "reference_retrieval:embedding_stub:factor",
     "deterministic_reference_selection",
     "retry_calculation",
@@ -83,10 +86,16 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
     compiled_report = compile_raw_evidence(RAW_EVIDENCE)
     blocked_report = open_calculation_obligation(compiled_report)
     planned_report = plan_calculation_resolution(blocked_report)
+    resolver_tasks = resolver_tasks_from_report(planned_report)
     retrieval_report = resolve_reference_retrieval_obligations(
         planned_report,
         reference_resolver(),
-        query_for_obligation=reference_query_for_obligation,
+        query_for_obligation=reference_query_for_obligation_from_resolver_tasks(
+            resolver_tasks,
+            query_texts=_reference_query_texts(resolver_tasks),
+            lens="factor",
+            reference_type="emission_factor",
+        ),
     )
     selected_report = apply_reference_selection(
         retrieval_report,
@@ -134,6 +143,14 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         subject=SubjectRef("claim", SUBJECT_ID),
         resolver_steps=RESOLVER_STEPS,
     )
+
+
+def _reference_query_texts(tasks) -> dict[str, str]:
+    return {
+        task.obligation_id: "Korea grid electricity factor 2024"
+        for task in tasks
+        if task.task_type == "reference_search"
+    }
 
 
 def _binding_for(

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -62,6 +62,8 @@ def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
         "compiler_tool.compile_interpretation",
         "open_calculation_obligation",
         "plan_calculation_resolution",
+        "resolver_tasks_from_report",
+        "resolver_task_to_reference_query",
         "reference_retrieval:embedding_stub:factor",
         "deterministic_reference_selection",
         "retry_calculation",

--- a/tests/test_minchoagnt_comp_adapter.py
+++ b/tests/test_minchoagnt_comp_adapter.py
@@ -9,7 +9,9 @@ from comp.compiler_tool import (
     EvidenceWitness,
     InterpretationHypothesis,
     ProofObligation,
+    EmbeddingResolverStub,
     ReferenceCatalog,
+    ReferenceIndexEntry,
     ReferenceRecord,
     SemanticJudgment,
     SemanticJudgmentRequirement,
@@ -204,4 +206,67 @@ def test_deterministic_comp_resolver_runs_reference_search_from_task_query():
     assert reference_ids == ["factor.kr_grid.2024.location_based"]
     assert resolution.result.report.obligations == ()
     assert resolution.result.report.resolved_obligations == (obligation,)
+    assert resolution.result.receipt is None
+
+
+def test_deterministic_comp_resolver_runs_reference_retrieval_from_task_query():
+    obligation_id = (
+        "resolve:ghg.electricity_factor_multiplication.v1:"
+        "hyp-1:co2e_emission:reference_search_required"
+    )
+    requirement = CalculationRequirement(
+        reason="unknown_reference",
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim_id="hyp-1:amount",
+        reference_binding_id="bind-amount-factor",
+        reference_id="factor.missing",
+    )
+    obligation = ProofObligation(
+        kind="reference_search_required",
+        field="co2e_emission",
+        reason="unknown_reference",
+        obligation_id=obligation_id,
+        claim_id="hyp-1:co2e_emission",
+        calculation_requirement=requirement,
+    )
+    compile_result = CompCompileResult(
+        hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
+        subject=SubjectRef("claim", "hyp-ref"),
+        report=CompileReport(status="blocked", obligations=(obligation,)),
+    )
+    resolver = DeterministicCompResolver(
+        reference_resolver=EmbeddingResolverStub(
+            entries=(
+                ReferenceIndexEntry(
+                    entry_id="idx-factor-kr-grid-2024",
+                    reference_id="factor.kr_grid.2024.location_based",
+                    reference_type="emission_factor",
+                    lens="factor",
+                    text="Korea grid electricity factor 2024 location based",
+                    reference_db_version="refdb-v1",
+                    index_version="embedding-stub-v1",
+                ),
+            )
+        ),
+        reference_queries={obligation_id: "Korea grid electricity factor 2024"},
+        reference_lens="factor",
+        reference_type="emission_factor",
+    )
+
+    resolution = resolver.resolve(compile_result)
+
+    assert resolution.reference_query_obligation_ids == (obligation_id,)
+    assert [
+        candidate.retrieval_method
+        for candidate in resolution.result.report.reference_candidates
+    ] == ["embedding_stub:factor"]
+    assert [
+        candidate.reference_id
+        for candidate in resolution.result.report.reference_candidates
+    ] == ["factor.kr_grid.2024.location_based"]
+    assert resolution.result.report.obligations == ()
+    assert resolution.result.report.resolved_obligations == (obligation,)
+    assert resolution.result.report.reference_bindings == ()
+    assert resolution.result.report.derived_claims == ()
     assert resolution.result.receipt is None

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -80,6 +80,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
         ReferenceIndexEntry,
         ReferenceQuery,
         ReferenceResolver,
+        reference_query_for_obligation_from_resolver_tasks,
+        reference_query_from_resolver_task,
         resolve_reference_retrieval_obligations,
         build_commit_receipt,
         compile_report_to_facts,
@@ -97,6 +99,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert ReferenceIndexEntry is not None
     assert ReferenceResolver is not None
     assert EmbeddingResolverStub is not None
+    assert reference_query_from_resolver_task is not None
+    assert reference_query_for_obligation_from_resolver_tasks is not None
     assert resolve_reference_retrieval_obligations is not None
 
 

--- a/tests/test_resolver_retrieval.py
+++ b/tests/test_resolver_retrieval.py
@@ -1,0 +1,150 @@
+import pytest
+
+from comp.compiler_tool import (
+    CalculationRequirement,
+    CompileReport,
+    EmbeddingResolverStub,
+    ProofObligation,
+    ReferenceIndexEntry,
+    ReferenceQuery,
+    resolver_tasks_from_report,
+    reference_query_for_obligation_from_resolver_tasks,
+    reference_query_from_resolver_task,
+    resolve_reference_retrieval_obligations,
+)
+
+
+def _reference_search_obligation() -> ProofObligation:
+    return ProofObligation(
+        kind="reference_search_required",
+        field="co2e_emission",
+        reason="unknown_reference",
+        obligation_id="resolve:formula-v1:claim-co2e:reference_search_required",
+        claim_id="claim-co2e",
+        calculation_requirement=CalculationRequirement(
+            reason="unknown_reference",
+            formula_id="formula-v1",
+            output_claim_id="claim-co2e",
+            input_claim_id="claim-electricity",
+            reference_binding_id="bind-electricity-factor",
+            reference_id="factor.missing",
+        ),
+    )
+
+
+def _resolver() -> EmbeddingResolverStub:
+    return EmbeddingResolverStub(
+        entries=(
+            ReferenceIndexEntry(
+                entry_id="idx-factor-kr-grid-2024",
+                reference_id="factor.kr_grid.2024.location_based",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea grid electricity factor 2024 location based",
+                reference_db_version="refdb-v1",
+                index_version="embedding-stub-v1",
+            ),
+        )
+    )
+
+
+def test_reference_query_from_resolver_task_preserves_task_identity():
+    task = resolver_tasks_from_report(
+        CompileReport(status="blocked", obligations=(_reference_search_obligation(),))
+    )[0]
+
+    query = reference_query_from_resolver_task(
+        task,
+        text="Korea grid electricity factor 2024",
+        lens="factor",
+        reference_type="emission_factor",
+    )
+
+    assert query == ReferenceQuery(
+        query_id=(
+            "reference-query:"
+            "resolve:formula-v1:claim-co2e:reference_search_required"
+        ),
+        text="Korea grid electricity factor 2024",
+        lens="factor",
+        reference_type="emission_factor",
+        source_artifact_ids=(
+            "resolver-task:resolve:formula-v1:claim-co2e:"
+            "reference_search_required",
+            "resolve:formula-v1:claim-co2e:reference_search_required",
+        ),
+    )
+
+
+def test_reference_query_from_resolver_task_rejects_non_reference_search_task():
+    task = resolver_tasks_from_report(
+        CompileReport(
+            status="review_required",
+            obligations=(
+                ProofObligation(
+                    kind="find_source_witness",
+                    field="unit",
+                    reason="missing_unit",
+                ),
+            ),
+        )
+    )[0]
+
+    with pytest.raises(ValueError, match="reference_search"):
+        reference_query_from_resolver_task(
+            task,
+            text="unit",
+            lens="unit",
+        )
+
+
+def test_reference_query_builder_from_tasks_feeds_retrieval_bridge():
+    report = CompileReport(
+        status="blocked",
+        obligations=(_reference_search_obligation(),),
+    )
+    tasks = resolver_tasks_from_report(report)
+
+    resolved = resolve_reference_retrieval_obligations(
+        report,
+        _resolver(),
+        query_for_obligation=reference_query_for_obligation_from_resolver_tasks(
+            tasks,
+            query_texts={
+                "resolve:formula-v1:claim-co2e:reference_search_required": (
+                    "Korea grid electricity factor 2024"
+                )
+            },
+            lens="factor",
+            reference_type="emission_factor",
+        ),
+    )
+
+    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+        "factor.kr_grid.2024.location_based"
+    ]
+    assert resolved.reference_candidates[0].authority == "candidate_only"
+    assert resolved.obligations == ()
+    assert resolved.resolved_obligations == (_reference_search_obligation(),)
+    assert resolved.reference_bindings == ()
+    assert resolved.derived_claims == ()
+
+
+def test_reference_query_builder_from_tasks_leaves_missing_query_open():
+    report = CompileReport(
+        status="blocked",
+        obligations=(_reference_search_obligation(),),
+    )
+
+    resolved = resolve_reference_retrieval_obligations(
+        report,
+        _resolver(),
+        query_for_obligation=reference_query_for_obligation_from_resolver_tasks(
+            resolver_tasks_from_report(report),
+            query_texts={},
+            lens="factor",
+            reference_type="emission_factor",
+        ),
+    )
+
+    assert resolved == report


### PR DESCRIPTION
## Summary

- Add `reference_query_from_resolver_task` and `reference_query_for_obligation_from_resolver_tasks` so resolver-facing `reference_search` tasks can produce `ReferenceQuery` artifacts without re-parsing obligations at call sites.
- Route the canonical working-loop scenario through `ResolverTask -> ReferenceQuery -> retrieval bridge` before deterministic reference selection.
- Teach `DeterministicCompResolver` to use a `ReferenceResolver` / retrieval bridge path while keeping the existing keyword catalog search path intact.

## Authority Boundary

The new helpers only create `ReferenceQuery` artifacts and feed candidate-only retrieval. They do not create `ReferenceBinding`, `DerivedClaim`, `CommitReceipt`, or public projection authority.

## Validation

- `python -m pytest tests/test_resolver_retrieval.py tests/test_resolver_tasks.py tests/test_minchoagnt_comp_adapter.py -q`
- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_package_smoke.py -q`
- `python -m pytest -q` (`220 passed`)
- `git diff --check HEAD~1..HEAD`