### PR TITLE
[codex] verify replay dependency fingerprints

### DIFF
--- a/comp/persistence/replay.py
+++ b/comp/persistence/replay.py
@@ -51,6 +51,7 @@ def replay_public_projection(
     refs = receipt_artifact_refs(receipt)
     artifact_digests = _verified_artifact_digests(refs, artifacts)
     _verify_projection_value_sources(receipt, artifacts)
+    _verify_dependency_fingerprint_sources(receipt, artifacts)
     return ProjectionReplayReport(
         receipt_key=ReceiptLedgerKey.from_receipt(receipt),
         projection_id=projection.projection_id,
@@ -97,6 +98,10 @@ def receipt_artifact_refs(receipt: CommitReceipt) -> tuple[ArtifactRef, ...]:
     refs.extend(
         ArtifactRef(formula_id, "formula")
         for formula_id in citations.formula_ids
+    )
+    refs.extend(
+        ArtifactRef(fingerprint.dependency_id, fingerprint.dependency_kind)
+        for fingerprint in citations.dependency_fingerprints
     )
     return _unique_refs(refs)
 
@@ -161,6 +166,37 @@ def _verify_projection_value_sources(
             raise ProjectionReplayBlocked(
                 "Projection replay source artifact value commitment mismatch: "
                 f"{commitment.field}."
+            )
+
+
+def _verify_dependency_fingerprint_sources(
+    receipt: CommitReceipt,
+    artifacts: InMemoryArtifactStore,
+) -> None:
+    if receipt.citations is None:
+        return
+
+    for fingerprint in receipt.citations.dependency_fingerprints:
+        try:
+            envelope = artifacts.get(fingerprint.dependency_id)
+        except KeyError as exc:
+            raise ProjectionReplayBlocked(
+                f"Projection replay missing artifact: {fingerprint.dependency_id}."
+            ) from exc
+        if envelope.artifact_kind != fingerprint.dependency_kind:
+            raise ProjectionReplayBlocked(
+                "Projection replay artifact kind mismatch: "
+                f"{fingerprint.dependency_id}."
+            )
+        if envelope.body.get("fingerprint") != fingerprint.fingerprint:
+            raise ProjectionReplayBlocked(
+                "Projection replay dependency fingerprint mismatch: "
+                f"{fingerprint.dependency_id}."
+            )
+        if envelope.body.get("digest_alg") != fingerprint.digest_alg:
+            raise ProjectionReplayBlocked(
+                "Projection replay dependency fingerprint algorithm mismatch: "
+                f"{fingerprint.dependency_id}."
             )
 
 

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -463,6 +463,12 @@ CompilerProfile / ReferenceRecord fingerprints
   canonical reference rows. CommitReceiptCitations can carry these dependency
   fingerprints, and replay reports surface the profile/reference world the
   receipt depended on.
+
+Dependency fingerprint envelopes
+  replay treats dependency fingerprints as receipt-cited artifact refs. The
+  stored dependency envelope must exist, match the dependency kind/id, pass body
+  digest verification, and carry the same fingerprint and digest algorithm as
+  the receipt citation.
 ```
 
 The implemented minimum behavior is:
@@ -481,12 +487,16 @@ The canonical raw-input working loop can be replayed from stored scenario
 artifact envelopes and its receipt ledger root.
 Replay reports dependency fingerprints cited by the receipt, starting with the
 compiler profile declaration and selected reference record.
+Replay blocks when a cited dependency fingerprint envelope is missing or its
+stored fingerprint no longer matches the receipt citation.
+The L-Energy scenario records and replays the same dependency fingerprint shape,
+including the retrieval-backed reference world and near-miss candidates.
 ```
 
 That completes the original in-memory substrate slice and attaches it to the
-canonical raw-input scenario harness. It does not yet mean production
-persistence exists, nor does it mean a database, retention policy, or dependency
-fingerprint manifest exists.
+canonical raw-input and L-Energy scenario harnesses. It does not yet mean
+production persistence exists, nor does it mean a database, retention policy, or
+catalog snapshot manifest exists.
 
 ---
 
@@ -495,27 +505,30 @@ fingerprint manifest exists.
 Recommended next code slice:
 
 ```text
-test/feat: extend replay dependencies beyond the canonical scenario
+feat: add ReferenceCatalogSnapshot manifest
 ```
 
 Candidate files:
 
 ```text
-tests/domain_scenarios/l_energy_pcf_governance/*
-tests/test_l_energy_pcf_scenario.py
-comp/persistence/*.py, only if the replay API needs a narrow helper
+comp/compiler_tool/reference_db.py
+comp/persistence/*.py
+tests/test_reference_*fingerprint*.py
+tests/test_persistence_projection_replay.py
 ```
 
 Minimum behavior:
 
 ```text
-L-Energy scenario records and replays the same dependency fingerprint shape as
-the canonical scenario.
-The replay harness can include more than one selected reference record.
-Scenario viewer payloads expose dependency fingerprints without raw reference
-record bodies.
-Negative tests block or flag replay when a cited dependency fingerprint is
-missing from the receipt or no longer matches a stored envelope.
+ReferenceCatalogSnapshot records catalog id/version plus selected record
+fingerprints.
+CommitReceipt can cite a catalog snapshot dependency alongside individual
+reference records, or replace individual record citations when the snapshot
+manifest is sufficient.
+Replay verifies the catalog snapshot envelope and can report which selected
+records were covered by the snapshot.
+Negative tests block replay when a selected record fingerprint is absent from the
+snapshot manifest.
 ```
 
 Non-goals for that slice:
@@ -529,24 +542,25 @@ no legal retention policy
 no full event sourcing
 no real embedding index persistence
 no production catalog snapshot store
+no real DB ingestion
 ```
 
-The goal is to move from "canonical replay can explain one profile and one
-reference record" toward "larger domain scenarios can carry the same replay
-explanation without hard-coding a single reference shape."
+The goal is to move from "receipt lists dependency fingerprints individually"
+toward "receipt can cite a compact reference-world manifest that still explains
+which canonical rows made the calculation meaningful."
 
 ---
 
 ## 13. Following Slice
 
-After the canonical scenario emits and replays stored envelopes, the next likely
-slice is dependency pinning:
+After reference catalog snapshots, the next likely slice is broader dependency
+pinning:
 
 ```text
-CompilerProfile declaration fingerprint
 DomainPack fingerprint
-selected ReferenceRecord envelope or digest
-ReferenceCatalogSnapshot manifest, later
+Rule/rubric declaration fingerprints
+Formula fingerprints backed by formula declaration envelopes
+Source evidence span digests
 ```
 
 That slice should keep the document's rule: replay explains the old receipt,

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -184,6 +184,8 @@ def _artifact_body_for_ref(
         return {"formula_id": ref.artifact_id}
     if ref.artifact_kind == "semantic_judgment":
         return {"judgment_id": ref.artifact_id}
+    if ref.artifact_kind in {"compiler_profile", "reference_record"}:
+        return _dependency_fingerprint_body(result, ref)
     raise AssertionError(f"Unsupported scenario artifact ref: {ref}.")
 
 
@@ -206,6 +208,27 @@ def _by_id(items, item_id: str, field: str):
         if getattr(item, field) == item_id:
             return item
     raise AssertionError(f"Scenario artifact not found: {item_id}.")
+
+
+def _dependency_fingerprint_body(
+    result: DomainScenarioResult,
+    ref: ArtifactRef,
+) -> dict[str, str]:
+    receipt = result.preparation.receipt
+    if receipt is None or receipt.citations is None:
+        raise AssertionError("Scenario dependency fingerprint requires a receipt.")
+    for fingerprint in receipt.citations.dependency_fingerprints:
+        if (
+            fingerprint.dependency_kind == ref.artifact_kind
+            and fingerprint.dependency_id == ref.artifact_id
+        ):
+            return {
+                "dependency_kind": fingerprint.dependency_kind,
+                "dependency_id": fingerprint.dependency_id,
+                "fingerprint": fingerprint.fingerprint,
+                "digest_alg": fingerprint.digest_alg,
+            }
+    raise AssertionError(f"Scenario dependency fingerprint not found: {ref}.")
 
 
 __all__ = [

--- a/tests/support/persistence_cases.py
+++ b/tests/support/persistence_cases.py
@@ -159,6 +159,8 @@ def artifact_body_for_ref(
         return body
     if ref.artifact_kind == "evidence_witness":
         return {"witness_id": ref.artifact_id, "source": "fixture"}
+    if ref.artifact_kind in {"compiler_profile", "reference_record"}:
+        return _dependency_fingerprint_body(ref)
     raise AssertionError(f"Unexpected artifact ref in test: {ref}")
 
 
@@ -168,6 +170,24 @@ def _claim_field(ref: ArtifactRef) -> str:
     if ":amount:" in ref.artifact_id:
         return "amount"
     return "unknown"
+
+
+def _dependency_fingerprint_body(ref: ArtifactRef) -> dict[str, str]:
+    if ref.artifact_id == "fixture-profile":
+        return {
+            "dependency_kind": "compiler_profile",
+            "dependency_id": "fixture-profile",
+            "fingerprint": "sha256:fixture-profile",
+            "digest_alg": "sha256",
+        }
+    if ref.artifact_id == "fixture-factor":
+        return {
+            "dependency_kind": "reference_record",
+            "dependency_id": "fixture-factor",
+            "fingerprint": "sha256:fixture-factor",
+            "digest_alg": "sha256",
+        }
+    raise AssertionError(f"Unexpected dependency fingerprint ref in test: {ref}")
 
 
 __all__ = [

--- a/tests/test_persistence_projection_replay.py
+++ b/tests/test_persistence_projection_replay.py
@@ -39,6 +39,8 @@ def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
     assert report.artifact_refs == receipt_artifact_refs(case.receipt)
     assert ArtifactRef("package-1", "commit_package") in report.artifact_refs
     assert ArtifactRef("decision-1", "governance_decision") in report.artifact_refs
+    assert ArtifactRef("fixture-profile", "compiler_profile") in report.artifact_refs
+    assert ArtifactRef("fixture-factor", "reference_record") in report.artifact_refs
     assert (
         ArtifactRef("checked_claim:amount:span-amount", "checked_claim")
         in report.artifact_refs
@@ -51,6 +53,50 @@ def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
         ("compiler_profile", "fixture-profile"),
         ("reference_record", "fixture-factor"),
     )
+
+
+def test_replay_blocks_when_dependency_fingerprint_artifact_is_missing():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+        skip=ArtifactRef("fixture-profile", "compiler_profile"),
+    )
+
+    with pytest.raises(ProjectionReplayBlocked, match="missing artifact"):
+        replay_public_projection(
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
+            artifacts=artifacts,
+        )
+
+
+def test_replay_blocks_when_dependency_fingerprint_artifact_mismatches():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+        override=ArtifactEnvelope.from_body(
+            artifact_id="fixture-factor",
+            artifact_kind="reference_record",
+            schema_version="dependency-fingerprint-v1",
+            body={
+                "dependency_kind": "reference_record",
+                "dependency_id": "fixture-factor",
+                "fingerprint": "sha256:wrong",
+                "digest_alg": "sha256",
+            },
+        ),
+    )
+
+    with pytest.raises(ProjectionReplayBlocked, match="dependency fingerprint"):
+        replay_public_projection(
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
+            artifacts=artifacts,
+        )
 
 
 def test_replay_blocks_when_required_artifact_is_missing():


### PR DESCRIPTION
## Summary
- treat dependency fingerprints as receipt-cited artifact refs during replay
- verify stored dependency envelopes exist, match dependency kind/id, pass body digest verification, and carry the same fingerprint/digest algorithm as the receipt citation
- add negative replay tests for missing and mismatched dependency fingerprint artifacts
- update scenario replay fixtures to store dependency fingerprint envelopes
- refresh the persistence boundary doc and point the next slice at reference catalog snapshot manifests

## Validation
- `python -m pytest tests/test_persistence_projection_replay.py tests/test_l_energy_pcf_scenario.py tests/test_canonical_working_loop_scenario.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`