### PR TITLE
[codex] classify architecture docs

### DIFF
--- a/docs/architecture/active-surface-cutover.md
+++ b/docs/architecture/active-surface-cutover.md
@@ -1,5 +1,10 @@
 # Active Surface Cutover Plan
 
+Status: historical-note
+Owner: docs
+Last checked against code: 2026-05-20
+Can block PRs: no
+
 이 문서는 rebuild branch에서 **active package surface**를 legacy pipeline에서 judgment/compiler-tool loop 중심으로 전환하는 첫 번째 cutover 기준을 정의한다.
 
 이 문서의 목적은 legacy 파일을 즉시 삭제하는 것이 아니다. 목적은 다음을 명확히 하는 것이다.

--- a/docs/architecture/extension-port-contracts.md
+++ b/docs/architecture/extension-port-contracts.md
@@ -1,6 +1,9 @@
 # Extension Port Contracts
 
-Status: active architecture contract.
+Status: active-contract
+Owner: trust-kernel
+Last checked against code: 2026-05-20
+Can block PRs: yes
 
 This document defines how outer-ring extensions attach to the `comp` trust
 kernel without gaining authority. It is a companion to

--- a/docs/architecture/legacy-archive-cutover-plan.md
+++ b/docs/architecture/legacy-archive-cutover-plan.md
@@ -1,5 +1,10 @@
 # Legacy Archive Cutover Plan
 
+Status: historical-note
+Owner: docs
+Last checked against code: 2026-05-20
+Can block PRs: no
+
 This document defines the PR sequence for moving `comp` from the legacy
 pass-pipeline surface toward the authority-first compiler-tool architecture.
 

--- a/docs/architecture/llm-orchestrated-compiler-tool-loop.md
+++ b/docs/architecture/llm-orchestrated-compiler-tool-loop.md
@@ -1,5 +1,10 @@
 # LLM-Orchestrated Compiler Tool Loop
 
+Status: historical-note
+Owner: agent-layer
+Last checked against code: 2026-05-20
+Can block PRs: no
+
 이 문서는 `comp`의 장기 방향 중 하나인 **LLM 주도 해석 루프와 compiler tool 검증 구조**를 계획 수준에서 고정한다.
 
 핵심 아이디어는 컴파일러가 전체 루프를 직접 주도하는 것이 아니라, **LLM agent가 컴파일러를 하나의 tool로 반복 호출하면서 해석을 안정화한다**는 점이다.

--- a/docs/architecture/llm-worker-orchestration.md
+++ b/docs/architecture/llm-worker-orchestration.md
@@ -1,6 +1,9 @@
 # LLM Worker Orchestration
 
-Status: provisional design note, not final architecture.
+Status: north-star
+Owner: agent-layer
+Last checked against code: 2026-05-20
+Can block PRs: limited
 
 This document captures the current working hypothesis for LLM orchestration in
 the `comp` rebuild. It builds on the existing authority boundary:

--- a/docs/architecture/memory-assisted-compiler-loop.md
+++ b/docs/architecture/memory-assisted-compiler-loop.md
@@ -1,5 +1,10 @@
 # Memory-Assisted Compiler Loop
 
+Status: active-contract
+Owner: agent-layer
+Last checked against code: 2026-05-20
+Can block PRs: yes
+
 This document fixes the integration boundary between `comp` and a
 Hermes-style memory/skill agent layer such as `minchoagnt`.
 

--- a/docs/architecture/trust-kernel-hardening.md
+++ b/docs/architecture/trust-kernel-hardening.md
@@ -1,6 +1,9 @@
 # Trust Kernel Hardening Standard
 
-Status: active standard for trust-kernel hardening PRs.
+Status: active-contract
+Owner: trust-kernel
+Last checked against code: 2026-05-20
+Can block PRs: yes
 
 This document fixes the implementation standard for the next slice of the
 `comp` rebuild. The goal is to keep `comp` as a small trust kernel rather than

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,52 +20,46 @@ The compiler does not create public truth directly. Public projection requires a
 
 ## Active Map
 
-Read these first:
+Read `architecture/document-governance.md` first when deciding whether a
+document can block a PR. The rest of the architecture docs are grouped by that
+authority model.
+
+### Active Contracts
+
+These documents can block PRs when a change violates their authority boundary
+without explicitly updating the contract.
 
 1. `architecture/document-governance.md`
 2. `architecture/trust-kernel-extension-rings.md`
 3. `architecture/extension-port-contracts.md`
-4. `architecture/retrieval-fabric-north-star.md`
-5. `architecture/obligation-kernel-working-theory.md`
-6. `architecture/trust-kernel-hardening.md`
-7. `architecture/domain-scenario-pack-generation.md`
-8. `architecture/llm-orchestrated-compiler-tool-loop.md`
-9. `architecture/llm-worker-orchestration.md`
-10. `architecture/memory-assisted-compiler-loop.md`
+4. `architecture/persistence-ledger-boundary.md`
+5. `architecture/trust-kernel-hardening.md`
+6. `architecture/memory-assisted-compiler-loop.md`
 
-`architecture/document-governance.md` defines doc authority levels: active
-contracts, implementation maps, north stars, and historical notes. Read it first
-when deciding whether a document can block a PR.
+### Implementation Maps
 
-`architecture/trust-kernel-extension-rings.md` is the active architecture frame
-for keeping `comp` small: outer rings submit artifacts or render views, while
-only deterministic gates inside the trust kernel promote authority.
+These documents track the current implementation shape. They can block a PR
+when the PR changes the mapped area but leaves the map stale.
 
-`architecture/extension-port-contracts.md` defines how extractors, resolvers,
-retrieval backends, profile providers, persistence stores, replay engines, and
-product shells attach without gaining authority.
+1. `architecture/obligation-kernel-working-theory.md`
+2. `architecture/domain-scenario-pack-generation.md`
 
-`architecture/retrieval-fabric-north-star.md` is the long-term direction for
-retrieval, embedding, LLM artifact resolution, typed reference authority, and
-compiler/receipt gates.
+### North Stars
 
-`architecture/obligation-kernel-working-theory.md` is the detailed working map
-for current implementation slices: semantic obligations, reference-grounded
-calculation, commit packages, governance decisions, and receipt-gated
-projection.
+These documents guide roadmap direction and review questions. They do not
+override active contracts.
 
-`architecture/trust-kernel-hardening.md` is the implementation standard for
-trust-kernel hardening: keep domain behavior explicit, fingerprint
-profile-active behavior, preserve retrieval/reference provenance, and keep the
-canonical scenario persistence-replayable.
+1. `architecture/retrieval-fabric-north-star.md`
+2. `architecture/llm-worker-orchestration.md`
 
-`architecture/domain-scenario-pack-generation.md` describes how to add
-replaceable Domain Scenario Lab packs without turning them into hard-coded
-golden fixtures.
+### Historical Notes
 
-`architecture/llm-worker-orchestration.md` records a provisional background LLM
-worker hypothesis: work orders, allowed tool menus, typed artifact submission,
-abstention, and scoreless embedding-informed routing.
+These documents preserve migration context and older reasoning. They cannot
+block PRs by themselves.
+
+1. `architecture/active-surface-cutover.md`
+2. `architecture/legacy-archive-cutover-plan.md`
+3. `architecture/llm-orchestrated-compiler-tool-loop.md`
 
 ## Compiler Tool Layers
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -211,6 +211,76 @@ def test_document_governance_classifies_architecture_doc_authority():
             assert line in text
 
 
+def test_architecture_docs_are_classified_by_governance_status():
+    expected_status = {
+        "active-surface-cutover.md": ("historical-note", "docs", "no"),
+        "document-governance.md": ("active-contract", "trust-kernel", "yes"),
+        "domain-scenario-pack-generation.md": (
+            "implementation-map",
+            "scenario-lab",
+            "limited",
+        ),
+        "extension-port-contracts.md": ("active-contract", "trust-kernel", "yes"),
+        "legacy-archive-cutover-plan.md": ("historical-note", "docs", "no"),
+        "llm-orchestrated-compiler-tool-loop.md": (
+            "historical-note",
+            "agent-layer",
+            "no",
+        ),
+        "llm-worker-orchestration.md": ("north-star", "agent-layer", "limited"),
+        "memory-assisted-compiler-loop.md": (
+            "active-contract",
+            "agent-layer",
+            "yes",
+        ),
+        "obligation-kernel-working-theory.md": (
+            "implementation-map",
+            "trust-kernel",
+            "limited",
+        ),
+        "persistence-ledger-boundary.md": ("active-contract", "persistence", "yes"),
+        "retrieval-fabric-north-star.md": ("north-star", "retrieval", "limited"),
+        "trust-kernel-extension-rings.md": ("active-contract", "trust-kernel", "yes"),
+        "trust-kernel-hardening.md": ("active-contract", "trust-kernel", "yes"),
+    }
+
+    architecture_docs = sorted(Path("docs/architecture").glob("*.md"))
+    assert {path.name for path in architecture_docs} == set(expected_status)
+
+    for path in architecture_docs:
+        status, owner, blocking = expected_status[path.name]
+        text = path.read_text(encoding="utf-8")
+        assert f"Status: {status}" in text
+        assert f"Owner: {owner}" in text
+        assert "Last checked against code: 2026-05-20" in text
+        assert f"Can block PRs: {blocking}" in text
+
+
+def test_docs_index_groups_architecture_docs_by_governance_authority():
+    docs_index = Path("docs/index.md").read_text(encoding="utf-8")
+
+    for heading in (
+        "### Active Contracts",
+        "### Implementation Maps",
+        "### North Stars",
+        "### Historical Notes",
+    ):
+        assert heading in docs_index
+
+    assert docs_index.index("### Active Contracts") < docs_index.index(
+        "### Implementation Maps"
+    )
+    assert docs_index.index("### Implementation Maps") < docs_index.index(
+        "### North Stars"
+    )
+    assert docs_index.index("### North Stars") < docs_index.index(
+        "### Historical Notes"
+    )
+    assert "architecture/active-surface-cutover.md" in docs_index
+    assert "architecture/legacy-archive-cutover-plan.md" in docs_index
+    assert "architecture/llm-orchestrated-compiler-tool-loop.md" in docs_index
+
+
 def test_pyproject_packages_comp_core_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
     from comp.persistence import (


### PR DESCRIPTION
## Summary
- Classify every `docs/architecture/*.md` document with the document governance header.
- Rework `docs/index.md` into Active Contracts, Implementation Maps, North Stars, and Historical Notes.
- Add smoke coverage so future architecture docs must be explicitly classified and indexed by governance authority.

## Notes
- No architecture documents were deleted in this PR.
- Older cutover / LLM loop notes are demoted to `historical-note` rather than removed.

## Validation
- `python -m pytest tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`