### PR TITLE
[codex] use profile-pinned retrieval in scenarios

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -25,10 +25,11 @@ expected receipt/projection
 Start with `canonical_working_loop`, the raw-input harness for new contributors.
 It begins with a raw evidence sentence, uses a deterministic extractor stub,
 passes through `CompilerTool`, opens a calculation obligation, resolves a
-reference search obligation through `ResolverTask`, `RetrievalQueryPolicy`, and
-the retrieval bridge, turns candidate-only retrieval results into a canonical
-binding through deterministic selection, calculates a derived claim, mints a
-commit receipt, and projects only through the receipt gate.
+reference search obligation through `ResolverTask`, a profile-active
+`RetrievalQueryPolicy`, and the retrieval bridge, turns candidate-only retrieval
+results into a canonical binding through deterministic selection, calculates a
+derived claim, mints a commit receipt, and projects only through the receipt
+gate.
 
 The smaller scenario `tiny_pcf` is a product-carbon-footprint slice that exercises
 reference search, near-miss rejection, canonical binding, calculation trace,
@@ -38,10 +39,10 @@ The first larger source-referenced pack is `l_energy_pcf_governance`, based on
 `minntcho/esg-platform` case `001-l-energy-pcf-governance`. It uses
 fixture-derived downstream claims from the platform expected receipt, but routes
 the L-Energy own-energy factor through a retrieval-backed slice: calculation
-blocked, reference search obligation, `ResolverTask`, `RetrievalQueryPolicy`,
-candidate-only embedding stub results, deterministic reference binding, retry,
-and receipt-gated projection. This keeps the case realistic without adding a
-full PCF workflow engine.
+blocked, reference search obligation, `ResolverTask`, profile-active
+`RetrievalQueryPolicy`, candidate-only embedding stub results, deterministic
+reference binding, retry, and receipt-gated projection. This keeps the case
+realistic without adding a full PCF workflow engine.
 
 ## Testing Philosophy
 

--- a/tests/domain_scenarios/canonical_working_loop/fixtures.py
+++ b/tests/domain_scenarios/canonical_working_loop/fixtures.py
@@ -8,6 +8,8 @@ from comp.compiler_tool import (
     ClaimHypothesis,
     CompileReport,
     CompilerTool,
+    CompilerProfile,
+    DomainPack,
     EvidenceWitness,
     EmbeddingResolverStub,
     InterpretationHypothesis,
@@ -218,6 +220,20 @@ def retrieval_query_policy() -> RetrievalQueryPolicy:
     )
 
 
+def profile() -> CompilerProfile:
+    return CompilerProfile(
+        profile_id=PROFILE_ID,
+        domain_packs=(
+            DomainPack(
+                domain_id="canonical-pcf",
+                version="2026.1",
+                retrieval_query_policies=(retrieval_query_policy(),),
+            ),
+        ),
+        active_retrieval_policy_ids=("pcf-canonical-retrieval-query-policy-v1",),
+    )
+
+
 def retrieval_query_context(report: CompileReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
     return {
@@ -288,6 +304,7 @@ __all__ = [
     "formula",
     "input_claim_from_report",
     "open_calculation_obligation",
+    "profile",
     "projection_source",
     "reference_resolver",
     "retrieval_query_context",

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -6,7 +6,7 @@ from comp.compiler_tool import (
     apply_reference_selection,
     plan_calculation_resolution,
     prepare_commit,
-    reference_query_for_obligation_from_policy,
+    reference_query_for_obligation_from_profile_policy,
     resolve_reference_retrieval_obligations,
     resolver_tasks_from_report,
     retry_blocked_calculation,
@@ -29,10 +29,10 @@ from tests.domain_scenarios.canonical_working_loop.fixtures import (
     formula,
     input_claim_from_report,
     open_calculation_obligation,
+    profile,
     projection_source,
     reference_resolver,
     retrieval_query_context,
-    retrieval_query_policy,
 )
 from tests.domain_scenarios.core import (
     DomainScenarioResult,
@@ -50,7 +50,7 @@ RESOLVER_STEPS = (
     "open_calculation_obligation",
     "plan_calculation_resolution",
     "resolver_tasks_from_report",
-    "retrieval_query_policy",
+    "profile_active_retrieval_policy",
     "resolver_task_to_reference_query",
     "reference_retrieval:embedding_stub:factor",
     "deterministic_reference_selection",
@@ -86,6 +86,7 @@ SCENARIO = ScenarioDefinition(
 
 
 def run_canonical_working_loop_scenario() -> DomainScenarioResult:
+    scenario_profile = profile()
     compiled_report = compile_raw_evidence(RAW_EVIDENCE)
     blocked_report = open_calculation_obligation(compiled_report)
     planned_report = plan_calculation_resolution(blocked_report)
@@ -93,9 +94,9 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
     retrieval_report = resolve_reference_retrieval_obligations(
         planned_report,
         reference_resolver(),
-        query_for_obligation=reference_query_for_obligation_from_policy(
+        query_for_obligation=reference_query_for_obligation_from_profile_policy(
             resolver_tasks,
-            policy=retrieval_query_policy(),
+            profile=scenario_profile,
             context=retrieval_query_context(compiled_report),
         ),
     )
@@ -124,7 +125,7 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         subject_id=SUBJECT_ID,
         public_row_id=PUBLIC_ROW_ID,
         projection_id="canonical-pcf-public-row",
-        profile_id=PROFILE_ID,
+        profile_id=scenario_profile.profile_id,
     )
     projection = None
     if preparation.receipt is not None:

--- a/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
@@ -8,7 +8,9 @@ from comp.compiler_tool import (
     CalculationTrace,
     CheckedClaim,
     CompileReport,
+    CompilerProfile,
     DerivedClaim,
+    DomainPack,
     EmbeddingResolverStub,
     ReferenceCatalog,
     ReferenceBinding,
@@ -306,6 +308,20 @@ def retrieval_query_policy() -> RetrievalQueryPolicy:
     )
 
 
+def profile() -> CompilerProfile:
+    return CompilerProfile(
+        profile_id=PROFILE_ID,
+        domain_packs=(
+            DomainPack(
+                domain_id="l-energy-pcf-governance",
+                version="2026.1",
+                retrieval_query_policies=(retrieval_query_policy(),),
+            ),
+        ),
+        active_retrieval_policy_ids=("l-energy-pcf-retrieval-query-policy-v1",),
+    )
+
+
 def retrieval_query_context() -> dict[str, object]:
     return {
         "geography": "Korea",
@@ -435,6 +451,7 @@ __all__ = [
     "downstream_reference_bindings",
     "formula",
     "input_claim",
+    "profile",
     "reference_resolver",
     "reference_bindings",
     "retrieval_query_context",

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -7,7 +7,7 @@ from comp.compiler_tool import (
     apply_reference_selection,
     plan_calculation_resolution,
     prepare_commit,
-    reference_query_for_obligation_from_policy,
+    reference_query_for_obligation_from_profile_policy,
     resolve_reference_retrieval_obligations,
     resolver_tasks_from_report,
     retry_blocked_calculation,
@@ -41,9 +41,9 @@ from tests.domain_scenarios.l_energy_pcf_governance.fixtures import (
     criteria,
     formula,
     input_claim,
+    profile,
     reference_resolver,
     retrieval_query_context,
-    retrieval_query_policy,
 )
 
 
@@ -52,7 +52,7 @@ RESOLVER_STEPS = (
     "open_l_energy_own_emission_calculation_obligation",
     "plan_calculation_resolution",
     "resolver_tasks_from_report",
-    "retrieval_query_policy",
+    "profile_active_retrieval_policy",
     "resolver_task_to_reference_query",
     "reference_retrieval:embedding_stub:factor",
     "deterministic_reference_selection",
@@ -126,15 +126,16 @@ def _projection_source(report) -> dict[str, object]:
 
 
 def _compile_retrieval_backed_report() -> CompileReport:
+    scenario_profile = profile()
     opened_report = blocked_report()
     planned_report = plan_calculation_resolution(opened_report)
     resolver_tasks = resolver_tasks_from_report(planned_report)
     retrieval_report = resolve_reference_retrieval_obligations(
         planned_report,
         reference_resolver(),
-        query_for_obligation=reference_query_for_obligation_from_policy(
+        query_for_obligation=reference_query_for_obligation_from_profile_policy(
             resolver_tasks,
-            policy=retrieval_query_policy(),
+            profile=scenario_profile,
             context=retrieval_query_context(),
         ),
     )

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -1,10 +1,12 @@
 from comp import ProjectionSpec
+from comp.compiler_tool import active_retrieval_query_policies
 from tests.domain_scenarios.assertions import assert_projection_tamper_blocked
 from tests.domain_scenarios.canonical_working_loop.fixtures import (
     RAW_EVIDENCE,
     compile_raw_evidence,
     extract_raw_evidence,
     open_calculation_obligation,
+    profile,
 )
 from tests.domain_scenarios.canonical_working_loop.scenario import (
     SCENARIO,
@@ -62,7 +64,7 @@ def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
         "open_calculation_obligation",
         "plan_calculation_resolution",
         "resolver_tasks_from_report",
-        "retrieval_query_policy",
+        "profile_active_retrieval_policy",
         "resolver_task_to_reference_query",
         "reference_retrieval:embedding_stub:factor",
         "deterministic_reference_selection",
@@ -85,6 +87,18 @@ def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
         "reporting_year": 2024,
         "co2e_kg": 504.0,
     }
+
+
+def test_canonical_working_loop_pins_retrieval_policy_in_profile():
+    scenario_profile = profile()
+
+    assert scenario_profile.active_retrieval_policy_ids == (
+        "pcf-canonical-retrieval-query-policy-v1",
+    )
+    assert tuple(
+        policy.policy_id
+        for policy in active_retrieval_query_policies(scenario_profile)
+    ) == ("pcf-canonical-retrieval-query-policy-v1",)
 
 
 def test_canonical_working_loop_receipt_rejects_tampered_projection_value():

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -1,5 +1,7 @@
 from tests.domain_scenarios.assertions import assert_receipt_trace
+from comp.compiler_tool import active_retrieval_query_policies
 from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
+from tests.domain_scenarios.l_energy_pcf_governance.fixtures import profile
 from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     EXPECTED_DERIVED_CLAIM_IDS,
     EXPECTED_FORMULA_IDS,
@@ -38,7 +40,7 @@ def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retriev
     result = run_l_energy_pcf_governance_scenario()
 
     assert "resolver_tasks_from_report" in result.resolver_steps
-    assert "retrieval_query_policy" in result.resolver_steps
+    assert "profile_active_retrieval_policy" in result.resolver_steps
     assert "reference_retrieval:embedding_stub:factor" in result.resolver_steps
     assert tuple(
         obligation.kind for obligation in result.report.resolved_obligations
@@ -81,6 +83,18 @@ def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retriev
     assert own_emission_claim.trace.reference_binding_ids == (
         "bind:pcf:electricity_factor",
     )
+
+
+def test_l_energy_pcf_governance_pins_retrieval_policy_in_profile():
+    scenario_profile = profile()
+
+    assert scenario_profile.active_retrieval_policy_ids == (
+        "l-energy-pcf-retrieval-query-policy-v1",
+    )
+    assert tuple(
+        policy.policy_id
+        for policy in active_retrieval_query_policies(scenario_profile)
+    ) == ("l-energy-pcf-retrieval-query-policy-v1",)
 
 
 def test_l_energy_pcf_governance_scenario_preserves_actor_receipt_trace():


### PR DESCRIPTION
## Summary

- add `CompilerProfile` fixtures to the canonical working loop and L-Energy scenario packs
- route scenario retrieval query construction through `reference_query_for_obligation_from_profile_policy`
- assert that both scenarios pin their active retrieval query policies in profile state
- update Domain Scenario Lab notes to describe profile-active retrieval policy usage

## Validation

- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py -q`
- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest tests/test_compiler_profile_contract.py tests/test_resolver_retrieval.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`