### PR TITLE
[codex] replay canonical scenario from persisted artifacts

### DIFF
--- a/comp/persistence/replay.py
+++ b/comp/persistence/replay.py
@@ -47,12 +47,14 @@ def replay_public_projection(
         receipt=receipt,
     )
     refs = receipt_artifact_refs(receipt)
+    artifact_digests = _verified_artifact_digests(refs, artifacts)
+    _verify_projection_value_sources(receipt, artifacts)
     return ProjectionReplayReport(
         receipt_key=ReceiptLedgerKey.from_receipt(receipt),
         projection_id=projection.projection_id,
         public_row=public_row,
         artifact_refs=refs,
-        artifact_digests=_verified_artifact_digests(refs, artifacts),
+        artifact_digests=artifact_digests,
     )
 
 
@@ -120,6 +122,43 @@ def _verified_artifact_digests(
             ) from exc
         digests.append((envelope.artifact_id, envelope.body_digest))
     return tuple(digests)
+
+
+def _verify_projection_value_sources(
+    receipt: CommitReceipt,
+    artifacts: InMemoryArtifactStore,
+) -> None:
+    if receipt.citations is None:
+        return
+
+    for commitment in receipt.citations.projection_value_commitments:
+        try:
+            envelope = artifacts.get(commitment.source_id)
+        except KeyError as exc:
+            raise ProjectionReplayBlocked(
+                f"Projection replay missing artifact: {commitment.source_id}."
+            ) from exc
+        if envelope.artifact_kind != commitment.source_kind:
+            raise ProjectionReplayBlocked(
+                f"Projection replay artifact kind mismatch: {commitment.source_id}."
+            )
+        if "value" not in envelope.body:
+            raise ProjectionReplayBlocked(
+                "Projection replay source artifact lacks committed value: "
+                f"{commitment.source_id}."
+            )
+        try:
+            matches = commitment.matches_value(envelope.body["value"])
+        except (TypeError, ValueError) as exc:
+            raise ProjectionReplayBlocked(
+                "Projection replay source artifact value cannot be verified: "
+                f"{commitment.source_id}."
+            ) from exc
+        if not matches:
+            raise ProjectionReplayBlocked(
+                "Projection replay source artifact value commitment mismatch: "
+                f"{commitment.field}."
+            )
 
 
 def _unique_refs(refs: list[ArtifactRef]) -> tuple[ArtifactRef, ...]:

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -452,6 +452,11 @@ comp/persistence/replay.py
 
 tests/support/persistence_cases.py
   keeps persistence test setup readable without hiding negative mutation cases.
+
+tests/domain_scenarios/persistence.py
+  records receipt-cited scenario artifacts into an in-memory artifact store,
+  records the CommitReceipt into an in-memory receipt ledger, and replays the
+  materialized scenario projection from those stored envelopes.
 ```
 
 The implemented minimum behavior is:
@@ -464,11 +469,16 @@ CommitReceipt can be recorded as an append-only ledger root.
 Materialized public projection is treated as a view, not authority.
 Replay verifies projection values against receipt commitments.
 Replay blocks when an artifact body or projected value no longer matches its digest.
+Replay verifies committed public values against the cited checked/derived source
+artifact body, not only against the materialized row.
+The canonical raw-input working loop can be replayed from stored scenario
+artifact envelopes and its receipt ledger root.
 ```
 
-That completes the original in-memory substrate slice. It does not yet mean
-production persistence exists, nor does it mean scenario runs automatically
-persist every artifact needed for replay.
+That completes the original in-memory substrate slice and attaches it to the
+canonical raw-input scenario harness. It does not yet mean production
+persistence exists, nor does it mean a database, retention policy, or dependency
+fingerprint manifest exists.
 
 ---
 
@@ -477,30 +487,28 @@ persist every artifact needed for replay.
 Recommended next code slice:
 
 ```text
-test/feat: replay canonical scenario from stored artifact envelopes
+feat: pin replay dependency fingerprints
 ```
 
 Candidate files:
 
 ```text
-tests/domain_scenarios/canonical_working_loop/scenario.py
-tests/domain_scenarios/canonical_working_loop/fixtures.py
-tests/test_canonical_working_loop_scenario.py
-tests/test_persistence_projection_replay.py
-comp/persistence/*.py, only if the replay API needs a narrow helper
+comp/compiler_tool/profiles.py
+comp/compiler_tool/references.py
+comp/persistence/*.py
+tests/test_persistence_*.py
+tests/test_compiler_profile_contract.py
 ```
 
 Minimum behavior:
 
 ```text
-Canonical working loop records receipt-cited artifacts in an InMemoryArtifactStore.
-The run records the CommitReceipt as an InMemoryReceiptLedger root.
-The scenario replays its materialized projection through replay_public_projection.
-Replay report includes package, governance decision, checked/derived sources,
-bindings, traces, formulas, and witness refs that are already present in receipt
-citations.
-Negative scenario blocks replay when a cited artifact is missing or its body
-digest drifts.
+CompilerProfile exposes a stable declaration fingerprint.
+ReferenceRecord or selected ReferenceBinding exposes a replayable record
+fingerprint.
+CommitReceipt citations can include those fingerprints without turning the
+current catalog or profile into replay authority.
+Replay can report which profile/reference world the receipt depended on.
 ```
 
 Non-goals for that slice:
@@ -512,11 +520,12 @@ no production storage backend
 no catalog ingestion pipeline
 no legal retention policy
 no full event sourcing
-no profile/domain/reference fingerprint implementation yet
+no real embedding index persistence
 ```
 
-The goal is to prove the replay substrate is not only unit-testable, but also
-attached to the raw-input canonical working loop.
+The goal is to move from "receipt can replay values and cited artifacts" toward
+"receipt can also explain the pinned profile/reference world that made those
+artifacts meaningful."
 
 ---
 

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from comp.judgment import ProjectionSpec
+from comp.persistence import (
+    ArtifactEnvelope,
+    ArtifactRef,
+    InMemoryArtifactStore,
+    InMemoryReceiptLedger,
+    ProjectionReplayReport,
+    receipt_artifact_refs,
+    replay_public_projection,
+)
+from tests.domain_scenarios.core import DomainScenarioResult
+
+
+@dataclass(frozen=True)
+class DomainScenarioReplayBundle:
+    artifacts: InMemoryArtifactStore
+    receipt_ledger: InMemoryReceiptLedger
+
+
+def scenario_replay_bundle(
+    result: DomainScenarioResult,
+    *,
+    skip: ArtifactRef | None = None,
+    override: ArtifactEnvelope | None = None,
+) -> DomainScenarioReplayBundle:
+    receipt = result.preparation.receipt
+    if receipt is None:
+        raise AssertionError("Scenario replay requires a commit receipt.")
+
+    artifacts = InMemoryArtifactStore()
+    for ref in receipt_artifact_refs(receipt):
+        if ref == skip:
+            continue
+        if override is not None and override.artifact_id == ref.artifact_id:
+            artifacts.record(override)
+            continue
+        artifacts.record(_artifact_envelope_for_ref(result, ref))
+
+    receipt_ledger = InMemoryReceiptLedger()
+    receipt_ledger.record(receipt)
+    return DomainScenarioReplayBundle(
+        artifacts=artifacts,
+        receipt_ledger=receipt_ledger,
+    )
+
+
+def replay_scenario_projection(
+    result: DomainScenarioResult,
+    projection: ProjectionSpec,
+    *,
+    bundle: DomainScenarioReplayBundle | None = None,
+) -> ProjectionReplayReport:
+    receipt = result.preparation.receipt
+    if receipt is None:
+        raise AssertionError("Scenario replay requires a commit receipt.")
+    if result.projection is None:
+        raise AssertionError("Scenario replay requires a materialized projection.")
+
+    replay_bundle = bundle or scenario_replay_bundle(result)
+    ledger_receipt = replay_bundle.receipt_ledger.get(
+        public_row_id=receipt.public_row_id,
+        projection_id=receipt.projection_id,
+        draft_id=receipt.draft_id,
+    )
+    return replay_public_projection(
+        result.projection,
+        projection,
+        receipt=ledger_receipt,
+        artifacts=replay_bundle.artifacts,
+    )
+
+
+def _artifact_envelope_for_ref(
+    result: DomainScenarioResult,
+    ref: ArtifactRef,
+) -> ArtifactEnvelope:
+    return ArtifactEnvelope.from_body(
+        artifact_id=ref.artifact_id,
+        artifact_kind=ref.artifact_kind,
+        schema_version="domain-scenario-v1",
+        body=_artifact_body_for_ref(result, ref),
+    )
+
+
+def _artifact_body_for_ref(
+    result: DomainScenarioResult,
+    ref: ArtifactRef,
+) -> dict[str, Any]:
+    if ref.artifact_kind == "commit_package":
+        package = result.preparation.package
+        return {
+            "package_id": package.package_id,
+            "subject_id": package.subject_id,
+            "report_status": package.report_status,
+            "complete": package.complete,
+            "reference_binding_ids": package.reference_binding_ids,
+            "derived_claim_ids": package.derived_claim_ids,
+            "calculation_trace_ids": package.calculation_trace_ids,
+            "formula_ids": package.formula_ids,
+            "open_obligation_ids": package.open_obligation_ids,
+            "hazard_ids": package.hazard_ids,
+        }
+    if ref.artifact_kind == "governance_decision":
+        decision = result.preparation.decision
+        return {
+            "decision_id": decision.decision_id,
+            "package_id": decision.package_id,
+            "subject_id": decision.subject_id,
+            "status": decision.status,
+            "reasons": decision.reasons,
+            "profile_id": decision.profile_id,
+        }
+    if ref.artifact_kind == "checked_claim":
+        claim = _checked_claim_by_source_id(result, ref.artifact_id)
+        return {
+            "claim_id": ref.artifact_id,
+            "field": claim.field,
+            "value": claim.value,
+            "witness_id": claim.witness_id,
+            "origin": claim.origin,
+        }
+    if ref.artifact_kind == "evidence_witness":
+        return {"witness_id": ref.artifact_id, "source": "domain_scenario"}
+    if ref.artifact_kind == "reference_binding":
+        binding = _by_id(
+            result.report.reference_bindings,
+            ref.artifact_id,
+            "binding_id",
+        )
+        return {
+            "binding_id": binding.binding_id,
+            "claim_id": binding.claim_id,
+            "reference_id": binding.reference_id,
+            "reference_type": binding.reference_type,
+            "selected_candidate_id": binding.selected_candidate_id,
+            "selector_rule_id": binding.selector_rule_id,
+            "source_witness_ids": binding.source_witness_ids,
+            "rejected_candidates": tuple(
+                {
+                    "candidate_id": candidate.candidate_id,
+                    "reference_id": candidate.reference_id,
+                    "reason": candidate.reason,
+                    "selector_rule_id": candidate.selector_rule_id,
+                }
+                for candidate in binding.rejected_candidates
+            ),
+            "authority": binding.authority,
+        }
+    if ref.artifact_kind == "derived_claim":
+        claim = _by_id(result.report.derived_claims, ref.artifact_id, "claim_id")
+        return {
+            "claim_id": claim.claim_id,
+            "field": claim.field,
+            "value": claim.value,
+            "unit": claim.unit,
+            "formula_id": claim.formula_id,
+            "trace_id": claim.trace.trace_id,
+            "origin": claim.origin,
+        }
+    if ref.artifact_kind == "calculation_trace":
+        trace = _trace_by_id(result, ref.artifact_id)
+        return {
+            "trace_id": trace.trace_id,
+            "formula_id": trace.formula_id,
+            "input_claim_ids": trace.input_claim_ids,
+            "reference_binding_ids": trace.reference_binding_ids,
+            "steps": tuple(
+                {
+                    "step_id": step.step_id,
+                    "operation": step.operation,
+                    "input_ids": step.input_ids,
+                    "output_value": step.output_value,
+                    "output_unit": step.output_unit,
+                }
+                for step in trace.steps
+            ),
+        }
+    if ref.artifact_kind == "formula":
+        return {"formula_id": ref.artifact_id}
+    if ref.artifact_kind == "semantic_judgment":
+        return {"judgment_id": ref.artifact_id}
+    raise AssertionError(f"Unsupported scenario artifact ref: {ref}.")
+
+
+def _checked_claim_by_source_id(result: DomainScenarioResult, source_id: str):
+    for claim in result.report.checked_claims:
+        if source_id == f"checked_claim:{claim.field}:{claim.witness_id}":
+            return claim
+    raise AssertionError(f"Scenario checked claim not found: {source_id}.")
+
+
+def _trace_by_id(result: DomainScenarioResult, trace_id: str):
+    for claim in result.report.derived_claims:
+        if claim.trace.trace_id == trace_id:
+            return claim.trace
+    raise AssertionError(f"Scenario calculation trace not found: {trace_id}.")
+
+
+def _by_id(items, item_id: str, field: str):
+    for item in items:
+        if getattr(item, field) == item_id:
+            return item
+    raise AssertionError(f"Scenario artifact not found: {item_id}.")
+
+
+__all__ = [
+    "DomainScenarioReplayBundle",
+    "replay_scenario_projection",
+    "scenario_replay_bundle",
+]

--- a/tests/support/persistence_cases.py
+++ b/tests/support/persistence_cases.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -99,6 +100,7 @@ def claim_envelope(
 def artifact_store_for_receipt(
     receipt: CommitReceipt,
     *,
+    committed_values: Mapping[str, Any] | None = None,
     skip: ArtifactRef | None = None,
     override: ArtifactEnvelope | None = None,
 ) -> InMemoryArtifactStore:
@@ -109,26 +111,39 @@ def artifact_store_for_receipt(
         if override is not None and override.artifact_id == ref.artifact_id:
             store.record(override)
             continue
-        store.record(artifact_for_ref(ref))
+        store.record(artifact_for_ref(ref, committed_values=committed_values))
     return store
 
 
-def artifact_for_ref(ref: ArtifactRef) -> ArtifactEnvelope:
+def artifact_for_ref(
+    ref: ArtifactRef,
+    *,
+    committed_values: Mapping[str, Any] | None = None,
+) -> ArtifactEnvelope:
     return ArtifactEnvelope.from_body(
         artifact_id=ref.artifact_id,
         artifact_kind=ref.artifact_kind,
         schema_version="v1",
-        body=artifact_body_for_ref(ref),
+        body=artifact_body_for_ref(ref, committed_values=committed_values),
     )
 
 
-def artifact_body_for_ref(ref: ArtifactRef) -> dict[str, Any]:
+def artifact_body_for_ref(
+    ref: ArtifactRef,
+    *,
+    committed_values: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     if ref.artifact_kind == "commit_package":
         return {"package_id": ref.artifact_id, "complete": True}
     if ref.artifact_kind == "governance_decision":
         return {"decision_id": ref.artifact_id, "status": "commit"}
     if ref.artifact_kind == "checked_claim":
-        return {"claim_id": ref.artifact_id, "field": _claim_field(ref)}
+        field = _claim_field(ref)
+        body = {"claim_id": ref.artifact_id, "field": field}
+        values = committed_values or {}
+        if field in values:
+            body["value"] = values[field]
+        return body
     if ref.artifact_kind == "evidence_witness":
         return {"witness_id": ref.artifact_id, "source": "fixture"}
     raise AssertionError(f"Unexpected artifact ref in test: {ref}")

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -1,5 +1,8 @@
+import pytest
+
 from comp import ProjectionSpec
 from comp.compiler_tool import active_retrieval_query_policies
+from comp.persistence import ArtifactRef, ProjectionReplayBlocked
 from tests.domain_scenarios.assertions import assert_projection_tamper_blocked
 from tests.domain_scenarios.canonical_working_loop.fixtures import (
     RAW_EVIDENCE,
@@ -13,6 +16,10 @@ from tests.domain_scenarios.canonical_working_loop.scenario import (
     run_canonical_working_loop_scenario,
 )
 from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
+from tests.domain_scenarios.persistence import (
+    replay_scenario_projection,
+    scenario_replay_bundle,
+)
 
 
 def test_canonical_working_loop_extracts_and_compiles_raw_text():
@@ -113,3 +120,53 @@ def test_canonical_working_loop_receipt_rejects_tampered_projection_value():
         {"co2e_kg": 999999},
         match="value commitment",
     )
+
+
+def test_canonical_working_loop_replays_projection_from_stored_artifacts():
+    result = run_canonical_working_loop_scenario()
+    projection = ProjectionSpec(
+        "canonical-pcf-public-row",
+        ("electricity_kwh", "reporting_year", "co2e_kg"),
+    )
+
+    replay = replay_scenario_projection(result, projection)
+
+    assert replay.public_row == result.projection
+    assert ArtifactRef(
+        "commit-package:product:canonical-raw-pcf-1",
+        "commit_package",
+    ) in replay.artifact_refs
+    assert ArtifactRef(
+        "governance-decision:commit-package:product:canonical-raw-pcf-1",
+        "governance_decision",
+    ) in replay.artifact_refs
+    assert ArtifactRef(
+        "checked_claim:electricity_kwh:w-electricity-kwh",
+        "checked_claim",
+    ) in replay.artifact_refs
+    assert ArtifactRef(
+        "canonical-raw:co2e_kg",
+        "derived_claim",
+    ) in replay.artifact_refs
+    assert ArtifactRef(
+        "trace:canonical-raw:co2e_kg",
+        "calculation_trace",
+    ) in replay.artifact_refs
+    assert dict(replay.artifact_digests)[
+        "canonical-raw:co2e_kg"
+    ].startswith("sha256:")
+
+
+def test_canonical_working_loop_replay_blocks_when_cited_artifact_is_missing():
+    result = run_canonical_working_loop_scenario()
+    projection = ProjectionSpec(
+        "canonical-pcf-public-row",
+        ("electricity_kwh", "reporting_year", "co2e_kg"),
+    )
+    bundle = scenario_replay_bundle(
+        result,
+        skip=ArtifactRef("canonical-raw:co2e_kg", "derived_claim"),
+    )
+
+    with pytest.raises(ProjectionReplayBlocked, match="missing artifact"):
+        replay_scenario_projection(result, projection, bundle=bundle)

--- a/tests/test_persistence_projection_replay.py
+++ b/tests/test_persistence_projection_replay.py
@@ -17,7 +17,10 @@ from tests.support.persistence_cases import (
 
 def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
     case = receipt_projection_case(amount=100)
-    artifacts = artifact_store_for_receipt(case.receipt)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
 
     report = replay_public_projection(
         case.source_values,
@@ -47,6 +50,7 @@ def test_replay_blocks_when_required_artifact_is_missing():
     case = receipt_projection_case(amount=100)
     artifacts = artifact_store_for_receipt(
         case.receipt,
+        committed_values=case.source_values,
         skip=ArtifactRef("decision-1", "governance_decision"),
     )
 
@@ -63,6 +67,7 @@ def test_replay_blocks_when_required_artifact_kind_mismatches():
     case = receipt_projection_case(amount=100)
     artifacts = artifact_store_for_receipt(
         case.receipt,
+        committed_values=case.source_values,
         override=ArtifactEnvelope.from_body(
             artifact_id="decision-1",
             artifact_kind="commit_package",
@@ -82,7 +87,10 @@ def test_replay_blocks_when_required_artifact_kind_mismatches():
 
 def test_replay_blocks_when_stored_artifact_body_drifts_after_recording():
     case = receipt_projection_case(amount=100)
-    artifacts = artifact_store_for_receipt(case.receipt)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
     artifacts.get("package-1").body["complete"] = False
 
     with pytest.raises(ProjectionReplayBlocked, match="body digest"):
@@ -94,9 +102,38 @@ def test_replay_blocks_when_stored_artifact_body_drifts_after_recording():
         )
 
 
+def test_replay_blocks_when_committed_source_artifact_value_drifts():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+        override=ArtifactEnvelope.from_body(
+            artifact_id="checked_claim:amount:span-amount",
+            artifact_kind="checked_claim",
+            schema_version="v1",
+            body={
+                "claim_id": "checked_claim:amount:span-amount",
+                "field": "amount",
+                "value": 999999,
+            },
+        ),
+    )
+
+    with pytest.raises(ProjectionReplayBlocked, match="value commitment mismatch"):
+        replay_public_projection(
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
+            artifacts=artifacts,
+        )
+
+
 def test_replay_blocks_when_materialized_row_no_longer_matches_receipt():
     case = receipt_projection_case(amount=100)
-    artifacts = artifact_store_for_receipt(case.receipt)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
 
     with pytest.raises(ProjectionReplayBlocked, match="cannot be replayed"):
         replay_public_projection(


### PR DESCRIPTION
## Summary
- add a domain scenario persistence harness that records receipt-cited artifacts into an in-memory artifact store and records the receipt into an in-memory ledger
- replay the canonical raw-input working loop projection from stored scenario artifacts
- strengthen persistence replay so projection value commitments are checked against the cited checked/derived source artifact body, not only the materialized row
- refresh the persistence boundary doc to mark canonical scenario replay as implemented and point the next slice at dependency fingerprints

## Validation
- `python -m pytest tests/test_persistence_projection_replay.py tests/test_canonical_working_loop_scenario.py tests/test_persistence_ledger_boundary.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`