### PR TITLE
[codex] add projection replay report

### DIFF
--- a/comp/persistence/__init__.py
+++ b/comp/persistence/__init__.py
@@ -11,19 +11,31 @@ from comp.persistence.ledger import (
     ProjectionReplayBlocked,
     ReceiptConflict,
     ReceiptLedgerKey,
+    verify_artifact_envelope,
     verify_materialized_public_projection,
+)
+from comp.persistence.replay import (
+    ArtifactRef,
+    ProjectionReplayReport,
+    receipt_artifact_refs,
+    replay_public_projection,
 )
 
 __all__ = [
     "ArtifactConflict",
     "ArtifactEnvelope",
+    "ArtifactRef",
     "ArtifactIntegrityError",
     "InMemoryArtifactStore",
     "InMemoryReceiptLedger",
     "PersistenceError",
     "ProjectionReplayBlocked",
+    "ProjectionReplayReport",
     "ReceiptConflict",
     "ReceiptLedgerKey",
     "artifact_digest",
+    "receipt_artifact_refs",
+    "replay_public_projection",
+    "verify_artifact_envelope",
     "verify_materialized_public_projection",
 ]

--- a/comp/persistence/ledger.py
+++ b/comp/persistence/ledger.py
@@ -59,7 +59,7 @@ class InMemoryArtifactStore:
     _envelopes: dict[str, ArtifactEnvelope] = field(default_factory=dict)
 
     def record(self, envelope: ArtifactEnvelope) -> ArtifactEnvelope:
-        _verify_envelope_digest(envelope)
+        verify_artifact_envelope(envelope)
         existing = self._envelopes.get(envelope.artifact_id)
         if existing is None:
             self._envelopes[envelope.artifact_id] = envelope
@@ -137,7 +137,7 @@ def verify_materialized_public_projection(
     return authorized_row
 
 
-def _verify_envelope_digest(envelope: ArtifactEnvelope) -> None:
+def verify_artifact_envelope(envelope: ArtifactEnvelope) -> None:
     expected_digest = artifact_digest(
         artifact_kind=envelope.artifact_kind,
         schema_version=envelope.schema_version,
@@ -164,4 +164,5 @@ __all__ = [
     "InMemoryArtifactStore",
     "InMemoryReceiptLedger",
     "verify_materialized_public_projection",
+    "verify_artifact_envelope",
 ]

--- a/comp/persistence/replay.py
+++ b/comp/persistence/replay.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from comp.judgment import CommitReceipt, ProjectionSpec
+from comp.persistence.ledger import (
+    ArtifactIntegrityError,
+    InMemoryArtifactStore,
+    ProjectionReplayBlocked,
+    ReceiptLedgerKey,
+    verify_artifact_envelope,
+    verify_materialized_public_projection,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactRef:
+    artifact_id: str
+    artifact_kind: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty("artifact_id", self.artifact_id)
+        _require_non_empty("artifact_kind", self.artifact_kind)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionReplayReport:
+    receipt_key: ReceiptLedgerKey
+    projection_id: str
+    public_row: dict[str, Any]
+    artifact_refs: tuple[ArtifactRef, ...]
+    artifact_digests: tuple[tuple[str, str], ...]
+
+
+def replay_public_projection(
+    row: Mapping[str, Any],
+    projection: ProjectionSpec,
+    *,
+    receipt: CommitReceipt,
+    artifacts: InMemoryArtifactStore,
+) -> ProjectionReplayReport:
+    public_row = verify_materialized_public_projection(
+        row,
+        projection,
+        receipt=receipt,
+    )
+    refs = receipt_artifact_refs(receipt)
+    return ProjectionReplayReport(
+        receipt_key=ReceiptLedgerKey.from_receipt(receipt),
+        projection_id=projection.projection_id,
+        public_row=public_row,
+        artifact_refs=refs,
+        artifact_digests=_verified_artifact_digests(refs, artifacts),
+    )
+
+
+def receipt_artifact_refs(receipt: CommitReceipt) -> tuple[ArtifactRef, ...]:
+    citations = receipt.citations
+    if citations is None:
+        return ()
+
+    refs: list[ArtifactRef] = [
+        ArtifactRef(citations.commit_package_id, "commit_package"),
+        ArtifactRef(citations.governance_decision_id, "governance_decision"),
+    ]
+    refs.extend(
+        ArtifactRef(commitment.source_id, commitment.source_kind)
+        for commitment in citations.projection_value_commitments
+    )
+    refs.extend(
+        ArtifactRef(witness_id, "evidence_witness")
+        for witness_id in citations.checked_claim_witness_ids
+    )
+    refs.extend(
+        ArtifactRef(judgment_id, "semantic_judgment")
+        for judgment_id in citations.semantic_judgment_ids
+    )
+    refs.extend(
+        ArtifactRef(binding_id, "reference_binding")
+        for binding_id in citations.reference_binding_ids
+    )
+    refs.extend(
+        ArtifactRef(derived_claim_id, "derived_claim")
+        for derived_claim_id in citations.derived_claim_ids
+    )
+    refs.extend(
+        ArtifactRef(trace_id, "calculation_trace")
+        for trace_id in citations.calculation_trace_ids
+    )
+    refs.extend(
+        ArtifactRef(formula_id, "formula")
+        for formula_id in citations.formula_ids
+    )
+    return _unique_refs(refs)
+
+
+def _verified_artifact_digests(
+    refs: tuple[ArtifactRef, ...],
+    artifacts: InMemoryArtifactStore,
+) -> tuple[tuple[str, str], ...]:
+    digests: list[tuple[str, str]] = []
+    for ref in refs:
+        try:
+            envelope = artifacts.get(ref.artifact_id)
+        except KeyError as exc:
+            raise ProjectionReplayBlocked(
+                f"Projection replay missing artifact: {ref.artifact_id}."
+            ) from exc
+        if envelope.artifact_kind != ref.artifact_kind:
+            raise ProjectionReplayBlocked(
+                f"Projection replay artifact kind mismatch: {ref.artifact_id}."
+            )
+        try:
+            verify_artifact_envelope(envelope)
+        except ArtifactIntegrityError as exc:
+            raise ProjectionReplayBlocked(
+                f"Projection replay artifact body digest mismatch: {ref.artifact_id}."
+            ) from exc
+        digests.append((envelope.artifact_id, envelope.body_digest))
+    return tuple(digests)
+
+
+def _unique_refs(refs: list[ArtifactRef]) -> tuple[ArtifactRef, ...]:
+    seen: set[ArtifactRef] = set()
+    unique: list[ArtifactRef] = []
+    for ref in refs:
+        if ref in seen:
+            continue
+        seen.add(ref)
+        unique.append(ref)
+    return tuple(unique)
+
+
+def _require_non_empty(field: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{field} is required.")
+
+
+__all__ = [
+    "ArtifactRef",
+    "ProjectionReplayReport",
+    "receipt_artifact_refs",
+    "replay_public_projection",
+]

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -146,9 +146,12 @@ def test_pyproject_packages_comp_core_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
     from comp.persistence import (
         ArtifactEnvelope,
+        ArtifactRef,
         InMemoryArtifactStore,
         InMemoryReceiptLedger,
+        ProjectionReplayReport,
         artifact_digest,
+        replay_public_projection,
         verify_materialized_public_projection,
     )
 
@@ -173,9 +176,12 @@ def test_pyproject_packages_comp_core_and_agent_layer():
     dependencies = pyproject["project"].get("dependencies", [])
     assert not any(dependency.startswith("lark") for dependency in dependencies)
     assert ArtifactEnvelope is not None
+    assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None
     assert InMemoryReceiptLedger is not None
+    assert ProjectionReplayReport is not None
     assert artifact_digest is not None
+    assert replay_public_projection is not None
     assert verify_materialized_public_projection is not None
 
 

--- a/tests/test_persistence_projection_replay.py
+++ b/tests/test_persistence_projection_replay.py
@@ -1,0 +1,203 @@
+import pytest
+
+from comp import (
+    CommitReceipt,
+    CommitReceiptCitations,
+    ProjectionSpec,
+    ProjectionValueCommitment,
+)
+from comp.persistence import (
+    ArtifactEnvelope,
+    ArtifactRef,
+    InMemoryArtifactStore,
+    ProjectionReplayBlocked,
+    ProjectionReplayReport,
+    ReceiptLedgerKey,
+    receipt_artifact_refs,
+    replay_public_projection,
+)
+
+
+def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
+    receipt = _receipt(amount=100)
+    artifacts = _artifact_store_for(receipt)
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+
+    report = replay_public_projection(
+        {"site": "plant-a", "amount": 100},
+        projection,
+        receipt=receipt,
+        artifacts=artifacts,
+    )
+
+    assert isinstance(report, ProjectionReplayReport)
+    assert report.receipt_key == ReceiptLedgerKey(
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        draft_id="draft-1",
+    )
+    assert report.public_row == {"site": "plant-a", "amount": 100}
+    assert report.artifact_refs == receipt_artifact_refs(receipt)
+    assert ArtifactRef("package-1", "commit_package") in report.artifact_refs
+    assert ArtifactRef("decision-1", "governance_decision") in report.artifact_refs
+    assert (
+        ArtifactRef("checked_claim:amount:span-amount", "checked_claim")
+        in report.artifact_refs
+    )
+    assert dict(report.artifact_digests)["package-1"].startswith("sha256:")
+
+
+def test_replay_blocks_when_required_artifact_is_missing():
+    receipt = _receipt(amount=100)
+    artifacts = _artifact_store_for(
+        receipt,
+        skip=ArtifactRef("decision-1", "governance_decision"),
+    )
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+
+    with pytest.raises(ProjectionReplayBlocked, match="missing artifact"):
+        replay_public_projection(
+            {"site": "plant-a", "amount": 100},
+            projection,
+            receipt=receipt,
+            artifacts=artifacts,
+        )
+
+
+def test_replay_blocks_when_required_artifact_kind_mismatches():
+    receipt = _receipt(amount=100)
+    artifacts = _artifact_store_for(
+        receipt,
+        override=ArtifactEnvelope.from_body(
+            artifact_id="decision-1",
+            artifact_kind="commit_package",
+            schema_version="v1",
+            body={"status": "commit"},
+        ),
+    )
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+
+    with pytest.raises(ProjectionReplayBlocked, match="artifact kind"):
+        replay_public_projection(
+            {"site": "plant-a", "amount": 100},
+            projection,
+            receipt=receipt,
+            artifacts=artifacts,
+        )
+
+
+def test_replay_blocks_when_stored_artifact_body_drifts_after_recording():
+    receipt = _receipt(amount=100)
+    artifacts = _artifact_store_for(receipt)
+    artifacts.get("package-1").body["complete"] = False
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+
+    with pytest.raises(ProjectionReplayBlocked, match="body digest"):
+        replay_public_projection(
+            {"site": "plant-a", "amount": 100},
+            projection,
+            receipt=receipt,
+            artifacts=artifacts,
+        )
+
+
+def test_replay_blocks_when_materialized_row_no_longer_matches_receipt():
+    receipt = _receipt(amount=100)
+    artifacts = _artifact_store_for(receipt)
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+
+    with pytest.raises(ProjectionReplayBlocked, match="cannot be replayed"):
+        replay_public_projection(
+            {"site": "plant-a", "amount": 999999},
+            projection,
+            receipt=receipt,
+            artifacts=artifacts,
+        )
+
+
+def _artifact_store_for(
+    receipt: CommitReceipt,
+    *,
+    skip: ArtifactRef | None = None,
+    override: ArtifactEnvelope | None = None,
+) -> InMemoryArtifactStore:
+    store = InMemoryArtifactStore()
+    for ref in receipt_artifact_refs(receipt):
+        if ref == skip:
+            continue
+        if override is not None and override.artifact_id == ref.artifact_id:
+            store.record(override)
+            continue
+        store.record(_artifact_for_ref(ref))
+    return store
+
+
+def _artifact_for_ref(ref: ArtifactRef) -> ArtifactEnvelope:
+    return ArtifactEnvelope.from_body(
+        artifact_id=ref.artifact_id,
+        artifact_kind=ref.artifact_kind,
+        schema_version="v1",
+        body=_artifact_body_for_ref(ref),
+    )
+
+
+def _artifact_body_for_ref(ref: ArtifactRef) -> dict:
+    if ref.artifact_kind == "commit_package":
+        return {"package_id": ref.artifact_id, "complete": True}
+    if ref.artifact_kind == "governance_decision":
+        return {"decision_id": ref.artifact_id, "status": "commit"}
+    if ref.artifact_kind == "checked_claim":
+        return {"claim_id": ref.artifact_id, "field": "amount"}
+    if ref.artifact_kind == "evidence_witness":
+        return {"witness_id": ref.artifact_id, "source": "fixture"}
+    raise AssertionError(f"Unexpected artifact ref in test: {ref}")
+
+
+def _receipt(*, amount: int) -> CommitReceipt:
+    commitments = (
+        ProjectionValueCommitment.from_value(
+            field="site",
+            source_kind="checked_claim",
+            source_id="checked_claim:site:span-site",
+            value="plant-a",
+        ),
+        ProjectionValueCommitment.from_value(
+            field="amount",
+            source_kind="checked_claim",
+            source_id="checked_claim:amount:span-amount",
+            value=amount,
+        ),
+    )
+    citations = CommitReceiptCitations(
+        governance_decision_id="decision-1",
+        governance_status="commit",
+        governance_reasons=("ready",),
+        commit_package_id="package-1",
+        commit_package_complete=True,
+        subject_id="facility-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        profile_id=None,
+        report_status="accepted",
+        checked_claim_fields=("site", "amount"),
+        checked_claim_witness_ids=("span-site", "span-amount"),
+        semantic_judgment_ids=(),
+        reference_binding_ids=(),
+        derived_claim_fields=(),
+        derived_claim_ids=(),
+        calculation_trace_ids=(),
+        formula_ids=(),
+        resolved_obligation_ids=(),
+        open_obligation_ids=(),
+        hazard_ids=(),
+        projection_value_commitments=commitments,
+    )
+    return CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("decision-1",),
+        barrier_snapshot=citations.to_barrier_snapshot(),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        citations=citations,
+    )


### PR DESCRIPTION
## Summary
- Add `comp.persistence.replay` with `ArtifactRef`, `ProjectionReplayReport`, `receipt_artifact_refs`, and `replay_public_projection`.
- Reuse receipt-gated projection validation so materialized public rows remain replayed views, not authority.
- Verify required artifact envelopes exist, match the expected kind, and still match their body digests during replay.
- Export the replay surface through `comp.persistence` and cover it in package smoke tests.

## Validation
- `python -m pytest tests\test_persistence_projection_replay.py tests\test_persistence_ledger_boundary.py tests\test_package_smoke.py -q` -> 20 passed
- `python -m pytest -q` -> 237 passed
- `git diff --check` -> exit 0