### PR TITLE
[codex] add Carbon Tech certificate submission scenario

### DIFF
--- a/tests/domain_scenarios/l_energy_pcf_governance/carbon_tech_certificate_submission.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/carbon_tech_certificate_submission.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+
+from comp import ProjectionSpec, SubjectRef, project_public_row
+from comp.compiler_tool import (
+    CalculationStep,
+    CalculationTrace,
+    CheckedClaim,
+    CompileReport,
+    DerivedClaim,
+    EvidenceWitness,
+    ProofObligation,
+    ReferenceBinding,
+    prepare_commit,
+    with_recomputed_status,
+)
+from tests.domain_scenarios.core import (
+    ScenarioContract,
+    ScenarioDefinition,
+    SourceRef,
+    build_domain_scenario_result,
+)
+
+
+SCENARIO_ID = "l_energy.carbon_tech_certificate_submission.v1"
+PROJECTION_ID = "l-energy-carbon-tech-certificate-submission"
+PROJECTION_FIELDS = (
+    "actor_id",
+    "submission_type",
+    "certificate_boundary",
+    "dqr",
+    "carbon_tech_final_emission_tco2e",
+)
+EXPECTED_PROJECTION = {
+    "actor_id": "carbon_tech",
+    "submission_type": "certificate",
+    "certificate_boundary": "Cradle-to-Gate",
+    "dqr": "Medium",
+    "carbon_tech_final_emission_tco2e": 13390,
+}
+
+SOURCE_CASE_ID = "001-l-energy-pcf-governance"
+SOURCE_COMMIT = "618c44dfcea1ee1e235550776acb78d8f20a7e0c"
+SUBJECT_ID = "case:001-l-energy-pcf-governance:carbon-tech-certificate"
+PUBLIC_ROW_ID = "public-row:carbon-tech-certificate-submission"
+
+FORMULA_ID = "pcf.carbon_tech_certificate_factor.v1"
+CERTIFICATE_FACTOR_BINDING_ID = "bind:carbon-tech:certificate_factor"
+FINAL_EMISSION_CLAIM_ID = "carbon-tech:final_emission_tco2e"
+CERTIFICATE_BOUNDARY_OBLIGATION_ID = (
+    "carbon-tech:certificate_boundary:supports_cradle_to_gate"
+)
+
+ACTOR_ID = "carbon_tech"
+SUBMISSION_TYPE = "certificate"
+CERTIFICATE_BOUNDARY = "Cradle-to-Gate"
+DQR = "Medium"
+ACTIVITY_INPUT_MODE = "certificate_only"
+PRODUCTION_TON = 8250
+CERTIFICATE_FACTOR_TCO2E_PER_TON = Decimal("1.623")
+
+RESOLVER_STEPS = (
+    "load_platform_carbon_tech_certificate_fixture",
+    "verify_certificate_boundary_context",
+    "bind_certificate_factor",
+    "calculate_certificate_emission",
+    "prepare_commit",
+    "receipt_gated_projection",
+)
+
+SOURCE_REFS = (
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/cases/001-l-energy-pcf-governance.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="docs/e2e/dummy-data-mapping-l-energy-pcf.md",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+    ),
+    SourceRef(
+        repo="minntcho/esg-platform",
+        commit=SOURCE_COMMIT,
+        path="tests/e2e/expected/001-l-energy-pcf-governance.receipt.json",
+    ),
+)
+
+
+def run_carbon_tech_certificate_submission_scenario():
+    report = carbon_tech_certificate_submission_report()
+    preparation = prepare_commit(
+        report,
+        subject_id=SUBJECT_ID,
+        public_row_id=PUBLIC_ROW_ID,
+        projection_id=PROJECTION_ID,
+    )
+    projection = None
+    if preparation.receipt is not None:
+        projection = project_public_row(
+            _projection_source(report),
+            ProjectionSpec(PROJECTION_ID, PROJECTION_FIELDS),
+            receipt=preparation.receipt,
+        )
+    return build_domain_scenario_result(
+        scenario_id=SCENARIO_ID,
+        report=report,
+        preparation=preparation,
+        projection=projection,
+        subject=SubjectRef("claim", SUBJECT_ID),
+        resolver_steps=RESOLVER_STEPS,
+    )
+
+
+def carbon_tech_certificate_submission_report() -> CompileReport:
+    return with_recomputed_status(
+        CompileReport(
+            status="accepted",
+            evidence_witnesses=_evidence_witnesses(),
+            checked_claims=_checked_claims(),
+            resolved_obligations=_resolved_obligations(),
+            reference_bindings=_reference_bindings(),
+            derived_claims=_derived_claims(),
+            can_project_public_row=True,
+        )
+    )
+
+
+def _evidence_witnesses() -> tuple[EvidenceWitness, ...]:
+    return (
+        EvidenceWitness(
+            witness_id="source:carbon-tech-certificate-metadata",
+            field="certificate_boundary",
+            source="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+            span="data_setup.carbon_tech.certificate.boundary",
+            text="Cradle-to-Gate",
+        ),
+        EvidenceWitness(
+            witness_id="source:carbon-tech-certificate-factor",
+            field="certificate_factor_tco2e_per_ton",
+            source="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+            span="data_setup.carbon_tech.certificate.factor",
+            text="1.623 tCO2e/ton",
+        ),
+        EvidenceWitness(
+            witness_id="source:carbon-tech-production",
+            field="production_ton",
+            source="tests/e2e/cases/001-l-energy-pcf-governance.yaml",
+            span="data_setup.carbon_tech.production_ton",
+            text="8,250 ton",
+        ),
+    )
+
+
+def _checked_claims() -> tuple[CheckedClaim, ...]:
+    return (
+        CheckedClaim(
+            "actor_id",
+            ACTOR_ID,
+            "source:carbon-tech-certificate-metadata",
+            "platform_fixture",
+        ),
+        CheckedClaim(
+            "submission_type",
+            SUBMISSION_TYPE,
+            "source:carbon-tech-certificate-metadata",
+            "certificate_submission",
+        ),
+        CheckedClaim(
+            "activity_input_mode",
+            ACTIVITY_INPUT_MODE,
+            "source:carbon-tech-certificate-metadata",
+            "certificate_submission",
+        ),
+        CheckedClaim(
+            "certificate_boundary",
+            CERTIFICATE_BOUNDARY,
+            "source:carbon-tech-certificate-metadata",
+            "certificate_submission",
+        ),
+        CheckedClaim(
+            "dqr",
+            DQR,
+            "source:carbon-tech-certificate-metadata",
+            "certificate_submission",
+        ),
+        CheckedClaim(
+            "production_ton",
+            PRODUCTION_TON,
+            "source:carbon-tech-production",
+            "certificate_submission",
+        ),
+    )
+
+
+def _resolved_obligations() -> tuple[ProofObligation, ...]:
+    return (
+        ProofObligation(
+            kind="certificate_boundary_supported",
+            field="certificate_boundary",
+            reason="supports_cradle_to_gate",
+            obligation_id=CERTIFICATE_BOUNDARY_OBLIGATION_ID,
+        ),
+    )
+
+
+def _reference_bindings() -> tuple[ReferenceBinding, ...]:
+    return (
+        ReferenceBinding(
+            binding_id=CERTIFICATE_FACTOR_BINDING_ID,
+            claim_id=SCENARIO_ID,
+            reference_id="platform.factor.carbon_tech_certificate_per_ton",
+            reference_type="certificate_factor",
+            selector_rule_id="platform.expected_receipt.fixture",
+            source_witness_ids=("source:carbon-tech-certificate-factor",),
+        ),
+    )
+
+
+def _derived_claims() -> tuple[DerivedClaim, ...]:
+    raw_emission = Decimal(PRODUCTION_TON) * CERTIFICATE_FACTOR_TCO2E_PER_TON
+    final_emission = _round_half_up(raw_emission)
+    return (
+        DerivedClaim(
+            claim_id=FINAL_EMISSION_CLAIM_ID,
+            field="carbon_tech_final_emission_tco2e",
+            value=final_emission,
+            unit="tCO2e",
+            origin="certificate_factor_calculated",
+            trace=CalculationTrace(
+                trace_id=f"trace:{FINAL_EMISSION_CLAIM_ID}",
+                formula_id=FORMULA_ID,
+                input_claim_ids=("production_ton",),
+                reference_binding_ids=(CERTIFICATE_FACTOR_BINDING_ID,),
+                steps=(
+                    CalculationStep(
+                        step_id="certificate-emission-raw-tco2e",
+                        operation="multiply",
+                        input_ids=("production_ton", CERTIFICATE_FACTOR_BINDING_ID),
+                        output_value=_number(raw_emission),
+                        output_unit="tCO2e",
+                    ),
+                    CalculationStep(
+                        step_id="rounded-certificate-emission-tco2e",
+                        operation="round",
+                        input_ids=("certificate-emission-raw-tco2e",),
+                        output_value=final_emission,
+                        output_unit="tCO2e",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def _projection_source(report: CompileReport) -> dict[str, object]:
+    values = {claim.field: claim.value for claim in report.checked_claims}
+    values.update({claim.field: claim.value for claim in report.derived_claims})
+    return values
+
+
+def _round_half_up(value: Decimal) -> int:
+    return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def _number(value: Decimal) -> int | float:
+    if value == value.to_integral_value():
+        return int(value)
+    return float(value)
+
+
+CARBON_TECH_CERTIFICATE_SCENARIO = ScenarioDefinition(
+    scenario_id=SCENARIO_ID,
+    title="Carbon Tech certificate submission",
+    run=run_carbon_tech_certificate_submission_scenario,
+    source_refs=SOURCE_REFS,
+    contract=ScenarioContract(
+        must_commit=True,
+        required_projection=EXPECTED_PROJECTION,
+        required_resolved_obligation_kinds=("certificate_boundary_supported",),
+        required_reference_binding_ids=(CERTIFICATE_FACTOR_BINDING_ID,),
+        required_derived_claim_ids=(FINAL_EMISSION_CLAIM_ID,),
+        required_receipt_reference_binding_ids=(CERTIFICATE_FACTOR_BINDING_ID,),
+        required_receipt_derived_claim_ids=(FINAL_EMISSION_CLAIM_ID,),
+        required_receipt_calculation_trace_ids=(
+            f"trace:{FINAL_EMISSION_CLAIM_ID}",
+        ),
+        required_receipt_formula_ids=(FORMULA_ID,),
+    ),
+)
+
+
+__all__ = [
+    "CARBON_TECH_CERTIFICATE_SCENARIO",
+    "CERTIFICATE_BOUNDARY_OBLIGATION_ID",
+    "CERTIFICATE_FACTOR_BINDING_ID",
+    "EXPECTED_PROJECTION",
+    "FINAL_EMISSION_CLAIM_ID",
+    "PROJECTION_FIELDS",
+    "PROJECTION_ID",
+    "SCENARIO_ID",
+    "carbon_tech_certificate_submission_report",
+    "run_carbon_tech_certificate_submission_scenario",
+]

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -13,6 +13,9 @@ from tests.domain_scenarios.l_energy_pcf_governance.alpha_invalid_allocation_rfi
 from tests.domain_scenarios.l_energy_pcf_governance.alpha_physical_allocation_correction import (
     ALPHA_PHYSICAL_ALLOCATION_SCENARIO,
 )
+from tests.domain_scenarios.l_energy_pcf_governance.carbon_tech_certificate_submission import (
+    CARBON_TECH_CERTIFICATE_SCENARIO,
+)
 from tests.domain_scenarios.l_energy_pcf_governance.steel_frame_proxy_assignment import (
     STEEL_FRAME_PROXY_SCENARIO,
 )
@@ -26,6 +29,7 @@ def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
         ALPHA_INVALID_ALLOCATION_SCENARIO,
         ALPHA_PHYSICAL_ALLOCATION_SCENARIO,
         STEEL_FRAME_PROXY_SCENARIO,
+        CARBON_TECH_CERTIFICATE_SCENARIO,
         L_ENERGY_PCF_GOVERNANCE_SCENARIO,
     )
 

--- a/tests/test_carbon_tech_certificate_submission_scenario.py
+++ b/tests/test_carbon_tech_certificate_submission_scenario.py
@@ -1,0 +1,129 @@
+import pytest
+
+from comp import ProjectionBlocked, ProjectionSpec, project_public_row
+from tests.domain_scenarios.core import assert_scenario_contract, run_scenario
+from tests.domain_scenarios.l_energy_pcf_governance.carbon_tech_certificate_submission import (
+    CARBON_TECH_CERTIFICATE_SCENARIO,
+    CERTIFICATE_BOUNDARY_OBLIGATION_ID,
+    CERTIFICATE_FACTOR_BINDING_ID,
+    EXPECTED_PROJECTION,
+    FINAL_EMISSION_CLAIM_ID,
+    PROJECTION_FIELDS,
+    PROJECTION_ID,
+    run_carbon_tech_certificate_submission_scenario,
+)
+from tests.domain_scenarios.registry import registered_scenarios
+
+
+def test_carbon_certificate_calculates_emission_from_certificate_factor():
+    result = run_carbon_tech_certificate_submission_scenario()
+
+    trace = _trace_for(result, FINAL_EMISSION_CLAIM_ID)
+    steps = {step.step_id: step.output_value for step in trace.steps}
+
+    assert steps == {
+        "certificate-emission-raw-tco2e": 13389.75,
+        "rounded-certificate-emission-tco2e": 13390,
+    }
+    assert tuple(
+        (claim.field, claim.value, claim.unit)
+        for claim in result.report.derived_claims
+    ) == (("carbon_tech_final_emission_tco2e", 13390, "tCO2e"),)
+
+
+def test_carbon_certificate_binds_certificate_factor_and_metadata():
+    result = run_carbon_tech_certificate_submission_scenario()
+
+    assert tuple(
+        (binding.binding_id, binding.reference_id, binding.reference_type)
+        for binding in result.report.reference_bindings
+    ) == (
+        (
+            CERTIFICATE_FACTOR_BINDING_ID,
+            "platform.factor.carbon_tech_certificate_per_ton",
+            "certificate_factor",
+        ),
+    )
+    assert {
+        (claim.field, claim.value)
+        for claim in result.report.checked_claims
+    } >= {
+        ("submission_type", "certificate"),
+        ("certificate_boundary", "Cradle-to-Gate"),
+        ("dqr", "Medium"),
+        ("production_ton", 8250),
+        ("activity_input_mode", "certificate_only"),
+    }
+    assert result.preparation.receipt is not None
+    assert result.preparation.receipt.citations.reference_binding_ids == (
+        CERTIFICATE_FACTOR_BINDING_ID,
+    )
+
+
+def test_carbon_certificate_boundary_is_resolved_without_activity_inputs():
+    result = run_carbon_tech_certificate_submission_scenario()
+
+    assert result.report.status == "accepted"
+    assert result.report.obligations == ()
+    assert result.report.hazards == ()
+    assert tuple(
+        (obligation.kind, obligation.field, obligation.reason)
+        for obligation in result.report.resolved_obligations
+    ) == (
+        (
+            "certificate_boundary_supported",
+            "certificate_boundary",
+            "supports_cradle_to_gate",
+        ),
+    )
+    assert CERTIFICATE_BOUNDARY_OBLIGATION_ID in (
+        result.preparation.receipt.citations.resolved_obligation_ids
+    )
+    assert result.preparation.receipt.citations.semantic_judgment_ids == ()
+    assert "activity_electricity_mwh" not in tuple(
+        claim.field for claim in result.report.checked_claims
+    )
+    assert "activity_lng_nm3" not in tuple(
+        claim.field for claim in result.report.checked_claims
+    )
+    assert tuple(
+        binding.reference_type for binding in result.report.reference_bindings
+    ) == ("certificate_factor",)
+
+
+def test_carbon_certificate_creates_receipt_and_projection():
+    result = run_carbon_tech_certificate_submission_scenario()
+
+    assert result.preparation.package.complete is True
+    assert result.preparation.decision.status == "commit"
+    assert result.preparation.receipt is not None
+    assert result.projection == EXPECTED_PROJECTION
+
+    with pytest.raises(ProjectionBlocked, match="value commitment mismatch"):
+        project_public_row(
+            {
+                **EXPECTED_PROJECTION,
+                "carbon_tech_final_emission_tco2e": 9999,
+            },
+            ProjectionSpec(PROJECTION_ID, PROJECTION_FIELDS),
+            receipt=result.preparation.receipt,
+        )
+
+
+def test_carbon_certificate_scenario_is_registered_with_contract():
+    scenarios = registered_scenarios()
+
+    assert "l_energy.carbon_tech_certificate_submission.v1" in tuple(
+        scenario.scenario_id for scenario in scenarios
+    )
+    assert_scenario_contract(
+        run_scenario(CARBON_TECH_CERTIFICATE_SCENARIO),
+        CARBON_TECH_CERTIFICATE_SCENARIO.contract,
+    )
+
+
+def _trace_for(result, claim_id):
+    for claim in result.report.derived_claims:
+        if claim.claim_id == claim_id:
+            return claim.trace
+    raise AssertionError(f"missing derived claim: {claim_id}")

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -43,6 +43,7 @@ def test_domain_scenario_cli_lists_registered_scenarios(capsys):
     assert "l_energy.alpha_invalid_allocation_rfi.v1" in captured.out
     assert "l_energy.alpha_physical_allocation_correction.v1" in captured.out
     assert "l_energy.steel_frame_proxy_assignment.v1" in captured.out
+    assert "l_energy.carbon_tech_certificate_submission.v1" in captured.out
     assert "l_energy_pcf_governance.v1" in captured.out
     assert "Canonical raw text PCF working loop" in captured.out
 
@@ -101,7 +102,7 @@ def test_domain_scenario_cli_runs_all_registered_scenarios(capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Domain Scenario Run" in captured.out
-    assert "Passed: 6/6" in captured.out
+    assert "Passed: 7/7" in captured.out
     assert "- canonical_working_loop.raw_text_pcf.v1: pass" in captured.out
     assert "- tiny_pcf.location_based_electricity.v1: pass" in captured.out
     assert "- l_energy.alpha_invalid_allocation_rfi.v1: pass" in captured.out
@@ -110,6 +111,7 @@ def test_domain_scenario_cli_runs_all_registered_scenarios(capsys):
         in captured.out
     )
     assert "- l_energy.steel_frame_proxy_assignment.v1: pass" in captured.out
+    assert "- l_energy.carbon_tech_certificate_submission.v1: pass" in captured.out
     assert "- l_energy_pcf_governance.v1: pass" in captured.out
     assert captured.err == ""
 
@@ -122,8 +124,9 @@ def test_domain_scenario_cli_runs_all_as_json(capsys):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert exit_code == 0
-    assert payload["summary"] == {"total": 6, "passed": 6, "failed": 0}
+    assert payload["summary"] == {"total": 7, "passed": 7, "failed": 0}
     assert tuple(item["status"] for item in payload["scenarios"]) == (
+        "pass",
         "pass",
         "pass",
         "pass",
@@ -137,6 +140,7 @@ def test_domain_scenario_cli_runs_all_as_json(capsys):
         "l_energy.alpha_invalid_allocation_rfi.v1",
         "l_energy.alpha_physical_allocation_correction.v1",
         "l_energy.steel_frame_proxy_assignment.v1",
+        "l_energy.carbon_tech_certificate_submission.v1",
         "l_energy_pcf_governance.v1",
     )
     assert "result" in payload["scenarios"][0]
@@ -180,6 +184,7 @@ def test_registered_scenarios_are_explicit_scenario_definitions():
         "l_energy.alpha_invalid_allocation_rfi.v1",
         "l_energy.alpha_physical_allocation_correction.v1",
         "l_energy.steel_frame_proxy_assignment.v1",
+        "l_energy.carbon_tech_certificate_submission.v1",
         "l_energy_pcf_governance.v1",
     )
     assert all(isinstance(scenario, ScenarioDefinition) for scenario in scenarios)


### PR DESCRIPTION
## What changed

- Added `l_energy.carbon_tech_certificate_submission.v1` as the PR4 L-Energy PCF governance scenario.
- Models Carbon Tech's certificate path with certificate metadata witnesses, Cradle-to-Gate boundary support, Medium DQR, and `certificate_only` activity input mode.
- Adds a `certificate_factor` `ReferenceBinding`, certificate emission calculation trace, commit receipt, and receipt-gated public projection.
- Registered the scenario and updated domain scenario CLI/run-all expectations.

## Why

This keeps certificate submissions inside the `comp` authority boundary without introducing a new binding class yet. The certificate-provided factor is represented as a reference binding type, while boundary support is retained as resolved deterministic context and no activity-data emission factor path is created.

## Validation

- `python -m pytest -q` -> `306 passed in 5.31s`