### PR TITLE
[codex] add contract ci gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Contract CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Python contract suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run unit and scenario tests
+        run: python -m pytest -q
+
+      - name: List registered domain scenarios
+        run: python -m tests.domain_scenarios list
+
+      - name: Run domain scenario contract gate
+        run: python -m tests.domain_scenarios run-all

--- a/README.md
+++ b/README.md
@@ -146,3 +146,16 @@ module을 옮기거나 키우기 전에 먼저 답해야 한다.
 ```
 
 답이 흐리면 relocation보다 architecture correction이 먼저다.
+
+## PR contract gate
+
+PR에서 확인해야 하는 최소 gate는 package smoke, unit tests, domain scenario
+contract다. 로컬에서는 아래 명령으로 GitHub Actions와 같은 핵심 검증을
+재현한다.
+
+```bash
+python -m pip install -e ".[test]"
+python -m pytest -q
+python -m tests.domain_scenarios list
+python -m tests.domain_scenarios run-all
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ description = "Receipt-gated proof package compiler for obligation, reference, c
 readme = "README.md"
 requires-python = ">=3.11"
 
+[project.optional-dependencies]
+test = ["pytest>=8"]
+
 [tool.setuptools]
 packages = [
   "comp",


### PR DESCRIPTION
## Summary

- Add a GitHub Actions Contract CI workflow for pull requests and pushes to `main`.
- Install the package with its `test` extra, run the pytest suite, and run the domain scenario contract gate.
- Document the local PR contract gate commands in `README.md`.

## Validation

- `python -m pip install -e ".[test]"`
- `python -m pytest -q` (`306 passed`)
- `python -m tests.domain_scenarios list`
- `python -m tests.domain_scenarios run-all` (`Passed: 7/7`)
- GitHub Actions `Contract CI / Python contract suite` passed on PR #210.