### PR TITLE
[codex] add document governance

### DIFF
--- a/docs/architecture/document-governance.md
+++ b/docs/architecture/document-governance.md
@@ -1,0 +1,131 @@
+# Document Governance
+
+Status: active-contract
+Owner: trust-kernel
+Last checked against code: 2026-05-20
+Can block PRs: yes
+
+This document defines how architecture documents gain or lose authority in the
+`comp` rebuild. Its goal is to keep docs useful as constraints without letting
+old notes outrank the current code.
+
+## Core Rule
+
+Documentation is not all equal.
+
+```text
+Some docs can block PRs.
+Some docs only map the current implementation.
+Some docs point north.
+Some docs are historical context.
+```
+
+Every architecture document that is used in review should declare its authority
+level near the top.
+
+## Authority Levels
+
+### Active Contract
+
+Defines invariants, authority boundaries, or package ownership rules.
+
+```text
+Can block PRs: yes
+```
+
+A PR may be rejected for violating an active contract unless the PR also updates
+the contract explicitly and explains why the boundary is changing.
+
+Examples:
+
+```text
+document-governance.md
+trust-kernel-extension-rings.md
+persistence-ledger-boundary.md
+```
+
+### Implementation Map
+
+Tracks the current shape of code, test harnesses, or scenario structure.
+
+```text
+Can block PRs: limited
+```
+
+An implementation map can block a PR when the PR changes the mapped area but
+does not update the map. It should not override an active contract.
+
+### North Star
+
+Describes long-term direction and preferred expansion paths.
+
+```text
+Can block PRs: limited
+```
+
+A north-star document can guide roadmap choices and review questions. It should
+not block a small implementation PR by itself unless the PR creates authority
+confusion that an active contract also forbids.
+
+### Historical / Exploratory Note
+
+Records prior reasoning, sketches, or migration history.
+
+```text
+Can block PRs: no
+```
+
+Historical and exploratory notes are useful context. They cannot block PRs by
+themselves.
+
+## Required Header
+
+Use this header shape for architecture documents that are expected to influence
+review:
+
+```text
+Status: active-contract | implementation-map | north-star | historical-note
+Owner: trust-kernel | persistence | retrieval | scenario-lab | agent-layer | docs
+Last checked against code: YYYY-MM-DD
+Can block PRs: yes | limited | no
+```
+
+`Last checked against code` means a human or agent compared the document against
+the code shape on that date. It is not a promise that the document will remain
+fresh forever.
+
+## Review Checklist
+
+Before adding or promoting a document, answer:
+
+```text
+Can this document block a PR?
+What kind of PR can it block?
+Which existing active contract does it refine?
+What stale text would mislead future work?
+Where is the implementation map that should change with code?
+```
+
+If those questions do not have clear answers, prefer a short section in an
+existing document over a new document.
+
+## Demotion Rule
+
+When a document becomes stale, do not leave it with implied authority.
+
+```text
+active-contract -> implementation-map
+implementation-map -> historical-note
+north-star -> historical-note
+```
+
+Demotion is not deletion. It preserves useful reasoning while removing review
+authority.
+
+## Practical Rule
+
+Good architecture docs do not merely enable work. They prevent unsafe work.
+
+```text
+If a document cannot name what it forbids, it is probably a note.
+```

--- a/docs/architecture/domain-scenario-pack-generation.md
+++ b/docs/architecture/domain-scenario-pack-generation.md
@@ -1,6 +1,9 @@
 # Domain Scenario Pack Generation
 
-Status: active guidance for Domain Scenario Lab growth.
+Status: implementation-map
+Owner: scenario-lab
+Last checked against code: 2026-05-20
+Can block PRs: limited
 
 This document defines how to add larger domain scenarios without turning them
 into hard-coded golden blobs. A scenario is not a one-off test file. It is a

--- a/docs/architecture/obligation-kernel-working-theory.md
+++ b/docs/architecture/obligation-kernel-working-theory.md
@@ -1,6 +1,9 @@
 # Obligation Kernel Working Theory
 
-Status: working theory, not final architecture.
+Status: implementation-map
+Owner: trust-kernel
+Last checked against code: 2026-05-20
+Can block PRs: limited
 
 This document captures the current direction for the rebuild branch after the
 receipt-gated projection slice. It is intentionally not an ADR. The goal is to

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -1,5 +1,10 @@
 # Persistence / Ledger Boundary
 
+Status: active-contract
+Owner: persistence
+Last checked against code: 2026-05-20
+Can block PRs: yes
+
 CommitReceipt as the durable explanation root.
 
 This document fixes the persistence boundary for the active `comp` rebuild. It

--- a/docs/architecture/retrieval-fabric-north-star.md
+++ b/docs/architecture/retrieval-fabric-north-star.md
@@ -1,5 +1,10 @@
 # Retrieval Fabric North Star
 
+Status: north-star
+Owner: retrieval
+Last checked against code: 2026-05-20
+Can block PRs: limited
+
 This document fixes the long-term direction for retrieval, LLM resolution,
 typed reference authority, compiler gates, and receipt-gated projection.
 

--- a/docs/architecture/trust-kernel-extension-rings.md
+++ b/docs/architecture/trust-kernel-extension-rings.md
@@ -1,6 +1,9 @@
 # Trust Kernel Extension Rings
 
-Status: active architecture frame.
+Status: active-contract
+Owner: trust-kernel
+Last checked against code: 2026-05-20
+Can block PRs: yes
 
 This document names the outer shape of the `comp` rebuild. The core is a small
 trust kernel. Domain logic, retrieval, LLM workers, parsers, persistence

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,15 +22,20 @@ The compiler does not create public truth directly. Public projection requires a
 
 Read these first:
 
-1. `architecture/trust-kernel-extension-rings.md`
-2. `architecture/extension-port-contracts.md`
-3. `architecture/retrieval-fabric-north-star.md`
-4. `architecture/obligation-kernel-working-theory.md`
-5. `architecture/trust-kernel-hardening.md`
-6. `architecture/domain-scenario-pack-generation.md`
-7. `architecture/llm-orchestrated-compiler-tool-loop.md`
-8. `architecture/llm-worker-orchestration.md`
-9. `architecture/memory-assisted-compiler-loop.md`
+1. `architecture/document-governance.md`
+2. `architecture/trust-kernel-extension-rings.md`
+3. `architecture/extension-port-contracts.md`
+4. `architecture/retrieval-fabric-north-star.md`
+5. `architecture/obligation-kernel-working-theory.md`
+6. `architecture/trust-kernel-hardening.md`
+7. `architecture/domain-scenario-pack-generation.md`
+8. `architecture/llm-orchestrated-compiler-tool-loop.md`
+9. `architecture/llm-worker-orchestration.md`
+10. `architecture/memory-assisted-compiler-loop.md`
+
+`architecture/document-governance.md` defines doc authority levels: active
+contracts, implementation maps, north stars, and historical notes. Read it first
+when deciding whether a document can block a PR.
 
 `architecture/trust-kernel-extension-rings.md` is the active architecture frame
 for keeping `comp` small: outer rings submit artifacts or render views, while

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -168,6 +168,49 @@ def test_domain_scenario_generation_guide_tracks_swappable_pack_contract():
     assert "minntcho/esg-platform" in guide
 
 
+def test_document_governance_classifies_architecture_doc_authority():
+    governance = Path(
+        "docs/architecture/document-governance.md"
+    ).read_text(encoding="utf-8")
+    docs_index = Path("docs/index.md").read_text(encoding="utf-8")
+
+    assert "Status: active-contract" in governance
+    assert "Can block PRs: yes" in governance
+    assert "Active Contract" in governance
+    assert "Implementation Map" in governance
+    assert "North Star" in governance
+    assert "Historical / Exploratory Note" in governance
+    assert "Can this document block a PR?" in governance
+    assert "document-governance.md" in docs_index
+
+    required_headers = {
+        "docs/architecture/trust-kernel-extension-rings.md": (
+            "Status: active-contract",
+            "Can block PRs: yes",
+        ),
+        "docs/architecture/persistence-ledger-boundary.md": (
+            "Status: active-contract",
+            "Can block PRs: yes",
+        ),
+        "docs/architecture/retrieval-fabric-north-star.md": (
+            "Status: north-star",
+            "Can block PRs: limited",
+        ),
+        "docs/architecture/obligation-kernel-working-theory.md": (
+            "Status: implementation-map",
+            "Can block PRs: limited",
+        ),
+        "docs/architecture/domain-scenario-pack-generation.md": (
+            "Status: implementation-map",
+            "Can block PRs: limited",
+        ),
+    }
+    for path, expected_lines in required_headers.items():
+        text = Path(path).read_text(encoding="utf-8")
+        for line in expected_lines:
+            assert line in text
+
+
 def test_pyproject_packages_comp_core_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
     from comp.persistence import (


### PR DESCRIPTION
## Summary
- Add `docs/architecture/document-governance.md` to classify architecture docs by review authority.
- Mark core architecture docs as active contracts, implementation maps, or north-star docs.
- Link the governance doc from `docs/index.md` and add a smoke test that keeps the authority headers from drifting.

## Validation
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`