### PR TITLE
[codex] assert scenario dependency fingerprints

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -82,6 +82,7 @@ DerivedClaim cannot authorize public projection
 CommitReceipt is required for projection
 open obligations prevent receipt issuance
 receipt traces binding, formula, calculation, and derived-claim evidence
+receipt dependency fingerprints pin replay profile/reference dependencies
 ```
 
 Weak assertions are preferred for surfaces that are still exploratory:

--- a/tests/domain_scenarios/core.py
+++ b/tests/domain_scenarios/core.py
@@ -11,7 +11,7 @@ from comp.compiler_tool import (
     commit_preparation_to_facts,
     compile_report_to_facts,
 )
-from comp.judgment import Fact, SubjectRef
+from comp.judgment import DependencyFingerprint, Fact, SubjectRef
 
 
 @dataclass(frozen=True)
@@ -40,6 +40,7 @@ class ScenarioContract:
     required_receipt_derived_claim_ids: tuple[str, ...] = ()
     required_receipt_calculation_trace_ids: tuple[str, ...] = ()
     required_receipt_formula_ids: tuple[str, ...] = ()
+    required_dependency_fingerprints: tuple[DependencyFingerprint, ...] = ()
     required_open_obligation_ids: tuple[str, ...] | None = ()
     required_hazard_ids: tuple[str, ...] | None = ()
 
@@ -159,6 +160,10 @@ def assert_scenario_contract(
             citations.formula_ids,
             contract.required_receipt_formula_ids,
         )
+        assert _contains_in_order(
+            citations.dependency_fingerprints,
+            contract.required_dependency_fingerprints,
+        )
 
     if contract.required_open_obligation_ids is not None:
         assert (
@@ -201,6 +206,7 @@ def _requires_receipt_citations(contract: ScenarioContract) -> bool:
             contract.required_receipt_derived_claim_ids,
             contract.required_receipt_calculation_trace_ids,
             contract.required_receipt_formula_ids,
+            contract.required_dependency_fingerprints,
         )
     )
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -74,6 +74,32 @@ PROJECTION_FIELDS = (
 )
 PROJECTION_ID = "l-energy-pcf-public-row"
 
+
+def _contract_dependency_fingerprints():
+    return _dependency_fingerprints_for_reference_ids(
+        profile(),
+        reference_pack(),
+        EXPECTED_REFERENCE_CANDIDATE_IDS,
+    )
+
+
+def _dependency_fingerprints_for_reference_ids(
+    scenario_profile,
+    pack: ScenarioReferencePack,
+    reference_ids: tuple[str, ...],
+):
+    fingerprints = [profile_declaration_fingerprint(scenario_profile)]
+    seen_reference_ids: set[str] = set()
+    for reference_id in reference_ids:
+        if reference_id in seen_reference_ids:
+            continue
+        seen_reference_ids.add(reference_id)
+        fingerprints.append(
+            reference_record_fingerprint(pack.catalog.get(reference_id))
+        )
+    return tuple(fingerprints)
+
+
 SCENARIO = ScenarioDefinition(
     scenario_id=SCENARIO_ID,
     title="L-Energy PCF Governance",
@@ -90,6 +116,7 @@ SCENARIO = ScenarioDefinition(
         required_receipt_derived_claim_ids=EXPECTED_DERIVED_CLAIM_IDS,
         required_receipt_calculation_trace_ids=EXPECTED_TRACE_IDS,
         required_receipt_formula_ids=EXPECTED_FORMULA_IDS,
+        required_dependency_fingerprints=_contract_dependency_fingerprints(),
     ),
 )
 
@@ -183,16 +210,11 @@ def _dependency_fingerprints(
     pack: ScenarioReferencePack,
     report: CompileReport,
 ):
-    fingerprints = [profile_declaration_fingerprint(scenario_profile)]
-    seen_reference_ids: set[str] = set()
-    for candidate in report.reference_candidates:
-        if candidate.reference_id in seen_reference_ids:
-            continue
-        seen_reference_ids.add(candidate.reference_id)
-        fingerprints.append(
-            reference_record_fingerprint(pack.catalog.get(candidate.reference_id))
-        )
-    return tuple(fingerprints)
+    return _dependency_fingerprints_for_reference_ids(
+        scenario_profile,
+        pack,
+        tuple(candidate.reference_id for candidate in report.reference_candidates),
+    )
 
 
 def _binding_for(

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -1,10 +1,13 @@
-from comp import ProjectionSpec
+import pytest
+
+from comp import DependencyFingerprint, ProjectionSpec
 from tests.domain_scenarios.assertions import (
     assert_projection_tamper_blocked,
     assert_receipt_trace,
 )
 from tests.domain_scenarios.core import (
     ScenarioDefinition,
+    ScenarioContract,
     SourceRef,
     assert_scenario_contract,
     run_scenario,
@@ -18,6 +21,9 @@ from tests.domain_scenarios.tiny_pcf.expected import (
     EXPECTED_RESOLVED_OBLIGATION_KINDS,
 )
 from tests.domain_scenarios.tiny_pcf.scenario import run_tiny_pcf_scenario
+from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
+    run_l_energy_pcf_governance_scenario,
+)
 
 
 def test_domain_scenario_cli_lists_registered_scenarios(capsys):
@@ -95,6 +101,22 @@ def test_registered_scenarios_run_through_shared_contract_assertions():
 
         assert_scenario_contract(result, scenario.contract)
         assert result.scenario_id == scenario.scenario_id
+
+
+def test_scenario_contract_rejects_missing_dependency_fingerprint():
+    result = run_l_energy_pcf_governance_scenario()
+    contract = ScenarioContract(
+        required_dependency_fingerprints=(
+            DependencyFingerprint(
+                dependency_kind="compiler_profile",
+                dependency_id="missing-profile",
+                fingerprint="sha256:missing",
+            ),
+        )
+    )
+
+    with pytest.raises(AssertionError):
+        assert_scenario_contract(result, contract)
 
 
 def test_source_ref_serializes_external_scenario_trace_metadata():

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -27,6 +27,24 @@ from tests.domain_scenarios.reference_packs import ScenarioReferencePack
 from tests.domain_scenarios.registry import registered_scenarios
 
 
+EXPECTED_DEPENDENCY_FINGERPRINT_IDS = (
+    ("compiler_profile", "pcf-governance-platform-fixture-v1"),
+    ("reference_record", "platform.factor.a_supplier_electricity_mwh_2025"),
+    ("reference_record", "platform.factor.electricity_mwh"),
+    ("reference_record", "platform.factor.electricity_mwh_2024"),
+    ("reference_record", "platform.factor.electricity_residual_mix_2025"),
+    ("reference_record", "platform.factor.global_average_electricity_mwh_2025"),
+    ("reference_record", "platform.factor.us_electricity_mwh_2025"),
+)
+
+
+def test_l_energy_contract_declares_dependency_fingerprints():
+    assert tuple(
+        (fingerprint.dependency_kind, fingerprint.dependency_id)
+        for fingerprint in L_ENERGY_SCENARIO.contract.required_dependency_fingerprints
+    ) == EXPECTED_DEPENDENCY_FINGERPRINT_IDS
+
+
 def test_l_energy_pcf_governance_scenario_is_registered_with_source_refs():
     scenarios = registered_scenarios()
 
@@ -194,21 +212,7 @@ def test_l_energy_pcf_governance_replays_projection_with_dependency_fingerprints
     assert tuple(
         (fingerprint.dependency_kind, fingerprint.dependency_id)
         for fingerprint in replay.dependency_fingerprints
-    ) == (
-        ("compiler_profile", "pcf-governance-platform-fixture-v1"),
-        (
-            "reference_record",
-            "platform.factor.a_supplier_electricity_mwh_2025",
-        ),
-        ("reference_record", "platform.factor.electricity_mwh"),
-        ("reference_record", "platform.factor.electricity_mwh_2024"),
-        ("reference_record", "platform.factor.electricity_residual_mix_2025"),
-        (
-            "reference_record",
-            "platform.factor.global_average_electricity_mwh_2025",
-        ),
-        ("reference_record", "platform.factor.us_electricity_mwh_2025"),
-    )
+    ) == EXPECTED_DEPENDENCY_FINGERPRINT_IDS
 
 
 def test_l_energy_pcf_governance_viewer_exports_dependency_fingerprints():
@@ -217,18 +221,4 @@ def test_l_energy_pcf_governance_viewer_exports_dependency_fingerprints():
     assert tuple(
         (item["dependency_kind"], item["dependency_id"])
         for item in exported["receipt_trace"]["dependency_fingerprints"]
-    ) == (
-        ("compiler_profile", "pcf-governance-platform-fixture-v1"),
-        (
-            "reference_record",
-            "platform.factor.a_supplier_electricity_mwh_2025",
-        ),
-        ("reference_record", "platform.factor.electricity_mwh"),
-        ("reference_record", "platform.factor.electricity_mwh_2024"),
-        ("reference_record", "platform.factor.electricity_residual_mix_2025"),
-        (
-            "reference_record",
-            "platform.factor.global_average_electricity_mwh_2025",
-        ),
-        ("reference_record", "platform.factor.us_electricity_mwh_2025"),
-    )
+    ) == EXPECTED_DEPENDENCY_FINGERPRINT_IDS


### PR DESCRIPTION
## Summary
- Extend `ScenarioContract` with required dependency fingerprint expectations.
- Make shared scenario contract assertions verify receipt-cited dependency fingerprints.
- Wire the L-Energy PCF Governance scenario contract to its profile/reference dependency fingerprints.
- Reduce duplicated L-Energy fingerprint id expectations and document the scenario invariant.

## Why
Dependency fingerprints were already present in receipts, replay bundles, and L-Energy-specific tests, but the shared Domain Scenario Lab contract did not know about them. This makes dependency pinning part of the canonical scenario assertion path instead of a one-off scenario check.

## Verification
- `python -m pytest tests\test_domain_scenario_lab.py tests\test_l_energy_pcf_scenario.py -q` -> 24 passed
- `python -m pytest tests\test_persistence_projection_replay.py tests\test_commit_receipt_builder.py -q` -> 18 passed
- `python -m pytest -q` -> 269 passed
- `git diff --check origin/main...HEAD` -> clean