### PR TITLE
[codex] expand l energy reference fixture

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -39,9 +39,9 @@ The first larger source-referenced pack is `l_energy_pcf_governance`, based on
 fixture-derived downstream claims from the platform expected receipt, but routes
 the L-Energy own-energy factor through a retrieval-backed slice: calculation
 blocked, reference search obligation, `ResolverTask`, `RetrievalQueryPolicy`,
-candidate-only embedding stub results, deterministic reference binding, retry,
-and receipt-gated projection. This keeps the case realistic without adding a
-full PCF workflow engine.
+candidate-only embedding stub results with near-miss reference rows,
+deterministic reference binding, retry, and receipt-gated projection. This keeps
+the case realistic without adding a full PCF workflow engine.
 
 ## Testing Philosophy
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/expected.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/expected.py
@@ -46,8 +46,26 @@ EXPECTED_REFERENCE_BINDING_IDS = (
 )
 
 EXPECTED_REFERENCE_CANDIDATE_IDS = (
+    "platform.factor.a_supplier_electricity_mwh_2025",
     "platform.factor.electricity_mwh",
     "platform.factor.electricity_mwh_2024",
+    "platform.factor.electricity_residual_mix_2025",
+    "platform.factor.global_average_electricity_mwh_2025",
+    "platform.factor.us_electricity_mwh_2025",
+)
+
+EXPECTED_REJECTED_ELECTRICITY_CANDIDATES = (
+    (
+        "platform.factor.a_supplier_electricity_mwh_2025",
+        "attribute_mismatch:method",
+    ),
+    ("platform.factor.electricity_mwh_2024", "attribute_mismatch:valid_period"),
+    ("platform.factor.electricity_residual_mix_2025", "attribute_mismatch:method"),
+    (
+        "platform.factor.global_average_electricity_mwh_2025",
+        "attribute_mismatch:geography",
+    ),
+    ("platform.factor.us_electricity_mwh_2025", "attribute_mismatch:geography"),
 )
 
 EXPECTED_RESOLVED_OBLIGATION_KINDS = (
@@ -80,6 +98,7 @@ __all__ = [
     "EXPECTED_REFERENCE_CANDIDATE_IDS",
     "EXPECTED_REFERENCE_BINDING_IDS",
     "EXPECTED_RESOLVED_OBLIGATION_KINDS",
+    "EXPECTED_REJECTED_ELECTRICITY_CANDIDATES",
     "EXPECTED_SOURCE_REFS",
     "EXPECTED_TRACE_IDS",
     "SCENARIO_ID",

--- a/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
@@ -237,6 +237,27 @@ def catalog() -> ReferenceCatalog:
                 witness_ids=("source:dummy-data-mapping",),
             ),
             ReferenceRecord(
+                reference_id="platform.factor.a_supplier_electricity_mwh_2025",
+                reference_type="emission_factor",
+                labels=("L-Energy supplier specific electricity factor 2025",),
+                aliases=("L-Energy electricity LNG factor 2025",),
+                description=(
+                    "Near-miss platform fixture factor with a supplier-specific "
+                    "method instead of the expected platform receipt method."
+                ),
+                attributes=(
+                    ("concept_id", "platform.concept.l_energy_own_energy"),
+                    ("geography", "KR"),
+                    ("valid_period", "2025"),
+                    ("method", "supplier_specific"),
+                    ("factor_value", 210),
+                    ("input_unit", "GWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:supplier-near-miss",),
+            ),
+            ReferenceRecord(
                 reference_id="platform.factor.electricity_mwh_2024",
                 reference_type="emission_factor",
                 labels=("L-Energy electricity and LNG factor 2024",),
@@ -255,6 +276,65 @@ def catalog() -> ReferenceCatalog:
                 ),
                 source="source:dummy-data-mapping",
                 witness_ids=("source:dummy-data-mapping:2024-near-miss",),
+            ),
+            ReferenceRecord(
+                reference_id="platform.factor.electricity_residual_mix_2025",
+                reference_type="emission_factor",
+                labels=("L-Energy residual mix electricity factor 2025",),
+                aliases=("Korea L-Energy market-based energy factor",),
+                description=(
+                    "Near-miss platform fixture factor with the wrong Scope 2 "
+                    "method."
+                ),
+                attributes=(
+                    ("concept_id", "platform.concept.l_energy_own_energy"),
+                    ("geography", "KR"),
+                    ("valid_period", "2025"),
+                    ("method", "market_based"),
+                    ("factor_value", 198),
+                    ("input_unit", "GWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:residual-mix-near-miss",),
+            ),
+            ReferenceRecord(
+                reference_id="platform.factor.global_average_electricity_mwh_2025",
+                reference_type="emission_factor",
+                labels=("Global average electricity LNG factor 2025",),
+                description=(
+                    "Near-miss platform fixture factor with the wrong geography."
+                ),
+                attributes=(
+                    ("concept_id", "platform.concept.l_energy_own_energy"),
+                    ("geography", "GLOBAL"),
+                    ("valid_period", "2025"),
+                    ("method", "platform_expected_receipt"),
+                    ("factor_value", 300),
+                    ("input_unit", "GWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:global-near-miss",),
+            ),
+            ReferenceRecord(
+                reference_id="platform.factor.us_electricity_mwh_2025",
+                reference_type="emission_factor",
+                labels=("US electricity LNG factor 2025",),
+                description=(
+                    "Near-miss platform fixture factor with a non-KR geography."
+                ),
+                attributes=(
+                    ("concept_id", "platform.concept.l_energy_own_energy"),
+                    ("geography", "US"),
+                    ("valid_period", "2025"),
+                    ("method", "platform_expected_receipt"),
+                    ("factor_value", 390),
+                    ("input_unit", "GWh"),
+                    ("output_unit", "tCO2e"),
+                ),
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:us-near-miss",),
             ),
         )
     )
@@ -275,6 +355,17 @@ def reference_resolver() -> EmbeddingResolverStub:
                 witness_ids=("source:dummy-data-mapping",),
             ),
             ReferenceIndexEntry(
+                entry_id="idx-l-energy-supplier-electricity-mwh-2025",
+                reference_id="platform.factor.a_supplier_electricity_mwh_2025",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea L-Energy electricity LNG factor 2025",
+                reference_db_version="l-energy-platform-fixture-v1",
+                index_version="l-energy-embedding-stub-v1",
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:supplier-near-miss",),
+            ),
+            ReferenceIndexEntry(
                 entry_id="idx-l-energy-electricity-mwh-2024",
                 reference_id="platform.factor.electricity_mwh_2024",
                 reference_type="emission_factor",
@@ -284,6 +375,39 @@ def reference_resolver() -> EmbeddingResolverStub:
                 index_version="l-energy-embedding-stub-v1",
                 source="source:dummy-data-mapping",
                 witness_ids=("source:dummy-data-mapping:2024-near-miss",),
+            ),
+            ReferenceIndexEntry(
+                entry_id="idx-l-energy-electricity-residual-mix-2025",
+                reference_id="platform.factor.electricity_residual_mix_2025",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea L-Energy residual mix electricity factor 2025",
+                reference_db_version="l-energy-platform-fixture-v1",
+                index_version="l-energy-embedding-stub-v1",
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:residual-mix-near-miss",),
+            ),
+            ReferenceIndexEntry(
+                entry_id="idx-l-energy-global-average-electricity-mwh-2025",
+                reference_id="platform.factor.global_average_electricity_mwh_2025",
+                reference_type="emission_factor",
+                lens="factor",
+                text="Korea global average electricity LNG factor 2025",
+                reference_db_version="l-energy-platform-fixture-v1",
+                index_version="l-energy-embedding-stub-v1",
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:global-near-miss",),
+            ),
+            ReferenceIndexEntry(
+                entry_id="idx-l-energy-us-electricity-mwh-2025",
+                reference_id="platform.factor.us_electricity_mwh_2025",
+                reference_type="emission_factor",
+                lens="factor",
+                text="US electricity LNG factor 2025",
+                reference_db_version="l-energy-platform-fixture-v1",
+                index_version="l-energy-embedding-stub-v1",
+                source="source:dummy-data-mapping",
+                witness_ids=("source:dummy-data-mapping:us-near-miss",),
             ),
         )
     )

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -4,6 +4,8 @@ from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     EXPECTED_DERIVED_CLAIM_IDS,
     EXPECTED_FORMULA_IDS,
     EXPECTED_PROJECTION,
+    EXPECTED_REFERENCE_CANDIDATE_IDS,
+    EXPECTED_REJECTED_ELECTRICITY_CANDIDATES,
     EXPECTED_SOURCE_REFS,
     EXPECTED_TRACE_IDS,
 )
@@ -48,9 +50,16 @@ def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retriev
         candidate.candidate_id for candidate in result.report.reference_candidates
     )
     assert candidate_ids == (
+        "embedding_stub:factor:idx-l-energy-supplier-electricity-mwh-2025",
         "embedding_stub:factor:idx-l-energy-electricity-mwh-2025",
         "embedding_stub:factor:idx-l-energy-electricity-mwh-2024",
+        "embedding_stub:factor:idx-l-energy-electricity-residual-mix-2025",
+        "embedding_stub:factor:idx-l-energy-global-average-electricity-mwh-2025",
+        "embedding_stub:factor:idx-l-energy-us-electricity-mwh-2025",
     )
+    assert tuple(
+        candidate.reference_id for candidate in result.report.reference_candidates
+    ) == EXPECTED_REFERENCE_CANDIDATE_IDS
     assert all(
         candidate.authority == "candidate_only"
         for candidate in result.report.reference_candidates
@@ -68,9 +77,7 @@ def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retriev
     assert tuple(
         (rejected.reference_id, rejected.reason)
         for rejected in electricity_binding.rejected_candidates
-    ) == (
-        ("platform.factor.electricity_mwh_2024", "attribute_mismatch:valid_period"),
-    )
+    ) == EXPECTED_REJECTED_ELECTRICITY_CANDIDATES
 
     own_emission_claim = next(
         claim


### PR DESCRIPTION
## Summary
- Expand the L-Energy retrieval-backed fixture with supplier-specific, market-based, global average, US geography, and prior-period near-miss reference rows.
- Keep the selected platform expected receipt factor as the only candidate that can become the electricity `ReferenceBinding`.
- Assert that all retrieved references remain `candidate_only` and that selector rejection reasons are preserved in the binding explanation.
- Preserve the newer `ScenarioReferencePack` structure from main while extending its catalog and resolver entries.

## Why
The L-Energy scenario now pressures the architecture with a more realistic reference search result set: high-scoring retrieval candidates can appear above or near the correct row, but only attribute-validated bindings authorize calculation.

## Conflict resolution
- Merged latest `main` into `codex/larger-reference-db-fixture`.
- Resolved the conflict by moving the new near-miss records into `_reference_records()` and `_reference_index_entries()` under the extracted reference-pack model.

## Verification
- `python -m pytest tests\test_l_energy_pcf_scenario.py tests\test_domain_scenario_lab.py tests\test_reference_selector.py tests\test_package_smoke.py -q` -> 28 passed
- `python -m pytest -q` -> 248 passed
- `git diff --check` -> clean aside from CRLF working-copy warnings