### PR TITLE
[codex] feat: add retrieval query policy

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -81,6 +81,9 @@ from comp.compiler_tool.resolver_tasks import (
     resolver_tasks_from_report,
 )
 from comp.compiler_tool.resolver_retrieval import (
+    RetrievalQueryPolicy,
+    RetrievalQueryRule,
+    reference_query_for_obligation_from_policy,
     reference_query_for_obligation_from_resolver_tasks,
     reference_query_from_resolver_task,
 )
@@ -158,6 +161,9 @@ __all__ = [
     "ResolverTask",
     "resolver_task_from_obligation",
     "resolver_tasks_from_report",
+    "RetrievalQueryPolicy",
+    "RetrievalQueryRule",
+    "reference_query_for_obligation_from_policy",
     "reference_query_for_obligation_from_resolver_tasks",
     "reference_query_from_resolver_task",
     "RETRIEVAL_LENSES",

--- a/comp/compiler_tool/resolver_retrieval.py
+++ b/comp/compiler_tool/resolver_retrieval.py
@@ -1,10 +1,31 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from string import Formatter
+from typing import Any
 
 from comp.compiler_tool.models import ProofObligation
 from comp.compiler_tool.resolver_tasks import ResolverTask, resolver_task_from_obligation
 from comp.compiler_tool.retrieval import ReferenceQuery, RetrievalLens
+
+
+@dataclass(frozen=True)
+class RetrievalQueryRule:
+    rule_id: str
+    lens: RetrievalLens
+    text_template: str
+    reference_type: str | None = None
+    task_type: str = "reference_search"
+    field: str | None = None
+    reason: str | None = None
+    formula_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RetrievalQueryPolicy:
+    policy_id: str
+    rules: tuple[RetrievalQueryRule, ...] = field(default_factory=tuple)
 
 
 def reference_query_from_resolver_task(
@@ -26,6 +47,39 @@ def reference_query_from_resolver_task(
         reference_type=reference_type,
         source_artifact_ids=(task.task_id, task.obligation_id),
     )
+
+
+def reference_query_for_obligation_from_policy(
+    tasks: tuple[ResolverTask, ...],
+    *,
+    policy: RetrievalQueryPolicy,
+    context: Mapping[str, Any] | None = None,
+) -> Callable[[ProofObligation], ReferenceQuery | None]:
+    context = context or {}
+    queries_by_obligation_id: dict[str, ReferenceQuery] = {}
+    for task in tasks:
+        rule = _matching_rule(task, policy)
+        if rule is None:
+            continue
+
+        text = _render_query_text(rule.text_template, task, context)
+        if text is None:
+            continue
+
+        queries_by_obligation_id[task.obligation_id] = (
+            reference_query_from_resolver_task(
+                task,
+                text=text,
+                lens=rule.lens,
+                reference_type=rule.reference_type,
+            )
+        )
+
+    def query_for_obligation(obligation: ProofObligation) -> ReferenceQuery | None:
+        obligation_id = resolver_task_from_obligation(obligation).obligation_id
+        return queries_by_obligation_id.get(obligation_id)
+
+    return query_for_obligation
 
 
 def reference_query_for_obligation_from_resolver_tasks(
@@ -53,7 +107,75 @@ def reference_query_for_obligation_from_resolver_tasks(
     return query_for_obligation
 
 
+def _matching_rule(
+    task: ResolverTask,
+    policy: RetrievalQueryPolicy,
+) -> RetrievalQueryRule | None:
+    for rule in policy.rules:
+        if _rule_matches_task(rule, task):
+            return rule
+    return None
+
+
+def _rule_matches_task(rule: RetrievalQueryRule, task: ResolverTask) -> bool:
+    if rule.task_type != task.task_type:
+        return False
+    if rule.field is not None and rule.field != task.field:
+        return False
+    if rule.reason is not None and rule.reason != task.reason:
+        return False
+    if rule.formula_id is not None and rule.formula_id != _task_value(
+        task,
+        "formula_id",
+    ):
+        return False
+    return True
+
+
+def _render_query_text(
+    template: str,
+    task: ResolverTask,
+    context: Mapping[str, Any],
+) -> str | None:
+    values = {
+        **_task_values(task),
+        **context,
+    }
+    required_names = _template_field_names(template)
+    if any(name not in values for name in required_names):
+        return None
+    return template.format_map(values)
+
+
+def _template_field_names(template: str) -> tuple[str, ...]:
+    return tuple(
+        field_name
+        for _, field_name, _, _ in Formatter().parse(template)
+        if field_name is not None and field_name
+    )
+
+
+def _task_values(task: ResolverTask) -> dict[str, Any]:
+    return {
+        **dict(task.payload),
+        "task_id": task.task_id,
+        "obligation_id": task.obligation_id,
+        "task_type": task.task_type,
+        "obligation_kind": task.obligation_kind,
+        "field": task.field,
+        "reason": task.reason,
+        "claim_id": task.claim_id,
+    }
+
+
+def _task_value(task: ResolverTask, key: str) -> Any:
+    return _task_values(task).get(key)
+
+
 __all__ = [
+    "RetrievalQueryPolicy",
+    "RetrievalQueryRule",
+    "reference_query_for_obligation_from_policy",
     "reference_query_for_obligation_from_resolver_tasks",
     "reference_query_from_resolver_task",
 ]

--- a/docs/architecture/retrieval-fabric-north-star.md
+++ b/docs/architecture/retrieval-fabric-north-star.md
@@ -497,6 +497,7 @@ raw evidence
 -> calculation_blocked
 -> reference_search_required
 -> ResolverTask
+-> RetrievalQueryPolicy
 -> ReferenceQuery
 -> retrieval bridge
 -> candidate-only ReferenceCandidate

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ calculation
 
 resolver tasks
   ProofObligation -> ResolverTask
+  RetrievalQueryPolicy
   ResolverTask -> ReferenceQuery
   resolver-facing task type, required artifact, and payload
 

--- a/minchoagnt/comp_adapter.py
+++ b/minchoagnt/comp_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
+from typing import Any
 
 from comp.compiler_tool import (
     CompileReport,
@@ -10,10 +11,12 @@ from comp.compiler_tool import (
     ProofObligation,
     ReferenceCatalog,
     ReferenceResolver,
+    RetrievalQueryPolicy,
     ResolverTask,
     SemanticJudgment,
     apply_semantic_judgments,
     compile_report_to_facts,
+    reference_query_for_obligation_from_policy,
     reference_query_for_obligation_from_resolver_tasks,
     resolve_reference_search_obligations,
     resolve_reference_retrieval_obligations,
@@ -90,6 +93,8 @@ class DeterministicCompResolver:
         reference_catalog: ReferenceCatalog | None = None,
         reference_resolver: ReferenceResolver | None = None,
         reference_queries: Mapping[str, str] | None = None,
+        reference_query_policy: RetrievalQueryPolicy | None = None,
+        reference_query_context: Mapping[str, Any] | None = None,
         reference_lens: str = "factor",
         reference_type: str | None = None,
         reference_limit: int = 10,
@@ -102,6 +107,8 @@ class DeterministicCompResolver:
         self.reference_catalog = reference_catalog
         self.reference_resolver = reference_resolver
         self.reference_queries = dict(reference_queries or {})
+        self.reference_query_policy = reference_query_policy
+        self.reference_query_context = dict(reference_query_context or {})
         self.reference_lens = reference_lens
         self.reference_type = reference_type
         self.reference_limit = reference_limit
@@ -119,20 +126,26 @@ class DeterministicCompResolver:
                 available_span_ids=self.available_span_ids,
             )
 
-        reference_query_obligation_ids = self._reference_query_obligation_ids(tasks)
-        if self.reference_resolver is not None and reference_query_obligation_ids:
+        if self.reference_resolver is not None:
+            query_for_obligation = self._retrieval_query_for_obligation(tasks)
+            reference_query_obligation_ids = (
+                self._retrieval_query_obligation_ids(
+                    report,
+                    query_for_obligation,
+                )
+            )
             report = resolve_reference_retrieval_obligations(
                 report,
                 self.reference_resolver,
-                query_for_obligation=reference_query_for_obligation_from_resolver_tasks(
-                    tasks,
-                    query_texts=self.reference_queries,
-                    lens=self.reference_lens,
-                    reference_type=self.reference_type,
-                ),
+                query_for_obligation=query_for_obligation,
                 limit=self.reference_limit,
             )
-        elif self.reference_catalog is not None and reference_query_obligation_ids:
+        else:
+            reference_query_obligation_ids = self._reference_query_obligation_ids(tasks)
+
+        if self.reference_resolver is None and (
+            self.reference_catalog is not None and reference_query_obligation_ids
+        ):
             report = resolve_reference_search_obligations(
                 report,
                 self.reference_catalog,
@@ -180,6 +193,31 @@ class DeterministicCompResolver:
     def _query_for_obligation(self, obligation: ProofObligation) -> str | None:
         task = resolver_task_from_obligation(obligation)
         return self.reference_queries.get(task.obligation_id)
+
+    def _retrieval_query_for_obligation(self, tasks: tuple[ResolverTask, ...]):
+        if self.reference_query_policy is not None:
+            return reference_query_for_obligation_from_policy(
+                tasks,
+                policy=self.reference_query_policy,
+                context=self.reference_query_context,
+            )
+        return reference_query_for_obligation_from_resolver_tasks(
+            tasks,
+            query_texts=self.reference_queries,
+            lens=self.reference_lens,
+            reference_type=self.reference_type,
+        )
+
+    def _retrieval_query_obligation_ids(
+        self,
+        report: CompileReport,
+        query_for_obligation,
+    ) -> tuple[str, ...]:
+        return tuple(
+            resolver_task_from_obligation(obligation).obligation_id
+            for obligation in report.obligations
+            if query_for_obligation(obligation) is not None
+        )
 
 
 __all__ = [

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -25,10 +25,10 @@ expected receipt/projection
 Start with `canonical_working_loop`, the raw-input harness for new contributors.
 It begins with a raw evidence sentence, uses a deterministic extractor stub,
 passes through `CompilerTool`, opens a calculation obligation, resolves a
-reference search obligation through the retrieval bridge, turns candidate-only
-retrieval results into a canonical binding through deterministic selection,
-calculates a derived claim, mints a commit receipt, and projects only through
-the receipt gate.
+reference search obligation through `ResolverTask`, `RetrievalQueryPolicy`, and
+the retrieval bridge, turns candidate-only retrieval results into a canonical
+binding through deterministic selection, calculates a derived claim, mints a
+commit receipt, and projects only through the receipt gate.
 
 The smaller scenario `tiny_pcf` is a product-carbon-footprint slice that exercises
 reference search, near-miss rejection, canonical binding, calculation trace,

--- a/tests/domain_scenarios/canonical_working_loop/fixtures.py
+++ b/tests/domain_scenarios/canonical_working_loop/fixtures.py
@@ -16,6 +16,8 @@ from comp.compiler_tool import (
     ReferenceIndexEntry,
     ReferenceRecord,
     ReferenceSelectionCriteria,
+    RetrievalQueryPolicy,
+    RetrievalQueryRule,
     apply_calculation_result,
     calculate_derived_claim,
 )
@@ -201,6 +203,29 @@ def reference_resolver() -> EmbeddingResolverStub:
     )
 
 
+def retrieval_query_policy() -> RetrievalQueryPolicy:
+    return RetrievalQueryPolicy(
+        policy_id="pcf-canonical-retrieval-query-policy-v1",
+        rules=(
+            RetrievalQueryRule(
+                rule_id="pcf-electricity-factor-query-v1",
+                formula_id="pcf.electricity_factor_multiplication.v1",
+                lens="factor",
+                reference_type="emission_factor",
+                text_template="{geography} grid electricity factor {reporting_year}",
+            ),
+        ),
+    )
+
+
+def retrieval_query_context(report: CompileReport) -> dict[str, object]:
+    values = {claim.field: claim.value for claim in report.checked_claims}
+    return {
+        "geography": "Korea" if values["geography"] == "KR" else values["geography"],
+        "reporting_year": values["reporting_year"],
+    }
+
+
 def criteria() -> ReferenceSelectionCriteria:
     return ReferenceSelectionCriteria(
         binding_id="bind-canonical-electricity-factor",
@@ -265,4 +290,6 @@ __all__ = [
     "open_calculation_obligation",
     "projection_source",
     "reference_resolver",
+    "retrieval_query_context",
+    "retrieval_query_policy",
 ]

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -6,7 +6,7 @@ from comp.compiler_tool import (
     apply_reference_selection,
     plan_calculation_resolution,
     prepare_commit,
-    reference_query_for_obligation_from_resolver_tasks,
+    reference_query_for_obligation_from_policy,
     resolve_reference_retrieval_obligations,
     resolver_tasks_from_report,
     retry_blocked_calculation,
@@ -31,6 +31,8 @@ from tests.domain_scenarios.canonical_working_loop.fixtures import (
     open_calculation_obligation,
     projection_source,
     reference_resolver,
+    retrieval_query_context,
+    retrieval_query_policy,
 )
 from tests.domain_scenarios.core import (
     DomainScenarioResult,
@@ -48,6 +50,7 @@ RESOLVER_STEPS = (
     "open_calculation_obligation",
     "plan_calculation_resolution",
     "resolver_tasks_from_report",
+    "retrieval_query_policy",
     "resolver_task_to_reference_query",
     "reference_retrieval:embedding_stub:factor",
     "deterministic_reference_selection",
@@ -90,11 +93,10 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
     retrieval_report = resolve_reference_retrieval_obligations(
         planned_report,
         reference_resolver(),
-        query_for_obligation=reference_query_for_obligation_from_resolver_tasks(
+        query_for_obligation=reference_query_for_obligation_from_policy(
             resolver_tasks,
-            query_texts=_reference_query_texts(resolver_tasks),
-            lens="factor",
-            reference_type="emission_factor",
+            policy=retrieval_query_policy(),
+            context=retrieval_query_context(compiled_report),
         ),
     )
     selected_report = apply_reference_selection(
@@ -143,14 +145,6 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         subject=SubjectRef("claim", SUBJECT_ID),
         resolver_steps=RESOLVER_STEPS,
     )
-
-
-def _reference_query_texts(tasks) -> dict[str, str]:
-    return {
-        task.obligation_id: "Korea grid electricity factor 2024"
-        for task in tasks
-        if task.task_type == "reference_search"
-    }
 
 
 def _binding_for(

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -63,6 +63,7 @@ def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
         "open_calculation_obligation",
         "plan_calculation_resolution",
         "resolver_tasks_from_report",
+        "retrieval_query_policy",
         "resolver_task_to_reference_query",
         "reference_retrieval:embedding_stub:factor",
         "deterministic_reference_selection",

--- a/tests/test_minchoagnt_comp_adapter.py
+++ b/tests/test_minchoagnt_comp_adapter.py
@@ -13,6 +13,8 @@ from comp.compiler_tool import (
     ReferenceCatalog,
     ReferenceIndexEntry,
     ReferenceRecord,
+    RetrievalQueryPolicy,
+    RetrievalQueryRule,
     SemanticJudgment,
     SemanticJudgmentRequirement,
 )
@@ -269,4 +271,122 @@ def test_deterministic_comp_resolver_runs_reference_retrieval_from_task_query():
     assert resolution.result.report.resolved_obligations == (obligation,)
     assert resolution.result.report.reference_bindings == ()
     assert resolution.result.report.derived_claims == ()
+    assert resolution.result.receipt is None
+
+
+def test_deterministic_comp_resolver_runs_reference_retrieval_from_query_policy():
+    obligation_id = (
+        "resolve:ghg.electricity_factor_multiplication.v1:"
+        "hyp-1:co2e_emission:reference_search_required"
+    )
+    requirement = CalculationRequirement(
+        reason="unknown_reference",
+        formula_id="ghg.electricity_factor_multiplication.v1",
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim_id="hyp-1:amount",
+        reference_binding_id="bind-amount-factor",
+        reference_id="factor.missing",
+    )
+    obligation = ProofObligation(
+        kind="reference_search_required",
+        field="co2e_emission",
+        reason="unknown_reference",
+        obligation_id=obligation_id,
+        claim_id="hyp-1:co2e_emission",
+        calculation_requirement=requirement,
+    )
+    compile_result = CompCompileResult(
+        hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
+        subject=SubjectRef("claim", "hyp-ref"),
+        report=CompileReport(status="blocked", obligations=(obligation,)),
+    )
+    resolver = DeterministicCompResolver(
+        reference_resolver=EmbeddingResolverStub(
+            entries=(
+                ReferenceIndexEntry(
+                    entry_id="idx-factor-kr-grid-2024",
+                    reference_id="factor.kr_grid.2024.location_based",
+                    reference_type="emission_factor",
+                    lens="factor",
+                    text="Korea grid electricity factor 2024 location based",
+                    reference_db_version="refdb-v1",
+                    index_version="embedding-stub-v1",
+                ),
+            )
+        ),
+        reference_query_policy=RetrievalQueryPolicy(
+            policy_id="ghg-reference-query-policy-v1",
+            rules=(
+                RetrievalQueryRule(
+                    rule_id="electricity-factor-query-v1",
+                    formula_id="ghg.electricity_factor_multiplication.v1",
+                    lens="factor",
+                    reference_type="emission_factor",
+                    text_template=(
+                        "{geography} grid electricity factor {reporting_year}"
+                    ),
+                ),
+            ),
+        ),
+        reference_query_context={"geography": "Korea", "reporting_year": 2024},
+    )
+
+    resolution = resolver.resolve(compile_result)
+
+    assert resolution.reference_query_obligation_ids == (obligation_id,)
+    assert [
+        candidate.reference_id
+        for candidate in resolution.result.report.reference_candidates
+    ] == ["factor.kr_grid.2024.location_based"]
+    assert resolution.result.report.resolved_obligations == (obligation,)
+    assert resolution.result.report.reference_bindings == ()
+    assert resolution.result.report.derived_claims == ()
+    assert resolution.result.receipt is None
+
+
+def test_deterministic_comp_resolver_leaves_reference_policy_task_open_without_context():
+    obligation_id = (
+        "resolve:ghg.electricity_factor_multiplication.v1:"
+        "hyp-1:co2e_emission:reference_search_required"
+    )
+    obligation = ProofObligation(
+        kind="reference_search_required",
+        field="co2e_emission",
+        reason="unknown_reference",
+        obligation_id=obligation_id,
+        claim_id="hyp-1:co2e_emission",
+        calculation_requirement=CalculationRequirement(
+            reason="unknown_reference",
+            formula_id="ghg.electricity_factor_multiplication.v1",
+            output_claim_id="hyp-1:co2e_emission",
+        ),
+    )
+    compile_result = CompCompileResult(
+        hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
+        subject=SubjectRef("claim", "hyp-ref"),
+        report=CompileReport(status="blocked", obligations=(obligation,)),
+    )
+    resolver = DeterministicCompResolver(
+        reference_resolver=EmbeddingResolverStub(entries=()),
+        reference_query_policy=RetrievalQueryPolicy(
+            policy_id="ghg-reference-query-policy-v1",
+            rules=(
+                RetrievalQueryRule(
+                    rule_id="electricity-factor-query-v1",
+                    formula_id="ghg.electricity_factor_multiplication.v1",
+                    lens="factor",
+                    reference_type="emission_factor",
+                    text_template=(
+                        "{geography} grid electricity factor {reporting_year}"
+                    ),
+                ),
+            ),
+        ),
+        reference_query_context={"geography": "Korea"},
+    )
+
+    resolution = resolver.resolve(compile_result)
+
+    assert resolution.reference_query_obligation_ids == ()
+    assert resolution.result.report == compile_result.report
     assert resolution.result.receipt is None

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -80,6 +80,9 @@ def test_readme_compiler_tool_import_surface_is_exported():
         ReferenceIndexEntry,
         ReferenceQuery,
         ReferenceResolver,
+        RetrievalQueryPolicy,
+        RetrievalQueryRule,
+        reference_query_for_obligation_from_policy,
         reference_query_for_obligation_from_resolver_tasks,
         reference_query_from_resolver_task,
         resolve_reference_retrieval_obligations,
@@ -99,6 +102,9 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert ReferenceIndexEntry is not None
     assert ReferenceResolver is not None
     assert EmbeddingResolverStub is not None
+    assert RetrievalQueryPolicy is not None
+    assert RetrievalQueryRule is not None
+    assert reference_query_for_obligation_from_policy is not None
     assert reference_query_from_resolver_task is not None
     assert reference_query_for_obligation_from_resolver_tasks is not None
     assert resolve_reference_retrieval_obligations is not None

--- a/tests/test_resolver_retrieval.py
+++ b/tests/test_resolver_retrieval.py
@@ -7,8 +7,11 @@ from comp.compiler_tool import (
     ProofObligation,
     ReferenceIndexEntry,
     ReferenceQuery,
+    RetrievalQueryPolicy,
+    RetrievalQueryRule,
     resolver_tasks_from_report,
     reference_query_for_obligation_from_resolver_tasks,
+    reference_query_for_obligation_from_policy,
     reference_query_from_resolver_task,
     resolve_reference_retrieval_obligations,
 )
@@ -144,6 +147,107 @@ def test_reference_query_builder_from_tasks_leaves_missing_query_open():
             query_texts={},
             lens="factor",
             reference_type="emission_factor",
+        ),
+    )
+
+    assert resolved == report
+
+
+def test_retrieval_query_policy_renders_reference_query_from_task_payload_and_context():
+    task = resolver_tasks_from_report(
+        CompileReport(status="blocked", obligations=(_reference_search_obligation(),))
+    )[0]
+    policy = RetrievalQueryPolicy(
+        policy_id="pcf-retrieval-policy-v1",
+        rules=(
+            RetrievalQueryRule(
+                rule_id="pcf-electricity-factor-query-v1",
+                formula_id="formula-v1",
+                lens="factor",
+                reference_type="emission_factor",
+                text_template="{geography} grid electricity factor {reporting_year}",
+            ),
+        ),
+    )
+
+    query = reference_query_for_obligation_from_policy(
+        (task,),
+        policy=policy,
+        context={"geography": "Korea", "reporting_year": 2024},
+    )(_reference_search_obligation())
+
+    assert query == ReferenceQuery(
+        query_id=(
+            "reference-query:"
+            "resolve:formula-v1:claim-co2e:reference_search_required"
+        ),
+        text="Korea grid electricity factor 2024",
+        lens="factor",
+        reference_type="emission_factor",
+        source_artifact_ids=(
+            "resolver-task:resolve:formula-v1:claim-co2e:"
+            "reference_search_required",
+            "resolve:formula-v1:claim-co2e:reference_search_required",
+        ),
+    )
+
+
+def test_retrieval_query_policy_leaves_obligation_open_without_matching_rule():
+    report = CompileReport(
+        status="blocked",
+        obligations=(_reference_search_obligation(),),
+    )
+    policy = RetrievalQueryPolicy(
+        policy_id="pcf-retrieval-policy-v1",
+        rules=(
+            RetrievalQueryRule(
+                rule_id="other-formula-query-v1",
+                formula_id="other-formula",
+                lens="factor",
+                reference_type="emission_factor",
+                text_template="{geography} grid electricity factor {reporting_year}",
+            ),
+        ),
+    )
+
+    resolved = resolve_reference_retrieval_obligations(
+        report,
+        _resolver(),
+        query_for_obligation=reference_query_for_obligation_from_policy(
+            resolver_tasks_from_report(report),
+            policy=policy,
+            context={"geography": "Korea", "reporting_year": 2024},
+        ),
+    )
+
+    assert resolved == report
+
+
+def test_retrieval_query_policy_leaves_obligation_open_without_required_context():
+    report = CompileReport(
+        status="blocked",
+        obligations=(_reference_search_obligation(),),
+    )
+    policy = RetrievalQueryPolicy(
+        policy_id="pcf-retrieval-policy-v1",
+        rules=(
+            RetrievalQueryRule(
+                rule_id="pcf-electricity-factor-query-v1",
+                formula_id="formula-v1",
+                lens="factor",
+                reference_type="emission_factor",
+                text_template="{geography} grid electricity factor {reporting_year}",
+            ),
+        ),
+    )
+
+    resolved = resolve_reference_retrieval_obligations(
+        report,
+        _resolver(),
+        query_for_obligation=reference_query_for_obligation_from_policy(
+            resolver_tasks_from_report(report),
+            policy=policy,
+            context={"geography": "Korea"},
         ),
     )
 


### PR DESCRIPTION
## Summary

- Add `RetrievalQueryPolicy` and `RetrievalQueryRule` so resolver-facing reference search tasks can produce `ReferenceQuery` artifacts from policy templates and runtime context.
- Route the canonical working-loop scenario through `RetrievalQueryPolicy -> ReferenceQuery -> retrieval bridge` instead of hard-coded query text.
- Teach `DeterministicCompResolver` to use policy-backed retrieval queries while preserving the existing explicit query-map and keyword catalog paths.

## Authority Boundary

The policy only proposes retrieval queries. It does not create `ReferenceBinding`, `DerivedClaim`, `CommitReceipt`, or public projection authority. Missing policy matches or missing template context leave the obligation open.

## Validation

- `python -m pytest tests/test_resolver_retrieval.py tests/test_minchoagnt_comp_adapter.py -q`
- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_domain_scenario_lab.py tests/test_package_smoke.py -q`
- `python -m pytest -q` (`232 passed`)
- `git diff --check HEAD~1..HEAD`