### PR TITLE
[codex] add Alpha Metal invalid allocation scenario

### DIFF
--- a/tests/domain_scenarios/l_energy_pcf_governance/alpha_invalid_allocation_rfi.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/alpha_invalid_allocation_rfi.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from comp import SubjectRef
+from comp.compiler_tool import (
+    CheckedClaim,
+    CompileReport,
+    EvidenceWitness,
+    FailedClaim,
+    Hazard,
+    ProofObligation,
+    prepare_commit,
+    with_recomputed_status,
+)
+from tests.domain_scenarios.core import (
+    ScenarioContract,
+    ScenarioDefinition,
+    SourceRef,
+    build_domain_scenario_result,
+)
+
+
+SCENARIO_ID = "l_energy.alpha_invalid_allocation_rfi.v1"
+PROJECTION_ID = "l-energy-alpha-invalid-allocation-rfi"
+PROJECTION_FIELDS = ("raw_material_name",)
+SOURCE_CASE_ID = "001-l-energy-pcf-governance"
+SOURCE_COMMIT = "618c44dfcea1ee1e235550776acb78d8f20a7e0c"
+SUBJECT_ID = "case:001-l-energy-pcf-governance:alpha-metal-invalid-allocation"
+PUBLIC_ROW_ID = "public-row:alpha-metal-invalid-allocation-rfi"
+RAW_MATERIAL_NAME = "알미늄 판넬"
+NORMALIZATION_SUGGESTION = "Aluminum Sheet"
+ALLOCATION_METHOD = "revenue_share"
+ALLOCATION_SHARE = 0.30
+ROLLING_RESIDENCE_OBLIGATION_ID = (
+    "alpha-metal:rolling_residence_time:physical_allocation_parameter_required"
+)
+METHODOLOGICAL_HAZARD_ID = (
+    "hazard:methodological_allocation_error:allocation_method:block"
+)
+
+RESOLVER_STEPS = (
+    "load_platform_alpha_invalid_allocation_fixture",
+    "material_normalization_suggestion:proposal_only",
+    "deterministic_allocation_method_rule",
+    "prepare_commit",
+    "projection_blocked",
+)
+
+SOURCE_REFS = (
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/cases/001-l-energy-pcf-governance.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/dummy-data-mapping-l-energy-pcf.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+    ),
+)
+
+
+def run_alpha_invalid_allocation_rfi_scenario():
+    report = alpha_invalid_allocation_report()
+    preparation = prepare_commit(
+        report,
+        subject_id=SUBJECT_ID,
+        public_row_id=PUBLIC_ROW_ID,
+        projection_id=PROJECTION_ID,
+    )
+    return build_domain_scenario_result(
+        scenario_id=SCENARIO_ID,
+        report=report,
+        preparation=preparation,
+        projection=None,
+        subject=SubjectRef("claim", SUBJECT_ID),
+        resolver_steps=RESOLVER_STEPS,
+    )
+
+
+def alpha_invalid_allocation_report() -> CompileReport:
+    return with_recomputed_status(
+        CompileReport(
+            status="accepted",
+            evidence_witnesses=(
+                EvidenceWitness(
+                    witness_id="source:alpha-metal-initial-submission",
+                    field="raw_material_name",
+                    source="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+                    span="data_setup.alpha_metal.raw_submission.raw_material_name",
+                    text=RAW_MATERIAL_NAME,
+                ),
+            ),
+            checked_claims=(
+                CheckedClaim(
+                    field="raw_material_name",
+                    value=RAW_MATERIAL_NAME,
+                    witness_id="source:alpha-metal-initial-submission",
+                    origin="supplier_submission",
+                ),
+            ),
+            failed_claims=(
+                FailedClaim(
+                    field="allocation_method",
+                    value=ALLOCATION_METHOD,
+                    reason="economic_allocation_not_allowed",
+                    origin="supplier_submission",
+                    witness_id="source:alpha-metal-initial-submission",
+                ),
+            ),
+            obligations=(
+                ProofObligation(
+                    kind="find_context",
+                    field="rolling_residence_time",
+                    reason="physical_allocation_parameter_required",
+                    obligation_id=ROLLING_RESIDENCE_OBLIGATION_ID,
+                ),
+            ),
+            hazards=(
+                Hazard(
+                    kind="methodological_allocation_error",
+                    field="allocation_method",
+                    severity="block",
+                ),
+            ),
+            can_project_public_row=False,
+        )
+    )
+
+
+ALPHA_INVALID_ALLOCATION_SCENARIO = ScenarioDefinition(
+    scenario_id=SCENARIO_ID,
+    title="Alpha Metal invalid allocation RFI",
+    run=run_alpha_invalid_allocation_rfi_scenario,
+    source_refs=SOURCE_REFS,
+    contract=ScenarioContract(
+        required_open_obligation_ids=(ROLLING_RESIDENCE_OBLIGATION_ID,),
+        required_hazard_ids=(METHODOLOGICAL_HAZARD_ID,),
+    ),
+)
+
+
+__all__ = [
+    "ALLOCATION_METHOD",
+    "ALLOCATION_SHARE",
+    "ALPHA_INVALID_ALLOCATION_SCENARIO",
+    "METHODOLOGICAL_HAZARD_ID",
+    "NORMALIZATION_SUGGESTION",
+    "PROJECTION_FIELDS",
+    "PROJECTION_ID",
+    "RAW_MATERIAL_NAME",
+    "RESOLVER_STEPS",
+    "ROLLING_RESIDENCE_OBLIGATION_ID",
+    "SCENARIO_ID",
+    "SOURCE_CASE_ID",
+    "alpha_invalid_allocation_report",
+    "run_alpha_invalid_allocation_rfi_scenario",
+]

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -7,6 +7,9 @@ from tests.domain_scenarios.canonical_working_loop.scenario import (
 from tests.domain_scenarios.l_energy_pcf_governance.scenario import (
     SCENARIO as L_ENERGY_PCF_GOVERNANCE_SCENARIO,
 )
+from tests.domain_scenarios.l_energy_pcf_governance.alpha_invalid_allocation_rfi import (
+    ALPHA_INVALID_ALLOCATION_SCENARIO,
+)
 from tests.domain_scenarios.tiny_pcf.scenario import SCENARIO as TINY_PCF_SCENARIO
 
 
@@ -14,6 +17,7 @@ def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
     return (
         CANONICAL_WORKING_LOOP_SCENARIO,
         TINY_PCF_SCENARIO,
+        ALPHA_INVALID_ALLOCATION_SCENARIO,
         L_ENERGY_PCF_GOVERNANCE_SCENARIO,
     )
 

--- a/tests/test_alpha_invalid_allocation_rfi_scenario.py
+++ b/tests/test_alpha_invalid_allocation_rfi_scenario.py
@@ -1,0 +1,86 @@
+import pytest
+
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
+from tests.domain_scenarios.l_energy_pcf_governance.alpha_invalid_allocation_rfi import (
+    ALPHA_INVALID_ALLOCATION_SCENARIO,
+    NORMALIZATION_SUGGESTION,
+    PROJECTION_FIELDS,
+    PROJECTION_ID,
+    RAW_MATERIAL_NAME,
+    run_alpha_invalid_allocation_rfi_scenario,
+)
+from tests.domain_scenarios.registry import registered_scenarios
+
+
+def test_alpha_revenue_share_opens_methodological_failed_claim():
+    result = run_alpha_invalid_allocation_rfi_scenario()
+
+    assert result.report.status == "blocked"
+    assert tuple(
+        (claim.field, claim.value, claim.reason)
+        for claim in result.report.failed_claims
+    ) == (("allocation_method", "revenue_share", "economic_allocation_not_allowed"),)
+    assert result.preparation.package.complete is False
+    assert result.preparation.decision.status == "hold"
+
+
+def test_alpha_revenue_share_requires_rolling_residence_time_context():
+    result = run_alpha_invalid_allocation_rfi_scenario()
+
+    assert tuple(
+        (obligation.kind, obligation.field, obligation.reason)
+        for obligation in result.report.obligations
+    ) == (
+        (
+            "find_context",
+            "rolling_residence_time",
+            "physical_allocation_parameter_required",
+        ),
+    )
+    assert result.preparation.package.open_obligation_ids == (
+        "alpha-metal:rolling_residence_time:physical_allocation_parameter_required",
+    )
+
+
+def test_alpha_normalization_suggestion_is_not_authoritative():
+    result = run_alpha_invalid_allocation_rfi_scenario()
+
+    assert RAW_MATERIAL_NAME == "알미늄 판넬"
+    assert NORMALIZATION_SUGGESTION == "Aluminum Sheet"
+    assert tuple(
+        (claim.field, claim.value)
+        for claim in result.report.checked_claims
+    ) == (("raw_material_name", RAW_MATERIAL_NAME),)
+    assert "normalized_material_name" not in tuple(
+        claim.field for claim in result.report.checked_claims
+    )
+    assert "Aluminum Sheet" not in tuple(
+        claim.value for claim in result.report.checked_claims
+    )
+
+
+def test_alpha_invalid_allocation_cannot_create_receipt_or_projection():
+    result = run_alpha_invalid_allocation_rfi_scenario()
+
+    assert result.report.reference_bindings == ()
+    assert result.report.derived_claims == ()
+    assert result.preparation.receipt is None
+    assert result.projection is None
+    with pytest.raises(ProjectionBlocked, match="CommitReceipt"):
+        project_public_row(
+            {"raw_material_name": RAW_MATERIAL_NAME},
+            ProjectionSpec(PROJECTION_ID, PROJECTION_FIELDS),
+        )
+
+
+def test_alpha_invalid_allocation_scenario_is_registered_with_contract():
+    scenarios = registered_scenarios()
+
+    assert "l_energy.alpha_invalid_allocation_rfi.v1" in tuple(
+        scenario.scenario_id for scenario in scenarios
+    )
+    assert_scenario_contract(
+        run_scenario(ALPHA_INVALID_ALLOCATION_SCENARIO),
+        ALPHA_INVALID_ALLOCATION_SCENARIO.contract,
+    )

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -40,6 +40,7 @@ def test_domain_scenario_cli_lists_registered_scenarios(capsys):
     assert exit_code == 0
     assert "canonical_working_loop.raw_text_pcf.v1" in captured.out
     assert "tiny_pcf.location_based_electricity.v1" in captured.out
+    assert "l_energy.alpha_invalid_allocation_rfi.v1" in captured.out
     assert "l_energy_pcf_governance.v1" in captured.out
     assert "Canonical raw text PCF working loop" in captured.out
 
@@ -98,9 +99,10 @@ def test_domain_scenario_cli_runs_all_registered_scenarios(capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Domain Scenario Run" in captured.out
-    assert "Passed: 3/3" in captured.out
+    assert "Passed: 4/4" in captured.out
     assert "- canonical_working_loop.raw_text_pcf.v1: pass" in captured.out
     assert "- tiny_pcf.location_based_electricity.v1: pass" in captured.out
+    assert "- l_energy.alpha_invalid_allocation_rfi.v1: pass" in captured.out
     assert "- l_energy_pcf_governance.v1: pass" in captured.out
     assert captured.err == ""
 
@@ -113,8 +115,9 @@ def test_domain_scenario_cli_runs_all_as_json(capsys):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert exit_code == 0
-    assert payload["summary"] == {"total": 3, "passed": 3, "failed": 0}
+    assert payload["summary"] == {"total": 4, "passed": 4, "failed": 0}
     assert tuple(item["status"] for item in payload["scenarios"]) == (
+        "pass",
         "pass",
         "pass",
         "pass",
@@ -122,6 +125,7 @@ def test_domain_scenario_cli_runs_all_as_json(capsys):
     assert tuple(item["scenario_id"] for item in payload["scenarios"]) == (
         "canonical_working_loop.raw_text_pcf.v1",
         "tiny_pcf.location_based_electricity.v1",
+        "l_energy.alpha_invalid_allocation_rfi.v1",
         "l_energy_pcf_governance.v1",
     )
     assert "result" in payload["scenarios"][0]
@@ -162,6 +166,7 @@ def test_registered_scenarios_are_explicit_scenario_definitions():
     assert tuple(scenario.scenario_id for scenario in scenarios) == (
         "canonical_working_loop.raw_text_pcf.v1",
         "tiny_pcf.location_based_electricity.v1",
+        "l_energy.alpha_invalid_allocation_rfi.v1",
         "l_energy_pcf_governance.v1",
     )
     assert all(isinstance(scenario, ScenarioDefinition) for scenario in scenarios)


### PR DESCRIPTION
## What changed

- Added `l_energy.alpha_invalid_allocation_rfi.v1` as a focused L-Energy PCF governance domain scenario.
- Registered the scenario in the domain scenario registry and updated CLI/run-all expectations.
- Added contract tests proving invalid `revenue_share` allocation stays outside commit receipts and public projections.

## Why

This keeps PR1 small: `comp` only asserts that a forbidden economic allocation method creates a methodological hazard plus missing `rolling_residence_time` context obligation. It does not model product RFI workflow, semantic judgment, normalization authority, or hazard lifecycle yet.

## Validation

- `python -m pytest -q` -> `291 passed in 5.16s`