### PR TITLE
[codex] add Steel Frame proxy assignment scenario

### DIFF
--- a/tests/domain_scenarios/l_energy_pcf_governance/steel_frame_proxy_assignment.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/steel_frame_proxy_assignment.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from comp import ProjectionSpec, SubjectRef, project_public_row
+from comp.compiler_tool import (
+    CalculationStep,
+    CalculationTrace,
+    CheckedClaim,
+    CompileReport,
+    DerivedClaim,
+    EvidenceWitness,
+    ProofObligation,
+    ReferenceBinding,
+    prepare_commit,
+    with_recomputed_status,
+)
+from tests.domain_scenarios.core import (
+    ScenarioContract,
+    ScenarioDefinition,
+    SourceRef,
+    build_domain_scenario_result,
+)
+
+
+SCENARIO_ID = "l_energy.steel_frame_proxy_assignment.v1"
+PROJECTION_ID = "l-energy-steel-frame-proxy-assignment"
+PROJECTION_FIELDS = (
+    "actor_id",
+    "supplier_submission_status",
+    "proxy_quality",
+    "missing_mass_ton",
+    "steel_frame_final_emission_tco2e",
+)
+EXPECTED_PROJECTION = {
+    "actor_id": "steel_frame",
+    "supplier_submission_status": "absent",
+    "proxy_quality": "Low",
+    "missing_mass_ton": 1900,
+    "steel_frame_final_emission_tco2e": 4750,
+}
+
+SOURCE_CASE_ID = "001-l-energy-pcf-governance"
+SOURCE_COMMIT = "618c44dfcea1ee1e235550776acb78d8f20a7e0c"
+SUBJECT_ID = "case:001-l-energy-pcf-governance:steel-frame-proxy-assignment"
+PUBLIC_ROW_ID = "public-row:steel-frame-proxy-assignment"
+
+FORMULA_ID = "pcf.steel_frame_proxy_assignment.v1"
+PROXY_BINDING_ID = "bind:steel-frame:proxy_factor"
+MISSING_MASS_CLAIM_ID = "steel-frame:missing_mass_ton"
+FINAL_EMISSION_CLAIM_ID = "steel-frame:final_emission_tco2e"
+SUPPLIER_ABSENCE_OBLIGATION_ID = (
+    "steel-frame:supplier_submission:supplier_submission_absent"
+)
+PROXY_FACTOR_OBLIGATION_ID = (
+    "steel-frame:proxy_factor:missing_supplier_evidence_requires_proxy"
+)
+
+ACTOR_ID = "steel_frame"
+SUPPLIER_SUBMISSION_STATUS = "absent"
+PROXY_QUALITY = "Low"
+REQUIRED_LOWER_TIER_INPUT_TON = 6300
+VERIFIED_ALPHA_INPUT_TON = 4400
+PROXY_FACTOR_TCO2E_PER_TON = Decimal("2.5")
+
+RESOLVER_STEPS = (
+    "load_platform_steel_frame_absence_fixture",
+    "derive_missing_lower_tier_mass",
+    "resolve_supplier_absence_to_proxy_path",
+    "bind_proxy_factor",
+    "calculate_proxy_emission",
+    "prepare_commit",
+    "receipt_gated_projection",
+)
+
+SOURCE_REFS = (
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/cases/001-l-energy-pcf-governance.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/dummy-data-mapping-l-energy-pcf.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="tests/e2e/expected/001-l-energy-pcf-governance.receipt.json",
+    ),
+)
+
+
+def run_steel_frame_proxy_assignment_scenario():
+    report = steel_frame_proxy_assignment_report()
+    preparation = prepare_commit(
+        report,
+        subject_id=SUBJECT_ID,
+        public_row_id=PUBLIC_ROW_ID,
+        projection_id=PROJECTION_ID,
+    )
+    projection = None
+    if preparation.receipt is not None:
+        projection = project_public_row(
+            _projection_source(report),
+            ProjectionSpec(PROJECTION_ID, PROJECTION_FIELDS),
+            receipt=preparation.receipt,
+        )
+    return build_domain_scenario_result(
+        scenario_id=SCENARIO_ID,
+        report=report,
+        preparation=preparation,
+        projection=projection,
+        subject=SubjectRef("claim", SUBJECT_ID),
+        resolver_steps=RESOLVER_STEPS,
+    )
+
+
+def steel_frame_proxy_assignment_report() -> CompileReport:
+    return with_recomputed_status(
+        CompileReport(
+            status="accepted",
+            evidence_witnesses=_evidence_witnesses(),
+            checked_claims=_checked_claims(),
+            resolved_obligations=_resolved_obligations(),
+            reference_bindings=_reference_bindings(),
+            derived_claims=_derived_claims(),
+            can_project_public_row=True,
+        )
+    )
+
+
+def _evidence_witnesses() -> tuple[EvidenceWitness, ...]:
+    return (
+        EvidenceWitness(
+            witness_id="source:c-pack-lower-tier-requirement",
+            field="required_lower_tier_input_ton",
+            source="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+            span="data_setup.c_pack.required_lower_tier_input_ton",
+            text="required lower-tier input 6,300 ton",
+        ),
+        EvidenceWitness(
+            witness_id="source:alpha-metal-verified-input",
+            field="verified_alpha_input_ton",
+            source="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+            span="data_setup.alpha_metal.corrected_submission.target_panel_ton",
+            text="Alpha Metal verified input 4,400 ton",
+        ),
+        EvidenceWitness(
+            witness_id="source:steel-frame-submission-absence",
+            field="supplier_submission_status",
+            source="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+            span="data_setup.steel_frame.submission_status",
+            text="Steel Frame supplier submission absent",
+        ),
+    )
+
+
+def _checked_claims() -> tuple[CheckedClaim, ...]:
+    return (
+        CheckedClaim(
+            "actor_id",
+            ACTOR_ID,
+            "source:steel-frame-submission-absence",
+            "platform_fixture",
+        ),
+        CheckedClaim(
+            "supplier_submission_status",
+            SUPPLIER_SUBMISSION_STATUS,
+            "source:steel-frame-submission-absence",
+            "platform_fixture",
+        ),
+        CheckedClaim(
+            "required_lower_tier_input_ton",
+            REQUIRED_LOWER_TIER_INPUT_TON,
+            "source:c-pack-lower-tier-requirement",
+            "platform_fixture",
+        ),
+        CheckedClaim(
+            "verified_alpha_input_ton",
+            VERIFIED_ALPHA_INPUT_TON,
+            "source:alpha-metal-verified-input",
+            "platform_fixture",
+        ),
+        CheckedClaim(
+            "proxy_quality",
+            PROXY_QUALITY,
+            "source:steel-frame-submission-absence",
+            "proxy_assignment",
+        ),
+    )
+
+
+def _resolved_obligations() -> tuple[ProofObligation, ...]:
+    return (
+        ProofObligation(
+            kind="find_source_witness",
+            field="steel_frame_supplier_submission",
+            reason="supplier_submission_absent",
+            obligation_id=SUPPLIER_ABSENCE_OBLIGATION_ID,
+        ),
+        ProofObligation(
+            kind="proxy_factor_required",
+            field="steel_frame_proxy_factor",
+            reason="missing_supplier_evidence_requires_proxy",
+            obligation_id=PROXY_FACTOR_OBLIGATION_ID,
+        ),
+    )
+
+
+def _reference_bindings() -> tuple[ReferenceBinding, ...]:
+    return (
+        ReferenceBinding(
+            binding_id=PROXY_BINDING_ID,
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.steel_proxy_per_ton",
+            reference_type="proxy_factor",
+            selector_rule_id="platform.expected_receipt.fixture",
+            source_witness_ids=("source:dummy-data-mapping",),
+        ),
+    )
+
+
+def _derived_claims() -> tuple[DerivedClaim, ...]:
+    missing_mass = REQUIRED_LOWER_TIER_INPUT_TON - VERIFIED_ALPHA_INPUT_TON
+    proxy_emission = int(Decimal(missing_mass) * PROXY_FACTOR_TCO2E_PER_TON)
+    missing_mass_step = CalculationStep(
+        step_id="missing-mass-ton",
+        operation="subtract",
+        input_ids=("required_lower_tier_input_ton", "verified_alpha_input_ton"),
+        output_value=missing_mass,
+        output_unit="ton",
+    )
+    proxy_emission_step = CalculationStep(
+        step_id="proxy-emission-tco2e",
+        operation="multiply",
+        input_ids=("missing-mass-ton", PROXY_BINDING_ID),
+        output_value=proxy_emission,
+        output_unit="tCO2e",
+    )
+    return (
+        DerivedClaim(
+            claim_id=MISSING_MASS_CLAIM_ID,
+            field="missing_mass_ton",
+            value=missing_mass,
+            unit="ton",
+            origin="proxy_assignment_calculated",
+            trace=CalculationTrace(
+                trace_id=f"trace:{MISSING_MASS_CLAIM_ID}",
+                formula_id=FORMULA_ID,
+                steps=(missing_mass_step,),
+            ),
+        ),
+        DerivedClaim(
+            claim_id=FINAL_EMISSION_CLAIM_ID,
+            field="steel_frame_final_emission_tco2e",
+            value=proxy_emission,
+            unit="tCO2e",
+            origin="proxy_assignment_calculated",
+            trace=CalculationTrace(
+                trace_id=f"trace:{FINAL_EMISSION_CLAIM_ID}",
+                formula_id=FORMULA_ID,
+                input_claim_ids=(MISSING_MASS_CLAIM_ID,),
+                reference_binding_ids=(PROXY_BINDING_ID,),
+                steps=(missing_mass_step, proxy_emission_step),
+            ),
+        ),
+    )
+
+
+def _projection_source(report: CompileReport) -> dict[str, object]:
+    values = {claim.field: claim.value for claim in report.checked_claims}
+    values.update({claim.field: claim.value for claim in report.derived_claims})
+    return values
+
+
+STEEL_FRAME_PROXY_SCENARIO = ScenarioDefinition(
+    scenario_id=SCENARIO_ID,
+    title="Steel Frame proxy assignment",
+    run=run_steel_frame_proxy_assignment_scenario,
+    source_refs=SOURCE_REFS,
+    contract=ScenarioContract(
+        must_commit=True,
+        required_projection=EXPECTED_PROJECTION,
+        required_resolved_obligation_kinds=(
+            "find_source_witness",
+            "proxy_factor_required",
+        ),
+        required_reference_binding_ids=(PROXY_BINDING_ID,),
+        required_derived_claim_ids=(MISSING_MASS_CLAIM_ID, FINAL_EMISSION_CLAIM_ID),
+        required_receipt_reference_binding_ids=(PROXY_BINDING_ID,),
+        required_receipt_derived_claim_ids=(
+            MISSING_MASS_CLAIM_ID,
+            FINAL_EMISSION_CLAIM_ID,
+        ),
+        required_receipt_calculation_trace_ids=(
+            f"trace:{MISSING_MASS_CLAIM_ID}",
+            f"trace:{FINAL_EMISSION_CLAIM_ID}",
+        ),
+        required_receipt_formula_ids=(FORMULA_ID,),
+    ),
+)
+
+
+__all__ = [
+    "EXPECTED_PROJECTION",
+    "FINAL_EMISSION_CLAIM_ID",
+    "PROJECTION_FIELDS",
+    "PROJECTION_ID",
+    "PROXY_BINDING_ID",
+    "SCENARIO_ID",
+    "STEEL_FRAME_PROXY_SCENARIO",
+    "SUPPLIER_ABSENCE_OBLIGATION_ID",
+    "run_steel_frame_proxy_assignment_scenario",
+    "steel_frame_proxy_assignment_report",
+]

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -13,6 +13,9 @@ from tests.domain_scenarios.l_energy_pcf_governance.alpha_invalid_allocation_rfi
 from tests.domain_scenarios.l_energy_pcf_governance.alpha_physical_allocation_correction import (
     ALPHA_PHYSICAL_ALLOCATION_SCENARIO,
 )
+from tests.domain_scenarios.l_energy_pcf_governance.steel_frame_proxy_assignment import (
+    STEEL_FRAME_PROXY_SCENARIO,
+)
 from tests.domain_scenarios.tiny_pcf.scenario import SCENARIO as TINY_PCF_SCENARIO
 
 
@@ -22,6 +25,7 @@ def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
         TINY_PCF_SCENARIO,
         ALPHA_INVALID_ALLOCATION_SCENARIO,
         ALPHA_PHYSICAL_ALLOCATION_SCENARIO,
+        STEEL_FRAME_PROXY_SCENARIO,
         L_ENERGY_PCF_GOVERNANCE_SCENARIO,
     )
 

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -42,6 +42,7 @@ def test_domain_scenario_cli_lists_registered_scenarios(capsys):
     assert "tiny_pcf.location_based_electricity.v1" in captured.out
     assert "l_energy.alpha_invalid_allocation_rfi.v1" in captured.out
     assert "l_energy.alpha_physical_allocation_correction.v1" in captured.out
+    assert "l_energy.steel_frame_proxy_assignment.v1" in captured.out
     assert "l_energy_pcf_governance.v1" in captured.out
     assert "Canonical raw text PCF working loop" in captured.out
 
@@ -100,7 +101,7 @@ def test_domain_scenario_cli_runs_all_registered_scenarios(capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Domain Scenario Run" in captured.out
-    assert "Passed: 5/5" in captured.out
+    assert "Passed: 6/6" in captured.out
     assert "- canonical_working_loop.raw_text_pcf.v1: pass" in captured.out
     assert "- tiny_pcf.location_based_electricity.v1: pass" in captured.out
     assert "- l_energy.alpha_invalid_allocation_rfi.v1: pass" in captured.out
@@ -108,6 +109,7 @@ def test_domain_scenario_cli_runs_all_registered_scenarios(capsys):
         "- l_energy.alpha_physical_allocation_correction.v1: pass"
         in captured.out
     )
+    assert "- l_energy.steel_frame_proxy_assignment.v1: pass" in captured.out
     assert "- l_energy_pcf_governance.v1: pass" in captured.out
     assert captured.err == ""
 
@@ -120,8 +122,9 @@ def test_domain_scenario_cli_runs_all_as_json(capsys):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert exit_code == 0
-    assert payload["summary"] == {"total": 5, "passed": 5, "failed": 0}
+    assert payload["summary"] == {"total": 6, "passed": 6, "failed": 0}
     assert tuple(item["status"] for item in payload["scenarios"]) == (
+        "pass",
         "pass",
         "pass",
         "pass",
@@ -133,6 +136,7 @@ def test_domain_scenario_cli_runs_all_as_json(capsys):
         "tiny_pcf.location_based_electricity.v1",
         "l_energy.alpha_invalid_allocation_rfi.v1",
         "l_energy.alpha_physical_allocation_correction.v1",
+        "l_energy.steel_frame_proxy_assignment.v1",
         "l_energy_pcf_governance.v1",
     )
     assert "result" in payload["scenarios"][0]
@@ -175,6 +179,7 @@ def test_registered_scenarios_are_explicit_scenario_definitions():
         "tiny_pcf.location_based_electricity.v1",
         "l_energy.alpha_invalid_allocation_rfi.v1",
         "l_energy.alpha_physical_allocation_correction.v1",
+        "l_energy.steel_frame_proxy_assignment.v1",
         "l_energy_pcf_governance.v1",
     )
     assert all(isinstance(scenario, ScenarioDefinition) for scenario in scenarios)

--- a/tests/test_steel_frame_proxy_assignment_scenario.py
+++ b/tests/test_steel_frame_proxy_assignment_scenario.py
@@ -1,0 +1,117 @@
+import pytest
+
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
+from tests.domain_scenarios.l_energy_pcf_governance.steel_frame_proxy_assignment import (
+    EXPECTED_PROJECTION,
+    FINAL_EMISSION_CLAIM_ID,
+    PROJECTION_FIELDS,
+    PROJECTION_ID,
+    PROXY_BINDING_ID,
+    STEEL_FRAME_PROXY_SCENARIO,
+    SUPPLIER_ABSENCE_OBLIGATION_ID,
+    run_steel_frame_proxy_assignment_scenario,
+)
+from tests.domain_scenarios.registry import registered_scenarios
+
+
+def test_steel_frame_proxy_calculates_missing_mass_and_emission():
+    result = run_steel_frame_proxy_assignment_scenario()
+
+    trace = _trace_for(result, FINAL_EMISSION_CLAIM_ID)
+    steps = {step.step_id: step.output_value for step in trace.steps}
+
+    assert steps == {
+        "missing-mass-ton": 1900,
+        "proxy-emission-tco2e": 4750,
+    }
+    assert tuple(
+        (claim.field, claim.value, claim.unit)
+        for claim in result.report.derived_claims
+    ) == (
+        ("missing_mass_ton", 1900, "ton"),
+        ("steel_frame_final_emission_tco2e", 4750, "tCO2e"),
+    )
+
+
+def test_steel_frame_proxy_binds_proxy_factor_and_low_quality_metadata():
+    result = run_steel_frame_proxy_assignment_scenario()
+
+    assert tuple(
+        (binding.binding_id, binding.reference_id, binding.reference_type)
+        for binding in result.report.reference_bindings
+    ) == (
+        (PROXY_BINDING_ID, "platform.factor.steel_proxy_per_ton", "proxy_factor"),
+    )
+    assert ("proxy_quality", "Low") in tuple(
+        (claim.field, claim.value) for claim in result.report.checked_claims
+    )
+    assert result.preparation.receipt is not None
+    assert result.preparation.receipt.citations.reference_binding_ids == (
+        PROXY_BINDING_ID,
+    )
+
+
+def test_steel_frame_missing_supplier_context_is_explicit_but_not_blocking():
+    result = run_steel_frame_proxy_assignment_scenario()
+
+    assert result.report.status == "accepted"
+    assert result.report.obligations == ()
+    assert result.report.hazards == ()
+    assert tuple(
+        (obligation.kind, obligation.field, obligation.reason)
+        for obligation in result.report.resolved_obligations
+    ) == (
+        (
+            "find_source_witness",
+            "steel_frame_supplier_submission",
+            "supplier_submission_absent",
+        ),
+        (
+            "proxy_factor_required",
+            "steel_frame_proxy_factor",
+            "missing_supplier_evidence_requires_proxy",
+        ),
+    )
+    assert result.preparation.package.open_obligation_ids == ()
+    assert SUPPLIER_ABSENCE_OBLIGATION_ID in (
+        result.preparation.receipt.citations.resolved_obligation_ids
+    )
+
+
+def test_steel_frame_proxy_creates_receipt_and_projection():
+    result = run_steel_frame_proxy_assignment_scenario()
+
+    assert result.preparation.package.complete is True
+    assert result.preparation.decision.status == "commit"
+    assert result.preparation.receipt is not None
+    assert result.projection == EXPECTED_PROJECTION
+
+    with pytest.raises(ProjectionBlocked, match="value commitment mismatch"):
+        project_public_row(
+            {
+                **EXPECTED_PROJECTION,
+                "steel_frame_final_emission_tco2e": 9999,
+            },
+            ProjectionSpec(PROJECTION_ID, PROJECTION_FIELDS),
+            receipt=result.preparation.receipt,
+        )
+
+
+def test_steel_frame_proxy_scenario_is_registered_with_contract():
+    scenarios = registered_scenarios()
+
+    assert "l_energy.steel_frame_proxy_assignment.v1" in tuple(
+        scenario.scenario_id for scenario in scenarios
+    )
+    assert_scenario_contract(
+        run_scenario(STEEL_FRAME_PROXY_SCENARIO),
+        STEEL_FRAME_PROXY_SCENARIO.contract,
+    )
+
+
+def _trace_for(result, claim_id):
+    for claim in result.report.derived_claims:
+        if claim.claim_id == claim_id:
+            return claim.trace
+    raise AssertionError(f"missing derived claim: {claim_id}")


### PR DESCRIPTION
## What changed

- Added `l_energy.steel_frame_proxy_assignment.v1` as the PR3 L-Energy PCF governance scenario.
- Models the absent Steel Frame supplier submission as explicit resolved governance context, not an open blocker.
- Adds a proxy factor `ReferenceBinding`, low proxy quality metadata, missing-mass calculation, proxy emission derived claim, commit receipt, and public projection.
- Registered the scenario and updated domain scenario CLI/run-all expectations.

## Why

This exercises the supply-chain governance path where missing supplier evidence must remain visible while still allowing a proxy-authorized calculation to commit. The receipt cites the proxy factor and resolved supplier-absence/proxy obligations so downstream roll-ups can preserve the dependency.

## Validation

- `python -m pytest -q` -> `301 passed in 5.26s`