### PR TITLE
[codex] pin retrieval policies in compiler profiles

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -43,6 +43,7 @@ from comp.compiler_tool.profiles import (
     RuleFamily,
     SemanticRubric,
     active_rule_families,
+    active_retrieval_query_policies,
     validate_compiler_profile,
 )
 from comp.compiler_tool.profile_runner import compile_with_profile
@@ -83,6 +84,8 @@ from comp.compiler_tool.resolver_tasks import (
 from comp.compiler_tool.resolver_retrieval import (
     RetrievalQueryPolicy,
     RetrievalQueryRule,
+    reference_query_for_obligation_from_profile_policy,
+    reference_query_for_obligation_from_policies,
     reference_query_for_obligation_from_policy,
     reference_query_for_obligation_from_resolver_tasks,
     reference_query_from_resolver_task,
@@ -163,6 +166,8 @@ __all__ = [
     "resolver_tasks_from_report",
     "RetrievalQueryPolicy",
     "RetrievalQueryRule",
+    "reference_query_for_obligation_from_policies",
+    "reference_query_for_obligation_from_profile_policy",
     "reference_query_for_obligation_from_policy",
     "reference_query_for_obligation_from_resolver_tasks",
     "reference_query_from_resolver_task",
@@ -182,6 +187,7 @@ __all__ = [
     "ProfileValidationError",
     "validate_compiler_profile",
     "active_rule_families",
+    "active_retrieval_query_policies",
     "compile_with_profile",
     "CompilerTool",
     "apply_semantic_judgments",

--- a/comp/compiler_tool/profiles.py
+++ b/comp/compiler_tool/profiles.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+if TYPE_CHECKING:
+    from comp.compiler_tool.resolver_retrieval import RetrievalQueryPolicy
 
 RuleEvaluator = Callable[[Any, Any, "CompilerProfile"], tuple[Any, ...]]
 
@@ -60,6 +63,9 @@ class DomainPack:
     rule_families: tuple[RuleFamily, ...] = field(default_factory=tuple)
     rubrics: tuple[SemanticRubric, ...] = field(default_factory=tuple)
     judge_policies: tuple[JudgePolicy, ...] = field(default_factory=tuple)
+    retrieval_query_policies: tuple["RetrievalQueryPolicy", ...] = field(
+        default_factory=tuple
+    )
     disabled_core_invariants: tuple[str, ...] = field(default_factory=tuple)
 
 
@@ -69,12 +75,13 @@ class CompilerProfile:
     domain_packs: tuple[DomainPack, ...] = field(default_factory=tuple)
     active_rule_ids: tuple[str, ...] = field(default_factory=tuple)
     active_rubric_ids: tuple[str, ...] = field(default_factory=tuple)
+    active_retrieval_policy_ids: tuple[str, ...] = field(default_factory=tuple)
     judge_policy_id: str | None = None
     projection_policy_id: str | None = None
     core_invariant_version: str = "core-invariants-v1"
 
     def rubric(self, rubric_id: str) -> SemanticRubric:
-        _, rubrics, _ = _catalogs(self)
+        _, rubrics, _, _ = _catalogs(self)
         try:
             return rubrics[rubric_id]
         except KeyError as exc:
@@ -83,7 +90,7 @@ class CompilerProfile:
     def judge_policy(self) -> JudgePolicy:
         if self.judge_policy_id is None:
             return JudgePolicy(judge_policy_id="default-empty-judge-policy")
-        _, _, judge_policies = _catalogs(self)
+        _, _, judge_policies, _ = _catalogs(self)
         try:
             return judge_policies[self.judge_policy_id]
         except KeyError as exc:
@@ -93,7 +100,7 @@ class CompilerProfile:
 
 
 def validate_compiler_profile(profile: CompilerProfile) -> None:
-    rules, rubrics, judge_policies = _catalogs(profile)
+    rules, rubrics, judge_policies, retrieval_policies = _catalogs(profile)
 
     for domain in profile.domain_packs:
         if domain.disabled_core_invariants:
@@ -109,6 +116,12 @@ def validate_compiler_profile(profile: CompilerProfile) -> None:
     for rubric_id in profile.active_rubric_ids:
         if rubric_id not in rubrics:
             raise ProfileValidationError(f"unknown active rubric id: {rubric_id}")
+
+    for policy_id in profile.active_retrieval_policy_ids:
+        if policy_id not in retrieval_policies:
+            raise ProfileValidationError(
+                f"unknown active retrieval policy id: {policy_id}"
+            )
 
     if profile.judge_policy_id is not None and profile.judge_policy_id not in judge_policies:
         raise ProfileValidationError(f"unknown judge policy id: {profile.judge_policy_id}")
@@ -133,13 +146,32 @@ def active_rule_families(
 ) -> tuple[RuleFamily, ...]:
     if validate:
         validate_compiler_profile(profile)
-    rules, _, _ = _catalogs(profile)
+    rules, _, _, _ = _catalogs(profile)
     return tuple(rules[rule_id] for rule_id in profile.active_rule_ids)
+
+
+def active_retrieval_query_policies(
+    profile: CompilerProfile,
+    *,
+    validate: bool = True,
+) -> tuple["RetrievalQueryPolicy", ...]:
+    if validate:
+        validate_compiler_profile(profile)
+    _, _, _, retrieval_policies = _catalogs(profile)
+    return tuple(
+        retrieval_policies[policy_id]
+        for policy_id in profile.active_retrieval_policy_ids
+    )
 
 
 def _catalogs(
     profile: CompilerProfile,
-) -> tuple[dict[str, RuleFamily], dict[str, SemanticRubric], dict[str, JudgePolicy]]:
+) -> tuple[
+    dict[str, RuleFamily],
+    dict[str, SemanticRubric],
+    dict[str, JudgePolicy],
+    dict[str, "RetrievalQueryPolicy"],
+]:
     return (
         _unique_by_id(
             [
@@ -168,6 +200,15 @@ def _catalogs(
             attr="judge_policy_id",
             label="judge policy id",
         ),
+        _unique_by_id(
+            [
+                policy
+                for domain in profile.domain_packs
+                for policy in domain.retrieval_query_policies
+            ],
+            attr="policy_id",
+            label="retrieval policy id",
+        ),
     )
 
 
@@ -193,4 +234,5 @@ __all__ = [
     "ProfileValidationError",
     "validate_compiler_profile",
     "active_rule_families",
+    "active_retrieval_query_policies",
 ]

--- a/comp/compiler_tool/resolver_retrieval.py
+++ b/comp/compiler_tool/resolver_retrieval.py
@@ -55,31 +55,60 @@ def reference_query_for_obligation_from_policy(
     policy: RetrievalQueryPolicy,
     context: Mapping[str, Any] | None = None,
 ) -> Callable[[ProofObligation], ReferenceQuery | None]:
+    return reference_query_for_obligation_from_policies(
+        tasks,
+        policies=(policy,),
+        context=context,
+    )
+
+
+def reference_query_for_obligation_from_policies(
+    tasks: tuple[ResolverTask, ...],
+    *,
+    policies: tuple[RetrievalQueryPolicy, ...],
+    context: Mapping[str, Any] | None = None,
+) -> Callable[[ProofObligation], ReferenceQuery | None]:
     context = context or {}
     queries_by_obligation_id: dict[str, ReferenceQuery] = {}
     for task in tasks:
-        rule = _matching_rule(task, policy)
-        if rule is None:
-            continue
-
-        text = _render_query_text(rule.text_template, task, context)
-        if text is None:
-            continue
-
-        queries_by_obligation_id[task.obligation_id] = (
-            reference_query_from_resolver_task(
-                task,
-                text=text,
-                lens=rule.lens,
-                reference_type=rule.reference_type,
-            )
-        )
+        query = _query_for_task_from_policies(task, policies, context)
+        if query is not None:
+            queries_by_obligation_id[task.obligation_id] = query
 
     def query_for_obligation(obligation: ProofObligation) -> ReferenceQuery | None:
         obligation_id = resolver_task_from_obligation(obligation).obligation_id
         return queries_by_obligation_id.get(obligation_id)
 
     return query_for_obligation
+
+
+def reference_query_for_obligation_from_profile_policy(
+    tasks: tuple[ResolverTask, ...],
+    *,
+    profile,
+    policy_id: str | None = None,
+    context: Mapping[str, Any] | None = None,
+) -> Callable[[ProofObligation], ReferenceQuery | None]:
+    from comp.compiler_tool.profiles import (
+        ProfileValidationError,
+        active_retrieval_query_policies,
+    )
+
+    active_policies = active_retrieval_query_policies(profile)
+    if policy_id is not None:
+        active_policies = tuple(
+            policy for policy in active_policies if policy.policy_id == policy_id
+        )
+        if not active_policies:
+            raise ProfileValidationError(
+                f"inactive retrieval policy id: {policy_id}"
+            )
+
+    return reference_query_for_obligation_from_policies(
+        tasks,
+        policies=active_policies,
+        context=context,
+    )
 
 
 def reference_query_for_obligation_from_resolver_tasks(
@@ -105,6 +134,29 @@ def reference_query_for_obligation_from_resolver_tasks(
         return queries_by_obligation_id.get(obligation_id)
 
     return query_for_obligation
+
+
+def _query_for_task_from_policies(
+    task: ResolverTask,
+    policies: tuple[RetrievalQueryPolicy, ...],
+    context: Mapping[str, Any],
+) -> ReferenceQuery | None:
+    for policy in policies:
+        rule = _matching_rule(task, policy)
+        if rule is None:
+            continue
+
+        text = _render_query_text(rule.text_template, task, context)
+        if text is None:
+            continue
+
+        return reference_query_from_resolver_task(
+            task,
+            text=text,
+            lens=rule.lens,
+            reference_type=rule.reference_type,
+        )
+    return None
 
 
 def _matching_rule(
@@ -175,6 +227,8 @@ def _task_value(task: ResolverTask, key: str) -> Any:
 __all__ = [
     "RetrievalQueryPolicy",
     "RetrievalQueryRule",
+    "reference_query_for_obligation_from_policies",
+    "reference_query_for_obligation_from_profile_policy",
     "reference_query_for_obligation_from_policy",
     "reference_query_for_obligation_from_resolver_tasks",
     "reference_query_from_resolver_task",

--- a/docs/architecture/obligation-kernel-working-theory.md
+++ b/docs/architecture/obligation-kernel-working-theory.md
@@ -1001,6 +1001,30 @@ No vector DB dependency is introduced.
 No real LLM call is introduced.
 ```
 
+The profile-pinning slice is:
+
+```text
+feat: pin retrieval query policies in CompilerProfile
+```
+
+Purpose:
+
+```text
+Make RetrievalQueryPolicy part of the active profile behavior lock.
+Reject unknown active retrieval policy ids during profile validation.
+Let resolver query builders use only profile-active retrieval policies.
+Keep retrieved candidates non-authoritative until deterministic selection.
+```
+
+Acceptance criteria:
+
+```text
+DomainPack can declare retrieval query policies.
+CompilerProfile can activate retrieval query policies by id and order.
+Unknown or duplicate retrieval policy ids are rejected.
+Profile-aware query builders reject inactive policy ids.
+```
+
 Non-goals:
 
 ```text
@@ -1040,7 +1064,6 @@ Should ReferenceCandidate / ReferenceBinding / DerivedClaim live in core or comp
 Should reference DB rows be part of DomainPack, external resources, or both?
 How should reference DB versions and vector index versions be pinned in CompilerProfile?
 How should evidence quality vectors map to scalar UI indicators without becoming authority?
-How should retrieval lens versions be pinned in CompilerProfile?
 How should embedding model ids and reference index versions appear in receipts?
 Should candidate graph edges become Fact records or a separate trace artifact?
 When should Domain Scenario Lab JSON become a stable fixture contract?
@@ -1062,4 +1085,6 @@ When should Domain Scenario Lab JSON become a stable fixture contract?
   and Domain Scenario Lab slices landed.
   Aligns next implementation direction with Retrieval lens interface and
   EmbeddingResolverStub.
+  Adds retrieval query policy pinning to CompilerProfile so resolver search
+  behavior is profile-active rather than ambient.
 ```

--- a/docs/architecture/retrieval-fabric-north-star.md
+++ b/docs/architecture/retrieval-fabric-north-star.md
@@ -487,6 +487,16 @@ PublicProjection
 
 Those remain separate deterministic gates.
 
+Retrieval query policies should be active only when pinned by the compiler
+profile:
+
+```text
+DomainPack declares RetrievalQueryPolicy
+CompilerProfile.active_retrieval_policy_ids locks the active set and order
+Profile-aware query builder turns ResolverTask into ReferenceQuery
+Inactive or unknown policy ids do not run
+```
+
 Once the bridge exists, the canonical raw-input scenario should use it as the
 standard path:
 
@@ -497,7 +507,7 @@ raw evidence
 -> calculation_blocked
 -> reference_search_required
 -> ResolverTask
--> RetrievalQueryPolicy
+-> profile-active RetrievalQueryPolicy
 -> ReferenceQuery
 -> retrieval bridge
 -> candidate-only ReferenceCandidate

--- a/tests/test_compiler_profile_contract.py
+++ b/tests/test_compiler_profile_contract.py
@@ -7,7 +7,10 @@ from comp.compiler_tool import (
     ProfileValidationError,
     RuleFamily,
     SemanticRubric,
+    RetrievalQueryPolicy,
+    RetrievalQueryRule,
     active_rule_families,
+    active_retrieval_query_policies,
     validate_compiler_profile,
 )
 
@@ -34,11 +37,27 @@ def _judge_policy(policy_id):
     )
 
 
+def _retrieval_policy(policy_id):
+    return RetrievalQueryPolicy(
+        policy_id=policy_id,
+        rules=(
+            RetrievalQueryRule(
+                rule_id=f"{policy_id}.rule",
+                formula_id="fixture.formula.v1",
+                lens="factor",
+                reference_type="emission_factor",
+                text_template="{geography} factor {reporting_year}",
+            ),
+        ),
+    )
+
+
 def _domain(
     *,
     rules,
     rubrics=(),
     judge_policies=(),
+    retrieval_query_policies=(),
     disabled_core_invariants=(),
 ):
     return DomainPack(
@@ -47,6 +66,7 @@ def _domain(
         rule_families=tuple(rules),
         rubrics=tuple(rubrics),
         judge_policies=tuple(judge_policies),
+        retrieval_query_policies=tuple(retrieval_query_policies),
         disabled_core_invariants=tuple(disabled_core_invariants),
     )
 
@@ -57,8 +77,11 @@ def test_compiler_profile_model_set_is_exported():
     assert RuleFamily is not None
     assert SemanticRubric is not None
     assert JudgePolicy is not None
+    assert RetrievalQueryPolicy is not None
+    assert RetrievalQueryRule is not None
     assert ProfileValidationError is not None
     assert active_rule_families is not None
+    assert active_retrieval_query_policies is not None
     assert validate_compiler_profile is not None
 
 
@@ -113,6 +136,46 @@ def test_profile_validation_rejects_unknown_judge_policy_id():
         validate_compiler_profile(profile)
 
 
+def test_profile_only_activates_named_retrieval_policies_in_profile_order():
+    inactive = _retrieval_policy("fixture.inactive_retrieval_policy.v1")
+    first = _retrieval_policy("fixture.first_retrieval_policy.v1")
+    second = _retrieval_policy("fixture.second_retrieval_policy.v1")
+    domain = _domain(
+        rules=(),
+        retrieval_query_policies=(inactive, first, second),
+    )
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(domain,),
+        active_retrieval_policy_ids=(
+            "fixture.second_retrieval_policy.v1",
+            "fixture.first_retrieval_policy.v1",
+        ),
+    )
+
+    validate_compiler_profile(profile)
+
+    assert active_retrieval_query_policies(profile) == (second, first)
+
+
+def test_profile_validation_rejects_unknown_active_retrieval_policy_id():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(
+                rules=(),
+                retrieval_query_policies=(
+                    _retrieval_policy("fixture.known_retrieval_policy.v1"),
+                ),
+            ),
+        ),
+        active_retrieval_policy_ids=("fixture.missing_retrieval_policy.v1",),
+    )
+
+    with pytest.raises(ProfileValidationError, match="unknown active retrieval policy"):
+        validate_compiler_profile(profile)
+
+
 def test_rule_required_rubrics_must_be_active_in_profile():
     rule = _rule(
         "fixture.semantic_rule.v1",
@@ -163,4 +226,22 @@ def test_duplicate_rule_ids_are_rejected():
     )
 
     with pytest.raises(ProfileValidationError, match="duplicate rule id"):
+        validate_compiler_profile(profile)
+
+
+def test_duplicate_retrieval_policy_ids_are_rejected():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(
+                rules=(),
+                retrieval_query_policies=(
+                    _retrieval_policy("fixture.duplicate_retrieval_policy.v1"),
+                    _retrieval_policy("fixture.duplicate_retrieval_policy.v1"),
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(ProfileValidationError, match="duplicate retrieval policy id"):
         validate_compiler_profile(profile)

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -82,6 +82,9 @@ def test_readme_compiler_tool_import_surface_is_exported():
         ReferenceResolver,
         RetrievalQueryPolicy,
         RetrievalQueryRule,
+        active_retrieval_query_policies,
+        reference_query_for_obligation_from_profile_policy,
+        reference_query_for_obligation_from_policies,
         reference_query_for_obligation_from_policy,
         reference_query_for_obligation_from_resolver_tasks,
         reference_query_from_resolver_task,
@@ -104,6 +107,9 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert EmbeddingResolverStub is not None
     assert RetrievalQueryPolicy is not None
     assert RetrievalQueryRule is not None
+    assert active_retrieval_query_policies is not None
+    assert reference_query_for_obligation_from_policies is not None
+    assert reference_query_for_obligation_from_profile_policy is not None
     assert reference_query_for_obligation_from_policy is not None
     assert reference_query_from_resolver_task is not None
     assert reference_query_for_obligation_from_resolver_tasks is not None

--- a/tests/test_resolver_retrieval.py
+++ b/tests/test_resolver_retrieval.py
@@ -3,14 +3,18 @@ import pytest
 from comp.compiler_tool import (
     CalculationRequirement,
     CompileReport,
+    CompilerProfile,
+    DomainPack,
     EmbeddingResolverStub,
     ProofObligation,
+    ProfileValidationError,
     ReferenceIndexEntry,
     ReferenceQuery,
     RetrievalQueryPolicy,
     RetrievalQueryRule,
     resolver_tasks_from_report,
     reference_query_for_obligation_from_resolver_tasks,
+    reference_query_for_obligation_from_profile_policy,
     reference_query_for_obligation_from_policy,
     reference_query_from_resolver_task,
     resolve_reference_retrieval_obligations,
@@ -252,3 +256,86 @@ def test_retrieval_query_policy_leaves_obligation_open_without_required_context(
     )
 
     assert resolved == report
+
+
+def test_profile_pinned_retrieval_policy_feeds_query_builder():
+    report = CompileReport(
+        status="blocked",
+        obligations=(_reference_search_obligation(),),
+    )
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            DomainPack(
+                domain_id="fixture",
+                version="2026.1",
+                retrieval_query_policies=(
+                    RetrievalQueryPolicy(
+                        policy_id="fixture.inactive-retrieval-policy.v1",
+                        rules=(),
+                    ),
+                    RetrievalQueryPolicy(
+                        policy_id="fixture.active-retrieval-policy.v1",
+                        rules=(
+                            RetrievalQueryRule(
+                                rule_id="fixture.active-factor-query.v1",
+                                formula_id="formula-v1",
+                                lens="factor",
+                                reference_type="emission_factor",
+                                text_template=(
+                                    "{geography} grid electricity factor "
+                                    "{reporting_year}"
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        active_retrieval_policy_ids=("fixture.active-retrieval-policy.v1",),
+    )
+
+    resolved = resolve_reference_retrieval_obligations(
+        report,
+        _resolver(),
+        query_for_obligation=reference_query_for_obligation_from_profile_policy(
+            resolver_tasks_from_report(report),
+            profile=profile,
+            context={"geography": "Korea", "reporting_year": 2024},
+        ),
+    )
+
+    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+        "factor.kr_grid.2024.location_based"
+    ]
+
+
+def test_profile_retrieval_query_builder_rejects_inactive_policy_id():
+    report = CompileReport(
+        status="blocked",
+        obligations=(_reference_search_obligation(),),
+    )
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            DomainPack(
+                domain_id="fixture",
+                version="2026.1",
+                retrieval_query_policies=(
+                    RetrievalQueryPolicy(
+                        policy_id="fixture.inactive-retrieval-policy.v1",
+                        rules=(),
+                    ),
+                ),
+            ),
+        ),
+        active_retrieval_policy_ids=(),
+    )
+
+    with pytest.raises(ProfileValidationError, match="inactive retrieval policy"):
+        reference_query_for_obligation_from_profile_policy(
+            resolver_tasks_from_report(report),
+            profile=profile,
+            policy_id="fixture.inactive-retrieval-policy.v1",
+            context={"geography": "Korea", "reporting_year": 2024},
+        )


### PR DESCRIPTION
## Summary

- add retrieval query policies to `DomainPack` and active retrieval policy ids to `CompilerProfile`
- validate unknown and duplicate retrieval policy ids through the profile contract
- expose `active_retrieval_query_policies` and profile-aware resolver query builders
- document that retrieval query behavior is profile-pinned rather than ambient

## Validation

- `python -m pytest tests/test_compiler_profile_contract.py tests/test_resolver_retrieval.py -q`
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py -q`
- `python -m pytest -q`
- `git diff --check`