### PR TITLE
[codex] extract L-Energy scenario reference pack

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -60,6 +60,7 @@ The shared test-support layer now exposes:
 ScenarioDefinition
 ScenarioContract
 SourceRef
+ScenarioReferencePack
 run_scenario()
 assert_scenario_contract()
 scenario_result_view()
@@ -104,3 +105,8 @@ Use `scenario_result_view()` when a test needs the viewer/export payload. Use
 `assert_projection_tamper_blocked()` for receipt value-gate negative tests.
 That keeps scenario tests focused on the contract instead of repeating receipt
 field traversal or projection tamper boilerplate in every pack.
+
+Use `ScenarioReferencePack` when a scenario needs a swappable reference fixture:
+it bundles the canonical `ReferenceCatalog`, retrieval resolver/index, and their
+fixture version labels so larger domain packs can replace reference data without
+rewiring the scenario runner.

--- a/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
@@ -27,6 +27,7 @@ from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     SCENARIO_ID,
     SOURCE_CASE_ID,
 )
+from tests.domain_scenarios.reference_packs import ScenarioReferencePack
 
 
 SUBJECT_ID = f"case:{SOURCE_CASE_ID}"
@@ -216,78 +217,90 @@ def blocked_report() -> CompileReport:
 
 
 def catalog() -> ReferenceCatalog:
-    return ReferenceCatalog(
-        records=(
-            ReferenceRecord(
-                reference_id="platform.factor.electricity_mwh",
-                reference_type="emission_factor",
-                labels=("L-Energy electricity and LNG factor 2025",),
-                aliases=("L-Energy own site energy factor",),
-                description=(
-                    "Platform fixture factor for L-Energy own energy emissions."
-                ),
-                attributes=(
-                    ("concept_id", "platform.concept.l_energy_own_energy"),
-                    ("geography", "KR"),
-                    ("valid_period", "2025"),
-                    ("method", "platform_expected_receipt"),
-                    ("factor_value", 226),
-                    ("input_unit", "GWh"),
-                    ("output_unit", "tCO2e"),
-                ),
-                source="source:dummy-data-mapping",
-                witness_ids=("source:dummy-data-mapping",),
-            ),
-            ReferenceRecord(
-                reference_id="platform.factor.electricity_mwh_2024",
-                reference_type="emission_factor",
-                labels=("L-Energy electricity and LNG factor 2024",),
-                aliases=("L-Energy historical own site energy factor",),
-                description=(
-                    "Near-miss platform fixture factor with the wrong valid period."
-                ),
-                attributes=(
-                    ("concept_id", "platform.concept.l_energy_own_energy"),
-                    ("geography", "KR"),
-                    ("valid_period", "2024"),
-                    ("method", "platform_expected_receipt"),
-                    ("factor_value", 220),
-                    ("input_unit", "GWh"),
-                    ("output_unit", "tCO2e"),
-                ),
-                source="source:dummy-data-mapping",
-                witness_ids=("source:dummy-data-mapping:2024-near-miss",),
-            ),
-        )
-    )
+    return reference_pack().catalog
 
 
 def reference_resolver() -> EmbeddingResolverStub:
-    return EmbeddingResolverStub(
-        entries=(
-            ReferenceIndexEntry(
-                entry_id="idx-l-energy-electricity-mwh-2025",
-                reference_id="platform.factor.electricity_mwh",
-                reference_type="emission_factor",
-                lens="factor",
-                text="Korea L-Energy electricity LNG factor 2025",
-                reference_db_version="l-energy-platform-fixture-v1",
-                index_version="l-energy-embedding-stub-v1",
-                source="source:dummy-data-mapping",
-                witness_ids=("source:dummy-data-mapping",),
+    return reference_pack().resolver
+
+
+def reference_pack() -> ScenarioReferencePack:
+    reference_db_version = "l-energy-platform-fixture-v1"
+    index_version = "l-energy-embedding-stub-v1"
+    return ScenarioReferencePack(
+        pack_id="l-energy-platform-reference-pack-v1",
+        reference_db_version=reference_db_version,
+        index_version=index_version,
+        catalog=ReferenceCatalog(records=_reference_records()),
+        resolver=EmbeddingResolverStub(entries=_reference_index_entries()),
+    )
+
+
+def _reference_records() -> tuple[ReferenceRecord, ...]:
+    return (
+        ReferenceRecord(
+            reference_id="platform.factor.electricity_mwh",
+            reference_type="emission_factor",
+            labels=("L-Energy electricity and LNG factor 2025",),
+            aliases=("L-Energy own site energy factor",),
+            description="Platform fixture factor for L-Energy own energy emissions.",
+            attributes=(
+                ("concept_id", "platform.concept.l_energy_own_energy"),
+                ("geography", "KR"),
+                ("valid_period", "2025"),
+                ("method", "platform_expected_receipt"),
+                ("factor_value", 226),
+                ("input_unit", "GWh"),
+                ("output_unit", "tCO2e"),
             ),
-            ReferenceIndexEntry(
-                entry_id="idx-l-energy-electricity-mwh-2024",
-                reference_id="platform.factor.electricity_mwh_2024",
-                reference_type="emission_factor",
-                lens="factor",
-                text="Korea L-Energy electricity LNG factor 2024",
-                reference_db_version="l-energy-platform-fixture-v1",
-                index_version="l-energy-embedding-stub-v1",
-                source="source:dummy-data-mapping",
-                witness_ids=("source:dummy-data-mapping:2024-near-miss",),
+            source="source:dummy-data-mapping",
+            witness_ids=("source:dummy-data-mapping",),
+        ),
+        ReferenceRecord(
+            reference_id="platform.factor.electricity_mwh_2024",
+            reference_type="emission_factor",
+            labels=("L-Energy electricity and LNG factor 2024",),
+            aliases=("L-Energy historical own site energy factor",),
+            description="Near-miss platform fixture factor with the wrong valid period.",
+            attributes=(
+                ("concept_id", "platform.concept.l_energy_own_energy"),
+                ("geography", "KR"),
+                ("valid_period", "2024"),
+                ("method", "platform_expected_receipt"),
+                ("factor_value", 220),
+                ("input_unit", "GWh"),
+                ("output_unit", "tCO2e"),
             ),
-        )
+            source="source:dummy-data-mapping",
+            witness_ids=("source:dummy-data-mapping:2024-near-miss",),
+        ),
+    )
+
+
+def _reference_index_entries() -> tuple[ReferenceIndexEntry, ...]:
+    return (
+        ReferenceIndexEntry(
+            entry_id="idx-l-energy-electricity-mwh-2025",
+            reference_id="platform.factor.electricity_mwh",
+            reference_type="emission_factor",
+            lens="factor",
+            text="Korea L-Energy electricity LNG factor 2025",
+            reference_db_version="l-energy-platform-fixture-v1",
+            index_version="l-energy-embedding-stub-v1",
+            source="source:dummy-data-mapping",
+            witness_ids=("source:dummy-data-mapping",),
+        ),
+        ReferenceIndexEntry(
+            entry_id="idx-l-energy-electricity-mwh-2024",
+            reference_id="platform.factor.electricity_mwh_2024",
+            reference_type="emission_factor",
+            lens="factor",
+            text="Korea L-Energy electricity LNG factor 2024",
+            reference_db_version="l-energy-platform-fixture-v1",
+            index_version="l-energy-embedding-stub-v1",
+            source="source:dummy-data-mapping",
+            witness_ids=("source:dummy-data-mapping:2024-near-miss",),
+        ),
     )
 
 
@@ -452,6 +465,7 @@ __all__ = [
     "formula",
     "input_claim",
     "profile",
+    "reference_pack",
     "reference_resolver",
     "reference_bindings",
     "retrieval_query_context",

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -37,14 +37,14 @@ from tests.domain_scenarios.l_energy_pcf_governance.fixtures import (
     SUBJECT_ID,
     attach_downstream_fixture_artifacts,
     blocked_report,
-    catalog,
     criteria,
     formula,
     input_claim,
     profile,
-    reference_resolver,
+    reference_pack,
     retrieval_query_context,
 )
+from tests.domain_scenarios.reference_packs import ScenarioReferencePack
 
 
 RESOLVER_STEPS = (
@@ -92,8 +92,13 @@ SCENARIO = ScenarioDefinition(
 )
 
 
-def run_l_energy_pcf_governance_scenario() -> DomainScenarioResult:
-    report = _compile_retrieval_backed_report()
+def run_l_energy_pcf_governance_scenario(
+    *,
+    reference_pack_override: ScenarioReferencePack | None = None,
+) -> DomainScenarioResult:
+    report = _compile_retrieval_backed_report(
+        reference_pack_override=reference_pack_override,
+    )
     preparation = prepare_commit(
         report,
         subject_id=SUBJECT_ID,
@@ -125,14 +130,18 @@ def _projection_source(report) -> dict[str, object]:
     return values
 
 
-def _compile_retrieval_backed_report() -> CompileReport:
+def _compile_retrieval_backed_report(
+    *,
+    reference_pack_override: ScenarioReferencePack | None = None,
+) -> CompileReport:
+    pack = reference_pack_override or reference_pack()
     scenario_profile = profile()
     opened_report = blocked_report()
     planned_report = plan_calculation_resolution(opened_report)
     resolver_tasks = resolver_tasks_from_report(planned_report)
     retrieval_report = resolve_reference_retrieval_obligations(
         planned_report,
-        reference_resolver(),
+        pack.resolver,
         query_for_obligation=reference_query_for_obligation_from_profile_policy(
             resolver_tasks,
             profile=scenario_profile,
@@ -141,7 +150,7 @@ def _compile_retrieval_backed_report() -> CompileReport:
     )
     selected_report = apply_reference_selection(
         retrieval_report,
-        catalog(),
+        pack.catalog,
         criteria=criteria(),
         field=formula().output_field,
     )
@@ -150,7 +159,7 @@ def _compile_retrieval_backed_report() -> CompileReport:
     if binding is not None:
         resolved_report = retry_blocked_calculation(
             selected_report,
-            catalog(),
+            pack.catalog,
             input_claim=input_claim(),
             reference_binding=binding,
             formula=formula(),

--- a/tests/domain_scenarios/reference_packs.py
+++ b/tests/domain_scenarios/reference_packs.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from comp.compiler_tool import EmbeddingResolverStub, ReferenceCatalog
+
+
+@dataclass(frozen=True)
+class ScenarioReferencePack:
+    pack_id: str
+    reference_db_version: str
+    index_version: str
+    catalog: ReferenceCatalog
+    resolver: EmbeddingResolverStub
+
+
+__all__ = ["ScenarioReferencePack"]

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -1,7 +1,7 @@
-from tests.domain_scenarios.assertions import assert_receipt_trace
 from comp.compiler_tool import active_retrieval_query_policies
+
+from tests.domain_scenarios.assertions import assert_receipt_trace
 from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
-from tests.domain_scenarios.l_energy_pcf_governance.fixtures import profile
 from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     EXPECTED_DERIVED_CLAIM_IDS,
     EXPECTED_FORMULA_IDS,
@@ -9,10 +9,15 @@ from tests.domain_scenarios.l_energy_pcf_governance.expected import (
     EXPECTED_SOURCE_REFS,
     EXPECTED_TRACE_IDS,
 )
+from tests.domain_scenarios.l_energy_pcf_governance.fixtures import (
+    profile,
+    reference_pack,
+)
 from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
     SCENARIO as L_ENERGY_SCENARIO,
     run_l_energy_pcf_governance_scenario,
 )
+from tests.domain_scenarios.reference_packs import ScenarioReferencePack
 from tests.domain_scenarios.registry import registered_scenarios
 
 
@@ -95,6 +100,47 @@ def test_l_energy_pcf_governance_pins_retrieval_policy_in_profile():
         policy.policy_id
         for policy in active_retrieval_query_policies(scenario_profile)
     ) == ("l-energy-pcf-retrieval-query-policy-v1",)
+
+
+def test_l_energy_reference_pack_bundles_catalog_and_retrieval_index():
+    pack = reference_pack()
+
+    assert isinstance(pack, ScenarioReferencePack)
+    assert pack.pack_id == "l-energy-platform-reference-pack-v1"
+    assert pack.reference_db_version == "l-energy-platform-fixture-v1"
+    assert pack.index_version == "l-energy-embedding-stub-v1"
+    assert tuple(record.reference_id for record in pack.catalog.records) == (
+        "platform.factor.electricity_mwh",
+        "platform.factor.electricity_mwh_2024",
+    )
+    assert tuple(entry.reference_id for entry in pack.resolver.entries) == (
+        "platform.factor.electricity_mwh",
+        "platform.factor.electricity_mwh_2024",
+    )
+
+
+def test_l_energy_scenario_accepts_swappable_reference_pack():
+    base_pack = reference_pack()
+    minimal_pack = ScenarioReferencePack(
+        pack_id="l-energy-minimal-reference-pack-v1",
+        reference_db_version=base_pack.reference_db_version,
+        index_version=base_pack.index_version,
+        catalog=type(base_pack.catalog)(
+            records=(base_pack.catalog.get("platform.factor.electricity_mwh"),),
+        ),
+        resolver=type(base_pack.resolver)(
+            entries=(base_pack.resolver.entries[0],),
+        ),
+    )
+
+    result = run_l_energy_pcf_governance_scenario(
+        reference_pack_override=minimal_pack,
+    )
+
+    assert result.projection == EXPECTED_PROJECTION
+    assert tuple(
+        candidate.reference_id for candidate in result.report.reference_candidates
+    ) == ("platform.factor.electricity_mwh",)
 
 
 def test_l_energy_pcf_governance_scenario_preserves_actor_receipt_trace():


### PR DESCRIPTION
## Summary

- add a `ScenarioReferencePack` test-support model for swappable scenario reference fixtures
- bundle the L-Energy reference catalog and embedding stub index into `reference_pack()`
- let the L-Energy scenario accept a reference pack override while preserving the default scenario flow
- add tests for reference pack metadata, catalog/index alignment, and swap behavior
- document `ScenarioReferencePack` in the Domain Scenario Lab README

## Validation

- `python -m pytest tests/test_l_energy_pcf_scenario.py::test_l_energy_reference_pack_bundles_catalog_and_retrieval_index tests/test_l_energy_pcf_scenario.py::test_l_energy_scenario_accepts_swappable_reference_pack -q`
- `python -m pytest tests/test_l_energy_pcf_scenario.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_package_smoke.py -q`
- `python -m pytest tests/test_l_energy_pcf_scenario.py tests/test_domain_scenario_lab.py tests/test_canonical_working_loop_scenario.py -q`
- `python -m pytest -q`
- `git diff --check`