### PR TITLE
[codex] extract persistence test builders

### DIFF
--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test support helpers."""

--- a/tests/support/persistence_cases.py
+++ b/tests/support/persistence_cases.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from comp import (
+    CommitReceipt,
+    CommitReceiptCitations,
+    ProjectionSpec,
+    ProjectionValueCommitment,
+)
+from comp.persistence import ArtifactEnvelope, ArtifactRef, InMemoryArtifactStore
+from comp.persistence import receipt_artifact_refs
+
+
+@dataclass(frozen=True, slots=True)
+class PersistenceProjectionCase:
+    receipt: CommitReceipt
+    projection: ProjectionSpec
+    source_values: dict[str, Any]
+    public_row: dict[str, Any]
+
+
+def receipt_projection_case(
+    *,
+    amount: int = 100,
+    site: str = "plant-a",
+) -> PersistenceProjectionCase:
+    commitments = (
+        ProjectionValueCommitment.from_value(
+            field="site",
+            source_kind="checked_claim",
+            source_id="checked_claim:site:span-site",
+            value=site,
+        ),
+        ProjectionValueCommitment.from_value(
+            field="amount",
+            source_kind="checked_claim",
+            source_id="checked_claim:amount:span-amount",
+            value=amount,
+        ),
+    )
+    citations = CommitReceiptCitations(
+        governance_decision_id="decision-1",
+        governance_status="commit",
+        governance_reasons=("ready",),
+        commit_package_id="package-1",
+        commit_package_complete=True,
+        subject_id="facility-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        profile_id=None,
+        report_status="accepted",
+        checked_claim_fields=("site", "amount"),
+        checked_claim_witness_ids=("span-site", "span-amount"),
+        semantic_judgment_ids=(),
+        reference_binding_ids=(),
+        derived_claim_fields=(),
+        derived_claim_ids=(),
+        calculation_trace_ids=(),
+        formula_ids=(),
+        resolved_obligation_ids=(),
+        open_obligation_ids=(),
+        hazard_ids=(),
+        projection_value_commitments=commitments,
+    )
+    receipt = CommitReceipt(
+        draft_id="draft-1",
+        winner_receipt_ids=("decision-1",),
+        barrier_snapshot=citations.to_barrier_snapshot(),
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        citations=citations,
+    )
+    projection = ProjectionSpec("public-row", ("site", "amount"))
+    public_row = {"site": site, "amount": amount}
+    return PersistenceProjectionCase(
+        receipt=receipt,
+        projection=projection,
+        source_values=dict(public_row),
+        public_row=public_row,
+    )
+
+
+def claim_envelope(
+    *,
+    value: int = 1200,
+    artifact_id: str = "artifact:claim:1",
+) -> ArtifactEnvelope:
+    return ArtifactEnvelope.from_body(
+        artifact_id=artifact_id,
+        artifact_kind="checked_claim",
+        schema_version="v1",
+        body={"field": "electricity_kwh", "value": value},
+    )
+
+
+def artifact_store_for_receipt(
+    receipt: CommitReceipt,
+    *,
+    skip: ArtifactRef | None = None,
+    override: ArtifactEnvelope | None = None,
+) -> InMemoryArtifactStore:
+    store = InMemoryArtifactStore()
+    for ref in receipt_artifact_refs(receipt):
+        if ref == skip:
+            continue
+        if override is not None and override.artifact_id == ref.artifact_id:
+            store.record(override)
+            continue
+        store.record(artifact_for_ref(ref))
+    return store
+
+
+def artifact_for_ref(ref: ArtifactRef) -> ArtifactEnvelope:
+    return ArtifactEnvelope.from_body(
+        artifact_id=ref.artifact_id,
+        artifact_kind=ref.artifact_kind,
+        schema_version="v1",
+        body=artifact_body_for_ref(ref),
+    )
+
+
+def artifact_body_for_ref(ref: ArtifactRef) -> dict[str, Any]:
+    if ref.artifact_kind == "commit_package":
+        return {"package_id": ref.artifact_id, "complete": True}
+    if ref.artifact_kind == "governance_decision":
+        return {"decision_id": ref.artifact_id, "status": "commit"}
+    if ref.artifact_kind == "checked_claim":
+        return {"claim_id": ref.artifact_id, "field": _claim_field(ref)}
+    if ref.artifact_kind == "evidence_witness":
+        return {"witness_id": ref.artifact_id, "source": "fixture"}
+    raise AssertionError(f"Unexpected artifact ref in test: {ref}")
+
+
+def _claim_field(ref: ArtifactRef) -> str:
+    if ":site:" in ref.artifact_id:
+        return "site"
+    if ":amount:" in ref.artifact_id:
+        return "amount"
+    return "unknown"
+
+
+__all__ = [
+    "PersistenceProjectionCase",
+    "artifact_body_for_ref",
+    "artifact_for_ref",
+    "artifact_store_for_receipt",
+    "claim_envelope",
+    "receipt_projection_case",
+]

--- a/tests/test_persistence_ledger_boundary.py
+++ b/tests/test_persistence_ledger_boundary.py
@@ -2,12 +2,6 @@ from dataclasses import replace
 
 import pytest
 
-from comp import (
-    CommitReceipt,
-    CommitReceiptCitations,
-    ProjectionSpec,
-    ProjectionValueCommitment,
-)
 from comp.persistence import (
     ArtifactConflict,
     ArtifactEnvelope,
@@ -18,11 +12,12 @@ from comp.persistence import (
     ReceiptConflict,
     verify_materialized_public_projection,
 )
+from tests.support.persistence_cases import claim_envelope, receipt_projection_case
 
 
 def test_artifact_store_records_envelopes_by_id_idempotently():
     store = InMemoryArtifactStore()
-    envelope = _claim_envelope(value=1200)
+    envelope = claim_envelope(value=1200)
 
     assert store.record(envelope) == envelope
     assert store.record(envelope) == envelope
@@ -33,8 +28,8 @@ def test_artifact_store_records_envelopes_by_id_idempotently():
 
 def test_artifact_store_rejects_same_id_with_different_body_digest():
     store = InMemoryArtifactStore()
-    envelope = _claim_envelope(value=1200)
-    changed = _claim_envelope(value=1201)
+    envelope = claim_envelope(value=1200)
+    changed = claim_envelope(value=1201)
 
     store.record(envelope)
 
@@ -46,7 +41,7 @@ def test_artifact_store_rejects_same_id_with_different_body_digest():
 
 def test_artifact_store_rejects_envelope_when_body_does_not_match_digest():
     store = InMemoryArtifactStore()
-    envelope = _claim_envelope(value=1200)
+    envelope = claim_envelope(value=1200)
     tampered = ArtifactEnvelope(
         artifact_id=envelope.artifact_id,
         artifact_kind=envelope.artifact_kind,
@@ -61,7 +56,7 @@ def test_artifact_store_rejects_envelope_when_body_does_not_match_digest():
 
 def test_receipt_ledger_records_commit_receipt_as_append_only_root():
     ledger = InMemoryReceiptLedger()
-    receipt = _receipt(amount=100)
+    receipt = receipt_projection_case(amount=100).receipt
 
     assert ledger.record(receipt) == receipt
     assert ledger.record(receipt) == receipt
@@ -76,7 +71,7 @@ def test_receipt_ledger_records_commit_receipt_as_append_only_root():
 
 def test_receipt_ledger_rejects_mutating_existing_receipt_root():
     ledger = InMemoryReceiptLedger()
-    receipt = _receipt(amount=100)
+    receipt = receipt_projection_case(amount=100).receipt
     changed = replace(
         receipt,
         authorized_fields=("site",),
@@ -92,91 +87,30 @@ def test_receipt_ledger_rejects_mutating_existing_receipt_root():
 
 
 def test_materialized_public_projection_is_a_receipt_verified_view():
-    projection = ProjectionSpec("public-row", ("site", "amount"))
-    receipt = _receipt(amount=100)
+    case = receipt_projection_case(amount=100)
 
     row = verify_materialized_public_projection(
-        {"site": "plant-a", "amount": 100},
-        projection,
-        receipt=receipt,
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
     )
 
-    assert row == {"site": "plant-a", "amount": 100}
+    assert row == case.public_row
 
 
 def test_materialized_public_projection_blocks_tampered_values_or_extra_fields():
-    projection = ProjectionSpec("public-row", ("site", "amount"))
-    receipt = _receipt(amount=100)
+    case = receipt_projection_case(amount=100)
 
     with pytest.raises(ProjectionReplayBlocked, match="cannot be replayed"):
         verify_materialized_public_projection(
             {"site": "plant-a", "amount": 999999},
-            projection,
-            receipt=receipt,
+            case.projection,
+            receipt=case.receipt,
         )
 
     with pytest.raises(ProjectionReplayBlocked, match="receipt-authorized view"):
         verify_materialized_public_projection(
             {"site": "plant-a", "amount": 100, "internal_note": "hidden"},
-            projection,
-            receipt=receipt,
+            case.projection,
+            receipt=case.receipt,
         )
-
-
-def _claim_envelope(*, value: int) -> ArtifactEnvelope:
-    return ArtifactEnvelope.from_body(
-        artifact_id="artifact:claim:1",
-        artifact_kind="checked_claim",
-        schema_version="v1",
-        body={"field": "electricity_kwh", "value": value},
-    )
-
-
-def _receipt(*, amount: int) -> CommitReceipt:
-    commitments = (
-        ProjectionValueCommitment.from_value(
-            field="site",
-            source_kind="checked_claim",
-            source_id="checked_claim:site:span-site",
-            value="plant-a",
-        ),
-        ProjectionValueCommitment.from_value(
-            field="amount",
-            source_kind="checked_claim",
-            source_id="checked_claim:amount:span-amount",
-            value=amount,
-        ),
-    )
-    citations = CommitReceiptCitations(
-        governance_decision_id="decision-1",
-        governance_status="commit",
-        governance_reasons=("ready",),
-        commit_package_id="package-1",
-        commit_package_complete=True,
-        subject_id="facility-1",
-        projection_id="public-row",
-        authorized_fields=("site", "amount"),
-        profile_id=None,
-        report_status="accepted",
-        checked_claim_fields=("site", "amount"),
-        checked_claim_witness_ids=("span-site", "span-amount"),
-        semantic_judgment_ids=(),
-        reference_binding_ids=(),
-        derived_claim_fields=(),
-        derived_claim_ids=(),
-        calculation_trace_ids=(),
-        formula_ids=(),
-        resolved_obligation_ids=(),
-        open_obligation_ids=(),
-        hazard_ids=(),
-        projection_value_commitments=commitments,
-    )
-    return CommitReceipt(
-        draft_id="draft-1",
-        winner_receipt_ids=("decision-1",),
-        barrier_snapshot=citations.to_barrier_snapshot(),
-        public_row_id="public-row-1",
-        projection_id="public-row",
-        authorized_fields=("site", "amount"),
-        citations=citations,
-    )

--- a/tests/test_persistence_projection_replay.py
+++ b/tests/test_persistence_projection_replay.py
@@ -1,32 +1,28 @@
 import pytest
 
-from comp import (
-    CommitReceipt,
-    CommitReceiptCitations,
-    ProjectionSpec,
-    ProjectionValueCommitment,
-)
 from comp.persistence import (
     ArtifactEnvelope,
     ArtifactRef,
-    InMemoryArtifactStore,
     ProjectionReplayBlocked,
     ProjectionReplayReport,
     ReceiptLedgerKey,
     receipt_artifact_refs,
     replay_public_projection,
 )
+from tests.support.persistence_cases import (
+    artifact_store_for_receipt,
+    receipt_projection_case,
+)
 
 
 def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
-    receipt = _receipt(amount=100)
-    artifacts = _artifact_store_for(receipt)
-    projection = ProjectionSpec("public-row", ("site", "amount"))
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(case.receipt)
 
     report = replay_public_projection(
-        {"site": "plant-a", "amount": 100},
-        projection,
-        receipt=receipt,
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
         artifacts=artifacts,
     )
 
@@ -36,8 +32,8 @@ def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
         projection_id="public-row",
         draft_id="draft-1",
     )
-    assert report.public_row == {"site": "plant-a", "amount": 100}
-    assert report.artifact_refs == receipt_artifact_refs(receipt)
+    assert report.public_row == case.public_row
+    assert report.artifact_refs == receipt_artifact_refs(case.receipt)
     assert ArtifactRef("package-1", "commit_package") in report.artifact_refs
     assert ArtifactRef("decision-1", "governance_decision") in report.artifact_refs
     assert (
@@ -48,26 +44,25 @@ def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
 
 
 def test_replay_blocks_when_required_artifact_is_missing():
-    receipt = _receipt(amount=100)
-    artifacts = _artifact_store_for(
-        receipt,
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
         skip=ArtifactRef("decision-1", "governance_decision"),
     )
-    projection = ProjectionSpec("public-row", ("site", "amount"))
 
     with pytest.raises(ProjectionReplayBlocked, match="missing artifact"):
         replay_public_projection(
-            {"site": "plant-a", "amount": 100},
-            projection,
-            receipt=receipt,
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
             artifacts=artifacts,
         )
 
 
 def test_replay_blocks_when_required_artifact_kind_mismatches():
-    receipt = _receipt(amount=100)
-    artifacts = _artifact_store_for(
-        receipt,
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
         override=ArtifactEnvelope.from_body(
             artifact_id="decision-1",
             artifact_kind="commit_package",
@@ -75,129 +70,38 @@ def test_replay_blocks_when_required_artifact_kind_mismatches():
             body={"status": "commit"},
         ),
     )
-    projection = ProjectionSpec("public-row", ("site", "amount"))
 
     with pytest.raises(ProjectionReplayBlocked, match="artifact kind"):
         replay_public_projection(
-            {"site": "plant-a", "amount": 100},
-            projection,
-            receipt=receipt,
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
             artifacts=artifacts,
         )
 
 
 def test_replay_blocks_when_stored_artifact_body_drifts_after_recording():
-    receipt = _receipt(amount=100)
-    artifacts = _artifact_store_for(receipt)
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(case.receipt)
     artifacts.get("package-1").body["complete"] = False
-    projection = ProjectionSpec("public-row", ("site", "amount"))
 
     with pytest.raises(ProjectionReplayBlocked, match="body digest"):
         replay_public_projection(
-            {"site": "plant-a", "amount": 100},
-            projection,
-            receipt=receipt,
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
             artifacts=artifacts,
         )
 
 
 def test_replay_blocks_when_materialized_row_no_longer_matches_receipt():
-    receipt = _receipt(amount=100)
-    artifacts = _artifact_store_for(receipt)
-    projection = ProjectionSpec("public-row", ("site", "amount"))
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(case.receipt)
 
     with pytest.raises(ProjectionReplayBlocked, match="cannot be replayed"):
         replay_public_projection(
             {"site": "plant-a", "amount": 999999},
-            projection,
-            receipt=receipt,
+            case.projection,
+            receipt=case.receipt,
             artifacts=artifacts,
         )
-
-
-def _artifact_store_for(
-    receipt: CommitReceipt,
-    *,
-    skip: ArtifactRef | None = None,
-    override: ArtifactEnvelope | None = None,
-) -> InMemoryArtifactStore:
-    store = InMemoryArtifactStore()
-    for ref in receipt_artifact_refs(receipt):
-        if ref == skip:
-            continue
-        if override is not None and override.artifact_id == ref.artifact_id:
-            store.record(override)
-            continue
-        store.record(_artifact_for_ref(ref))
-    return store
-
-
-def _artifact_for_ref(ref: ArtifactRef) -> ArtifactEnvelope:
-    return ArtifactEnvelope.from_body(
-        artifact_id=ref.artifact_id,
-        artifact_kind=ref.artifact_kind,
-        schema_version="v1",
-        body=_artifact_body_for_ref(ref),
-    )
-
-
-def _artifact_body_for_ref(ref: ArtifactRef) -> dict:
-    if ref.artifact_kind == "commit_package":
-        return {"package_id": ref.artifact_id, "complete": True}
-    if ref.artifact_kind == "governance_decision":
-        return {"decision_id": ref.artifact_id, "status": "commit"}
-    if ref.artifact_kind == "checked_claim":
-        return {"claim_id": ref.artifact_id, "field": "amount"}
-    if ref.artifact_kind == "evidence_witness":
-        return {"witness_id": ref.artifact_id, "source": "fixture"}
-    raise AssertionError(f"Unexpected artifact ref in test: {ref}")
-
-
-def _receipt(*, amount: int) -> CommitReceipt:
-    commitments = (
-        ProjectionValueCommitment.from_value(
-            field="site",
-            source_kind="checked_claim",
-            source_id="checked_claim:site:span-site",
-            value="plant-a",
-        ),
-        ProjectionValueCommitment.from_value(
-            field="amount",
-            source_kind="checked_claim",
-            source_id="checked_claim:amount:span-amount",
-            value=amount,
-        ),
-    )
-    citations = CommitReceiptCitations(
-        governance_decision_id="decision-1",
-        governance_status="commit",
-        governance_reasons=("ready",),
-        commit_package_id="package-1",
-        commit_package_complete=True,
-        subject_id="facility-1",
-        projection_id="public-row",
-        authorized_fields=("site", "amount"),
-        profile_id=None,
-        report_status="accepted",
-        checked_claim_fields=("site", "amount"),
-        checked_claim_witness_ids=("span-site", "span-amount"),
-        semantic_judgment_ids=(),
-        reference_binding_ids=(),
-        derived_claim_fields=(),
-        derived_claim_ids=(),
-        calculation_trace_ids=(),
-        formula_ids=(),
-        resolved_obligation_ids=(),
-        open_obligation_ids=(),
-        hazard_ids=(),
-        projection_value_commitments=commitments,
-    )
-    return CommitReceipt(
-        draft_id="draft-1",
-        winner_receipt_ids=("decision-1",),
-        barrier_snapshot=citations.to_barrier_snapshot(),
-        public_row_id="public-row-1",
-        projection_id="public-row",
-        authorized_fields=("site", "amount"),
-        citations=citations,
-    )


### PR DESCRIPTION
## Summary
- Add `tests.support.persistence_cases` for shared persistence projection cases, receipt builders, and artifact store setup.
- Refactor persistence ledger and replay tests to focus on behavior instead of repeating `CommitReceiptCitations` and `ProjectionValueCommitment` setup.
- Keep negative mutation cases visible in the test bodies while moving only normal-case fixture construction to support helpers.

## Validation
- `python -m pytest tests\test_persistence_envelope.py tests\test_persistence_ledger_boundary.py tests\test_persistence_projection_replay.py -q` -> 18 passed
- `python -m pytest -q` -> 237 passed
- `git diff --check HEAD~1..HEAD` -> exit 0