### PR TITLE
[codex] normalize scenario lab test helpers

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -58,6 +58,9 @@ ScenarioContract
 SourceRef
 run_scenario()
 assert_scenario_contract()
+scenario_result_view()
+assert_receipt_trace()
+assert_projection_tamper_blocked()
 registered_scenarios()
 ```
 
@@ -91,3 +94,9 @@ the exact function where profile-aware gating is enforced
 Scenario payloads should stay stable enough for a viewer to explain the run, but
 tests should avoid asserting one huge exported JSON blob. Prefer targeted checks
 that prove the authority boundary and traceability story still hold.
+
+Use `scenario_result_view()` when a test needs the viewer/export payload. Use
+`assert_receipt_trace()` for receipt citation checks, and
+`assert_projection_tamper_blocked()` for receipt value-gate negative tests.
+That keeps scenario tests focused on the contract instead of repeating receipt
+field traversal or projection tamper boilerplate in every pack.

--- a/tests/domain_scenarios/assertions.py
+++ b/tests/domain_scenarios/assertions.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+
+
+def assert_projection_tamper_blocked(
+    result,
+    projection: ProjectionSpec,
+    overrides: Mapping[str, Any],
+    *,
+    match: str = "value commitment",
+) -> None:
+    if result.projection is None:
+        raise AssertionError("scenario result has no projection to tamper")
+    if result.preparation.receipt is None:
+        raise AssertionError("scenario result has no receipt to enforce projection")
+
+    tampered_values = dict(result.projection)
+    tampered_values.update(overrides)
+
+    with pytest.raises(ProjectionBlocked, match=match):
+        project_public_row(
+            tampered_values,
+            projection,
+            receipt=result.preparation.receipt,
+        )
+
+
+def assert_receipt_trace(
+    result,
+    *,
+    reference_binding_ids: tuple[str, ...] | None = None,
+    derived_claim_ids: tuple[str, ...] | None = None,
+    calculation_trace_ids: tuple[str, ...] | None = None,
+    formula_ids: tuple[str, ...] | None = None,
+) -> None:
+    if result.preparation.receipt is None:
+        raise AssertionError("scenario result has no receipt")
+    if result.preparation.receipt.citations is None:
+        raise AssertionError("scenario receipt has no citations")
+
+    citations = result.preparation.receipt.citations
+    if reference_binding_ids is not None:
+        assert citations.reference_binding_ids == reference_binding_ids
+    if derived_claim_ids is not None:
+        assert citations.derived_claim_ids == derived_claim_ids
+    if calculation_trace_ids is not None:
+        assert citations.calculation_trace_ids == calculation_trace_ids
+    if formula_ids is not None:
+        assert citations.formula_ids == formula_ids
+
+
+__all__ = [
+    "assert_projection_tamper_blocked",
+    "assert_receipt_trace",
+]

--- a/tests/domain_scenarios/core.py
+++ b/tests/domain_scenarios/core.py
@@ -64,74 +64,9 @@ class DomainScenarioResult:
     resolver_steps: tuple[str, ...]
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "scenario_id": self.scenario_id,
-            "resolver_steps": self.resolver_steps,
-            "report": {
-                "status": self.report.status,
-                "open_obligations": [
-                    _obligation_view(obligation)
-                    for obligation in self.report.obligations
-                ],
-                "resolved_obligations": [
-                    _obligation_view(obligation)
-                    for obligation in self.report.resolved_obligations
-                ],
-                "reference_candidates": [
-                    {
-                        "candidate_id": candidate.candidate_id,
-                        "reference_id": candidate.reference_id,
-                        "reference_type": candidate.reference_type,
-                        "retrieval_method": candidate.retrieval_method,
-                        "retrieval_score": candidate.retrieval_score,
-                        "authority": candidate.authority,
-                    }
-                    for candidate in self.report.reference_candidates
-                ],
-                "reference_bindings": [
-                    {
-                        "binding_id": binding.binding_id,
-                        "reference_id": binding.reference_id,
-                        "selected_candidate_id": binding.selected_candidate_id,
-                        "rejected_candidates": [
-                            {
-                                "reference_id": rejected.reference_id,
-                                "reason": rejected.reason,
-                            }
-                            for rejected in binding.rejected_candidates
-                        ],
-                    }
-                    for binding in self.report.reference_bindings
-                ],
-                "derived_claims": [
-                    {
-                        "claim_id": claim.claim_id,
-                        "field": claim.field,
-                        "value": claim.value,
-                        "unit": claim.unit,
-                        "trace_id": claim.trace.trace_id,
-                        "formula_id": claim.formula_id,
-                        "reference_binding_ids": claim.trace.reference_binding_ids,
-                    }
-                    for claim in self.report.derived_claims
-                ],
-            },
-            "commit": {
-                "package_id": self.preparation.package.package_id,
-                "package_complete": self.preparation.package.complete,
-                "governance_status": self.preparation.decision.status,
-                "receipt_id": (
-                    self.preparation.receipt.public_row_id
-                    if self.preparation.receipt is not None
-                    else None
-                ),
-            },
-            "facts": {
-                "report_count": len(self.report_facts),
-                "commit_count": len(self.commit_facts),
-            },
-            "projection": self.projection,
-        }
+        from tests.domain_scenarios.views import scenario_result_view
+
+        return scenario_result_view(self)
 
     def to_json(self) -> str:
         return json.dumps(_json_ready(self.to_dict()), indent=2, sort_keys=True)
@@ -232,15 +167,6 @@ def assert_scenario_contract(
         )
     if contract.required_hazard_ids is not None:
         assert result.preparation.package.hazard_ids == contract.required_hazard_ids
-
-
-def _obligation_view(obligation) -> dict[str, str | None]:
-    return {
-        "obligation_id": obligation.obligation_id,
-        "kind": obligation.kind,
-        "field": obligation.field,
-        "reason": obligation.reason,
-    }
 
 
 def _json_ready(value):

--- a/tests/domain_scenarios/views.py
+++ b/tests/domain_scenarios/views.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def scenario_result_view(result) -> dict[str, Any]:
+    return {
+        "scenario_id": result.scenario_id,
+        "resolver_steps": result.resolver_steps,
+        "report": report_view(result.report),
+        "commit": commit_view(result.preparation),
+        "receipt_trace": receipt_trace_view(
+            result.preparation.receipt,
+        ),
+        "facts": {
+            "report_count": len(result.report_facts),
+            "commit_count": len(result.commit_facts),
+        },
+        "projection": result.projection,
+    }
+
+
+def report_view(report) -> dict[str, Any]:
+    return {
+        "status": report.status,
+        "open_obligations": [
+            _obligation_view(obligation)
+            for obligation in report.obligations
+        ],
+        "resolved_obligations": [
+            _obligation_view(obligation)
+            for obligation in report.resolved_obligations
+        ],
+        "reference_candidates": [
+            {
+                "candidate_id": candidate.candidate_id,
+                "reference_id": candidate.reference_id,
+                "reference_type": candidate.reference_type,
+                "retrieval_method": candidate.retrieval_method,
+                "retrieval_score": candidate.retrieval_score,
+                "authority": candidate.authority,
+            }
+            for candidate in report.reference_candidates
+        ],
+        "reference_bindings": [
+            {
+                "binding_id": binding.binding_id,
+                "reference_id": binding.reference_id,
+                "selected_candidate_id": binding.selected_candidate_id,
+                "rejected_candidates": [
+                    {
+                        "reference_id": rejected.reference_id,
+                        "reason": rejected.reason,
+                    }
+                    for rejected in binding.rejected_candidates
+                ],
+            }
+            for binding in report.reference_bindings
+        ],
+        "derived_claims": [
+            {
+                "claim_id": claim.claim_id,
+                "field": claim.field,
+                "value": claim.value,
+                "unit": claim.unit,
+                "trace_id": claim.trace.trace_id,
+                "formula_id": claim.formula_id,
+                "reference_binding_ids": claim.trace.reference_binding_ids,
+            }
+            for claim in report.derived_claims
+        ],
+    }
+
+
+def commit_view(preparation) -> dict[str, Any]:
+    return {
+        "package_id": preparation.package.package_id,
+        "package_complete": preparation.package.complete,
+        "governance_status": preparation.decision.status,
+        "receipt_id": (
+            preparation.receipt.public_row_id
+            if preparation.receipt is not None
+            else None
+        ),
+    }
+
+
+def receipt_trace_view(receipt) -> dict[str, Any] | None:
+    if receipt is None or receipt.citations is None:
+        return None
+
+    citations = receipt.citations
+    return {
+        "reference_binding_ids": citations.reference_binding_ids,
+        "derived_claim_ids": citations.derived_claim_ids,
+        "calculation_trace_ids": citations.calculation_trace_ids,
+        "formula_ids": citations.formula_ids,
+        "value_commitments": [
+            {
+                "field": commitment.field,
+                "source_kind": commitment.source_kind,
+                "source_id": commitment.source_id,
+                "value_digest": commitment.value_digest,
+                "digest_alg": commitment.digest_alg,
+            }
+            for commitment in citations.projection_value_commitments
+        ],
+    }
+
+
+def _obligation_view(obligation) -> dict[str, str | None]:
+    return {
+        "obligation_id": obligation.obligation_id,
+        "kind": obligation.kind,
+        "field": obligation.field,
+        "reason": obligation.reason,
+    }
+
+
+__all__ = [
+    "commit_view",
+    "receipt_trace_view",
+    "report_view",
+    "scenario_result_view",
+]

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -1,6 +1,5 @@
-import pytest
-
-from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from comp import ProjectionSpec
+from tests.domain_scenarios.assertions import assert_projection_tamper_blocked
 from tests.domain_scenarios.canonical_working_loop.fixtures import (
     RAW_EVIDENCE,
     compile_raw_evidence,
@@ -91,17 +90,12 @@ def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
 def test_canonical_working_loop_receipt_rejects_tampered_projection_value():
     result = run_canonical_working_loop_scenario()
 
-    assert result.preparation.receipt is not None
-    with pytest.raises(ProjectionBlocked, match="value commitment"):
-        project_public_row(
-            {
-                "electricity_kwh": 1200,
-                "reporting_year": 2024,
-                "co2e_kg": 999999,
-            },
-            ProjectionSpec(
-                "canonical-pcf-public-row",
-                ("electricity_kwh", "reporting_year", "co2e_kg"),
-            ),
-            receipt=result.preparation.receipt,
-        )
+    assert_projection_tamper_blocked(
+        result,
+        ProjectionSpec(
+            "canonical-pcf-public-row",
+            ("electricity_kwh", "reporting_year", "co2e_kg"),
+        ),
+        {"co2e_kg": 999999},
+        match="value commitment",
+    )

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -1,6 +1,8 @@
-import pytest
-
-from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from comp import ProjectionSpec
+from tests.domain_scenarios.assertions import (
+    assert_projection_tamper_blocked,
+    assert_receipt_trace,
+)
 from tests.domain_scenarios.core import (
     ScenarioDefinition,
     SourceRef,
@@ -8,6 +10,7 @@ from tests.domain_scenarios.core import (
     run_scenario,
 )
 from tests.domain_scenarios.registry import registered_scenarios
+from tests.domain_scenarios.views import scenario_result_view
 from tests.domain_scenarios.tiny_pcf.expected import (
     EXPECTED_PROJECTION,
     EXPECTED_REFERENCE_CANDIDATE_IDS,
@@ -65,13 +68,12 @@ def test_tiny_pcf_scenario_runs_reference_to_receipt_flow():
 def test_tiny_pcf_scenario_rejects_tampered_projection_value():
     result = run_tiny_pcf_scenario()
 
-    assert result.preparation.receipt is not None
-    with pytest.raises(ProjectionBlocked, match="value commitment"):
-        project_public_row(
-            {"electricity_kwh": 1200, "co2e_kg": 999999},
-            ProjectionSpec("pcf-public-row", ("electricity_kwh", "co2e_kg")),
-            receipt=result.preparation.receipt,
-        )
+    assert_projection_tamper_blocked(
+        result,
+        ProjectionSpec("pcf-public-row", ("electricity_kwh", "co2e_kg")),
+        {"co2e_kg": 999999},
+        match="value commitment",
+    )
 
 
 def test_tiny_pcf_scenario_preserves_traceable_domain_artifacts():
@@ -97,6 +99,57 @@ def test_tiny_pcf_scenario_preserves_traceable_domain_artifacts():
     assert derived.claim_id == "tiny-pcf:co2e_kg"
     assert derived.value == 504.0
     assert derived.trace.reference_binding_ids == ("bind-electricity-factor",)
+
+    assert_receipt_trace(
+        result,
+        reference_binding_ids=("bind-electricity-factor",),
+        derived_claim_ids=("tiny-pcf:co2e_kg",),
+        calculation_trace_ids=("trace:tiny-pcf:co2e_kg",),
+        formula_ids=("pcf.electricity_factor_multiplication.v1",),
+    )
+
+
+def test_scenario_result_view_exposes_receipt_trace_without_raw_values():
+    result = run_tiny_pcf_scenario()
+
+    view = scenario_result_view(result)
+
+    assert view == result.to_dict()
+    assert view["receipt_trace"]["reference_binding_ids"] == (
+        "bind-electricity-factor",
+    )
+    assert view["receipt_trace"]["derived_claim_ids"] == ("tiny-pcf:co2e_kg",)
+    assert view["receipt_trace"]["calculation_trace_ids"] == (
+        "trace:tiny-pcf:co2e_kg",
+    )
+    assert view["receipt_trace"]["formula_ids"] == (
+        "pcf.electricity_factor_multiplication.v1",
+    )
+
+    commitments = view["receipt_trace"]["value_commitments"]
+    assert commitments == [
+        {
+            "field": "electricity_kwh",
+            "source_kind": "checked_claim",
+            "source_id": "checked_claim:electricity_kwh:span-electricity-amount",
+            "value_digest": (
+                "sha256:"
+                "7aa3fcfca9c3b08fbec22b363aa33f2f23d6dbecf3cb935c06c6900cb24d91bb"
+            ),
+            "digest_alg": "sha256",
+        },
+        {
+            "field": "co2e_kg",
+            "source_kind": "derived_claim",
+            "source_id": "tiny-pcf:co2e_kg",
+            "value_digest": (
+                "sha256:"
+                "042ee367826ac0a5248c3e060dbd2466bd9e44a5f11d5ba2dcab18417e888a9b"
+            ),
+            "digest_alg": "sha256",
+        },
+    ]
+    assert all("value" not in commitment for commitment in commitments)
 
 
 def test_tiny_pcf_scenario_exports_json_ready_viewer_payload():

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -1,3 +1,4 @@
+from tests.domain_scenarios.assertions import assert_receipt_trace
 from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
 from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     EXPECTED_DERIVED_CLAIM_IDS,
@@ -42,15 +43,12 @@ def test_l_energy_pcf_governance_scenario_preserves_actor_receipt_trace():
     assert tuple(claim.claim_id for claim in result.report.derived_claims) == (
         EXPECTED_DERIVED_CLAIM_IDS
     )
-    assert result.preparation.receipt is not None
-    assert result.preparation.receipt.citations is not None
-    assert result.preparation.receipt.citations.derived_claim_ids == (
-        EXPECTED_DERIVED_CLAIM_IDS
+    assert_receipt_trace(
+        result,
+        derived_claim_ids=EXPECTED_DERIVED_CLAIM_IDS,
+        calculation_trace_ids=EXPECTED_TRACE_IDS,
+        formula_ids=EXPECTED_FORMULA_IDS,
     )
-    assert result.preparation.receipt.citations.calculation_trace_ids == (
-        EXPECTED_TRACE_IDS
-    )
-    assert result.preparation.receipt.citations.formula_ids == EXPECTED_FORMULA_IDS
 
 
 def test_l_energy_pcf_governance_scenario_exports_targeted_viewer_payload():


### PR DESCRIPTION
## Summary
- Extract scenario viewer/export payload construction into `tests.domain_scenarios.views`.
- Add shared scenario assertions for receipt trace checks and projection tamper negative tests.
- Update canonical, tiny PCF, and L-Energy scenario tests to use the shared helpers.
- Document the new Scenario Lab helper surface in the scenario README.

## Why
This keeps scenario tests focused on authority-boundary contracts instead of repeating receipt traversal and projection tamper boilerplate as more scenario packs land.

## Verification
- `python -m pytest tests\test_domain_scenario_lab.py tests\test_canonical_working_loop_scenario.py tests\test_l_energy_pcf_scenario.py tests\test_package_smoke.py -q` -> 24 passed
- `python -m pytest -q` -> 238 passed
- `git diff --check` -> clean aside from CRLF working-copy warnings