### PR TITLE
[codex] pin replay dependency fingerprints

### DIFF
--- a/comp/__init__.py
+++ b/comp/__init__.py
@@ -12,6 +12,7 @@ from comp.judgment import (
     CommitReceiptCitations,
     CommitSpec,
     CompiledJudgmentProgram,
+    DependencyFingerprint,
     DraftSnapshot,
     Fact,
     FactTag,
@@ -63,6 +64,7 @@ __all__ = [
     "project_public_row",
     "SelectionReceipt",
     "ProjectionValueCommitment",
+    "DependencyFingerprint",
     "CommitReceipt",
     "CommitReceiptCitations",
 ]

--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -44,6 +44,7 @@ from comp.compiler_tool.profiles import (
     SemanticRubric,
     active_rule_families,
     active_retrieval_query_policies,
+    profile_declaration_fingerprint,
     validate_compiler_profile,
 )
 from comp.compiler_tool.profile_runner import compile_with_profile
@@ -51,6 +52,7 @@ from comp.compiler_tool.reference_db import (
     ReferenceCatalog,
     ReferenceLookupError,
     ReferenceRecord,
+    reference_record_fingerprint,
 )
 from comp.compiler_tool.reference_resolution import (
     ReferenceSearchQuery,
@@ -71,7 +73,11 @@ from comp.compiler_tool.receipt_builder import (
     ReceiptBuildBlocked,
     build_commit_receipt,
 )
-from comp.judgment.receipts import CommitReceiptCitations, ProjectionValueCommitment
+from comp.judgment.receipts import (
+    CommitReceiptCitations,
+    DependencyFingerprint,
+    ProjectionValueCommitment,
+)
 from comp.compiler_tool.report_status import (
     recompute_report_status,
     with_recomputed_status,
@@ -149,10 +155,12 @@ __all__ = [
     "ReceiptBuildBlocked",
     "CommitReceiptCitations",
     "ProjectionValueCommitment",
+    "DependencyFingerprint",
     "build_commit_receipt",
     "ReferenceLookupError",
     "ReferenceRecord",
     "ReferenceCatalog",
+    "reference_record_fingerprint",
     "ReferenceSearchQuery",
     "resolve_reference_search_obligations",
     "apply_reference_selection",
@@ -188,6 +196,7 @@ __all__ = [
     "validate_compiler_profile",
     "active_rule_families",
     "active_retrieval_query_policies",
+    "profile_declaration_fingerprint",
     "compile_with_profile",
     "CompilerTool",
     "apply_semantic_judgments",

--- a/comp/compiler_tool/commit_flow.py
+++ b/comp/compiler_tool/commit_flow.py
@@ -7,7 +7,7 @@ from comp.compiler_tool.commit_package import CommitPackage, build_commit_packag
 from comp.compiler_tool.governance import GovernanceDecision, decide_governance
 from comp.compiler_tool.models import CompileReport
 from comp.compiler_tool.receipt_builder import build_commit_receipt
-from comp.judgment.receipts import CommitReceipt
+from comp.judgment.receipts import CommitReceipt, DependencyFingerprint
 
 
 @dataclass(frozen=True)
@@ -31,6 +31,7 @@ def prepare_commit(
     decision_id: str | None = None,
     profile_id: str | None = None,
     semantic_judgment_ids: Iterable[str] = (),
+    dependency_fingerprints: Iterable[DependencyFingerprint] = (),
 ) -> CommitPreparation:
     package = build_commit_package(
         report,
@@ -38,6 +39,7 @@ def prepare_commit(
         package_id=package_id,
         profile_id=profile_id,
         semantic_judgment_ids=semantic_judgment_ids,
+        dependency_fingerprints=dependency_fingerprints,
     )
     decision = decide_governance(package, decision_id=decision_id)
     receipt = None

--- a/comp/compiler_tool/commit_package.py
+++ b/comp/compiler_tool/commit_package.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 
 from comp.compiler_tool.models import CompileReport, Hazard, ProofObligation
 from comp.compiler_tool.report_status import recompute_report_status
-from comp.judgment.receipts import ProjectionValueCommitment
+from comp.judgment.receipts import DependencyFingerprint, ProjectionValueCommitment
 
 
 @dataclass(frozen=True)
@@ -22,6 +22,9 @@ class CommitPackage:
     calculation_trace_ids: tuple[str, ...] = field(default_factory=tuple)
     formula_ids: tuple[str, ...] = field(default_factory=tuple)
     projection_value_commitments: tuple[ProjectionValueCommitment, ...] = field(
+        default_factory=tuple
+    )
+    dependency_fingerprints: tuple[DependencyFingerprint, ...] = field(
         default_factory=tuple
     )
     open_obligation_ids: tuple[str, ...] = field(default_factory=tuple)
@@ -42,6 +45,7 @@ def build_commit_package(
     package_id: str | None = None,
     profile_id: str | None = None,
     semantic_judgment_ids: Iterable[str] = (),
+    dependency_fingerprints: Iterable[DependencyFingerprint] = (),
 ) -> CommitPackage:
     report_status = recompute_report_status(report)
     open_obligation_ids = tuple(
@@ -71,6 +75,7 @@ def build_commit_package(
         ),
         formula_ids=_unique(claim.formula_id for claim in report.derived_claims),
         projection_value_commitments=_projection_value_commitments(report),
+        dependency_fingerprints=tuple(dependency_fingerprints),
         open_obligation_ids=open_obligation_ids,
         resolved_obligation_ids=tuple(
             _obligation_id(obligation)

--- a/comp/compiler_tool/profiles.py
+++ b/comp/compiler_tool/profiles.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
+from comp.judgment.receipts import DependencyFingerprint
+
 if TYPE_CHECKING:
     from comp.compiler_tool.resolver_retrieval import RetrievalQueryPolicy
 
@@ -164,6 +166,29 @@ def active_retrieval_query_policies(
     )
 
 
+def profile_declaration_fingerprint(
+    profile: CompilerProfile,
+) -> DependencyFingerprint:
+    validate_compiler_profile(profile)
+    return DependencyFingerprint.from_payload(
+        dependency_kind="compiler_profile",
+        dependency_id=profile.profile_id,
+        payload={
+            "profile_id": profile.profile_id,
+            "core_invariant_version": profile.core_invariant_version,
+            "active_rule_ids": profile.active_rule_ids,
+            "active_rubric_ids": profile.active_rubric_ids,
+            "active_retrieval_policy_ids": profile.active_retrieval_policy_ids,
+            "judge_policy_id": profile.judge_policy_id,
+            "projection_policy_id": profile.projection_policy_id,
+            "domain_packs": tuple(
+                _domain_pack_fingerprint_payload(domain)
+                for domain in profile.domain_packs
+            ),
+        },
+    )
+
+
 def _catalogs(
     profile: CompilerProfile,
 ) -> tuple[
@@ -225,6 +250,55 @@ def _unique_by_id(items: list[T], *, attr: str, label: str) -> dict[str, T]:
     return out
 
 
+def _domain_pack_fingerprint_payload(domain: DomainPack) -> dict[str, Any]:
+    return {
+        "domain_id": domain.domain_id,
+        "version": domain.version,
+        "rule_families": tuple(
+            {
+                "rule_id": rule.rule_id,
+                "required_rubric_ids": rule.required_rubric_ids,
+            }
+            for rule in domain.rule_families
+        ),
+        "rubrics": tuple(
+            {
+                "rubric_id": rubric.rubric_id,
+                "acceptable_verdicts": rubric.acceptable_verdicts,
+                "required_verdict": rubric.required_verdict,
+            }
+            for rubric in domain.rubrics
+        ),
+        "judge_policies": tuple(
+            {
+                "judge_policy_id": policy.judge_policy_id,
+                "allowed_judges": policy.allowed_judges,
+            }
+            for policy in domain.judge_policies
+        ),
+        "retrieval_query_policies": tuple(
+            {
+                "policy_id": policy.policy_id,
+                "rules": tuple(
+                    {
+                        "rule_id": rule.rule_id,
+                        "lens": rule.lens,
+                        "text_template": rule.text_template,
+                        "reference_type": rule.reference_type,
+                        "task_type": rule.task_type,
+                        "field": rule.field,
+                        "reason": rule.reason,
+                        "formula_id": rule.formula_id,
+                    }
+                    for rule in policy.rules
+                ),
+            }
+            for policy in domain.retrieval_query_policies
+        ),
+        "disabled_core_invariants": domain.disabled_core_invariants,
+    }
+
+
 __all__ = [
     "RuleFamily",
     "SemanticRubric",
@@ -235,4 +309,5 @@ __all__ = [
     "validate_compiler_profile",
     "active_rule_families",
     "active_retrieval_query_policies",
+    "profile_declaration_fingerprint",
 ]

--- a/comp/compiler_tool/receipt_builder.py
+++ b/comp/compiler_tool/receipt_builder.py
@@ -83,6 +83,7 @@ def _receipt_citations(
         open_obligation_ids=package.open_obligation_ids,
         hazard_ids=package.hazard_ids,
         projection_value_commitments=package.projection_value_commitments,
+        dependency_fingerprints=package.dependency_fingerprints,
     )
 
 

--- a/comp/compiler_tool/reference_db.py
+++ b/comp/compiler_tool/reference_db.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from comp.compiler_tool.references import ReferenceCandidate
+from comp.judgment.receipts import DependencyFingerprint
 
 
 class ReferenceLookupError(KeyError):
@@ -91,6 +92,23 @@ class ReferenceCatalog:
         )
 
 
+def reference_record_fingerprint(record: ReferenceRecord) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="reference_record",
+        dependency_id=record.reference_id,
+        payload={
+            "reference_id": record.reference_id,
+            "reference_type": record.reference_type,
+            "labels": record.labels,
+            "aliases": record.aliases,
+            "description": record.description,
+            "attributes": record.attributes,
+            "source": record.source,
+            "witness_ids": record.witness_ids,
+        },
+    )
+
+
 def _match_score(query: str, record: ReferenceRecord) -> float:
     normalized_query = _normalize_text(query)
     names = (*record.labels, *record.aliases)
@@ -122,4 +140,5 @@ __all__ = [
     "ReferenceLookupError",
     "ReferenceRecord",
     "ReferenceCatalog",
+    "reference_record_fingerprint",
 ]

--- a/comp/judgment/__init__.py
+++ b/comp/judgment/__init__.py
@@ -29,6 +29,7 @@ from comp.judgment.program import (
 from comp.judgment.receipts import (
     CommitReceipt,
     CommitReceiptCitations,
+    DependencyFingerprint,
     ProjectionValueCommitment,
     SelectionReceipt,
 )
@@ -60,6 +61,7 @@ __all__ = [
     "project_public_row",
     "SelectionReceipt",
     "ProjectionValueCommitment",
+    "DependencyFingerprint",
     "CommitReceipt",
     "CommitReceiptCitations",
 ]

--- a/comp/judgment/receipts.py
+++ b/comp/judgment/receipts.py
@@ -47,6 +47,28 @@ class ProjectionValueCommitment:
 
 
 @dataclass(frozen=True, slots=True)
+class DependencyFingerprint:
+    dependency_kind: str
+    dependency_id: str
+    fingerprint: str
+    digest_alg: str = "sha256"
+
+    @classmethod
+    def from_payload(
+        cls,
+        *,
+        dependency_kind: str,
+        dependency_id: str,
+        payload: Mapping[str, Any],
+    ) -> "DependencyFingerprint":
+        return cls(
+            dependency_kind=dependency_kind,
+            dependency_id=dependency_id,
+            fingerprint=_value_digest(payload),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class CommitReceiptCitations:
     governance_decision_id: str
     governance_status: str
@@ -70,6 +92,9 @@ class CommitReceiptCitations:
     open_obligation_ids: tuple[str, ...]
     hazard_ids: tuple[str, ...]
     projection_value_commitments: tuple[ProjectionValueCommitment, ...] = field(
+        default_factory=tuple
+    )
+    dependency_fingerprints: tuple[DependencyFingerprint, ...] = field(
         default_factory=tuple
     )
 
@@ -100,6 +125,7 @@ class CommitReceiptCitations:
                 "projection_value_commitments",
                 self.projection_value_commitments,
             ),
+            ("dependency_fingerprints", self.dependency_fingerprints),
         )
 
 
@@ -169,6 +195,7 @@ def _canonical_value(value: Any) -> Any:
 __all__ = [
     "SelectionReceipt",
     "ProjectionValueCommitment",
+    "DependencyFingerprint",
     "CommitReceipt",
     "CommitReceiptCitations",
 ]

--- a/comp/persistence/replay.py
+++ b/comp/persistence/replay.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from comp.judgment import CommitReceipt, ProjectionSpec
+from comp.judgment.receipts import DependencyFingerprint
 from comp.persistence.ledger import (
     ArtifactIntegrityError,
     InMemoryArtifactStore,
@@ -32,6 +33,7 @@ class ProjectionReplayReport:
     public_row: dict[str, Any]
     artifact_refs: tuple[ArtifactRef, ...]
     artifact_digests: tuple[tuple[str, str], ...]
+    dependency_fingerprints: tuple[DependencyFingerprint, ...] = ()
 
 
 def replay_public_projection(
@@ -55,6 +57,7 @@ def replay_public_projection(
         public_row=public_row,
         artifact_refs=refs,
         artifact_digests=artifact_digests,
+        dependency_fingerprints=_dependency_fingerprints(receipt),
     )
 
 
@@ -170,6 +173,14 @@ def _unique_refs(refs: list[ArtifactRef]) -> tuple[ArtifactRef, ...]:
         seen.add(ref)
         unique.append(ref)
     return tuple(unique)
+
+
+def _dependency_fingerprints(
+    receipt: CommitReceipt,
+) -> tuple[DependencyFingerprint, ...]:
+    if receipt.citations is None:
+        return ()
+    return receipt.citations.dependency_fingerprints
 
 
 def _require_non_empty(field: str, value: str) -> None:

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -457,6 +457,12 @@ tests/domain_scenarios/persistence.py
   records receipt-cited scenario artifacts into an in-memory artifact store,
   records the CommitReceipt into an in-memory receipt ledger, and replays the
   materialized scenario projection from those stored envelopes.
+
+CompilerProfile / ReferenceRecord fingerprints
+  expose stable declaration fingerprints for the active profile and selected
+  canonical reference rows. CommitReceiptCitations can carry these dependency
+  fingerprints, and replay reports surface the profile/reference world the
+  receipt depended on.
 ```
 
 The implemented minimum behavior is:
@@ -473,6 +479,8 @@ Replay verifies committed public values against the cited checked/derived source
 artifact body, not only against the materialized row.
 The canonical raw-input working loop can be replayed from stored scenario
 artifact envelopes and its receipt ledger root.
+Replay reports dependency fingerprints cited by the receipt, starting with the
+compiler profile declaration and selected reference record.
 ```
 
 That completes the original in-memory substrate slice and attaches it to the
@@ -487,28 +495,27 @@ fingerprint manifest exists.
 Recommended next code slice:
 
 ```text
-feat: pin replay dependency fingerprints
+test/feat: extend replay dependencies beyond the canonical scenario
 ```
 
 Candidate files:
 
 ```text
-comp/compiler_tool/profiles.py
-comp/compiler_tool/references.py
-comp/persistence/*.py
-tests/test_persistence_*.py
-tests/test_compiler_profile_contract.py
+tests/domain_scenarios/l_energy_pcf_governance/*
+tests/test_l_energy_pcf_scenario.py
+comp/persistence/*.py, only if the replay API needs a narrow helper
 ```
 
 Minimum behavior:
 
 ```text
-CompilerProfile exposes a stable declaration fingerprint.
-ReferenceRecord or selected ReferenceBinding exposes a replayable record
-fingerprint.
-CommitReceipt citations can include those fingerprints without turning the
-current catalog or profile into replay authority.
-Replay can report which profile/reference world the receipt depended on.
+L-Energy scenario records and replays the same dependency fingerprint shape as
+the canonical scenario.
+The replay harness can include more than one selected reference record.
+Scenario viewer payloads expose dependency fingerprints without raw reference
+record bodies.
+Negative tests block or flag replay when a cited dependency fingerprint is
+missing from the receipt or no longer matches a stored envelope.
 ```
 
 Non-goals for that slice:
@@ -521,11 +528,12 @@ no catalog ingestion pipeline
 no legal retention policy
 no full event sourcing
 no real embedding index persistence
+no production catalog snapshot store
 ```
 
-The goal is to move from "receipt can replay values and cited artifacts" toward
-"receipt can also explain the pinned profile/reference world that made those
-artifacts meaningful."
+The goal is to move from "canonical replay can explain one profile and one
+reference record" toward "larger domain scenarios can carry the same replay
+explanation without hard-coding a single reference shape."
 
 ---
 

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -6,7 +6,9 @@ from comp.compiler_tool import (
     apply_reference_selection,
     plan_calculation_resolution,
     prepare_commit,
+    profile_declaration_fingerprint,
     reference_query_for_obligation_from_profile_policy,
+    reference_record_fingerprint,
     resolve_reference_retrieval_obligations,
     resolver_tasks_from_report,
     retry_blocked_calculation,
@@ -126,6 +128,10 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         public_row_id=PUBLIC_ROW_ID,
         projection_id="canonical-pcf-public-row",
         profile_id=scenario_profile.profile_id,
+        dependency_fingerprints=_dependency_fingerprints(
+            scenario_profile,
+            binding,
+        ),
     )
     projection = None
     if preparation.receipt is not None:
@@ -146,6 +152,18 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         subject=SubjectRef("claim", SUBJECT_ID),
         resolver_steps=RESOLVER_STEPS,
     )
+
+
+def _dependency_fingerprints(
+    scenario_profile,
+    binding: ReferenceBinding | None,
+):
+    fingerprints = [profile_declaration_fingerprint(scenario_profile)]
+    if binding is not None:
+        fingerprints.append(
+            reference_record_fingerprint(catalog().get(binding.reference_id))
+        )
+    return tuple(fingerprints)
 
 
 def _binding_for(

--- a/tests/support/persistence_cases.py
+++ b/tests/support/persistence_cases.py
@@ -7,6 +7,7 @@ from typing import Any
 from comp import (
     CommitReceipt,
     CommitReceiptCitations,
+    DependencyFingerprint,
     ProjectionSpec,
     ProjectionValueCommitment,
 )
@@ -64,6 +65,18 @@ def receipt_projection_case(
         open_obligation_ids=(),
         hazard_ids=(),
         projection_value_commitments=commitments,
+        dependency_fingerprints=(
+            DependencyFingerprint(
+                dependency_kind="compiler_profile",
+                dependency_id="fixture-profile",
+                fingerprint="sha256:fixture-profile",
+            ),
+            DependencyFingerprint(
+                dependency_kind="reference_record",
+                dependency_id="fixture-factor",
+                fingerprint="sha256:fixture-factor",
+            ),
+        ),
     )
     receipt = CommitReceipt(
         draft_id="draft-1",

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -155,6 +155,13 @@ def test_canonical_working_loop_replays_projection_from_stored_artifacts():
     assert dict(replay.artifact_digests)[
         "canonical-raw:co2e_kg"
     ].startswith("sha256:")
+    assert tuple(
+        (fingerprint.dependency_kind, fingerprint.dependency_id)
+        for fingerprint in replay.dependency_fingerprints
+    ) == (
+        ("compiler_profile", "pcf-canonical-loop-v1"),
+        ("reference_record", "pcf.factor.kr_grid_2024.location_based"),
+    )
 
 
 def test_canonical_working_loop_replay_blocks_when_cited_artifact_is_missing():

--- a/tests/test_commit_receipt_builder.py
+++ b/tests/test_commit_receipt_builder.py
@@ -8,6 +8,7 @@ from comp.compiler_tool import (
     CommitReceiptCitations,
     CompileReport,
     DerivedClaim,
+    DependencyFingerprint,
     ProjectionValueCommitment,
     ReceiptBuildBlocked,
     build_commit_package,
@@ -113,6 +114,38 @@ def test_commit_receipt_builder_exposes_typed_citations():
         "ghg.electricity_factor_multiplication.v1",
     )
     assert receipt.citations.to_barrier_snapshot() == receipt.barrier_snapshot
+
+
+def test_commit_receipt_builder_cites_dependency_fingerprints():
+    dependency = DependencyFingerprint(
+        dependency_kind="compiler_profile",
+        dependency_id="esg-ghg-v1",
+        fingerprint="sha256:profile",
+    )
+    package = CommitPackage(
+        package_id="commit-package:facility-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        checked_claim_fields=("amount",),
+        checked_claim_witness_ids=("span-amount",),
+        dependency_fingerprints=(dependency,),
+        profile_id="esg-ghg-v1",
+        complete=True,
+    )
+    decision = decide_governance(package)
+
+    receipt = build_commit_receipt(
+        package,
+        decision,
+        public_row_id="public-row-1",
+        projection_id="public-row",
+    )
+
+    assert receipt.citations is not None
+    assert receipt.citations.dependency_fingerprints == (dependency,)
+    assert dict(receipt.barrier_snapshot)["dependency_fingerprints"] == (
+        dependency,
+    )
 
 
 def test_commit_receipt_builder_commits_checked_and_derived_projection_values():

--- a/tests/test_compiler_profile_contract.py
+++ b/tests/test_compiler_profile_contract.py
@@ -11,6 +11,7 @@ from comp.compiler_tool import (
     RetrievalQueryRule,
     active_rule_families,
     active_retrieval_query_policies,
+    profile_declaration_fingerprint,
     validate_compiler_profile,
 )
 
@@ -245,3 +246,44 @@ def test_duplicate_retrieval_policy_ids_are_rejected():
 
     with pytest.raises(ProfileValidationError, match="duplicate retrieval policy id"):
         validate_compiler_profile(profile)
+
+
+def test_profile_declaration_fingerprint_pins_active_behavior_ids():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(
+                rules=(_rule("fixture.rule.v1"),),
+                rubrics=(_rubric("fixture.rubric.v1"),),
+                judge_policies=(_judge_policy("fixture.judge_policy.v1"),),
+                retrieval_query_policies=(
+                    _retrieval_policy("fixture.retrieval_policy.v1"),
+                ),
+            ),
+        ),
+        active_rule_ids=("fixture.rule.v1",),
+        active_rubric_ids=("fixture.rubric.v1",),
+        active_retrieval_policy_ids=("fixture.retrieval_policy.v1",),
+        judge_policy_id="fixture.judge_policy.v1",
+        projection_policy_id="fixture.projection.v1",
+    )
+
+    fingerprint = profile_declaration_fingerprint(profile)
+    same_fingerprint = profile_declaration_fingerprint(profile)
+    changed_fingerprint = profile_declaration_fingerprint(
+        CompilerProfile(
+            profile_id="fixture-profile",
+            domain_packs=profile.domain_packs,
+            active_rule_ids=(),
+            active_rubric_ids=("fixture.rubric.v1",),
+            active_retrieval_policy_ids=("fixture.retrieval_policy.v1",),
+            judge_policy_id="fixture.judge_policy.v1",
+            projection_policy_id="fixture.projection.v1",
+        )
+    )
+
+    assert fingerprint.dependency_kind == "compiler_profile"
+    assert fingerprint.dependency_id == "fixture-profile"
+    assert fingerprint.fingerprint.startswith("sha256:")
+    assert fingerprint == same_fingerprint
+    assert fingerprint != changed_fingerprint

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -5,6 +5,7 @@ import comp
 from comp import (
     CommitReceipt,
     CommitReceiptCitations,
+    DependencyFingerprint,
     Fact,
     FixpointEngine,
     JudgmentState,
@@ -63,6 +64,7 @@ def test_top_level_package_exposes_active_judgment_surface():
     assert SelectionReceipt is not None
     assert CommitReceipt is not None
     assert CommitReceiptCitations is not None
+    assert DependencyFingerprint is not None
 
 
 def test_top_level_package_no_longer_exports_legacy_runner_surface():
@@ -83,11 +85,13 @@ def test_readme_compiler_tool_import_surface_is_exported():
         RetrievalQueryPolicy,
         RetrievalQueryRule,
         active_retrieval_query_policies,
+        profile_declaration_fingerprint,
         reference_query_for_obligation_from_profile_policy,
         reference_query_for_obligation_from_policies,
         reference_query_for_obligation_from_policy,
         reference_query_for_obligation_from_resolver_tasks,
         reference_query_from_resolver_task,
+        reference_record_fingerprint,
         resolve_reference_retrieval_obligations,
         build_commit_receipt,
         compile_report_to_facts,
@@ -108,11 +112,13 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert RetrievalQueryPolicy is not None
     assert RetrievalQueryRule is not None
     assert active_retrieval_query_policies is not None
+    assert profile_declaration_fingerprint is not None
     assert reference_query_for_obligation_from_policies is not None
     assert reference_query_for_obligation_from_profile_policy is not None
     assert reference_query_for_obligation_from_policy is not None
     assert reference_query_from_resolver_task is not None
     assert reference_query_for_obligation_from_resolver_tasks is not None
+    assert reference_record_fingerprint is not None
     assert resolve_reference_retrieval_obligations is not None
 
 

--- a/tests/test_persistence_projection_replay.py
+++ b/tests/test_persistence_projection_replay.py
@@ -44,6 +44,13 @@ def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
         in report.artifact_refs
     )
     assert dict(report.artifact_digests)["package-1"].startswith("sha256:")
+    assert tuple(
+        (fingerprint.dependency_kind, fingerprint.dependency_id)
+        for fingerprint in report.dependency_fingerprints
+    ) == (
+        ("compiler_profile", "fixture-profile"),
+        ("reference_record", "fixture-factor"),
+    )
 
 
 def test_replay_blocks_when_required_artifact_is_missing():

--- a/tests/test_reference_record_fingerprints.py
+++ b/tests/test_reference_record_fingerprints.py
@@ -1,0 +1,30 @@
+from comp.compiler_tool import ReferenceRecord, reference_record_fingerprint
+
+
+def _record(*, factor_value=0.42):
+    return ReferenceRecord(
+        reference_id="pcf.factor.kr_grid_2024.location_based",
+        reference_type="emission_factor",
+        labels=("Korea grid electricity factor 2024",),
+        aliases=("KR electricity grid factor",),
+        description="Location-based electricity emission factor for Korea in 2024.",
+        attributes=(
+            ("geography", "KR"),
+            ("valid_period", "2024"),
+            ("factor_value", factor_value),
+        ),
+        source="pcf-reference-catalog-v1",
+        witness_ids=("factor-row-kr-grid-2024",),
+    )
+
+
+def test_reference_record_fingerprint_pins_canonical_record_body():
+    fingerprint = reference_record_fingerprint(_record())
+    same_fingerprint = reference_record_fingerprint(_record())
+    changed_fingerprint = reference_record_fingerprint(_record(factor_value=0.43))
+
+    assert fingerprint.dependency_kind == "reference_record"
+    assert fingerprint.dependency_id == "pcf.factor.kr_grid_2024.location_based"
+    assert fingerprint.fingerprint.startswith("sha256:")
+    assert fingerprint == same_fingerprint
+    assert fingerprint != changed_fingerprint


### PR DESCRIPTION
## Summary
- add typed `DependencyFingerprint` citations for profile/reference replay dependencies
- add stable compiler profile declaration fingerprints and canonical reference record fingerprints
- thread dependency fingerprints through `CommitPackage`, `CommitReceiptCitations`, barrier snapshots, and replay reports
- attach profile/reference fingerprints to the canonical raw-input scenario replay path
- refresh the persistence boundary doc now that the fingerprint slice is implemented

## Validation
- `python -m pytest tests/test_compiler_profile_contract.py tests/test_reference_record_fingerprints.py tests/test_commit_receipt_builder.py tests/test_persistence_projection_replay.py tests/test_canonical_working_loop_scenario.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`