### PR TITLE
[codex] add domain scenario runner

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -110,3 +110,28 @@ Use `ScenarioReferencePack` when a scenario needs a swappable reference fixture:
 it bundles the canonical `ReferenceCatalog`, retrieval resolver/index, and their
 fixture version labels so larger domain packs can replace reference data without
 rewiring the scenario runner.
+
+## Local Runner
+
+The scenario registry can also be inspected without opening the pytest files:
+
+```bash
+python -m tests.domain_scenarios list
+```
+
+Run one scenario as a human-readable trace summary:
+
+```bash
+python -m tests.domain_scenarios run canonical_working_loop.raw_text_pcf.v1
+```
+
+Use `--json` when a test, viewer, or debugging script needs the existing
+`DomainScenarioResult` viewer payload:
+
+```bash
+python -m tests.domain_scenarios run l_energy_pcf_governance.v1 --json
+```
+
+The runner is intentionally generic. It only knows about `ScenarioDefinition`,
+`registered_scenarios()`, `run_scenario()`, and `DomainScenarioResult`; scenario
+packs own their domain fixtures and expected contracts.

--- a/tests/domain_scenarios/__main__.py
+++ b/tests/domain_scenarios/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from tests.domain_scenarios.cli import main
+
+
+raise SystemExit(main())

--- a/tests/domain_scenarios/cli.py
+++ b/tests/domain_scenarios/cli.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable, Sequence
+
+from tests.domain_scenarios.core import (
+    DomainScenarioResult,
+    ScenarioDefinition,
+    assert_scenario_contract,
+    run_scenario,
+)
+from tests.domain_scenarios.registry import registered_scenarios
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "list":
+        print(_render_scenario_list(registered_scenarios()))
+        return 0
+
+    if args.command == "run":
+        scenario = _find_scenario(args.scenario_id)
+        if scenario is None:
+            print(_unknown_scenario_message(args.scenario_id), file=sys.stderr)
+            return 2
+
+        result = run_scenario(scenario)
+        assert_scenario_contract(result, scenario.contract)
+        if args.json:
+            print(result.to_json())
+        else:
+            print(render_scenario_summary(scenario, result))
+        return 0
+
+    parser.print_help(sys.stderr)
+    return 2
+
+
+def render_scenario_summary(
+    scenario: ScenarioDefinition,
+    result: DomainScenarioResult,
+) -> str:
+    lines = [
+        f"Scenario: {scenario.scenario_id}",
+        f"Title: {scenario.title}",
+        f"Status: {result.report.status}",
+        f"Commit: {result.preparation.decision.status}",
+        f"Projection: {'present' if result.projection is not None else 'absent'}",
+        "",
+        "Resolver steps:",
+    ]
+    lines.extend(f"- {step}" for step in result.resolver_steps)
+    lines.extend(
+        (
+            "",
+            "Receipt trace:",
+        )
+    )
+
+    citations = (
+        result.preparation.receipt.citations
+        if result.preparation.receipt is not None
+        else None
+    )
+    if citations is None:
+        lines.append("- receipt citations: absent")
+    else:
+        lines.extend(
+            (
+                f"- reference bindings: {len(citations.reference_binding_ids)}",
+                f"- derived claims: {len(citations.derived_claim_ids)}",
+                f"- calculation traces: {len(citations.calculation_trace_ids)}",
+                f"- formulas: {len(citations.formula_ids)}",
+            )
+        )
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m tests.domain_scenarios",
+        description="Run registered Domain Scenario Lab packs.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("list", help="List registered domain scenarios.")
+
+    run = subparsers.add_parser("run", help="Run one registered domain scenario.")
+    run.add_argument("scenario_id", help="Scenario id from the registry.")
+    run.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the scenario result viewer payload as JSON.",
+    )
+    return parser
+
+
+def _render_scenario_list(scenarios: Iterable[ScenarioDefinition]) -> str:
+    return "\n".join(
+        f"{scenario.scenario_id}\t{scenario.title}"
+        for scenario in scenarios
+    )
+
+
+def _find_scenario(scenario_id: str) -> ScenarioDefinition | None:
+    for scenario in registered_scenarios():
+        if scenario.scenario_id == scenario_id:
+            return scenario
+    return None
+
+
+def _unknown_scenario_message(scenario_id: str) -> str:
+    known = ", ".join(scenario.scenario_id for scenario in registered_scenarios())
+    return f"unknown scenario id: {scenario_id}\nknown scenarios: {known}"
+
+
+__all__ = ["main", "render_scenario_summary"]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -20,6 +20,62 @@ from tests.domain_scenarios.tiny_pcf.expected import (
 from tests.domain_scenarios.tiny_pcf.scenario import run_tiny_pcf_scenario
 
 
+def test_domain_scenario_cli_lists_registered_scenarios(capsys):
+    from tests.domain_scenarios.cli import main
+
+    exit_code = main(["list"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "canonical_working_loop.raw_text_pcf.v1" in captured.out
+    assert "tiny_pcf.location_based_electricity.v1" in captured.out
+    assert "l_energy_pcf_governance.v1" in captured.out
+    assert "Canonical raw text PCF working loop" in captured.out
+
+
+def test_domain_scenario_cli_runs_human_summary(capsys):
+    from tests.domain_scenarios.cli import main
+
+    exit_code = main(["run", "tiny_pcf.location_based_electricity.v1"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Scenario: tiny_pcf.location_based_electricity.v1" in captured.out
+    assert "Title: Tiny PCF location-based electricity" in captured.out
+    assert "Status: accepted" in captured.out
+    assert "Commit: commit" in captured.out
+    assert "Projection: present" in captured.out
+    assert "Resolver steps:" in captured.out
+    assert "- deterministic_reference_selection" in captured.out
+    assert "Receipt trace:" in captured.out
+    assert "- reference bindings: 1" in captured.out
+    assert "- derived claims: 1" in captured.out
+
+
+def test_domain_scenario_cli_runs_json_view(capsys):
+    from tests.domain_scenarios.cli import main
+
+    exit_code = main(["run", "tiny_pcf.location_based_electricity.v1", "--json"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert '"scenario_id": "tiny_pcf.location_based_electricity.v1"' in captured.out
+    assert '"projection": {' in captured.out
+    assert captured.err == ""
+
+
+def test_domain_scenario_cli_rejects_unknown_scenario(capsys):
+    from tests.domain_scenarios.cli import main
+
+    exit_code = main(["run", "missing.scenario"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "unknown scenario id: missing.scenario" in captured.err
+    assert "known scenarios:" in captured.err
+
+
 def test_registered_scenarios_are_explicit_scenario_definitions():
     scenarios = registered_scenarios()
 


### PR DESCRIPTION
## Summary
- Add a Domain Scenario Lab CLI with `list` and `run <scenario_id>` commands.
- Support human-readable scenario summaries and `--json` viewer payload output.
- Wire `python -m tests.domain_scenarios` through a small `__main__` entrypoint.
- Document the local runner in the Domain Scenario Lab README.

## Why
This makes registered scenarios swappable through one runner surface, so contributors can inspect canonical, tiny PCF, and L-Energy flows without opening pytest internals.

## Verification
- `python -m pytest tests\test_domain_scenario_lab.py -q` -> 12 passed
- `python -m pytest tests\test_canonical_working_loop_scenario.py tests\test_l_energy_pcf_scenario.py -q` -> 17 passed
- `python -m pytest -q` -> 265 passed
- `git diff --check origin/main...HEAD` -> clean
- `python -m tests.domain_scenarios list`
- `python -m tests.domain_scenarios run tiny_pcf.location_based_electricity.v1`