### PR TITLE
[codex] pin source evidence spans

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -35,6 +35,7 @@ from comp.compiler_tool.models import (
     SemanticJudgmentRequirement,
     UncheckedArea,
     UnknownClaim,
+    evidence_witness_fingerprint,
 )
 from comp.compiler_tool.profiles import (
     CompilerProfile,
@@ -129,6 +130,7 @@ __all__ = [
     "InterpretationHypothesis",
     "ClaimHypothesis",
     "EvidenceWitness",
+    "evidence_witness_fingerprint",
     "CompileReport",
     "CheckedClaim",
     "FailedClaim",

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 
 from comp.compiler_tool.calculations import CalculationRequirement, DerivedClaim
 from comp.compiler_tool.references import ReferenceBinding, ReferenceCandidate
+from comp.judgment.receipts import DependencyFingerprint
 
 CompileStatus = Literal[
     "accepted",
@@ -34,6 +35,20 @@ class EvidenceWitness:
     @property
     def grounded(self) -> bool:
         return self.source is not None or self.span is not None
+
+
+def evidence_witness_fingerprint(witness: EvidenceWitness) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="evidence_witness",
+        dependency_id=witness.witness_id,
+        payload={
+            "witness_id": witness.witness_id,
+            "field": witness.field,
+            "source": witness.source,
+            "span": witness.span,
+            "text": witness.text,
+        },
+    )
 
 
 @dataclass(frozen=True)
@@ -118,6 +133,7 @@ class Hazard:
 @dataclass(frozen=True)
 class CompileReport:
     status: CompileStatus
+    evidence_witnesses: tuple[EvidenceWitness, ...] = field(default_factory=tuple)
     checked_claims: tuple[CheckedClaim, ...] = field(default_factory=tuple)
     failed_claims: tuple[FailedClaim, ...] = field(default_factory=tuple)
     unknowns: tuple[UnknownClaim, ...] = field(default_factory=tuple)

--- a/comp/compiler_tool/profile_runner.py
+++ b/comp/compiler_tool/profile_runner.py
@@ -23,6 +23,7 @@ def compile_with_profile(
     return with_recomputed_status(
         CompileReport(
             status="accepted",
+            evidence_witnesses=hypothesis.witnesses,
             obligations=tuple(obligations),
             can_project_public_row=False,
         )

--- a/comp/compiler_tool/semantic.py
+++ b/comp/compiler_tool/semantic.py
@@ -71,6 +71,7 @@ def apply_semantic_judgments(
     return with_recomputed_status(
         CompileReport(
             status=report.status,
+            evidence_witnesses=report.evidence_witnesses,
             checked_claims=report.checked_claims,
             failed_claims=report.failed_claims,
             unknowns=report.unknowns,

--- a/comp/compiler_tool/tool.py
+++ b/comp/compiler_tool/tool.py
@@ -108,6 +108,7 @@ class CompilerTool:
         return with_recomputed_status(
             CompileReport(
                 status="accepted",
+                evidence_witnesses=tuple(hypothesis.witnesses),
                 checked_claims=tuple(checked),
                 failed_claims=tuple(failed),
                 unknowns=tuple(unknowns),

--- a/comp/persistence/replay.py
+++ b/comp/persistence/replay.py
@@ -52,6 +52,7 @@ def replay_public_projection(
     artifact_digests = _verified_artifact_digests(refs, artifacts)
     _verify_projection_value_sources(receipt, artifacts)
     _verify_dependency_fingerprint_sources(receipt, artifacts)
+    _verify_source_evidence_span_fingerprints(receipt, artifacts)
     _verify_reference_catalog_snapshot_coverage(receipt, artifacts)
     return ProjectionReplayReport(
         receipt_key=ReceiptLedgerKey.from_receipt(receipt),
@@ -236,6 +237,41 @@ def _verify_profile_lock_body(
             "Projection replay profile lock fingerprint mismatch: "
             f"{fingerprint.dependency_id}."
         )
+
+
+def _verify_source_evidence_span_fingerprints(
+    receipt: CommitReceipt,
+    artifacts: InMemoryArtifactStore,
+) -> None:
+    if receipt.citations is None:
+        return
+
+    for fingerprint in receipt.citations.dependency_fingerprints:
+        if fingerprint.dependency_kind != "evidence_witness":
+            continue
+        envelope = artifacts.get(fingerprint.dependency_id)
+        actual = _evidence_witness_fingerprint_from_body(envelope.body)
+        if actual.fingerprint != fingerprint.fingerprint:
+            raise ProjectionReplayBlocked(
+                "Projection replay source evidence fingerprint mismatch: "
+                f"{fingerprint.dependency_id}."
+            )
+
+
+def _evidence_witness_fingerprint_from_body(
+    body: Mapping[str, Any],
+) -> DependencyFingerprint:
+    return DependencyFingerprint.from_payload(
+        dependency_kind="evidence_witness",
+        dependency_id=str(body.get("witness_id", "")),
+        payload={
+            "witness_id": body.get("witness_id"),
+            "field": body.get("field"),
+            "source": body.get("source"),
+            "span": body.get("span"),
+            "text": body.get("text"),
+        },
+    )
 
 
 def _verify_reference_catalog_snapshot_coverage(

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -472,6 +472,11 @@ CalculationFormula / ReferenceRecord fingerprints
   reference rows. This lets replay explain both the calculation formula world
   and the reference world behind derived claims.
 
+EvidenceWitness fingerprints
+  expose stable source evidence fingerprints for checked claim witnesses. Replay
+  can recompute the witness source/span/text fingerprint from the stored
+  evidence witness artifact and block if the source span drifts.
+
 Dependency fingerprint envelopes
   replay treats dependency fingerprints as receipt-cited artifact refs. The
   stored dependency envelope must exist, match the dependency kind/id, pass body
@@ -506,9 +511,13 @@ Replay blocks when a cited dependency fingerprint envelope is missing or its
 stored fingerprint no longer matches the receipt citation.
 Replay blocks when a cited reference catalog snapshot omits a selected
 reference record fingerprint required by the receipt.
+Replay blocks when a cited evidence witness artifact no longer matches the
+source/span/text fingerprint cited by the receipt.
 The L-Energy scenario records and replays the same dependency fingerprint shape,
 including the retrieval-backed reference world, formula declaration world, domain
 pack declaration world, and near-miss candidates.
+The canonical raw-input working loop records and replays evidence witness
+fingerprints for the raw text spans that grounded checked claims.
 ```
 
 That completes the original in-memory substrate slice and attaches it to the
@@ -523,7 +532,7 @@ production catalog snapshot store exists.
 Recommended next code slice:
 
 ```text
-feat: add source evidence span integrity fingerprints
+feat: export receipt dependency graph
 ```
 
 Candidate files:
@@ -531,19 +540,18 @@ Candidate files:
 ```text
 comp/persistence/*.py
 tests/domain_scenarios/*.py
-tests/test_*source*.py
+tests/domain_scenarios/views.py
 tests/test_persistence_projection_replay.py
 ```
 
 Minimum behavior:
 
 ```text
-EvidenceWitness or source span artifacts expose stable source text/container
-digests.
-CommitReceipt can cite source evidence fingerprints alongside checked claim
-witness ids.
-Replay verifies cited source span envelopes when they are present.
-Scenario replay reports show which raw source spans grounded the checked claims.
+Replay reports or scenario views expose a graph-friendly edge list:
+source evidence -> evidence witness -> checked claim -> derived claim -> receipt.
+Dependency fingerprints appear as typed nodes with digest metadata.
+Viewer payloads can answer why a public field exists without re-running the
+compiler.
 ```
 
 Non-goals for that slice:
@@ -560,21 +568,20 @@ no production catalog snapshot store
 no real DB ingestion
 ```
 
-The goal is to move from "receipt pins the profile, formula, domain, and
-reference worlds" toward "receipt also pins the raw evidence spans that grounded
-checked claims."
+The goal is to move from "receipt pins all major dependency worlds" toward
+"receipt replay can be rendered as a readable proof graph."
 
 ---
 
 ## 13. Following Slice
 
-After source evidence span integrity, the next likely slice is dependency graph
-export:
+After dependency graph export, the next likely slice is source container
+fingerprints:
 
 ```text
-receipt dependency graph export
-source -> witness -> checked claim -> derived claim -> receipt edges
-viewer-friendly replay explanation payload
+source container fingerprints
+source document/version ids
+replay verification for source container digests
 ```
 
 That slice should keep the document's rule: replay explains the old receipt,

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -7,6 +7,7 @@ from comp.compiler_tool import (
     apply_reference_selection,
     calculation_formula_declaration_fingerprint,
     domain_pack_declaration_fingerprint,
+    evidence_witness_fingerprint,
     plan_calculation_resolution,
     prepare_commit,
     profile_declaration_fingerprint,
@@ -135,6 +136,7 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         profile_id=scenario_profile.profile_id,
         dependency_fingerprints=_dependency_fingerprints(
             scenario_profile,
+            resolved_report,
             binding,
         ),
     )
@@ -166,6 +168,7 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
 
 def _dependency_fingerprints(
     scenario_profile,
+    report,
     binding: ReferenceBinding | None,
 ):
     fingerprints = [
@@ -175,6 +178,11 @@ def _dependency_fingerprints(
             for domain in scenario_profile.domain_packs
         ),
         calculation_formula_declaration_fingerprint(formula()),
+        *tuple(
+            evidence_witness_fingerprint(witness)
+            for witness in report.evidence_witnesses
+            if witness.witness_id in _checked_claim_witness_ids(report)
+        ),
     ]
     if binding is not None:
         record_fingerprint = reference_record_fingerprint(
@@ -192,6 +200,10 @@ def _dependency_fingerprints(
         )
         fingerprints.append(record_fingerprint)
     return tuple(fingerprints)
+
+
+def _checked_claim_witness_ids(report) -> set[str]:
+    return {claim.witness_id for claim in report.checked_claims}
 
 
 def _binding_for(

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from comp.judgment import ProjectionSpec
+from comp.compiler_tool import evidence_witness_fingerprint
 from comp.persistence import (
     ArtifactEnvelope,
     ArtifactRef,
@@ -131,7 +132,21 @@ def _artifact_body_for_ref(
             "origin": claim.origin,
         }
     if ref.artifact_kind == "evidence_witness":
-        return {"witness_id": ref.artifact_id, "source": "domain_scenario"}
+        witness = _evidence_witness_by_id(result, ref.artifact_id)
+        if witness is None:
+            return {"witness_id": ref.artifact_id, "source": "domain_scenario"}
+        fingerprint = evidence_witness_fingerprint(witness)
+        return {
+            "dependency_kind": fingerprint.dependency_kind,
+            "dependency_id": fingerprint.dependency_id,
+            "witness_id": witness.witness_id,
+            "field": witness.field,
+            "source": witness.source,
+            "span": witness.span,
+            "text": witness.text,
+            "fingerprint": fingerprint.fingerprint,
+            "digest_alg": fingerprint.digest_alg,
+        }
     if ref.artifact_kind == "reference_binding":
         binding = _by_id(
             result.report.reference_bindings,
@@ -203,6 +218,13 @@ def _checked_claim_by_source_id(result: DomainScenarioResult, source_id: str):
         if source_id == f"checked_claim:{claim.field}:{claim.witness_id}":
             return claim
     raise AssertionError(f"Scenario checked claim not found: {source_id}.")
+
+
+def _evidence_witness_by_id(result: DomainScenarioResult, witness_id: str):
+    for witness in result.report.evidence_witnesses:
+        if witness.witness_id == witness_id:
+            return witness
+    return None
 
 
 def _trace_by_id(result: DomainScenarioResult, trace_id: str):

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -2,7 +2,7 @@ import pytest
 
 from comp import ProjectionSpec
 from comp.compiler_tool import active_retrieval_query_policies
-from comp.persistence import ArtifactRef, ProjectionReplayBlocked
+from comp.persistence import ArtifactEnvelope, ArtifactRef, ProjectionReplayBlocked
 from tests.domain_scenarios.assertions import assert_projection_tamper_blocked
 from tests.domain_scenarios.canonical_working_loop.fixtures import (
     RAW_EVIDENCE,
@@ -44,6 +44,13 @@ def test_canonical_working_loop_extracts_and_compiles_raw_text():
         "unit",
         "reporting_year",
         "geography",
+    ]
+    assert [witness.witness_id for witness in report.evidence_witnesses] == [
+        "w-activity",
+        "w-electricity-kwh",
+        "w-unit",
+        "w-reporting-year",
+        "w-geography",
     ]
     assert report.obligations == ()
     assert report.can_project_public_row is False
@@ -161,16 +168,61 @@ def test_canonical_working_loop_replays_projection_from_stored_artifacts():
     ) == (
         ("compiler_profile", "pcf-canonical-loop-v1"),
         ("domain_pack", "domain_pack:canonical-pcf:2026.1"),
-          (
-              "calculation_formula",
-              "calculation_formula:pcf.electricity_factor_multiplication.v1",
-          ),
-          (
-              "reference_catalog_snapshot",
-              "reference_catalog_snapshot:pcf-reference-catalog:pcf-reference-catalog-v1",
-          ),
-          ("reference_record", "pcf.factor.kr_grid_2024.location_based"),
-      )
+        (
+            "calculation_formula",
+            "calculation_formula:pcf.electricity_factor_multiplication.v1",
+        ),
+        ("evidence_witness", "w-activity"),
+        ("evidence_witness", "w-electricity-kwh"),
+        ("evidence_witness", "w-unit"),
+        ("evidence_witness", "w-reporting-year"),
+        ("evidence_witness", "w-geography"),
+        (
+            "reference_catalog_snapshot",
+            "reference_catalog_snapshot:pcf-reference-catalog:pcf-reference-catalog-v1",
+        ),
+        ("reference_record", "pcf.factor.kr_grid_2024.location_based"),
+    )
+
+
+def test_canonical_working_loop_replay_blocks_when_source_span_drifts():
+    result = run_canonical_working_loop_scenario()
+    projection = ProjectionSpec(
+        "canonical-pcf-public-row",
+        ("electricity_kwh", "reporting_year", "co2e_kg"),
+    )
+    assert result.preparation.receipt is not None
+    assert result.preparation.receipt.citations is not None
+    fingerprint = next(
+        fingerprint
+        for fingerprint in result.preparation.receipt.citations.dependency_fingerprints
+        if (
+            fingerprint.dependency_kind == "evidence_witness"
+            and fingerprint.dependency_id == "w-electricity-kwh"
+        )
+    )
+    bundle = scenario_replay_bundle(
+        result,
+        override=ArtifactEnvelope.from_body(
+            artifact_id="w-electricity-kwh",
+            artifact_kind="evidence_witness",
+            schema_version="domain-scenario-v1",
+            body={
+                "dependency_kind": "evidence_witness",
+                "dependency_id": "w-electricity-kwh",
+                "witness_id": "w-electricity-kwh",
+                "field": "electricity_kwh",
+                "source": "raw-evidence:canonical-working-loop",
+                "span": "9999kWh",
+                "text": RAW_EVIDENCE,
+                "fingerprint": fingerprint.fingerprint,
+                "digest_alg": fingerprint.digest_alg,
+            },
+        ),
+    )
+
+    with pytest.raises(ProjectionReplayBlocked, match="source evidence"):
+        replay_scenario_projection(result, projection, bundle=bundle)
 
 
 def test_canonical_working_loop_replay_blocks_when_cited_artifact_is_missing():

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -88,6 +88,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
         active_retrieval_query_policies,
         calculation_formula_declaration_fingerprint,
         domain_pack_declaration_fingerprint,
+        evidence_witness_fingerprint,
         profile_declaration_fingerprint,
         reference_catalog_snapshot_fingerprint,
         reference_query_for_obligation_from_profile_policy,
@@ -120,6 +121,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert RetrievalQueryRule is not None
     assert calculation_formula_declaration_fingerprint is not None
     assert domain_pack_declaration_fingerprint is not None
+    assert evidence_witness_fingerprint is not None
     assert active_retrieval_query_policies is not None
     assert profile_declaration_fingerprint is not None
     assert reference_query_for_obligation_from_policies is not None

--- a/tests/test_source_evidence_fingerprints.py
+++ b/tests/test_source_evidence_fingerprints.py
@@ -1,0 +1,27 @@
+from comp.compiler_tool import EvidenceWitness, evidence_witness_fingerprint
+
+
+def _witness(*, span="1200kWh", text="Seoul office used 1200kWh electricity."):
+    return EvidenceWitness(
+        witness_id="w-electricity-kwh",
+        field="electricity_kwh",
+        source="raw-evidence:canonical-working-loop",
+        span=span,
+        text=text,
+    )
+
+
+def test_evidence_witness_fingerprint_pins_source_span_body():
+    fingerprint = evidence_witness_fingerprint(_witness())
+    same_fingerprint = evidence_witness_fingerprint(_witness())
+    changed_span_fingerprint = evidence_witness_fingerprint(_witness(span="9999kWh"))
+    changed_text_fingerprint = evidence_witness_fingerprint(
+        _witness(text="Seoul office used 9999kWh electricity.")
+    )
+
+    assert fingerprint.dependency_kind == "evidence_witness"
+    assert fingerprint.dependency_id == "w-electricity-kwh"
+    assert fingerprint.fingerprint.startswith("sha256:")
+    assert fingerprint == same_fingerprint
+    assert fingerprint != changed_span_fingerprint
+    assert fingerprint != changed_text_fingerprint


### PR DESCRIPTION
## Summary
- add `evidence_witness_fingerprint()` for stable source/span/text commitments
- preserve `EvidenceWitness` artifacts on `CompileReport` through compiler/profile/semantic flows
- include raw evidence witness fingerprints in the canonical working-loop receipt dependencies
- make replay recompute cited evidence witness fingerprints from stored source artifacts and block drift
- update persistence boundary docs so the next slice is dependency graph export

## Verification
- `python -m pytest tests/test_source_evidence_fingerprints.py tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py tests/test_domain_scenario_lab.py tests/test_persistence_projection_replay.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check` (only Windows CRLF warnings)