### PR TITLE
[codex] add semantic LLM work orders

### DIFF
--- a/docs/architecture/llm-worker-orchestration.md
+++ b/docs/architecture/llm-worker-orchestration.md
@@ -519,6 +519,20 @@ abstain artifact model
 deterministic fake LLM worker for tests
 ```
 
+Current implemented subset:
+
+```text
+LLMWorkOrder model
+semantic-judgment work-order creation from ResolverTask
+AbstentionArtifact
+DeterministicLLMWorker fixture
+apply_llm_worker_results for submitted SemanticJudgment artifacts
+```
+
+This subset is intentionally semantic-only. It gives the agent layer a typed
+artifact-submission loop without adding a real LLM provider, a reading candidate
+model, or projection authority.
+
 Acceptance criteria:
 
 ```text

--- a/minchoagnt/__init__.py
+++ b/minchoagnt/__init__.py
@@ -17,6 +17,16 @@ from minchoagnt.review import (
 )
 from minchoagnt.skills import SkillStore
 from minchoagnt.workbench import ReviewWorkbench, WorkbenchRun
+from minchoagnt.work_orders import (
+    AbstentionArtifact,
+    DeterministicLLMWorker,
+    LLMWorkerResult,
+    LLMWorkerSubmission,
+    LLMWorkOrder,
+    apply_llm_worker_results,
+    semantic_work_orders_from_result,
+    semantic_work_orders_from_tasks,
+)
 
 __all__ = [
     "ChatResult",
@@ -36,4 +46,12 @@ __all__ = [
     "ReviewWorkbench",
     "SkillStore",
     "WorkbenchRun",
+    "LLMWorkOrder",
+    "LLMWorkerSubmission",
+    "LLMWorkerResult",
+    "AbstentionArtifact",
+    "DeterministicLLMWorker",
+    "semantic_work_orders_from_result",
+    "semantic_work_orders_from_tasks",
+    "apply_llm_worker_results",
 ]

--- a/minchoagnt/work_orders.py
+++ b/minchoagnt/work_orders.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from comp.compiler_tool import (
+    ResolverTask,
+    SemanticJudgment,
+    apply_semantic_judgments,
+    resolver_tasks_from_report,
+)
+from minchoagnt.comp_adapter import CompCompileResult
+
+
+@dataclass(frozen=True)
+class LLMWorkOrder:
+    work_order_id: str
+    target_id: str
+    target_kind: str
+    task_kind: str
+    context_bundle: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+    allowed_tools: tuple[str, ...] = field(default_factory=tuple)
+    forbidden_outputs: tuple[str, ...] = field(default_factory=tuple)
+    expected_artifacts: tuple[str, ...] = field(default_factory=tuple)
+    budget: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    @property
+    def can_authorize_public_projection(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class LLMWorkerSubmission:
+    work_order_id: str
+    tool_name: str
+    artifact: Any
+
+
+@dataclass(frozen=True)
+class AbstentionArtifact:
+    abstention_id: str
+    work_order_id: str
+    reason: str
+    category: str
+
+    @property
+    def can_authorize_public_projection(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class LLMWorkerResult:
+    work_order_id: str
+    submissions: tuple[LLMWorkerSubmission, ...] = field(default_factory=tuple)
+    abstention: AbstentionArtifact | None = None
+
+    @property
+    def can_authorize_public_projection(self) -> bool:
+        return False
+
+
+class DeterministicLLMWorker:
+    """Fixture LLM worker that submits typed artifacts without compiler authority."""
+
+    def __init__(
+        self,
+        *,
+        submissions: Iterable[LLMWorkerSubmission] = (),
+        abstentions: Iterable[AbstentionArtifact] = (),
+    ):
+        self.submissions = tuple(submissions)
+        self.abstentions = tuple(abstentions)
+
+    def run(self, work_order: LLMWorkOrder) -> LLMWorkerResult:
+        abstention = _matching_abstention(self.abstentions, work_order)
+        if abstention is not None:
+            return LLMWorkerResult(
+                work_order_id=work_order.work_order_id,
+                abstention=abstention,
+            )
+
+        submissions = tuple(
+            submission
+            for submission in self.submissions
+            if submission.work_order_id == work_order.work_order_id
+        )
+        forbidden = _first_forbidden_submission(work_order, submissions)
+        if forbidden is not None:
+            return LLMWorkerResult(
+                work_order_id=work_order.work_order_id,
+                abstention=AbstentionArtifact(
+                    abstention_id=(
+                        f"abstain:{work_order.work_order_id}:forbidden_tool"
+                    ),
+                    work_order_id=work_order.work_order_id,
+                    reason=(
+                        f"Tool {forbidden.tool_name} is not allowed for this "
+                        "work order."
+                    ),
+                    category="forbidden_tool",
+                ),
+            )
+
+        return LLMWorkerResult(
+            work_order_id=work_order.work_order_id,
+            submissions=_limit_submissions(work_order, submissions),
+        )
+
+
+def semantic_work_orders_from_result(
+    result: CompCompileResult,
+) -> tuple[LLMWorkOrder, ...]:
+    return semantic_work_orders_from_tasks(resolver_tasks_from_report(result.report))
+
+
+def semantic_work_orders_from_tasks(
+    tasks: tuple[ResolverTask, ...],
+) -> tuple[LLMWorkOrder, ...]:
+    return tuple(
+        _semantic_work_order(task)
+        for task in tasks
+        if task.task_type == "semantic_judgment"
+    )
+
+
+def apply_llm_worker_results(
+    result: CompCompileResult,
+    worker_results: Iterable[LLMWorkerResult],
+    *,
+    available_span_ids: Iterable[str] | None = None,
+) -> CompCompileResult:
+    judgments = tuple(
+        submission.artifact
+        for worker_result in worker_results
+        for submission in worker_result.submissions
+        if (
+            submission.tool_name == "submit_semantic_judgment"
+            and isinstance(submission.artifact, SemanticJudgment)
+        )
+    )
+    if not judgments:
+        return replace(result, receipt=None)
+
+    return replace(
+        result,
+        report=apply_semantic_judgments(
+            result.report,
+            judgments,
+            available_span_ids=available_span_ids,
+        ),
+        receipt=None,
+    )
+
+
+def _semantic_work_order(task: ResolverTask) -> LLMWorkOrder:
+    return LLMWorkOrder(
+        work_order_id=f"llm-work-order:{task.obligation_id}",
+        target_id=task.obligation_id,
+        target_kind="proof_obligation",
+        task_kind="semantic_judgment",
+        context_bundle=task.payload,
+        allowed_tools=(
+            "submit_semantic_judgment",
+            "flag_conflict",
+            "abstain_with_reason",
+        ),
+        forbidden_outputs=(
+            "create_reference_binding",
+            "create_commit_receipt",
+            "project_public_row",
+        ),
+        expected_artifacts=("semantic_judgment", "abstention"),
+        budget=(("max_artifacts", 1),),
+    )
+
+
+def _matching_abstention(
+    abstentions: tuple[AbstentionArtifact, ...],
+    work_order: LLMWorkOrder,
+) -> AbstentionArtifact | None:
+    for abstention in abstentions:
+        if abstention.work_order_id == work_order.work_order_id:
+            return abstention
+    return None
+
+
+def _first_forbidden_submission(
+    work_order: LLMWorkOrder,
+    submissions: tuple[LLMWorkerSubmission, ...],
+) -> LLMWorkerSubmission | None:
+    allowed = set(work_order.allowed_tools)
+    forbidden = set(work_order.forbidden_outputs)
+    for submission in submissions:
+        if submission.tool_name in forbidden or submission.tool_name not in allowed:
+            return submission
+    return None
+
+
+def _limit_submissions(
+    work_order: LLMWorkOrder,
+    submissions: tuple[LLMWorkerSubmission, ...],
+) -> tuple[LLMWorkerSubmission, ...]:
+    budget = dict(work_order.budget)
+    max_artifacts = budget.get("max_artifacts")
+    if isinstance(max_artifacts, int):
+        return submissions[:max_artifacts]
+    return submissions
+
+
+__all__ = [
+    "LLMWorkOrder",
+    "LLMWorkerSubmission",
+    "LLMWorkerResult",
+    "AbstentionArtifact",
+    "DeterministicLLMWorker",
+    "semantic_work_orders_from_result",
+    "semantic_work_orders_from_tasks",
+    "apply_llm_worker_results",
+]

--- a/tests/test_minchoagnt_llm_work_orders.py
+++ b/tests/test_minchoagnt_llm_work_orders.py
@@ -1,0 +1,173 @@
+from comp.compiler_tool import (
+    CompileReport,
+    InterpretationHypothesis,
+    ProofObligation,
+    SemanticJudgment,
+    SemanticJudgmentRequirement,
+)
+from comp.judgment import SubjectRef
+from minchoagnt import (
+    AbstentionArtifact,
+    CompCompileResult,
+    DeterministicLLMWorker,
+    LLMWorkOrder,
+    LLMWorkerSubmission,
+    apply_llm_worker_results,
+    semantic_work_orders_from_result,
+)
+
+
+def _semantic_obligation() -> ProofObligation:
+    return ProofObligation(
+        kind="semantic_judgment_required",
+        field="scope2_method",
+        reason="support_required",
+        obligation_id="obl-scope2",
+        claim_id="claim-scope2",
+        semantic_requirement=SemanticJudgmentRequirement(
+            question="Does this span support market-based Scope 2?",
+            claim_id="claim-scope2",
+            evidence_span_ids=("span-17",),
+            rubric_id="ghg-protocol-scope2-method-v1",
+            acceptable_verdicts=("supports", "refutes", "ambiguous"),
+            required_verdict="supports",
+            allowed_judges=("llm/scope2-worker",),
+        ),
+    )
+
+
+def _compile_result() -> CompCompileResult:
+    return CompCompileResult(
+        hypothesis=InterpretationHypothesis("hyp-sem", "facility-1"),
+        subject=SubjectRef("claim", "hyp-sem"),
+        report=CompileReport(
+            status="review_required",
+            obligations=(_semantic_obligation(),),
+        ),
+    )
+
+
+def _judgment() -> SemanticJudgment:
+    return SemanticJudgment(
+        judgment_id="judgment-scope2",
+        obligation_id="obl-scope2",
+        verdict="supports",
+        rubric_id="ghg-protocol-scope2-method-v1",
+        judge="llm/scope2-worker",
+        cited_span_ids=("span-17",),
+        rationale="The cited span states a market-based Scope 2 method.",
+    )
+
+
+def test_semantic_resolver_task_becomes_llm_work_order_with_limited_tools():
+    result = _compile_result()
+
+    work_orders = semantic_work_orders_from_result(result)
+
+    assert work_orders == (
+        LLMWorkOrder(
+            work_order_id="llm-work-order:obl-scope2",
+            target_id="obl-scope2",
+            target_kind="proof_obligation",
+            task_kind="semantic_judgment",
+            context_bundle=(
+                ("question", "Does this span support market-based Scope 2?"),
+                ("rubric_id", "ghg-protocol-scope2-method-v1"),
+                ("acceptable_verdicts", ("supports", "refutes", "ambiguous")),
+                ("required_verdict", "supports"),
+                ("allowed_judges", ("llm/scope2-worker",)),
+                ("evidence_span_ids", ("span-17",)),
+            ),
+            allowed_tools=(
+                "submit_semantic_judgment",
+                "flag_conflict",
+                "abstain_with_reason",
+            ),
+            forbidden_outputs=(
+                "create_reference_binding",
+                "create_commit_receipt",
+                "project_public_row",
+            ),
+            expected_artifacts=("semantic_judgment", "abstention"),
+            budget=(("max_artifacts", 1),),
+        ),
+    )
+    assert work_orders[0].can_authorize_public_projection is False
+
+
+def test_deterministic_llm_worker_submits_semantic_judgment_artifact_only():
+    result = _compile_result()
+    worker = DeterministicLLMWorker(
+        submissions=(
+            LLMWorkerSubmission(
+                work_order_id="llm-work-order:obl-scope2",
+                tool_name="submit_semantic_judgment",
+                artifact=_judgment(),
+            ),
+        ),
+    )
+
+    worker_results = tuple(
+        worker.run(order) for order in semantic_work_orders_from_result(result)
+    )
+    resolved = apply_llm_worker_results(
+        result,
+        worker_results,
+        available_span_ids=("span-17",),
+    )
+
+    assert resolved.report.status == "accepted"
+    assert resolved.report.obligations == ()
+    assert resolved.report.resolved_obligations == (_semantic_obligation(),)
+    assert resolved.receipt is None
+
+
+def test_llm_worker_abstention_leaves_semantic_obligation_open():
+    result = _compile_result()
+    worker = DeterministicLLMWorker(
+        abstentions=(
+            AbstentionArtifact(
+                abstention_id="abstain-scope2",
+                work_order_id="llm-work-order:obl-scope2",
+                reason="The provided span is not enough to judge the method.",
+                category="cannot_resolve_from_available_context",
+            ),
+        ),
+    )
+
+    worker_results = tuple(
+        worker.run(order) for order in semantic_work_orders_from_result(result)
+    )
+    unresolved = apply_llm_worker_results(
+        result,
+        worker_results,
+        available_span_ids=("span-17",),
+    )
+
+    assert unresolved.report.status == "review_required"
+    assert unresolved.report.obligations == (_semantic_obligation(),)
+    assert unresolved.report.resolved_obligations == ()
+    assert unresolved.receipt is None
+
+
+def test_deterministic_llm_worker_rejects_forbidden_tool_submission():
+    order = semantic_work_orders_from_result(_compile_result())[0]
+    worker = DeterministicLLMWorker(
+        submissions=(
+            LLMWorkerSubmission(
+                work_order_id=order.work_order_id,
+                tool_name="create_commit_receipt",
+                artifact={"receipt": "fake"},
+            ),
+        ),
+    )
+
+    result = worker.run(order)
+
+    assert result.submissions == ()
+    assert result.abstention == AbstentionArtifact(
+        abstention_id="abstain:llm-work-order:obl-scope2:forbidden_tool",
+        work_order_id="llm-work-order:obl-scope2",
+        reason="Tool create_commit_receipt is not allowed for this work order.",
+        category="forbidden_tool",
+    )


### PR DESCRIPTION
## Summary
- add typed LLM work orders, worker submissions, abstentions, and a deterministic fake worker in `minchoagnt`
- convert semantic resolver tasks into limited artifact-submission work orders
- apply submitted `SemanticJudgment` artifacts through compiler validation while keeping receipt/projection authority out of the worker layer
- update the LLM worker orchestration docs with the implemented semantic-only subset

## Validation
- `python -m pytest tests/test_minchoagnt_llm_work_orders.py tests/test_minchoagnt_comp_adapter.py tests/test_package_smoke.py -q`
- `python -m pytest tests/test_semantic_judgment_obligations.py tests/test_resolver_tasks.py -q`
- `python -m pytest -q`
- `git diff --check`