### PR TITLE
[codex] remove ambient compiler domain defaults

### DIFF
--- a/comp/compiler_tool/tool.py
+++ b/comp/compiler_tool/tool.py
@@ -21,10 +21,8 @@ class CompilerTool:
     def __init__(
         self,
         *,
-        allowed_units: frozenset[str] = frozenset({"kwh"}),
-        known_fields: frozenset[str] = frozenset(
-            {"activity", "amount", "unit", "reporting_year"}
-        ),
+        allowed_units: frozenset[str] = frozenset(),
+        known_fields: frozenset[str] = frozenset(),
     ) -> None:
         self.allowed_units = frozenset(unit.lower() for unit in allowed_units)
         self.known_fields = known_fields
@@ -103,7 +101,7 @@ class CompilerTool:
                 )
             )
 
-        if "unit" not in claim_fields:
+        if "unit" in self.known_fields and "unit" not in claim_fields:
             hazards.append(Hazard(kind="missing_unit", field="unit", severity="review"))
             self._add_find_source_witness(obligations, "unit", "missing_unit")
 

--- a/docs/superpowers/plans/2026-05-20-trust-kernel-hardening.md
+++ b/docs/superpowers/plans/2026-05-20-trust-kernel-hardening.md
@@ -60,7 +60,7 @@ def test_compiler_tool_has_no_domain_known_fields_by_default():
 Run:
 
 ```bash
-pytest tests/test_compiler_tool_contract.py::test_compiler_tool_has_no_domain_known_fields_by_default -q
+python -m pytest tests/test_compiler_tool_contract.py::test_compiler_tool_has_no_domain_known_fields_by_default -q
 ```
 
 Expected: FAIL because default `CompilerTool` currently knows `activity`.
@@ -116,7 +116,7 @@ return CompilerTool(
 Run:
 
 ```bash
-pytest tests/test_compiler_tool_contract.py tests/test_canonical_working_loop_scenario.py -q
+python -m pytest tests/test_compiler_tool_contract.py tests/test_canonical_working_loop_scenario.py -q
 ```
 
 Expected: all selected tests pass.
@@ -189,7 +189,7 @@ def test_profile_fingerprint_changes_when_active_policy_changes():
 Run:
 
 ```bash
-pytest tests/test_compiler_profile_contract.py::test_profile_fingerprint_is_stable_for_same_active_behavior tests/test_compiler_profile_contract.py::test_profile_fingerprint_changes_when_active_policy_changes -q
+python -m pytest tests/test_compiler_profile_contract.py::test_profile_fingerprint_is_stable_for_same_active_behavior tests/test_compiler_profile_contract.py::test_profile_fingerprint_changes_when_active_policy_changes -q
 ```
 
 Expected: import error or attribute error because `profile_fingerprint` does not
@@ -255,7 +255,7 @@ profile_fingerprint,
 Run:
 
 ```bash
-pytest tests/test_compiler_profile_contract.py -q
+python -m pytest tests/test_compiler_profile_contract.py -q
 ```
 
 Expected: all profile contract tests pass.
@@ -308,7 +308,7 @@ checked claim.
 Run:
 
 ```bash
-pytest tests/test_commit_receipt_builder.py::test_commit_receipt_cites_profile_fingerprint -q
+python -m pytest tests/test_commit_receipt_builder.py::test_commit_receipt_cites_profile_fingerprint -q
 ```
 
 Expected: FAIL because package and citations do not carry the field.
@@ -357,7 +357,7 @@ profile_fingerprint_digest=package.profile_fingerprint_digest,
 Run:
 
 ```bash
-pytest tests/test_commit_receipt_builder.py tests/test_receipt_gated_projection.py -q
+python -m pytest tests/test_commit_receipt_builder.py tests/test_receipt_gated_projection.py -q
 ```
 
 Expected: all selected tests pass.
@@ -400,7 +400,7 @@ this task as a frozen optional field with default `None`.
 Run:
 
 ```bash
-pytest tests/test_canonical_working_loop_scenario.py::test_canonical_working_loop_replays_projection_from_receipt_artifacts -q
+python -m pytest tests/test_canonical_working_loop_scenario.py::test_canonical_working_loop_replays_projection_from_receipt_artifacts -q
 ```
 
 Expected: FAIL because the scenario does not yet expose replay.
@@ -467,7 +467,7 @@ Pass `projection_replay=projection_replay` into
 Run:
 
 ```bash
-pytest tests/test_canonical_working_loop_scenario.py tests/test_persistence_projection_replay.py -q
+python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_persistence_projection_replay.py -q
 ```
 
 Expected: all selected tests pass.
@@ -484,7 +484,7 @@ Expected: all selected tests pass.
 Run:
 
 ```bash
-pytest -q
+python -m pytest -q
 ```
 
 Expected: all tests pass.

--- a/tests/domain_scenarios/canonical_working_loop/fixtures.py
+++ b/tests/domain_scenarios/canonical_working_loop/fixtures.py
@@ -96,6 +96,7 @@ def extract_raw_evidence(raw_text: str) -> InterpretationHypothesis:
 
 def compile_raw_evidence(raw_text: str) -> CompileReport:
     return CompilerTool(
+        allowed_units=frozenset({"kwh"}),
         known_fields=frozenset(
             {
                 "activity",

--- a/tests/test_compiler_tool_contract.py
+++ b/tests/test_compiler_tool_contract.py
@@ -12,6 +12,8 @@ from comp.compiler_tool import (
     UncheckedArea,
 )
 
+TINY_KNOWN_FIELDS = frozenset({"activity", "amount", "unit", "reporting_year"})
+
 
 def _hypothesis(*, claims, witnesses=()):
     return InterpretationHypothesis(
@@ -53,8 +55,28 @@ def test_compiler_tool_contract_model_set_is_exported():
     assert Hazard is not None
 
 
+def test_compiler_tool_has_no_domain_known_fields_by_default():
+    report = CompilerTool().compile_interpretation(
+        _hypothesis(
+            claims=(
+                _claim("activity", "electricity", "w-activity"),
+            ),
+            witnesses=(_witness("w-activity", "activity"),),
+        )
+    )
+
+    assert report.status == "unchecked"
+    assert report.checked_claims == ()
+    assert report.unchecked_areas == (
+        UncheckedArea(field="activity", reason="missing_rule_coverage"),
+    )
+
+
 def test_unsupported_unit_blocks_and_requests_source_witness():
-    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+    report = CompilerTool(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    ).compile_interpretation(
         _hypothesis(
             claims=(
                 _claim("activity", "electricity", "w-activity"),
@@ -80,7 +102,10 @@ def test_unsupported_unit_blocks_and_requests_source_witness():
 
 
 def test_witness_id_must_resolve_to_grounded_matching_witness():
-    tool = CompilerTool(allowed_units=frozenset({"kwh"}))
+    tool = CompilerTool(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    )
 
     cases = [
         ((), "missing_source_witness"),
@@ -109,7 +134,10 @@ def test_witness_id_must_resolve_to_grounded_matching_witness():
 
 
 def test_unknown_and_unchecked_are_distinct_and_not_pass():
-    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+    report = CompilerTool(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    ).compile_interpretation(
         _hypothesis(
             claims=(
                 _claim("reporting_year", None),
@@ -135,7 +163,10 @@ def test_unknown_and_unchecked_are_distinct_and_not_pass():
 
 
 def test_missing_unit_is_review_required_hazard_not_public_projection():
-    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+    report = CompilerTool(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    ).compile_interpretation(
         _hypothesis(
             claims=(
                 _claim("activity", "electricity", "w-activity"),
@@ -161,7 +192,10 @@ def test_missing_unit_is_review_required_hazard_not_public_projection():
 
 
 def test_accepted_report_is_not_public_projection_authority():
-    report = CompilerTool(allowed_units=frozenset({"kwh"})).compile_interpretation(
+    report = CompilerTool(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    ).compile_interpretation(
         _hypothesis(
             claims=(
                 _claim("activity", "electricity", "w-activity"),

--- a/tests/test_minchoagnt_comp_adapter.py
+++ b/tests/test_minchoagnt_comp_adapter.py
@@ -29,6 +29,8 @@ from minchoagnt import (
     SkillStore,
 )
 
+TINY_KNOWN_FIELDS = frozenset({"activity", "amount", "unit", "reporting_year"})
+
 
 def test_minchoagnt_layer_is_available_without_expanding_comp_surface():
     assert MiniAgent is not None
@@ -43,7 +45,10 @@ def test_minchoagnt_layer_is_available_without_expanding_comp_surface():
 
 
 def test_comp_adapter_calls_compiler_tool_without_projection_authority():
-    adapter = CompCompilerAdapter(allowed_units=frozenset({"kwh"}))
+    adapter = CompCompilerAdapter(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    )
     hypothesis = InterpretationHypothesis(
         hypothesis_id="hyp-1",
         subject_id="claim-1",
@@ -75,7 +80,10 @@ def test_comp_adapter_calls_compiler_tool_without_projection_authority():
 
 
 def test_comp_adapter_can_append_report_facts_without_minting_receipts():
-    adapter = CompCompilerAdapter(allowed_units=frozenset({"kwh"}))
+    adapter = CompCompilerAdapter(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    )
     hypothesis = InterpretationHypothesis(
         hypothesis_id="hyp-2",
         subject_id="claim-2",
@@ -93,7 +101,10 @@ def test_comp_adapter_can_append_report_facts_without_minting_receipts():
 
 
 def test_comp_adapter_exposes_resolver_tasks_for_agent_loop():
-    adapter = CompCompilerAdapter(allowed_units=frozenset({"kwh"}))
+    adapter = CompCompilerAdapter(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    )
     result = adapter.compile(
         InterpretationHypothesis(
             hypothesis_id="hyp-3",


### PR DESCRIPTION
## Summary

- Remove ambient ESG-ish defaults from `CompilerTool`; domain fields and units now have to be passed explicitly.
- Keep canonical PCF and minchoagnt tests explicit about their tiny-domain field/unit policy.
- Update the trust-kernel hardening plan to use `python -m pytest`, which is the stable test invocation in this Windows shell.

## Context

The docs/planning portion of this work already landed in #181. While implementing the broader plan, #180 and #182 landed the persistence replay and dependency fingerprint pieces on `main`, so this PR keeps only the remaining non-duplicative hardening: removing core/domain leakage from the compiler default policy.

## Validation

- `python -m pytest tests/test_compiler_tool_contract.py tests/test_minchoagnt_comp_adapter.py tests/test_canonical_working_loop_scenario.py tests/test_compiler_profile_contract.py tests/test_commit_receipt_builder.py -q` -> `45 passed in 0.43s`
- `git diff --check origin/main...HEAD`
- `python -m pytest -q` -> `259 passed in 5.00s`
