### PR TITLE
[codex] normalize scenario trace output

### DIFF
--- a/tests/domain_scenarios/cli.py
+++ b/tests/domain_scenarios/cli.py
@@ -145,7 +145,35 @@ def render_scenario_summary(
                 f"- formulas: {len(citations.formula_ids)}",
             )
         )
+    lines.extend(
+        (
+            "",
+            "Replay trace:",
+        )
+    )
+    replay_trace = result.to_dict().get("replay_trace")
+    if replay_trace is None:
+        lines.append("- status: absent")
+    else:
+        lines.extend(
+            (
+                f"- status: {replay_trace['status']}",
+                f"- artifacts: {len(replay_trace.get('artifact_refs', ()))}",
+                f"- dependency manifests: {_dependency_manifest_count(replay_trace)}",
+            )
+        )
     return "\n".join(lines)
+
+
+def _dependency_manifest_count(replay_trace: dict[str, object]) -> int:
+    manifests = replay_trace.get("dependency_manifests")
+    if not isinstance(manifests, dict):
+        return 0
+    return sum(
+        len(items)
+        for items in manifests.values()
+        if isinstance(items, list)
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/domain_scenarios/views.py
+++ b/tests/domain_scenarios/views.py
@@ -12,6 +12,7 @@ def scenario_result_view(result) -> dict[str, Any]:
         "receipt_trace": receipt_trace_view(
             result.preparation.receipt,
         ),
+        "replay_trace": replay_trace_view(result),
         "facts": {
             "report_count": len(result.report_facts),
             "commit_count": len(result.commit_facts),
@@ -117,6 +118,111 @@ def receipt_trace_view(receipt) -> dict[str, Any] | None:
     }
 
 
+def replay_trace_view(result) -> dict[str, Any] | None:
+    receipt = result.preparation.receipt
+    if receipt is None or result.projection is None:
+        return None
+
+    from comp import ProjectionSpec
+    from comp.persistence import ProjectionReplayBlocked
+    from tests.domain_scenarios.persistence import (
+        replay_scenario_projection,
+        scenario_replay_bundle,
+    )
+
+    bundle = scenario_replay_bundle(result)
+    try:
+        replay = replay_scenario_projection(
+            result,
+            ProjectionSpec(receipt.projection_id, tuple(result.projection.keys())),
+            bundle=bundle,
+        )
+    except ProjectionReplayBlocked as exc:
+        return {
+            "status": "blocked",
+            "reason": str(exc),
+        }
+
+    return {
+        "status": "replayed",
+        "receipt_key": {
+            "public_row_id": replay.receipt_key.public_row_id,
+            "projection_id": replay.receipt_key.projection_id,
+            "draft_id": replay.receipt_key.draft_id,
+        },
+        "projection_id": replay.projection_id,
+        "artifact_refs": [
+            {
+                "artifact_id": ref.artifact_id,
+                "artifact_kind": ref.artifact_kind,
+            }
+            for ref in replay.artifact_refs
+        ],
+        "artifact_digests": [
+            {
+                "artifact_id": artifact_id,
+                "body_digest": body_digest,
+            }
+            for artifact_id, body_digest in replay.artifact_digests
+        ],
+        "dependency_manifests": _dependency_manifests_view(
+            replay.dependency_fingerprints,
+            bundle.artifacts,
+        ),
+    }
+
+
+def _dependency_manifests_view(fingerprints, artifacts) -> dict[str, list[dict[str, Any]]]:
+    profile_locks = []
+    catalog_snapshots = []
+    reference_records = []
+    for fingerprint in fingerprints:
+        envelope = artifacts.get(fingerprint.dependency_id)
+        if fingerprint.dependency_kind == "compiler_profile":
+            profile_lock = envelope.body.get("profile_lock")
+            if isinstance(profile_lock, dict):
+                profile_locks.append(
+                    {
+                        "profile_id": profile_lock["profile_id"],
+                        "active_rule_count": len(profile_lock["active_rule_ids"]),
+                        "active_rubric_count": len(
+                            profile_lock["active_rubric_ids"]
+                        ),
+                        "active_retrieval_policy_count": len(
+                            profile_lock["active_retrieval_policy_ids"]
+                        ),
+                        "domain_pack_count": len(profile_lock["domain_packs"]),
+                    }
+                )
+        elif fingerprint.dependency_kind == "reference_catalog_snapshot":
+            selected = envelope.body.get(
+                "record_fingerprints",
+                envelope.body.get("selected_record_fingerprints", ()),
+            )
+            catalog_snapshots.append(
+                {
+                    "snapshot_id": fingerprint.dependency_id,
+                    "catalog_id": envelope.body.get("catalog_id"),
+                    "version": envelope.body.get(
+                        "catalog_version",
+                        envelope.body.get("version"),
+                    ),
+                    "selected_record_count": len(selected),
+                }
+            )
+        elif fingerprint.dependency_kind == "reference_record":
+            reference_records.append(
+                {
+                    "reference_id": fingerprint.dependency_id,
+                }
+            )
+    return {
+        "profile_locks": profile_locks,
+        "catalog_snapshots": catalog_snapshots,
+        "reference_records": reference_records,
+    }
+
+
 def _obligation_view(obligation) -> dict[str, str | None]:
     return {
         "obligation_id": obligation.obligation_id,
@@ -129,6 +235,7 @@ def _obligation_view(obligation) -> dict[str, str | None]:
 __all__ = [
     "commit_view",
     "receipt_trace_view",
+    "replay_trace_view",
     "report_view",
     "scenario_result_view",
 ]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -23,6 +23,9 @@ from tests.domain_scenarios.tiny_pcf.expected import (
     EXPECTED_RESOLVED_OBLIGATION_KINDS,
 )
 from tests.domain_scenarios.tiny_pcf.scenario import run_tiny_pcf_scenario
+from tests.domain_scenarios.canonical_working_loop.scenario import (
+    run_canonical_working_loop_scenario,
+)
 from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
     run_l_energy_pcf_governance_scenario,
 )
@@ -58,6 +61,9 @@ def test_domain_scenario_cli_runs_human_summary(capsys):
     assert "Receipt trace:" in captured.out
     assert "- reference bindings: 1" in captured.out
     assert "- derived claims: 1" in captured.out
+    assert "Replay trace:" in captured.out
+    assert "- status: replayed" in captured.out
+    assert "- artifacts:" in captured.out
 
 
 def test_domain_scenario_cli_runs_json_view(capsys):
@@ -296,6 +302,52 @@ def test_scenario_result_view_exposes_receipt_trace_without_raw_values():
         },
     ]
     assert all("value" not in commitment for commitment in commitments)
+
+
+def test_scenario_result_view_exposes_replay_trace_manifest_summary():
+    result = run_canonical_working_loop_scenario()
+
+    view = scenario_result_view(result)
+
+    replay_trace = view["replay_trace"]
+    assert replay_trace["status"] == "replayed"
+    assert replay_trace["receipt_key"] == {
+        "public_row_id": "public-row:canonical-raw-pcf-1",
+        "projection_id": "canonical-pcf-public-row",
+        "draft_id": "commit-package:product:canonical-raw-pcf-1",
+    }
+    assert {
+        "artifact_id": "pcf-canonical-loop-v1",
+        "artifact_kind": "compiler_profile",
+    } in replay_trace["artifact_refs"]
+    assert any(
+        item["artifact_id"] == "canonical-raw:co2e_kg"
+        and item["body_digest"].startswith("sha256:")
+        for item in replay_trace["artifact_digests"]
+    )
+    assert replay_trace["dependency_manifests"]["profile_locks"] == [
+        {
+            "profile_id": "pcf-canonical-loop-v1",
+            "active_rule_count": 0,
+            "active_rubric_count": 0,
+            "active_retrieval_policy_count": 1,
+            "domain_pack_count": 1,
+        }
+    ]
+    assert replay_trace["dependency_manifests"]["catalog_snapshots"] == [
+        {
+            "snapshot_id": (
+                "reference_catalog_snapshot:"
+                "pcf-reference-catalog:"
+                "pcf-reference-catalog-v1"
+            ),
+            "catalog_id": "pcf-reference-catalog",
+            "version": "pcf-reference-catalog-v1",
+            "selected_record_count": 1,
+        }
+    ]
+    assert "public_row" not in replay_trace
+    assert "value" not in str(replay_trace["artifact_digests"])
 
 
 def test_tiny_pcf_scenario_exports_json_ready_viewer_payload():


### PR DESCRIPTION
## Summary

- Add a `replay_trace` section to Domain Scenario Lab viewer payloads with replay status, receipt key, artifact refs, artifact digests, and dependency manifest summaries.
- Extend the human CLI summary to show replay status, artifact count, and dependency manifest count.
- Keep trace output digest/id oriented and avoid exposing raw committed source values in the replay trace.

## Stack

1. #189: scenario catalog snapshot citation
2. #190: profile lock manifest
3. This PR: normalized scenario trace output

## Validation

- `python -m pytest tests/test_domain_scenario_lab.py tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py -q`
- Final stack: `python -m pytest -q` -> `281 passed`
- `git diff --check origin/main...HEAD`