### PR TITLE
[codex] run all domain scenarios from cli

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -126,11 +126,18 @@ Run one scenario as a human-readable trace summary:
 python -m tests.domain_scenarios run canonical_working_loop.raw_text_pcf.v1
 ```
 
+Run every registered scenario through the same contract assertion path:
+
+```bash
+python -m tests.domain_scenarios run-all
+```
+
 Use `--json` when a test, viewer, or debugging script needs the existing
-`DomainScenarioResult` viewer payload:
+`DomainScenarioResult` viewer payload or an aggregate run payload:
 
 ```bash
 python -m tests.domain_scenarios run l_energy_pcf_governance.v1 --json
+python -m tests.domain_scenarios run-all --json
 ```
 
 The runner is intentionally generic. It only knows about `ScenarioDefinition`,

--- a/tests/domain_scenarios/cli.py
+++ b/tests/domain_scenarios/cli.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
 
 from tests.domain_scenarios.core import (
     DomainScenarioResult,
@@ -11,6 +14,17 @@ from tests.domain_scenarios.core import (
     run_scenario,
 )
 from tests.domain_scenarios.registry import registered_scenarios
+
+
+@dataclass(frozen=True)
+class ScenarioRunStatus:
+    scenario: ScenarioDefinition
+    result: DomainScenarioResult | None
+    error: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return self.error is None
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -35,8 +49,63 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(render_scenario_summary(scenario, result))
         return 0
 
+    if args.command == "run-all":
+        statuses = run_all_scenarios()
+        if args.json:
+            print(render_run_all_json(statuses))
+        else:
+            print(render_run_all_summary(statuses))
+        return 0 if all(status.passed for status in statuses) else 1
+
     parser.print_help(sys.stderr)
     return 2
+
+
+def run_all_scenarios() -> tuple[ScenarioRunStatus, ...]:
+    statuses: list[ScenarioRunStatus] = []
+    for scenario in registered_scenarios():
+        try:
+            result = run_scenario(scenario)
+            assert_scenario_contract(result, scenario.contract)
+        except AssertionError as exc:
+            statuses.append(
+                ScenarioRunStatus(
+                    scenario=scenario,
+                    result=None,
+                    error=str(exc) or exc.__class__.__name__,
+                )
+            )
+        else:
+            statuses.append(ScenarioRunStatus(scenario=scenario, result=result))
+    return tuple(statuses)
+
+
+def render_run_all_summary(statuses: Sequence[ScenarioRunStatus]) -> str:
+    passed = sum(1 for status in statuses if status.passed)
+    lines = [
+        "Domain Scenario Run",
+        f"Passed: {passed}/{len(statuses)}",
+        "",
+        "Scenarios:",
+    ]
+    for status in statuses:
+        label = "pass" if status.passed else "fail"
+        detail = _run_status_detail(status)
+        lines.append(f"- {status.scenario.scenario_id}: {label}{detail}")
+    return "\n".join(lines)
+
+
+def render_run_all_json(statuses: Sequence[ScenarioRunStatus]) -> str:
+    passed = sum(1 for status in statuses if status.passed)
+    payload = {
+        "summary": {
+            "total": len(statuses),
+            "passed": passed,
+            "failed": len(statuses) - passed,
+        },
+        "scenarios": [_run_status_payload(status) for status in statuses],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
 
 
 def render_scenario_summary(
@@ -95,6 +164,16 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print the scenario result viewer payload as JSON.",
     )
+
+    run_all = subparsers.add_parser(
+        "run-all",
+        help="Run all registered domain scenarios and assert their contracts.",
+    )
+    run_all.add_argument(
+        "--json",
+        action="store_true",
+        help="Print an aggregate scenario run payload as JSON.",
+    )
     return parser
 
 
@@ -117,4 +196,35 @@ def _unknown_scenario_message(scenario_id: str) -> str:
     return f"unknown scenario id: {scenario_id}\nknown scenarios: {known}"
 
 
-__all__ = ["main", "render_scenario_summary"]
+def _run_status_detail(status: ScenarioRunStatus) -> str:
+    if not status.passed:
+        return f" ({status.error})"
+    assert status.result is not None
+    projection = "projection" if status.result.projection is not None else "no projection"
+    return (
+        f" ({status.result.report.status}, "
+        f"{status.result.preparation.decision.status}, {projection})"
+    )
+
+
+def _run_status_payload(status: ScenarioRunStatus) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "scenario_id": status.scenario.scenario_id,
+        "title": status.scenario.title,
+        "status": "pass" if status.passed else "fail",
+    }
+    if status.result is None:
+        payload["error"] = status.error
+    else:
+        payload["result"] = status.result.to_dict()
+    return payload
+
+
+__all__ = [
+    "ScenarioRunStatus",
+    "main",
+    "render_run_all_json",
+    "render_run_all_summary",
+    "render_scenario_summary",
+    "run_all_scenarios",
+]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from comp import DependencyFingerprint, ProjectionSpec
@@ -80,6 +82,72 @@ def test_domain_scenario_cli_rejects_unknown_scenario(capsys):
     assert captured.out == ""
     assert "unknown scenario id: missing.scenario" in captured.err
     assert "known scenarios:" in captured.err
+
+
+def test_domain_scenario_cli_runs_all_registered_scenarios(capsys):
+    from tests.domain_scenarios.cli import main
+
+    exit_code = main(["run-all"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Domain Scenario Run" in captured.out
+    assert "Passed: 3/3" in captured.out
+    assert "- canonical_working_loop.raw_text_pcf.v1: pass" in captured.out
+    assert "- tiny_pcf.location_based_electricity.v1: pass" in captured.out
+    assert "- l_energy_pcf_governance.v1: pass" in captured.out
+    assert captured.err == ""
+
+
+def test_domain_scenario_cli_runs_all_as_json(capsys):
+    from tests.domain_scenarios.cli import main
+
+    exit_code = main(["run-all", "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["summary"] == {"total": 3, "passed": 3, "failed": 0}
+    assert tuple(item["status"] for item in payload["scenarios"]) == (
+        "pass",
+        "pass",
+        "pass",
+    )
+    assert tuple(item["scenario_id"] for item in payload["scenarios"]) == (
+        "canonical_working_loop.raw_text_pcf.v1",
+        "tiny_pcf.location_based_electricity.v1",
+        "l_energy_pcf_governance.v1",
+    )
+    assert "result" in payload["scenarios"][0]
+    assert captured.err == ""
+
+
+def test_domain_scenario_cli_run_all_reports_contract_failure(capsys, monkeypatch):
+    from tests.domain_scenarios import cli
+
+    failing_scenario = ScenarioDefinition(
+        scenario_id="tiny_pcf.failure_fixture.v1",
+        title="Tiny PCF failure fixture",
+        run=run_tiny_pcf_scenario,
+        contract=ScenarioContract(
+            required_dependency_fingerprints=(
+                DependencyFingerprint(
+                    dependency_kind="compiler_profile",
+                    dependency_id="missing-profile",
+                    fingerprint="sha256:missing",
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(cli, "registered_scenarios", lambda: (failing_scenario,))
+
+    exit_code = cli.main(["run-all"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Passed: 0/1" in captured.out
+    assert "- tiny_pcf.failure_fixture.v1: fail" in captured.out
+    assert captured.err == ""
 
 
 def test_registered_scenarios_are_explicit_scenario_definitions():


### PR DESCRIPTION
## Summary
- Add `python -m tests.domain_scenarios run-all` to execute every registered scenario through the shared contract assertion path.
- Add `run-all --json` for an aggregate viewer/debug payload with per-scenario results.
- Report contract assertion failures with a non-zero exit code instead of pretending the full registry passed.
- Document the new runner commands in the Domain Scenario Lab README.

## Why
The scenario lab now has multiple registered packs and stronger scenario contracts. This gives contributors one command to verify the whole registry outside pytest internals while preserving the existing single-scenario runner.

## Verification
- `python -m pytest tests\test_domain_scenario_lab.py -q` -> 16 passed
- `python -m pytest tests\test_domain_scenario_lab.py tests\test_l_energy_pcf_scenario.py -q` -> 27 passed
- `python -m pytest -q` -> 274 passed
- `git diff --check` -> clean
- `python -m tests.domain_scenarios run-all`
- `python -m tests.domain_scenarios run-all --json`