### PR TITLE
[codex] add reference catalog snapshot fingerprints

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -50,8 +50,10 @@ from comp.compiler_tool.profiles import (
 from comp.compiler_tool.profile_runner import compile_with_profile
 from comp.compiler_tool.reference_db import (
     ReferenceCatalog,
+    ReferenceCatalogSnapshot,
     ReferenceLookupError,
     ReferenceRecord,
+    reference_catalog_snapshot_fingerprint,
     reference_record_fingerprint,
 )
 from comp.compiler_tool.reference_resolution import (
@@ -160,7 +162,9 @@ __all__ = [
     "ReferenceLookupError",
     "ReferenceRecord",
     "ReferenceCatalog",
+    "ReferenceCatalogSnapshot",
     "reference_record_fingerprint",
+    "reference_catalog_snapshot_fingerprint",
     "ReferenceSearchQuery",
     "resolve_reference_search_obligations",
     "apply_reference_selection",

--- a/comp/compiler_tool/reference_db.py
+++ b/comp/compiler_tool/reference_db.py
@@ -92,6 +92,36 @@ class ReferenceCatalog:
         )
 
 
+@dataclass(frozen=True)
+class ReferenceCatalogSnapshot:
+    snapshot_id: str
+    catalog_id: str
+    catalog_version: str
+    record_fingerprints: tuple[DependencyFingerprint, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_catalog(
+        cls,
+        catalog: ReferenceCatalog,
+        *,
+        catalog_id: str,
+        catalog_version: str,
+        selected_reference_ids: tuple[str, ...] = (),
+    ) -> "ReferenceCatalogSnapshot":
+        selected_ids = selected_reference_ids or tuple(
+            record.reference_id for record in catalog.records
+        )
+        return cls(
+            snapshot_id=f"reference_catalog_snapshot:{catalog_id}:{catalog_version}",
+            catalog_id=catalog_id,
+            catalog_version=catalog_version,
+            record_fingerprints=tuple(
+                reference_record_fingerprint(catalog.get(reference_id))
+                for reference_id in selected_ids
+            ),
+        )
+
+
 def reference_record_fingerprint(record: ReferenceRecord) -> DependencyFingerprint:
     return DependencyFingerprint.from_payload(
         dependency_kind="reference_record",
@@ -107,6 +137,35 @@ def reference_record_fingerprint(record: ReferenceRecord) -> DependencyFingerpri
             "witness_ids": record.witness_ids,
         },
     )
+
+
+def reference_catalog_snapshot_fingerprint(
+    snapshot: ReferenceCatalogSnapshot,
+) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="reference_catalog_snapshot",
+        dependency_id=snapshot.snapshot_id,
+        payload={
+            "snapshot_id": snapshot.snapshot_id,
+            "catalog_id": snapshot.catalog_id,
+            "catalog_version": snapshot.catalog_version,
+            "record_fingerprints": tuple(
+                _dependency_fingerprint_payload(fingerprint)
+                for fingerprint in snapshot.record_fingerprints
+            ),
+        },
+    )
+
+
+def _dependency_fingerprint_payload(
+    fingerprint: DependencyFingerprint,
+) -> dict[str, str]:
+    return {
+        "dependency_kind": fingerprint.dependency_kind,
+        "dependency_id": fingerprint.dependency_id,
+        "fingerprint": fingerprint.fingerprint,
+        "digest_alg": fingerprint.digest_alg,
+    }
 
 
 def _match_score(query: str, record: ReferenceRecord) -> float:
@@ -140,5 +199,7 @@ __all__ = [
     "ReferenceLookupError",
     "ReferenceRecord",
     "ReferenceCatalog",
+    "ReferenceCatalogSnapshot",
     "reference_record_fingerprint",
+    "reference_catalog_snapshot_fingerprint",
 ]

--- a/comp/persistence/replay.py
+++ b/comp/persistence/replay.py
@@ -52,6 +52,7 @@ def replay_public_projection(
     artifact_digests = _verified_artifact_digests(refs, artifacts)
     _verify_projection_value_sources(receipt, artifacts)
     _verify_dependency_fingerprint_sources(receipt, artifacts)
+    _verify_reference_catalog_snapshot_coverage(receipt, artifacts)
     return ProjectionReplayReport(
         receipt_key=ReceiptLedgerKey.from_receipt(receipt),
         projection_id=projection.projection_id,
@@ -198,6 +199,55 @@ def _verify_dependency_fingerprint_sources(
                 "Projection replay dependency fingerprint algorithm mismatch: "
                 f"{fingerprint.dependency_id}."
             )
+
+
+def _verify_reference_catalog_snapshot_coverage(
+    receipt: CommitReceipt,
+    artifacts: InMemoryArtifactStore,
+) -> None:
+    if receipt.citations is None:
+        return
+
+    reference_records = tuple(
+        fingerprint
+        for fingerprint in receipt.citations.dependency_fingerprints
+        if fingerprint.dependency_kind == "reference_record"
+    )
+    catalog_snapshots = tuple(
+        fingerprint
+        for fingerprint in receipt.citations.dependency_fingerprints
+        if fingerprint.dependency_kind == "reference_catalog_snapshot"
+    )
+    if not reference_records or not catalog_snapshots:
+        return
+
+    covered_records: set[tuple[str, str]] = set()
+    for snapshot in catalog_snapshots:
+        envelope = artifacts.get(snapshot.dependency_id)
+        covered_records.update(_catalog_snapshot_record_keys(envelope.body))
+
+    for fingerprint in reference_records:
+        record_key = (fingerprint.dependency_id, fingerprint.fingerprint)
+        if record_key not in covered_records:
+            raise ProjectionReplayBlocked(
+                "Projection replay catalog snapshot missing reference record: "
+                f"{fingerprint.dependency_id}."
+            )
+
+
+def _catalog_snapshot_record_keys(
+    snapshot_body: Mapping[str, Any],
+) -> set[tuple[str, str]]:
+    records = snapshot_body.get("record_fingerprints", ())
+    record_keys: set[tuple[str, str]] = set()
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        dependency_id = record.get("dependency_id")
+        fingerprint = record.get("fingerprint")
+        if isinstance(dependency_id, str) and isinstance(fingerprint, str):
+            record_keys.add((dependency_id, fingerprint))
+    return record_keys
 
 
 def _unique_refs(refs: list[ArtifactRef]) -> tuple[ArtifactRef, ...]:

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -387,16 +387,19 @@ Do not try to hash arbitrary Python callables as the first implementation. Rule
 and rubric ids, domain pack versions, package versions, and git revisions are
 more realistic first pins.
 
-Later layers may add:
+Current additional layer:
 
 ```text
 ReferenceCatalogSnapshot
   catalog_id
   catalog_version
-  record_digests
-  source
-  effective_date
+  selected reference record fingerprints
+  replay coverage check for cited reference records
+```
 
+Later layers may add:
+
+```text
 DomainPackFingerprint
   domain_id
   version
@@ -469,6 +472,12 @@ Dependency fingerprint envelopes
   stored dependency envelope must exist, match the dependency kind/id, pass body
   digest verification, and carry the same fingerprint and digest algorithm as
   the receipt citation.
+
+ReferenceCatalogSnapshot manifests
+  replay treats catalog snapshots as receipt-cited dependency artifacts. When a
+  receipt cites both a catalog snapshot and selected reference record
+  fingerprints, the snapshot envelope must include those selected record
+  fingerprints in its manifest.
 ```
 
 The implemented minimum behavior is:
@@ -489,6 +498,8 @@ Replay reports dependency fingerprints cited by the receipt, starting with the
 compiler profile declaration and selected reference record.
 Replay blocks when a cited dependency fingerprint envelope is missing or its
 stored fingerprint no longer matches the receipt citation.
+Replay blocks when a cited reference catalog snapshot omits a selected
+reference record fingerprint required by the receipt.
 The L-Energy scenario records and replays the same dependency fingerprint shape,
 including the retrieval-backed reference world and near-miss candidates.
 ```
@@ -496,7 +507,7 @@ including the retrieval-backed reference world and near-miss candidates.
 That completes the original in-memory substrate slice and attaches it to the
 canonical raw-input and L-Energy scenario harnesses. It does not yet mean
 production persistence exists, nor does it mean a database, retention policy, or
-catalog snapshot manifest exists.
+production catalog snapshot store exists.
 
 ---
 
@@ -505,30 +516,30 @@ catalog snapshot manifest exists.
 Recommended next code slice:
 
 ```text
-feat: add ReferenceCatalogSnapshot manifest
+feat: add broader dependency declaration fingerprints
 ```
 
 Candidate files:
 
 ```text
-comp/compiler_tool/reference_db.py
+comp/compiler_tool/profiles.py
+comp/compiler_tool/calculations.py
 comp/persistence/*.py
-tests/test_reference_*fingerprint*.py
+tests/test_*fingerprint*.py
 tests/test_persistence_projection_replay.py
 ```
 
 Minimum behavior:
 
 ```text
-ReferenceCatalogSnapshot records catalog id/version plus selected record
-fingerprints.
-CommitReceipt can cite a catalog snapshot dependency alongside individual
-reference records, or replace individual record citations when the snapshot
-manifest is sufficient.
-Replay verifies the catalog snapshot envelope and can report which selected
-records were covered by the snapshot.
-Negative tests block replay when a selected record fingerprint is absent from the
-snapshot manifest.
+DomainPack, active rule/rubric declarations, and formula declarations expose
+stable dependency fingerprints.
+CommitReceipt can cite these declaration fingerprints alongside profile,
+reference record, and catalog snapshot fingerprints.
+Replay verifies the matching dependency fingerprint envelopes when they are
+cited.
+Scenario replay reports show which profile, reference world, formula world, and
+domain rule world made the receipt meaningful.
 ```
 
 Non-goals for that slice:
@@ -545,22 +556,21 @@ no production catalog snapshot store
 no real DB ingestion
 ```
 
-The goal is to move from "receipt lists dependency fingerprints individually"
-toward "receipt can cite a compact reference-world manifest that still explains
-which canonical rows made the calculation meaningful."
+The goal is to move from "receipt pins profile and reference-world dependencies"
+toward "receipt also pins the formula and domain declaration world that made the
+compiler decision meaningful."
 
 ---
 
 ## 13. Following Slice
 
-After reference catalog snapshots, the next likely slice is broader dependency
-pinning:
+After broader dependency fingerprints, the next likely slice is source evidence
+span integrity:
 
 ```text
-DomainPack fingerprint
-Rule/rubric declaration fingerprints
-Formula fingerprints backed by formula declaration envelopes
 Source evidence span digests
+EvidenceWitness source container fingerprints
+Replay verification for cited source span digests
 ```
 
 That slice should keep the document's rule: replay explains the old receipt,

--- a/tests/support/persistence_cases.py
+++ b/tests/support/persistence_cases.py
@@ -76,6 +76,11 @@ def receipt_projection_case(
                 dependency_id="fixture-factor",
                 fingerprint="sha256:fixture-factor",
             ),
+            DependencyFingerprint(
+                dependency_kind="reference_catalog_snapshot",
+                dependency_id="reference_catalog_snapshot:fixture-catalog:2026.1",
+                fingerprint="sha256:fixture-reference-catalog-snapshot",
+            ),
         ),
     )
     receipt = CommitReceipt(
@@ -159,7 +164,11 @@ def artifact_body_for_ref(
         return body
     if ref.artifact_kind == "evidence_witness":
         return {"witness_id": ref.artifact_id, "source": "fixture"}
-    if ref.artifact_kind in {"compiler_profile", "reference_record"}:
+    if ref.artifact_kind in {
+        "compiler_profile",
+        "reference_record",
+        "reference_catalog_snapshot",
+    }:
         return _dependency_fingerprint_body(ref)
     raise AssertionError(f"Unexpected artifact ref in test: {ref}")
 
@@ -172,7 +181,7 @@ def _claim_field(ref: ArtifactRef) -> str:
     return "unknown"
 
 
-def _dependency_fingerprint_body(ref: ArtifactRef) -> dict[str, str]:
+def _dependency_fingerprint_body(ref: ArtifactRef) -> dict[str, Any]:
     if ref.artifact_id == "fixture-profile":
         return {
             "dependency_kind": "compiler_profile",
@@ -186,6 +195,21 @@ def _dependency_fingerprint_body(ref: ArtifactRef) -> dict[str, str]:
             "dependency_id": "fixture-factor",
             "fingerprint": "sha256:fixture-factor",
             "digest_alg": "sha256",
+        }
+    if ref.artifact_id == "reference_catalog_snapshot:fixture-catalog:2026.1":
+        return {
+            "dependency_kind": "reference_catalog_snapshot",
+            "dependency_id": "reference_catalog_snapshot:fixture-catalog:2026.1",
+            "fingerprint": "sha256:fixture-reference-catalog-snapshot",
+            "digest_alg": "sha256",
+            "record_fingerprints": (
+                {
+                    "dependency_kind": "reference_record",
+                    "dependency_id": "fixture-factor",
+                    "fingerprint": "sha256:fixture-factor",
+                    "digest_alg": "sha256",
+                },
+            ),
         }
     raise AssertionError(f"Unexpected dependency fingerprint ref in test: {ref}")
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -82,10 +82,12 @@ def test_readme_compiler_tool_import_surface_is_exported():
         ReferenceIndexEntry,
         ReferenceQuery,
         ReferenceResolver,
+        ReferenceCatalogSnapshot,
         RetrievalQueryPolicy,
         RetrievalQueryRule,
         active_retrieval_query_policies,
         profile_declaration_fingerprint,
+        reference_catalog_snapshot_fingerprint,
         reference_query_for_obligation_from_profile_policy,
         reference_query_for_obligation_from_policies,
         reference_query_for_obligation_from_policy,
@@ -108,6 +110,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert ReferenceQuery is not None
     assert ReferenceIndexEntry is not None
     assert ReferenceResolver is not None
+    assert ReferenceCatalogSnapshot is not None
     assert EmbeddingResolverStub is not None
     assert RetrievalQueryPolicy is not None
     assert RetrievalQueryRule is not None
@@ -118,6 +121,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert reference_query_for_obligation_from_policy is not None
     assert reference_query_from_resolver_task is not None
     assert reference_query_for_obligation_from_resolver_tasks is not None
+    assert reference_catalog_snapshot_fingerprint is not None
     assert reference_record_fingerprint is not None
     assert resolve_reference_retrieval_obligations is not None
 

--- a/tests/test_persistence_projection_replay.py
+++ b/tests/test_persistence_projection_replay.py
@@ -42,6 +42,13 @@ def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
     assert ArtifactRef("fixture-profile", "compiler_profile") in report.artifact_refs
     assert ArtifactRef("fixture-factor", "reference_record") in report.artifact_refs
     assert (
+        ArtifactRef(
+            "reference_catalog_snapshot:fixture-catalog:2026.1",
+            "reference_catalog_snapshot",
+        )
+        in report.artifact_refs
+    )
+    assert (
         ArtifactRef("checked_claim:amount:span-amount", "checked_claim")
         in report.artifact_refs
     )
@@ -52,6 +59,10 @@ def test_replay_public_projection_explains_row_from_receipt_and_artifacts():
     ) == (
         ("compiler_profile", "fixture-profile"),
         ("reference_record", "fixture-factor"),
+        (
+            "reference_catalog_snapshot",
+            "reference_catalog_snapshot:fixture-catalog:2026.1",
+        ),
     )
 
 
@@ -91,6 +102,36 @@ def test_replay_blocks_when_dependency_fingerprint_artifact_mismatches():
     )
 
     with pytest.raises(ProjectionReplayBlocked, match="dependency fingerprint"):
+        replay_public_projection(
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
+            artifacts=artifacts,
+        )
+
+
+def test_replay_blocks_when_catalog_snapshot_omits_reference_record():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+        override=ArtifactEnvelope.from_body(
+            artifact_id="reference_catalog_snapshot:fixture-catalog:2026.1",
+            artifact_kind="reference_catalog_snapshot",
+            schema_version="dependency-fingerprint-v1",
+            body={
+                "dependency_kind": "reference_catalog_snapshot",
+                "dependency_id": "reference_catalog_snapshot:fixture-catalog:2026.1",
+                "fingerprint": (
+                    "sha256:fixture-reference-catalog-snapshot"
+                ),
+                "digest_alg": "sha256",
+                "record_fingerprints": (),
+            },
+        ),
+    )
+
+    with pytest.raises(ProjectionReplayBlocked, match="catalog snapshot"):
         replay_public_projection(
             case.source_values,
             case.projection,

--- a/tests/test_reference_record_fingerprints.py
+++ b/tests/test_reference_record_fingerprints.py
@@ -1,9 +1,19 @@
-from comp.compiler_tool import ReferenceRecord, reference_record_fingerprint
+from comp.compiler_tool import (
+    ReferenceCatalog,
+    ReferenceCatalogSnapshot,
+    ReferenceRecord,
+    reference_catalog_snapshot_fingerprint,
+    reference_record_fingerprint,
+)
 
 
-def _record(*, factor_value=0.42):
+def _record(
+    *,
+    reference_id="pcf.factor.kr_grid_2024.location_based",
+    factor_value=0.42,
+):
     return ReferenceRecord(
-        reference_id="pcf.factor.kr_grid_2024.location_based",
+        reference_id=reference_id,
         reference_type="emission_factor",
         labels=("Korea grid electricity factor 2024",),
         aliases=("KR electricity grid factor",),
@@ -28,3 +38,45 @@ def test_reference_record_fingerprint_pins_canonical_record_body():
     assert fingerprint.fingerprint.startswith("sha256:")
     assert fingerprint == same_fingerprint
     assert fingerprint != changed_fingerprint
+
+
+def test_reference_catalog_snapshot_fingerprint_pins_record_manifest():
+    catalog = ReferenceCatalog(
+        records=(
+            _record(),
+            _record(
+                reference_id="pcf.factor.kr_grid_2023.location_based",
+                factor_value=0.43,
+            ),
+        )
+    )
+    snapshot = ReferenceCatalogSnapshot.from_catalog(
+        catalog,
+        catalog_id="pcf-reference-catalog",
+        catalog_version="2026.1",
+        selected_reference_ids=("pcf.factor.kr_grid_2024.location_based",),
+    )
+    same_snapshot = ReferenceCatalogSnapshot.from_catalog(
+        catalog,
+        catalog_id="pcf-reference-catalog",
+        catalog_version="2026.1",
+        selected_reference_ids=("pcf.factor.kr_grid_2024.location_based",),
+    )
+    changed_snapshot = ReferenceCatalogSnapshot.from_catalog(
+        catalog,
+        catalog_id="pcf-reference-catalog",
+        catalog_version="2026.2",
+        selected_reference_ids=("pcf.factor.kr_grid_2024.location_based",),
+    )
+
+    fingerprint = reference_catalog_snapshot_fingerprint(snapshot)
+
+    assert snapshot.snapshot_id == "reference_catalog_snapshot:pcf-reference-catalog:2026.1"
+    assert tuple(record.dependency_id for record in snapshot.record_fingerprints) == (
+        "pcf.factor.kr_grid_2024.location_based",
+    )
+    assert fingerprint.dependency_kind == "reference_catalog_snapshot"
+    assert fingerprint.dependency_id == snapshot.snapshot_id
+    assert fingerprint.fingerprint.startswith("sha256:")
+    assert fingerprint == reference_catalog_snapshot_fingerprint(same_snapshot)
+    assert fingerprint != reference_catalog_snapshot_fingerprint(changed_snapshot)


### PR DESCRIPTION
## Summary
- add `ReferenceCatalogSnapshot` and a stable catalog snapshot dependency fingerprint
- export the snapshot model/helper through `comp.compiler_tool`
- make replay verify that cited catalog snapshot manifests cover selected `reference_record` fingerprints
- update persistence docs/tests for snapshot dependency coverage

## Verification
- `python -m pytest tests/test_reference_record_fingerprints.py tests/test_persistence_projection_replay.py tests/test_package_smoke.py -q`
- `python -m pytest tests/test_domain_scenario_lab.py tests/test_l_energy_pcf_scenario.py tests/test_canonical_working_loop_scenario.py -q`
- `python -m pytest -q`
- `git diff --check` (only Windows CRLF warnings)