### PR TITLE
[codex] cite scenario catalog snapshots

### DIFF
--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from comp import ProjectionSpec, SubjectRef, project_public_row
 from comp.compiler_tool import (
+    ReferenceCatalogSnapshot,
     ReferenceBinding,
     apply_reference_selection,
     calculation_formula_declaration_fingerprint,
@@ -9,6 +10,7 @@ from comp.compiler_tool import (
     plan_calculation_resolution,
     prepare_commit,
     profile_declaration_fingerprint,
+    reference_catalog_snapshot_fingerprint,
     reference_query_for_obligation_from_profile_policy,
     reference_record_fingerprint,
     resolve_reference_retrieval_obligations,
@@ -169,9 +171,20 @@ def _dependency_fingerprints(
         calculation_formula_declaration_fingerprint(formula()),
     ]
     if binding is not None:
-        fingerprints.append(
-            reference_record_fingerprint(catalog().get(binding.reference_id))
+        record_fingerprint = reference_record_fingerprint(
+            catalog().get(binding.reference_id)
         )
+        fingerprints.append(
+            reference_catalog_snapshot_fingerprint(
+                ReferenceCatalogSnapshot.from_catalog(
+                    catalog(),
+                    catalog_id="pcf-reference-catalog",
+                    catalog_version="pcf-reference-catalog-v1",
+                    selected_reference_ids=(binding.reference_id,),
+                )
+            )
+        )
+        fingerprints.append(record_fingerprint)
     return tuple(fingerprints)
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from comp import ProjectionSpec, SubjectRef, project_public_row
 from comp.compiler_tool import (
     CompileReport,
+    ReferenceCatalogSnapshot,
     ReferenceBinding,
     apply_reference_selection,
     calculation_formula_declaration_fingerprint,
@@ -10,6 +11,7 @@ from comp.compiler_tool import (
     plan_calculation_resolution,
     prepare_commit,
     profile_declaration_fingerprint,
+    reference_catalog_snapshot_fingerprint,
     reference_query_for_obligation_from_profile_policy,
     reference_record_fingerprint,
     resolve_reference_retrieval_obligations,
@@ -98,14 +100,29 @@ def _dependency_fingerprints_for_reference_ids(
         ),
         calculation_formula_declaration_fingerprint(formula()),
     ]
+    selected_reference_ids = []
+    record_fingerprints = []
     seen_reference_ids: set[str] = set()
     for reference_id in reference_ids:
         if reference_id in seen_reference_ids:
             continue
         seen_reference_ids.add(reference_id)
-        fingerprints.append(
+        selected_reference_ids.append(reference_id)
+        record_fingerprints.append(
             reference_record_fingerprint(pack.catalog.get(reference_id))
         )
+    if selected_reference_ids:
+        fingerprints.append(
+            reference_catalog_snapshot_fingerprint(
+                ReferenceCatalogSnapshot.from_catalog(
+                    pack.catalog,
+                    catalog_id=pack.pack_id,
+                    catalog_version=pack.reference_db_version,
+                    selected_reference_ids=tuple(selected_reference_ids),
+                )
+            )
+        )
+        fingerprints.extend(record_fingerprints)
     return tuple(fingerprints)
 
 

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -184,6 +184,8 @@ def _artifact_body_for_ref(
         return {"formula_id": ref.artifact_id}
     if ref.artifact_kind == "semantic_judgment":
         return {"judgment_id": ref.artifact_id}
+    if ref.artifact_kind == "reference_catalog_snapshot":
+        return _reference_catalog_snapshot_body(result, ref)
     dependency_body = _dependency_fingerprint_body(result, ref)
     if dependency_body is not None:
         return dependency_body
@@ -230,6 +232,58 @@ def _dependency_fingerprint_body(
                 "digest_alg": fingerprint.digest_alg,
             }
     return None
+
+
+def _reference_catalog_snapshot_body(
+    result: DomainScenarioResult,
+    ref: ArtifactRef,
+) -> dict[str, Any]:
+    dependency_body = _dependency_fingerprint_body(result, ref)
+    if dependency_body is None:
+        raise AssertionError(f"Scenario dependency fingerprint not found: {ref}.")
+    catalog_id, catalog_version = _catalog_snapshot_parts(ref.artifact_id)
+    body = dict(dependency_body)
+    body.update(
+        {
+            "snapshot_id": ref.artifact_id,
+            "catalog_id": catalog_id,
+            "catalog_version": catalog_version,
+            "record_fingerprints": tuple(
+                record_body
+                for record_body in (
+                    _dependency_fingerprint_body(
+                        result,
+                        ArtifactRef(
+                            fingerprint.dependency_id,
+                            fingerprint.dependency_kind,
+                        ),
+                    )
+                    for fingerprint in _dependency_fingerprints(result)
+                    if fingerprint.dependency_kind == "reference_record"
+                )
+                if record_body is not None
+            ),
+        }
+    )
+    return body
+
+
+def _catalog_snapshot_parts(snapshot_id: str) -> tuple[str, str]:
+    prefix = "reference_catalog_snapshot:"
+    if not snapshot_id.startswith(prefix):
+        return snapshot_id, ""
+    rest = snapshot_id[len(prefix):]
+    if ":" not in rest:
+        return rest, ""
+    catalog_id, catalog_version = rest.rsplit(":", 1)
+    return catalog_id, catalog_version
+
+
+def _dependency_fingerprints(result: DomainScenarioResult):
+    receipt = result.preparation.receipt
+    if receipt is None or receipt.citations is None:
+        return ()
+    return receipt.citations.dependency_fingerprints
 
 
 __all__ = [

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -161,12 +161,16 @@ def test_canonical_working_loop_replays_projection_from_stored_artifacts():
     ) == (
         ("compiler_profile", "pcf-canonical-loop-v1"),
         ("domain_pack", "domain_pack:canonical-pcf:2026.1"),
-        (
-            "calculation_formula",
-            "calculation_formula:pcf.electricity_factor_multiplication.v1",
-        ),
-        ("reference_record", "pcf.factor.kr_grid_2024.location_based"),
-    )
+          (
+              "calculation_formula",
+              "calculation_formula:pcf.electricity_factor_multiplication.v1",
+          ),
+          (
+              "reference_catalog_snapshot",
+              "reference_catalog_snapshot:pcf-reference-catalog:pcf-reference-catalog-v1",
+          ),
+          ("reference_record", "pcf.factor.kr_grid_2024.location_based"),
+      )
 
 
 def test_canonical_working_loop_replay_blocks_when_cited_artifact_is_missing():

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -31,6 +31,10 @@ EXPECTED_DEPENDENCY_FINGERPRINT_IDS = (
     ("compiler_profile", "pcf-governance-platform-fixture-v1"),
     ("domain_pack", "domain_pack:l-energy-pcf-governance:2026.1"),
     ("calculation_formula", "calculation_formula:pcf-demo-2025.0"),
+    (
+        "reference_catalog_snapshot",
+        "reference_catalog_snapshot:l-energy-platform-reference-pack-v1:l-energy-platform-fixture-v1",
+    ),
     ("reference_record", "platform.factor.a_supplier_electricity_mwh_2025"),
     ("reference_record", "platform.factor.electricity_mwh"),
     ("reference_record", "platform.factor.electricity_mwh_2024"),


### PR DESCRIPTION
## Summary

- Make canonical and L-Energy scenario receipts cite `reference_catalog_snapshot` dependencies using the existing snapshot API from `main`.
- Teach Domain Scenario Lab replay envelopes how to materialize snapshot bodies for scenario-cited catalog snapshots.
- Update scenario dependency assertions so replay explains the compact catalog snapshot, domain/formula declarations, and selected reference rows.

## Stack

1. This PR: scenario catalog snapshot citation
2. #190: profile lock manifest
3. #191: normalized scenario trace output

## Note

`main` already contains the core `ReferenceCatalogSnapshot` model and replay coverage checks from #187. This PR is the remaining scenario integration layer, rebased on top of #193's domain/formula declaration fingerprints.

## Validation

- `python -m pytest tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py tests/test_domain_scenario_lab.py -q`
- Final stack: `python -m pytest -q` -> `281 passed`
- `git diff --check origin/main...HEAD`