### PR TITLE
[codex] pin domain and formula declarations

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -8,6 +8,7 @@ from comp.compiler_tool.calculations import (
     CalculationStep,
     CalculationTrace,
     DerivedClaim,
+    calculation_formula_declaration_fingerprint,
     calculate_derived_claim,
 )
 from comp.compiler_tool.calculation_flow import resolve_reference_grounded_calculation
@@ -44,7 +45,10 @@ from comp.compiler_tool.profiles import (
     SemanticRubric,
     active_rule_families,
     active_retrieval_query_policies,
+    domain_pack_declaration_fingerprint,
     profile_declaration_fingerprint,
+    rule_family_declaration_fingerprint,
+    semantic_rubric_declaration_fingerprint,
     validate_compiler_profile,
 )
 from comp.compiler_tool.profile_runner import compile_with_profile
@@ -139,6 +143,7 @@ __all__ = [
     "CalculationStep",
     "CalculationTrace",
     "DerivedClaim",
+    "calculation_formula_declaration_fingerprint",
     "calculate_derived_claim",
     "resolve_reference_grounded_calculation",
     "apply_calculation_result",
@@ -201,6 +206,9 @@ __all__ = [
     "active_rule_families",
     "active_retrieval_query_policies",
     "profile_declaration_fingerprint",
+    "domain_pack_declaration_fingerprint",
+    "rule_family_declaration_fingerprint",
+    "semantic_rubric_declaration_fingerprint",
     "compile_with_profile",
     "CompilerTool",
     "apply_semantic_judgments",

--- a/comp/compiler_tool/calculations.py
+++ b/comp/compiler_tool/calculations.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from comp.compiler_tool.reference_db import ReferenceCatalog, ReferenceLookupError
 from comp.compiler_tool.references import ReferenceBinding
+from comp.judgment.receipts import DependencyFingerprint
 
 
 @dataclass(frozen=True)
@@ -191,6 +192,23 @@ def calculate_derived_claim(
     )
 
 
+def calculation_formula_declaration_fingerprint(
+    formula: CalculationFormula,
+) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="calculation_formula",
+        dependency_id=f"calculation_formula:{formula.formula_id}",
+        payload={
+            "formula_id": formula.formula_id,
+            "output_field": formula.output_field,
+            "output_unit": formula.output_unit,
+            "factor_value_attribute": formula.factor_value_attribute,
+            "input_unit_attribute": formula.input_unit_attribute,
+            "output_unit_attribute": formula.output_unit_attribute,
+        },
+    )
+
+
 def _blocked(requirement: CalculationRequirement) -> CalculationResult:
     return CalculationResult(
         status="blocked",
@@ -240,6 +258,7 @@ __all__ = [
     "DerivedClaim",
     "CalculationInput",
     "CalculationFormula",
+    "calculation_formula_declaration_fingerprint",
     "CalculationRequirement",
     "CalculationResult",
     "calculate_derived_claim",

--- a/comp/compiler_tool/profiles.py
+++ b/comp/compiler_tool/profiles.py
@@ -189,6 +189,32 @@ def profile_declaration_fingerprint(
     )
 
 
+def domain_pack_declaration_fingerprint(domain: DomainPack) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="domain_pack",
+        dependency_id=f"domain_pack:{domain.domain_id}:{domain.version}",
+        payload=_domain_pack_fingerprint_payload(domain),
+    )
+
+
+def rule_family_declaration_fingerprint(rule: RuleFamily) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="rule_family",
+        dependency_id=rule.rule_id,
+        payload=_rule_family_fingerprint_payload(rule),
+    )
+
+
+def semantic_rubric_declaration_fingerprint(
+    rubric: SemanticRubric,
+) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="semantic_rubric",
+        dependency_id=rubric.rubric_id,
+        payload=_semantic_rubric_fingerprint_payload(rubric),
+    )
+
+
 def _catalogs(
     profile: CompilerProfile,
 ) -> tuple[
@@ -255,47 +281,66 @@ def _domain_pack_fingerprint_payload(domain: DomainPack) -> dict[str, Any]:
         "domain_id": domain.domain_id,
         "version": domain.version,
         "rule_families": tuple(
-            {
-                "rule_id": rule.rule_id,
-                "required_rubric_ids": rule.required_rubric_ids,
-            }
+            _rule_family_fingerprint_payload(rule)
             for rule in domain.rule_families
         ),
         "rubrics": tuple(
-            {
-                "rubric_id": rubric.rubric_id,
-                "acceptable_verdicts": rubric.acceptable_verdicts,
-                "required_verdict": rubric.required_verdict,
-            }
+            _semantic_rubric_fingerprint_payload(rubric)
             for rubric in domain.rubrics
         ),
         "judge_policies": tuple(
-            {
-                "judge_policy_id": policy.judge_policy_id,
-                "allowed_judges": policy.allowed_judges,
-            }
+            _judge_policy_fingerprint_payload(policy)
             for policy in domain.judge_policies
         ),
         "retrieval_query_policies": tuple(
-            {
-                "policy_id": policy.policy_id,
-                "rules": tuple(
-                    {
-                        "rule_id": rule.rule_id,
-                        "lens": rule.lens,
-                        "text_template": rule.text_template,
-                        "reference_type": rule.reference_type,
-                        "task_type": rule.task_type,
-                        "field": rule.field,
-                        "reason": rule.reason,
-                        "formula_id": rule.formula_id,
-                    }
-                    for rule in policy.rules
-                ),
-            }
+            _retrieval_query_policy_fingerprint_payload(policy)
             for policy in domain.retrieval_query_policies
         ),
         "disabled_core_invariants": domain.disabled_core_invariants,
+    }
+
+
+def _rule_family_fingerprint_payload(rule: RuleFamily) -> dict[str, Any]:
+    return {
+        "rule_id": rule.rule_id,
+        "required_rubric_ids": rule.required_rubric_ids,
+        "description": rule.description,
+    }
+
+
+def _semantic_rubric_fingerprint_payload(rubric: SemanticRubric) -> dict[str, Any]:
+    return {
+        "rubric_id": rubric.rubric_id,
+        "acceptable_verdicts": rubric.acceptable_verdicts,
+        "required_verdict": rubric.required_verdict,
+        "description": rubric.description,
+    }
+
+
+def _judge_policy_fingerprint_payload(policy: JudgePolicy) -> dict[str, Any]:
+    return {
+        "judge_policy_id": policy.judge_policy_id,
+        "allowed_judges": policy.allowed_judges,
+        "description": policy.description,
+    }
+
+
+def _retrieval_query_policy_fingerprint_payload(policy) -> dict[str, Any]:
+    return {
+        "policy_id": policy.policy_id,
+        "rules": tuple(
+            {
+                "rule_id": rule.rule_id,
+                "lens": rule.lens,
+                "text_template": rule.text_template,
+                "reference_type": rule.reference_type,
+                "task_type": rule.task_type,
+                "field": rule.field,
+                "reason": rule.reason,
+                "formula_id": rule.formula_id,
+            }
+            for rule in policy.rules
+        ),
     }
 
 
@@ -310,4 +355,7 @@ __all__ = [
     "active_rule_families",
     "active_retrieval_query_policies",
     "profile_declaration_fingerprint",
+    "domain_pack_declaration_fingerprint",
+    "rule_family_declaration_fingerprint",
+    "semantic_rubric_declaration_fingerprint",
 ]

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -461,11 +461,16 @@ tests/domain_scenarios/persistence.py
   records the CommitReceipt into an in-memory receipt ledger, and replays the
   materialized scenario projection from those stored envelopes.
 
-CompilerProfile / ReferenceRecord fingerprints
-  expose stable declaration fingerprints for the active profile and selected
-  canonical reference rows. CommitReceiptCitations can carry these dependency
-  fingerprints, and replay reports surface the profile/reference world the
+CompilerProfile / DomainPack / RuleFamily / SemanticRubric fingerprints
+  expose stable declaration fingerprints for the active profile and domain
+  declaration world. CommitReceiptCitations can carry these dependency
+  fingerprints, and replay reports surface the profile/domain/rule world the
   receipt depended on.
+
+CalculationFormula / ReferenceRecord fingerprints
+  expose stable declaration fingerprints for formulas and selected canonical
+  reference rows. This lets replay explain both the calculation formula world
+  and the reference world behind derived claims.
 
 Dependency fingerprint envelopes
   replay treats dependency fingerprints as receipt-cited artifact refs. The
@@ -495,13 +500,15 @@ artifact body, not only against the materialized row.
 The canonical raw-input working loop can be replayed from stored scenario
 artifact envelopes and its receipt ledger root.
 Replay reports dependency fingerprints cited by the receipt, starting with the
-compiler profile declaration and selected reference record.
+compiler profile declaration, domain pack declarations, calculation formula
+declarations, and selected reference records.
 Replay blocks when a cited dependency fingerprint envelope is missing or its
 stored fingerprint no longer matches the receipt citation.
 Replay blocks when a cited reference catalog snapshot omits a selected
 reference record fingerprint required by the receipt.
 The L-Energy scenario records and replays the same dependency fingerprint shape,
-including the retrieval-backed reference world and near-miss candidates.
+including the retrieval-backed reference world, formula declaration world, domain
+pack declaration world, and near-miss candidates.
 ```
 
 That completes the original in-memory substrate slice and attaches it to the
@@ -516,30 +523,27 @@ production catalog snapshot store exists.
 Recommended next code slice:
 
 ```text
-feat: add broader dependency declaration fingerprints
+feat: add source evidence span integrity fingerprints
 ```
 
 Candidate files:
 
 ```text
-comp/compiler_tool/profiles.py
-comp/compiler_tool/calculations.py
 comp/persistence/*.py
-tests/test_*fingerprint*.py
+tests/domain_scenarios/*.py
+tests/test_*source*.py
 tests/test_persistence_projection_replay.py
 ```
 
 Minimum behavior:
 
 ```text
-DomainPack, active rule/rubric declarations, and formula declarations expose
-stable dependency fingerprints.
-CommitReceipt can cite these declaration fingerprints alongside profile,
-reference record, and catalog snapshot fingerprints.
-Replay verifies the matching dependency fingerprint envelopes when they are
-cited.
-Scenario replay reports show which profile, reference world, formula world, and
-domain rule world made the receipt meaningful.
+EvidenceWitness or source span artifacts expose stable source text/container
+digests.
+CommitReceipt can cite source evidence fingerprints alongside checked claim
+witness ids.
+Replay verifies cited source span envelopes when they are present.
+Scenario replay reports show which raw source spans grounded the checked claims.
 ```
 
 Non-goals for that slice:
@@ -556,21 +560,21 @@ no production catalog snapshot store
 no real DB ingestion
 ```
 
-The goal is to move from "receipt pins profile and reference-world dependencies"
-toward "receipt also pins the formula and domain declaration world that made the
-compiler decision meaningful."
+The goal is to move from "receipt pins the profile, formula, domain, and
+reference worlds" toward "receipt also pins the raw evidence spans that grounded
+checked claims."
 
 ---
 
 ## 13. Following Slice
 
-After broader dependency fingerprints, the next likely slice is source evidence
-span integrity:
+After source evidence span integrity, the next likely slice is dependency graph
+export:
 
 ```text
-Source evidence span digests
-EvidenceWitness source container fingerprints
-Replay verification for cited source span digests
+receipt dependency graph export
+source -> witness -> checked claim -> derived claim -> receipt edges
+viewer-friendly replay explanation payload
 ```
 
 That slice should keep the document's rule: replay explains the old receipt,

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -4,6 +4,8 @@ from comp import ProjectionSpec, SubjectRef, project_public_row
 from comp.compiler_tool import (
     ReferenceBinding,
     apply_reference_selection,
+    calculation_formula_declaration_fingerprint,
+    domain_pack_declaration_fingerprint,
     plan_calculation_resolution,
     prepare_commit,
     profile_declaration_fingerprint,
@@ -158,7 +160,14 @@ def _dependency_fingerprints(
     scenario_profile,
     binding: ReferenceBinding | None,
 ):
-    fingerprints = [profile_declaration_fingerprint(scenario_profile)]
+    fingerprints = [
+        profile_declaration_fingerprint(scenario_profile),
+        *(
+            domain_pack_declaration_fingerprint(domain)
+            for domain in scenario_profile.domain_packs
+        ),
+        calculation_formula_declaration_fingerprint(formula()),
+    ]
     if binding is not None:
         fingerprints.append(
             reference_record_fingerprint(catalog().get(binding.reference_id))

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -5,6 +5,8 @@ from comp.compiler_tool import (
     CompileReport,
     ReferenceBinding,
     apply_reference_selection,
+    calculation_formula_declaration_fingerprint,
+    domain_pack_declaration_fingerprint,
     plan_calculation_resolution,
     prepare_commit,
     profile_declaration_fingerprint,
@@ -88,7 +90,14 @@ def _dependency_fingerprints_for_reference_ids(
     pack: ScenarioReferencePack,
     reference_ids: tuple[str, ...],
 ):
-    fingerprints = [profile_declaration_fingerprint(scenario_profile)]
+    fingerprints = [
+        profile_declaration_fingerprint(scenario_profile),
+        *(
+            domain_pack_declaration_fingerprint(domain)
+            for domain in scenario_profile.domain_packs
+        ),
+        calculation_formula_declaration_fingerprint(formula()),
+    ]
     seen_reference_ids: set[str] = set()
     for reference_id in reference_ids:
         if reference_id in seen_reference_ids:

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -184,8 +184,9 @@ def _artifact_body_for_ref(
         return {"formula_id": ref.artifact_id}
     if ref.artifact_kind == "semantic_judgment":
         return {"judgment_id": ref.artifact_id}
-    if ref.artifact_kind in {"compiler_profile", "reference_record"}:
-        return _dependency_fingerprint_body(result, ref)
+    dependency_body = _dependency_fingerprint_body(result, ref)
+    if dependency_body is not None:
+        return dependency_body
     raise AssertionError(f"Unsupported scenario artifact ref: {ref}.")
 
 
@@ -213,7 +214,7 @@ def _by_id(items, item_id: str, field: str):
 def _dependency_fingerprint_body(
     result: DomainScenarioResult,
     ref: ArtifactRef,
-) -> dict[str, str]:
+) -> dict[str, str] | None:
     receipt = result.preparation.receipt
     if receipt is None or receipt.citations is None:
         raise AssertionError("Scenario dependency fingerprint requires a receipt.")
@@ -228,7 +229,7 @@ def _dependency_fingerprint_body(
                 "fingerprint": fingerprint.fingerprint,
                 "digest_alg": fingerprint.digest_alg,
             }
-    raise AssertionError(f"Scenario dependency fingerprint not found: {ref}.")
+    return None
 
 
 __all__ = [

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -160,6 +160,11 @@ def test_canonical_working_loop_replays_projection_from_stored_artifacts():
         for fingerprint in replay.dependency_fingerprints
     ) == (
         ("compiler_profile", "pcf-canonical-loop-v1"),
+        ("domain_pack", "domain_pack:canonical-pcf:2026.1"),
+        (
+            "calculation_formula",
+            "calculation_formula:pcf.electricity_factor_multiplication.v1",
+        ),
         ("reference_record", "pcf.factor.kr_grid_2024.location_based"),
     )
 

--- a/tests/test_declaration_fingerprints.py
+++ b/tests/test_declaration_fingerprints.py
@@ -1,0 +1,133 @@
+from comp.compiler_tool import (
+    CalculationFormula,
+    DomainPack,
+    RetrievalQueryPolicy,
+    RetrievalQueryRule,
+    RuleFamily,
+    SemanticRubric,
+    calculation_formula_declaration_fingerprint,
+    domain_pack_declaration_fingerprint,
+    rule_family_declaration_fingerprint,
+    semantic_rubric_declaration_fingerprint,
+)
+
+
+def test_calculation_formula_declaration_fingerprint_pins_formula_contract():
+    formula = CalculationFormula(
+        formula_id="pcf.electricity_factor_multiplication.v1",
+        output_field="co2e_kg",
+        output_unit="kgCO2e",
+    )
+    same_formula = CalculationFormula(
+        formula_id="pcf.electricity_factor_multiplication.v1",
+        output_field="co2e_kg",
+        output_unit="kgCO2e",
+    )
+    changed_formula = CalculationFormula(
+        formula_id="pcf.electricity_factor_multiplication.v1",
+        output_field="co2e_tonnes",
+        output_unit="tCO2e",
+    )
+
+    fingerprint = calculation_formula_declaration_fingerprint(formula)
+
+    assert fingerprint.dependency_kind == "calculation_formula"
+    assert (
+        fingerprint.dependency_id
+        == "calculation_formula:pcf.electricity_factor_multiplication.v1"
+    )
+    assert fingerprint.fingerprint.startswith("sha256:")
+    assert fingerprint == calculation_formula_declaration_fingerprint(same_formula)
+    assert fingerprint != calculation_formula_declaration_fingerprint(changed_formula)
+
+
+def test_rule_and_rubric_declaration_fingerprints_pin_semantic_contracts():
+    rule = RuleFamily(
+        rule_id="pcf.scope2_method_support.v1",
+        required_rubric_ids=("pcf.scope2_method_support.rubric.v1",),
+        description="Opens a semantic judgment for Scope 2 method support.",
+    )
+    changed_rule = RuleFamily(
+        rule_id="pcf.scope2_method_support.v1",
+        required_rubric_ids=("pcf.scope2_method_support.rubric.v2",),
+        description="Opens a semantic judgment for Scope 2 method support.",
+    )
+    rubric = SemanticRubric(
+        rubric_id="pcf.scope2_method_support.rubric.v1",
+        acceptable_verdicts=("supports", "refutes", "ambiguous"),
+        required_verdict="supports",
+        description="Determines whether a cited span supports the method.",
+    )
+    changed_rubric = SemanticRubric(
+        rubric_id="pcf.scope2_method_support.rubric.v1",
+        acceptable_verdicts=("supports", "refutes"),
+        required_verdict="supports",
+        description="Determines whether a cited span supports the method.",
+    )
+
+    rule_fingerprint = rule_family_declaration_fingerprint(rule)
+    rubric_fingerprint = semantic_rubric_declaration_fingerprint(rubric)
+
+    assert rule_fingerprint.dependency_kind == "rule_family"
+    assert rule_fingerprint.dependency_id == "pcf.scope2_method_support.v1"
+    assert rule_fingerprint != rule_family_declaration_fingerprint(changed_rule)
+    assert rubric_fingerprint.dependency_kind == "semantic_rubric"
+    assert rubric_fingerprint.dependency_id == "pcf.scope2_method_support.rubric.v1"
+    assert rubric_fingerprint != semantic_rubric_declaration_fingerprint(
+        changed_rubric
+    )
+
+
+def test_domain_pack_declaration_fingerprint_pins_domain_policy_manifest():
+    domain = DomainPack(
+        domain_id="canonical-pcf",
+        version="2026.1",
+        rule_families=(
+            RuleFamily(
+                rule_id="pcf.scope2_method_support.v1",
+                required_rubric_ids=("pcf.scope2_method_support.rubric.v1",),
+            ),
+        ),
+        rubrics=(
+            SemanticRubric(
+                rubric_id="pcf.scope2_method_support.rubric.v1",
+                acceptable_verdicts=("supports", "refutes", "ambiguous"),
+            ),
+        ),
+        retrieval_query_policies=(
+            RetrievalQueryPolicy(
+                policy_id="pcf-canonical-retrieval-query-policy-v1",
+                rules=(
+                    RetrievalQueryRule(
+                        rule_id="pcf-electricity-factor-query-v1",
+                        formula_id="pcf.electricity_factor_multiplication.v1",
+                        lens="factor",
+                        reference_type="emission_factor",
+                        text_template="{geography} grid electricity factor",
+                    ),
+                ),
+            ),
+        ),
+    )
+    same_domain = DomainPack(
+        domain_id="canonical-pcf",
+        version="2026.1",
+        rule_families=domain.rule_families,
+        rubrics=domain.rubrics,
+        retrieval_query_policies=domain.retrieval_query_policies,
+    )
+    changed_domain = DomainPack(
+        domain_id="canonical-pcf",
+        version="2026.2",
+        rule_families=domain.rule_families,
+        rubrics=domain.rubrics,
+        retrieval_query_policies=domain.retrieval_query_policies,
+    )
+
+    fingerprint = domain_pack_declaration_fingerprint(domain)
+
+    assert fingerprint.dependency_kind == "domain_pack"
+    assert fingerprint.dependency_id == "domain_pack:canonical-pcf:2026.1"
+    assert fingerprint.fingerprint.startswith("sha256:")
+    assert fingerprint == domain_pack_declaration_fingerprint(same_domain)
+    assert fingerprint != domain_pack_declaration_fingerprint(changed_domain)

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -29,6 +29,8 @@ from tests.domain_scenarios.registry import registered_scenarios
 
 EXPECTED_DEPENDENCY_FINGERPRINT_IDS = (
     ("compiler_profile", "pcf-governance-platform-fixture-v1"),
+    ("domain_pack", "domain_pack:l-energy-pcf-governance:2026.1"),
+    ("calculation_formula", "calculation_formula:pcf-demo-2025.0"),
     ("reference_record", "platform.factor.a_supplier_electricity_mwh_2025"),
     ("reference_record", "platform.factor.electricity_mwh"),
     ("reference_record", "platform.factor.electricity_mwh_2024"),

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -86,6 +86,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
         RetrievalQueryPolicy,
         RetrievalQueryRule,
         active_retrieval_query_policies,
+        calculation_formula_declaration_fingerprint,
+        domain_pack_declaration_fingerprint,
         profile_declaration_fingerprint,
         reference_catalog_snapshot_fingerprint,
         reference_query_for_obligation_from_profile_policy,
@@ -95,6 +97,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
         reference_query_from_resolver_task,
         reference_record_fingerprint,
         resolve_reference_retrieval_obligations,
+        rule_family_declaration_fingerprint,
+        semantic_rubric_declaration_fingerprint,
         build_commit_receipt,
         compile_report_to_facts,
         prepare_commit,
@@ -114,6 +118,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert EmbeddingResolverStub is not None
     assert RetrievalQueryPolicy is not None
     assert RetrievalQueryRule is not None
+    assert calculation_formula_declaration_fingerprint is not None
+    assert domain_pack_declaration_fingerprint is not None
     assert active_retrieval_query_policies is not None
     assert profile_declaration_fingerprint is not None
     assert reference_query_for_obligation_from_policies is not None
@@ -123,6 +129,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert reference_query_for_obligation_from_resolver_tasks is not None
     assert reference_catalog_snapshot_fingerprint is not None
     assert reference_record_fingerprint is not None
+    assert rule_family_declaration_fingerprint is not None
+    assert semantic_rubric_declaration_fingerprint is not None
     assert resolve_reference_retrieval_obligations is not None
 
 


### PR DESCRIPTION
## Summary
- add stable dependency fingerprints for calculation formulas, domain packs, rule families, and semantic rubrics
- export the new declaration fingerprint helpers through `comp.compiler_tool`
- include domain pack and formula declaration fingerprints in canonical and L-Energy scenario receipts/replay
- let scenario replay materialize any receipt-cited dependency fingerprint artifact generically
- refresh persistence boundary docs so the next slice is source evidence span integrity

## Verification
- `python -m pytest tests/test_declaration_fingerprints.py tests/test_compiler_profile_contract.py tests/test_l_energy_pcf_scenario.py tests/test_canonical_working_loop_scenario.py tests/test_package_smoke.py -q`
- `python -m pytest tests/test_persistence_projection_replay.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest -q`
- `git diff --check` (only Windows CRLF warnings)