### PR TITLE
[codex] replay L-Energy dependency fingerprints

### DIFF
--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -7,7 +7,9 @@ from comp.compiler_tool import (
     apply_reference_selection,
     plan_calculation_resolution,
     prepare_commit,
+    profile_declaration_fingerprint,
     reference_query_for_obligation_from_profile_policy,
+    reference_record_fingerprint,
     resolve_reference_retrieval_obligations,
     resolver_tasks_from_report,
     retry_blocked_calculation,
@@ -96,8 +98,11 @@ def run_l_energy_pcf_governance_scenario(
     *,
     reference_pack_override: ScenarioReferencePack | None = None,
 ) -> DomainScenarioResult:
+    pack = reference_pack_override or reference_pack()
+    scenario_profile = profile()
     report = _compile_retrieval_backed_report(
-        reference_pack_override=reference_pack_override,
+        reference_pack_override=pack,
+        scenario_profile=scenario_profile,
     )
     preparation = prepare_commit(
         report,
@@ -105,6 +110,11 @@ def run_l_energy_pcf_governance_scenario(
         public_row_id=PUBLIC_ROW_ID,
         projection_id=PROJECTION_ID,
         profile_id=PROFILE_ID,
+        dependency_fingerprints=_dependency_fingerprints(
+            scenario_profile,
+            pack,
+            report,
+        ),
     )
     projection = None
     if preparation.receipt is not None:
@@ -132,10 +142,10 @@ def _projection_source(report) -> dict[str, object]:
 
 def _compile_retrieval_backed_report(
     *,
-    reference_pack_override: ScenarioReferencePack | None = None,
+    reference_pack_override: ScenarioReferencePack,
+    scenario_profile,
 ) -> CompileReport:
-    pack = reference_pack_override or reference_pack()
-    scenario_profile = profile()
+    pack = reference_pack_override
     opened_report = blocked_report()
     planned_report = plan_calculation_resolution(opened_report)
     resolver_tasks = resolver_tasks_from_report(planned_report)
@@ -166,6 +176,23 @@ def _compile_retrieval_backed_report(
             output_claim_id=OUTPUT_CLAIM_ID,
         )
     return attach_downstream_fixture_artifacts(resolved_report)
+
+
+def _dependency_fingerprints(
+    scenario_profile,
+    pack: ScenarioReferencePack,
+    report: CompileReport,
+):
+    fingerprints = [profile_declaration_fingerprint(scenario_profile)]
+    seen_reference_ids: set[str] = set()
+    for candidate in report.reference_candidates:
+        if candidate.reference_id in seen_reference_ids:
+            continue
+        seen_reference_ids.add(candidate.reference_id)
+        fingerprints.append(
+            reference_record_fingerprint(pack.catalog.get(candidate.reference_id))
+        )
+    return tuple(fingerprints)
 
 
 def _binding_for(

--- a/tests/domain_scenarios/views.py
+++ b/tests/domain_scenarios/views.py
@@ -105,6 +105,15 @@ def receipt_trace_view(receipt) -> dict[str, Any] | None:
             }
             for commitment in citations.projection_value_commitments
         ],
+        "dependency_fingerprints": [
+            {
+                "dependency_kind": fingerprint.dependency_kind,
+                "dependency_id": fingerprint.dependency_id,
+                "fingerprint": fingerprint.fingerprint,
+                "digest_alg": fingerprint.digest_alg,
+            }
+            for fingerprint in citations.dependency_fingerprints
+        ],
     }
 
 

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -1,3 +1,4 @@
+from comp import ProjectionSpec
 from comp.compiler_tool import active_retrieval_query_policies
 
 from tests.domain_scenarios.assertions import assert_receipt_trace
@@ -16,9 +17,12 @@ from tests.domain_scenarios.l_energy_pcf_governance.fixtures import (
     reference_pack,
 )
 from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
+    PROJECTION_FIELDS,
+    PROJECTION_ID,
     SCENARIO as L_ENERGY_SCENARIO,
     run_l_energy_pcf_governance_scenario,
 )
+from tests.domain_scenarios.persistence import replay_scenario_projection
 from tests.domain_scenarios.reference_packs import ScenarioReferencePack
 from tests.domain_scenarios.registry import registered_scenarios
 
@@ -175,4 +179,56 @@ def test_l_energy_pcf_governance_scenario_exports_targeted_viewer_payload():
     assert exported["projection"] == EXPECTED_PROJECTION
     assert len(exported["report"]["derived_claims"]) == len(
         EXPECTED_DERIVED_CLAIM_IDS
+    )
+
+
+def test_l_energy_pcf_governance_replays_projection_with_dependency_fingerprints():
+    result = run_l_energy_pcf_governance_scenario()
+
+    replay = replay_scenario_projection(
+        result,
+        ProjectionSpec(PROJECTION_ID, PROJECTION_FIELDS),
+    )
+
+    assert replay.public_row == EXPECTED_PROJECTION
+    assert tuple(
+        (fingerprint.dependency_kind, fingerprint.dependency_id)
+        for fingerprint in replay.dependency_fingerprints
+    ) == (
+        ("compiler_profile", "pcf-governance-platform-fixture-v1"),
+        (
+            "reference_record",
+            "platform.factor.a_supplier_electricity_mwh_2025",
+        ),
+        ("reference_record", "platform.factor.electricity_mwh"),
+        ("reference_record", "platform.factor.electricity_mwh_2024"),
+        ("reference_record", "platform.factor.electricity_residual_mix_2025"),
+        (
+            "reference_record",
+            "platform.factor.global_average_electricity_mwh_2025",
+        ),
+        ("reference_record", "platform.factor.us_electricity_mwh_2025"),
+    )
+
+
+def test_l_energy_pcf_governance_viewer_exports_dependency_fingerprints():
+    exported = run_l_energy_pcf_governance_scenario().to_dict()
+
+    assert tuple(
+        (item["dependency_kind"], item["dependency_id"])
+        for item in exported["receipt_trace"]["dependency_fingerprints"]
+    ) == (
+        ("compiler_profile", "pcf-governance-platform-fixture-v1"),
+        (
+            "reference_record",
+            "platform.factor.a_supplier_electricity_mwh_2025",
+        ),
+        ("reference_record", "platform.factor.electricity_mwh"),
+        ("reference_record", "platform.factor.electricity_mwh_2024"),
+        ("reference_record", "platform.factor.electricity_residual_mix_2025"),
+        (
+            "reference_record",
+            "platform.factor.global_average_electricity_mwh_2025",
+        ),
+        ("reference_record", "platform.factor.us_electricity_mwh_2025"),
     )


### PR DESCRIPTION
## Summary
- attach dependency fingerprints to the L-Energy PCF scenario receipt path
- include the active compiler profile fingerprint plus retrieved reference-record fingerprints for the retrieval-backed reference world
- expose dependency fingerprints in the Domain Scenario Lab receipt trace viewer payload
- add replay coverage proving the L-Energy public projection carries those dependency fingerprints

## Validation
- `python -m pytest tests/test_l_energy_pcf_scenario.py -q`
- `python -m pytest tests/test_domain_scenario_lab.py tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py tests/test_persistence_projection_replay.py -q`
- `python -m pytest -q`
- `git diff --check`