### PR TITLE
[codex] make L-Energy scenario retrieval-backed

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -36,9 +36,12 @@ commit preparation, and receipt-gated projection.
 
 The first larger source-referenced pack is `l_energy_pcf_governance`, based on
 `minntcho/esg-platform` case `001-l-energy-pcf-governance`. It uses
-fixture-derived claims from the platform expected receipt to test whether a
-realistic PCF governance case can be represented as `comp` authority artifacts
-without adding a full PCF workflow engine.
+fixture-derived downstream claims from the platform expected receipt, but routes
+the L-Energy own-energy factor through a retrieval-backed slice: calculation
+blocked, reference search obligation, `ResolverTask`, `RetrievalQueryPolicy`,
+candidate-only embedding stub results, deterministic reference binding, retry,
+and receipt-gated projection. This keeps the case realistic without adding a
+full PCF workflow engine.
 
 ## Testing Philosophy
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/expected.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/expected.py
@@ -45,6 +45,16 @@ EXPECTED_REFERENCE_BINDING_IDS = (
     "bind:pcf:ncm811_factor",
 )
 
+EXPECTED_REFERENCE_CANDIDATE_IDS = (
+    "platform.factor.electricity_mwh",
+    "platform.factor.electricity_mwh_2024",
+)
+
+EXPECTED_RESOLVED_OBLIGATION_KINDS = (
+    "reference_search_required",
+    "calculation_blocked",
+)
+
 EXPECTED_DERIVED_CLAIM_IDS = (
     "l-energy:own_emission_tco2e",
     "alpha-metal:final_emission_tco2e",
@@ -67,7 +77,9 @@ __all__ = [
     "EXPECTED_DERIVED_CLAIM_IDS",
     "EXPECTED_FORMULA_IDS",
     "EXPECTED_PROJECTION",
+    "EXPECTED_REFERENCE_CANDIDATE_IDS",
     "EXPECTED_REFERENCE_BINDING_IDS",
+    "EXPECTED_RESOLVED_OBLIGATION_KINDS",
     "EXPECTED_SOURCE_REFS",
     "EXPECTED_TRACE_IDS",
     "SCENARIO_ID",

--- a/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from comp.compiler_tool import (
+    CalculationFormula,
+    CalculationInput,
     CalculationTrace,
     CheckedClaim,
     CompileReport,
     DerivedClaim,
+    EmbeddingResolverStub,
+    ReferenceCatalog,
     ReferenceBinding,
+    ReferenceIndexEntry,
+    ReferenceRecord,
+    ReferenceSelectionCriteria,
+    RetrievalQueryPolicy,
+    RetrievalQueryRule,
+    apply_calculation_result,
+    calculate_derived_claim,
+    with_recomputed_status,
 )
 from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     SCENARIO_ID,
@@ -17,6 +31,9 @@ SUBJECT_ID = f"case:{SOURCE_CASE_ID}"
 PUBLIC_ROW_ID = f"public-row:{SOURCE_CASE_ID}"
 PROFILE_ID = "pcf-governance-platform-fixture-v1"
 FORMULA_ID = "pcf-demo-2025.0"
+INPUT_CLAIM_ID = "l-energy:total_energy_gwh"
+OUTPUT_CLAIM_ID = "l-energy:own_emission_tco2e"
+ELECTRICITY_BINDING_ID = "bind:pcf:electricity_factor"
 
 
 def checked_claims() -> tuple[CheckedClaim, ...]:
@@ -45,7 +62,7 @@ def checked_claims() -> tuple[CheckedClaim, ...]:
 def reference_bindings() -> tuple[ReferenceBinding, ...]:
     return (
         ReferenceBinding(
-            binding_id="bind:pcf:electricity_factor",
+            binding_id=ELECTRICITY_BINDING_ID,
             claim_id=SCENARIO_ID,
             reference_id="platform.factor.electricity_mwh",
             reference_type="emission_factor",
@@ -87,14 +104,22 @@ def reference_bindings() -> tuple[ReferenceBinding, ...]:
     )
 
 
+def downstream_reference_bindings() -> tuple[ReferenceBinding, ...]:
+    return tuple(
+        binding
+        for binding in reference_bindings()
+        if binding.binding_id != ELECTRICITY_BINDING_ID
+    )
+
+
 def derived_claims() -> tuple[DerivedClaim, ...]:
     return (
         _derived_claim(
-            claim_id="l-energy:own_emission_tco2e",
+            claim_id=OUTPUT_CLAIM_ID,
             field="l_energy_own_emission_tco2e",
             value=1695,
             reference_binding_ids=(
-                "bind:pcf:electricity_factor",
+                ELECTRICITY_BINDING_ID,
                 "bind:pcf:lng_factor",
             ),
         ),
@@ -161,6 +186,182 @@ def derived_claims() -> tuple[DerivedClaim, ...]:
     )
 
 
+def downstream_derived_claims() -> tuple[DerivedClaim, ...]:
+    return tuple(
+        claim for claim in derived_claims() if claim.claim_id != OUTPUT_CLAIM_ID
+    )
+
+
+def blocked_report() -> CompileReport:
+    result = calculate_derived_claim(
+        output_claim_id=OUTPUT_CLAIM_ID,
+        input_claim=input_claim(),
+        reference_binding=ReferenceBinding(
+            binding_id=ELECTRICITY_BINDING_ID,
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.unresolved_l_energy_energy",
+            reference_type="emission_factor",
+        ),
+        catalog=ReferenceCatalog(records=()),
+        formula=formula(),
+    )
+    return apply_calculation_result(
+        CompileReport(status="accepted", checked_claims=checked_claims()),
+        result,
+        output_claim_id=OUTPUT_CLAIM_ID,
+        formula=formula(),
+    )
+
+
+def catalog() -> ReferenceCatalog:
+    return ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="platform.factor.electricity_mwh",
+                reference_type="emission_factor",
+                labels=("L-Energy electricity and LNG factor 2025",),
+                aliases=("L-Energy own site energy factor",),
+                description=(
+                    "Platform fixture factor for L-Energy own energy emissions."
+                ),
+                attributes=(
+                    ("concept_id", "platform.concept.l_energy_own_energy"),
+                    ("geography", "KR"),
+                    ("valid_period", "2025"),
+                    ("method", "platform_expected_receipt"),
+                    ("factor_value", 226),
+                    ("input_unit", "GWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping",),
+            ),
+            ReferenceRecord(
+                reference_id="platform.factor.electricity_mwh_2024",
+                reference_type="emission_factor",
+                labels=("L-Energy electricity and LNG factor 2024",),
+                aliases=("L-Energy historical own site energy factor",),
+                description=(
+                    "Near-miss platform fixture factor with the wrong valid period."
+                ),
+                attributes=(
+                    ("concept_id", "platform.concept.l_energy_own_energy"),
+                    ("geography", "KR"),
+                    ("valid_period", "2024"),
+                    ("method", "platform_expected_receipt"),
+                    ("factor_value", 220),
+                    ("input_unit", "GWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:2024-near-miss",),
+            ),
+        )
+    )
+
+
+def reference_resolver() -> EmbeddingResolverStub:
+    return EmbeddingResolverStub(
+        entries=(
+            ReferenceIndexEntry(
+                entry_id="idx-l-energy-electricity-mwh-2025",
+                reference_id="platform.factor.electricity_mwh",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea L-Energy electricity LNG factor 2025",
+                reference_db_version="l-energy-platform-fixture-v1",
+                index_version="l-energy-embedding-stub-v1",
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping",),
+            ),
+            ReferenceIndexEntry(
+                entry_id="idx-l-energy-electricity-mwh-2024",
+                reference_id="platform.factor.electricity_mwh_2024",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea L-Energy electricity LNG factor 2024",
+                reference_db_version="l-energy-platform-fixture-v1",
+                index_version="l-energy-embedding-stub-v1",
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:2024-near-miss",),
+            ),
+        )
+    )
+
+
+def retrieval_query_policy() -> RetrievalQueryPolicy:
+    return RetrievalQueryPolicy(
+        policy_id="l-energy-pcf-retrieval-query-policy-v1",
+        rules=(
+            RetrievalQueryRule(
+                rule_id="l-energy-own-energy-factor-query-v1",
+                formula_id=FORMULA_ID,
+                lens="factor",
+                reference_type="emission_factor",
+                text_template=(
+                    "{geography} L-Energy electricity LNG factor {reporting_year}"
+                ),
+            ),
+        ),
+    )
+
+
+def retrieval_query_context() -> dict[str, object]:
+    return {
+        "geography": "Korea",
+        "reporting_year": "2025",
+    }
+
+
+def criteria() -> ReferenceSelectionCriteria:
+    return ReferenceSelectionCriteria(
+        binding_id=ELECTRICITY_BINDING_ID,
+        claim_id=SCENARIO_ID,
+        reference_type="emission_factor",
+        selector_rule_id="pcf.factor_selector.v1",
+        required_attributes=(
+            ("concept_id", "platform.concept.l_energy_own_energy"),
+            ("geography", "KR"),
+            ("valid_period", "2025"),
+            ("method", "platform_expected_receipt"),
+        ),
+    )
+
+
+def input_claim() -> CalculationInput:
+    return CalculationInput(
+        claim_id=INPUT_CLAIM_ID,
+        field="total_energy_gwh",
+        value=7.5,
+        unit="GWh",
+    )
+
+
+def formula() -> CalculationFormula:
+    return CalculationFormula(
+        formula_id=FORMULA_ID,
+        output_field="l_energy_own_emission_tco2e",
+        output_unit="tCO2e",
+    )
+
+
+def attach_downstream_fixture_artifacts(report: CompileReport) -> CompileReport:
+    return with_recomputed_status(
+        replace(
+            report,
+            reference_bindings=_append_missing_reference_bindings(
+                report.reference_bindings,
+                downstream_reference_bindings(),
+            ),
+            derived_claims=_append_missing_derived_claims(
+                report.derived_claims,
+                downstream_derived_claims(),
+            ),
+            can_project_public_row=False,
+        )
+    )
+
+
 def compile_report() -> CompileReport:
     return CompileReport(
         status="accepted",
@@ -193,13 +394,49 @@ def _derived_claim(
     )
 
 
+def _append_missing_reference_bindings(
+    existing: tuple[ReferenceBinding, ...],
+    additions: tuple[ReferenceBinding, ...],
+) -> tuple[ReferenceBinding, ...]:
+    binding_ids = {binding.binding_id for binding in existing}
+    return (
+        *existing,
+        *(binding for binding in additions if binding.binding_id not in binding_ids),
+    )
+
+
+def _append_missing_derived_claims(
+    existing: tuple[DerivedClaim, ...],
+    additions: tuple[DerivedClaim, ...],
+) -> tuple[DerivedClaim, ...]:
+    claim_ids = {claim.claim_id for claim in existing}
+    return (
+        *existing,
+        *(claim for claim in additions if claim.claim_id not in claim_ids),
+    )
+
+
 __all__ = [
+    "ELECTRICITY_BINDING_ID",
     "FORMULA_ID",
+    "INPUT_CLAIM_ID",
+    "OUTPUT_CLAIM_ID",
     "PROFILE_ID",
     "PUBLIC_ROW_ID",
     "SUBJECT_ID",
+    "attach_downstream_fixture_artifacts",
+    "blocked_report",
+    "catalog",
     "checked_claims",
     "compile_report",
+    "criteria",
     "derived_claims",
+    "downstream_derived_claims",
+    "downstream_reference_bindings",
+    "formula",
+    "input_claim",
+    "reference_resolver",
     "reference_bindings",
+    "retrieval_query_context",
+    "retrieval_query_policy",
 ]

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 from comp import ProjectionSpec, SubjectRef, project_public_row
-from comp.compiler_tool import prepare_commit
+from comp.compiler_tool import (
+    CompileReport,
+    ReferenceBinding,
+    apply_reference_selection,
+    plan_calculation_resolution,
+    prepare_commit,
+    reference_query_for_obligation_from_policy,
+    resolve_reference_retrieval_obligations,
+    resolver_tasks_from_report,
+    retry_blocked_calculation,
+)
 from tests.domain_scenarios.core import (
     DomainScenarioResult,
     ScenarioContract,
@@ -12,23 +22,42 @@ from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     EXPECTED_DERIVED_CLAIM_IDS,
     EXPECTED_FORMULA_IDS,
     EXPECTED_PROJECTION,
+    EXPECTED_REFERENCE_CANDIDATE_IDS,
     EXPECTED_REFERENCE_BINDING_IDS,
+    EXPECTED_RESOLVED_OBLIGATION_KINDS,
     EXPECTED_SOURCE_REFS,
     EXPECTED_TRACE_IDS,
     SCENARIO_ID,
 )
 from tests.domain_scenarios.l_energy_pcf_governance.fixtures import (
+    ELECTRICITY_BINDING_ID,
+    OUTPUT_CLAIM_ID,
     PROFILE_ID,
     PUBLIC_ROW_ID,
     SUBJECT_ID,
-    compile_report,
+    attach_downstream_fixture_artifacts,
+    blocked_report,
+    catalog,
+    criteria,
+    formula,
+    input_claim,
+    reference_resolver,
+    retrieval_query_context,
+    retrieval_query_policy,
 )
 
 
 RESOLVER_STEPS = (
     "load_platform_expected_receipt_fixture",
-    "create_fixture_reference_bindings",
-    "create_fixture_derived_claims",
+    "open_l_energy_own_emission_calculation_obligation",
+    "plan_calculation_resolution",
+    "resolver_tasks_from_report",
+    "retrieval_query_policy",
+    "resolver_task_to_reference_query",
+    "reference_retrieval:embedding_stub:factor",
+    "deterministic_reference_selection",
+    "retry_calculation",
+    "attach_fixture_downstream_claims",
     "prepare_commit",
     "receipt_gated_projection",
 )
@@ -51,6 +80,8 @@ SCENARIO = ScenarioDefinition(
     contract=ScenarioContract(
         must_commit=True,
         required_projection=EXPECTED_PROJECTION,
+        required_resolved_obligation_kinds=EXPECTED_RESOLVED_OBLIGATION_KINDS,
+        required_reference_candidate_ids=EXPECTED_REFERENCE_CANDIDATE_IDS,
         required_reference_binding_ids=EXPECTED_REFERENCE_BINDING_IDS,
         required_derived_claim_ids=EXPECTED_DERIVED_CLAIM_IDS,
         required_receipt_reference_binding_ids=EXPECTED_REFERENCE_BINDING_IDS,
@@ -62,7 +93,7 @@ SCENARIO = ScenarioDefinition(
 
 
 def run_l_energy_pcf_governance_scenario() -> DomainScenarioResult:
-    report = compile_report()
+    report = _compile_retrieval_backed_report()
     preparation = prepare_commit(
         report,
         subject_id=SUBJECT_ID,
@@ -92,6 +123,49 @@ def _projection_source(report) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
     values.update({claim.field: claim.value for claim in report.derived_claims})
     return values
+
+
+def _compile_retrieval_backed_report() -> CompileReport:
+    opened_report = blocked_report()
+    planned_report = plan_calculation_resolution(opened_report)
+    resolver_tasks = resolver_tasks_from_report(planned_report)
+    retrieval_report = resolve_reference_retrieval_obligations(
+        planned_report,
+        reference_resolver(),
+        query_for_obligation=reference_query_for_obligation_from_policy(
+            resolver_tasks,
+            policy=retrieval_query_policy(),
+            context=retrieval_query_context(),
+        ),
+    )
+    selected_report = apply_reference_selection(
+        retrieval_report,
+        catalog(),
+        criteria=criteria(),
+        field=formula().output_field,
+    )
+    binding = _binding_for(selected_report.reference_bindings, ELECTRICITY_BINDING_ID)
+    resolved_report = selected_report
+    if binding is not None:
+        resolved_report = retry_blocked_calculation(
+            selected_report,
+            catalog(),
+            input_claim=input_claim(),
+            reference_binding=binding,
+            formula=formula(),
+            output_claim_id=OUTPUT_CLAIM_ID,
+        )
+    return attach_downstream_fixture_artifacts(resolved_report)
+
+
+def _binding_for(
+    bindings: tuple[ReferenceBinding, ...],
+    binding_id: str,
+) -> ReferenceBinding | None:
+    for binding in reversed(bindings):
+        if binding.binding_id == binding_id:
+            return binding
+    return None
 
 
 __all__ = ["SCENARIO", "run_l_energy_pcf_governance_scenario"]

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -33,6 +33,55 @@ def test_l_energy_pcf_governance_scenario_reproduces_platform_summary():
     assert result.projection == EXPECTED_PROJECTION
 
 
+def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retrieval():
+    result = run_l_energy_pcf_governance_scenario()
+
+    assert "resolver_tasks_from_report" in result.resolver_steps
+    assert "retrieval_query_policy" in result.resolver_steps
+    assert "reference_retrieval:embedding_stub:factor" in result.resolver_steps
+    assert tuple(
+        obligation.kind for obligation in result.report.resolved_obligations
+    ) == ("reference_search_required", "calculation_blocked")
+
+    candidate_ids = tuple(
+        candidate.candidate_id for candidate in result.report.reference_candidates
+    )
+    assert candidate_ids == (
+        "embedding_stub:factor:idx-l-energy-electricity-mwh-2025",
+        "embedding_stub:factor:idx-l-energy-electricity-mwh-2024",
+    )
+    assert all(
+        candidate.authority == "candidate_only"
+        for candidate in result.report.reference_candidates
+    )
+
+    electricity_binding = next(
+        binding
+        for binding in result.report.reference_bindings
+        if binding.binding_id == "bind:pcf:electricity_factor"
+    )
+    assert (
+        electricity_binding.selected_candidate_id
+        == "embedding_stub:factor:idx-l-energy-electricity-mwh-2025"
+    )
+    assert tuple(
+        (rejected.reference_id, rejected.reason)
+        for rejected in electricity_binding.rejected_candidates
+    ) == (
+        ("platform.factor.electricity_mwh_2024", "attribute_mismatch:valid_period"),
+    )
+
+    own_emission_claim = next(
+        claim
+        for claim in result.report.derived_claims
+        if claim.claim_id == "l-energy:own_emission_tco2e"
+    )
+    assert own_emission_claim.origin == "calculated"
+    assert own_emission_claim.trace.reference_binding_ids == (
+        "bind:pcf:electricity_factor",
+    )
+
+
 def test_l_energy_pcf_governance_scenario_preserves_actor_receipt_trace():
     result = run_scenario(L_ENERGY_SCENARIO)
 


### PR DESCRIPTION
## Summary

- route the L-Energy own-energy factor through a retrieval-backed scenario slice
- add candidate-only embedding stub results plus deterministic selection with a 2024 near-miss rejection
- preserve the existing platform summary projection, receipt contract, and downstream fixture claims
- update the Domain Scenario Lab note so the L-Energy pack description matches the new flow

## Validation

- `python -m pytest tests/test_l_energy_pcf_scenario.py -q`
- `python -m pytest tests/test_domain_scenario_lab.py tests/test_canonical_working_loop_scenario.py -q`
- `python -m pytest tests/test_resolver_retrieval.py tests/test_minchoagnt_comp_adapter.py tests/test_retrieval_resolution.py tests/test_retrieval_lens_interface.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`