### PR TITLE
[codex] harden proof compiler boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ from comp.compiler_tool import prepare_commit, build_commit_receipt
 from comp.compiler_tool import compile_report_to_facts
 ```
 
+`comp.persistence`는 replayable artifact record와 receipt ledger surface를
+노출한다. persisted row는 authority가 아니라 receipt로 재검증되어야 하는
+view다.
+
+```python
+from comp.persistence import ArtifactEnvelope, InMemoryArtifactStore
+from comp.persistence import InMemoryReceiptLedger
+from comp.persistence import replay_public_projection
+```
+
 legacy pipeline runner, pass-pipeline module, compatibility facade는 active
 package source가 아니다. 필요하면 archive reference material로만 취급한다.
 

--- a/comp/compiler_tool/calculations.py
+++ b/comp/compiler_tool/calculations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from numbers import Number
 from typing import Any
 
@@ -17,6 +17,9 @@ class CalculationStep:
     input_ids: tuple[str, ...] = field(default_factory=tuple)
     output_value: Any = None
     output_unit: str | None = None
+    exact_output_value: Decimal | None = None
+    rounding_quantum: str | None = None
+    rounding_mode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -66,6 +69,8 @@ class CalculationFormula:
     factor_value_attribute: str = "factor_value"
     input_unit_attribute: str = "input_unit"
     output_unit_attribute: str = "output_unit"
+    rounding_quantum: str | None = None
+    rounding_mode: str = "ROUND_HALF_UP"
 
 
 @dataclass(frozen=True)
@@ -153,7 +158,9 @@ def calculate_derived_claim(
             )
         )
 
-    if not isinstance(input_claim.value, Number) or not isinstance(factor_value, Number):
+    input_value = _decimal_number(input_claim.value)
+    factor_decimal = _decimal_number(factor_value)
+    if input_value is None or factor_decimal is None:
         return _blocked(
             _requirement(
                 reason="non_numeric_input",
@@ -164,7 +171,8 @@ def calculate_derived_claim(
             )
         )
 
-    output_value = _multiply(input_claim.value, factor_value)
+    exact_output_value = _apply_rounding(input_value * factor_decimal, formula)
+    output_value = _number(exact_output_value)
     trace = CalculationTrace(
         trace_id=f"trace:{output_claim_id}",
         formula_id=formula.formula_id,
@@ -177,6 +185,13 @@ def calculate_derived_claim(
                 input_ids=(input_claim.claim_id, reference_binding.binding_id),
                 output_value=output_value,
                 output_unit=formula.output_unit,
+                exact_output_value=exact_output_value,
+                rounding_quantum=formula.rounding_quantum,
+                rounding_mode=(
+                    formula.rounding_mode
+                    if formula.rounding_quantum is not None
+                    else None
+                ),
             ),
         ),
     )
@@ -205,6 +220,8 @@ def calculation_formula_declaration_fingerprint(
             "factor_value_attribute": formula.factor_value_attribute,
             "input_unit_attribute": formula.input_unit_attribute,
             "output_unit_attribute": formula.output_unit_attribute,
+            "rounding_quantum": formula.rounding_quantum,
+            "rounding_mode": formula.rounding_mode,
         },
     )
 
@@ -245,8 +262,33 @@ def _requirement(
     )
 
 
-def _multiply(left: Number, right: Number) -> int | float:
-    value = Decimal(str(left)) * Decimal(str(right))
+ROUNDING_MODES = {
+    "ROUND_HALF_UP": ROUND_HALF_UP,
+}
+
+
+def _decimal_number(value: Any) -> Decimal | None:
+    if isinstance(value, bool) or not isinstance(value, Number):
+        return None
+    try:
+        decimal = value if isinstance(value, Decimal) else Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    if not decimal.is_finite():
+        return None
+    return decimal
+
+
+def _apply_rounding(value: Decimal, formula: CalculationFormula) -> Decimal:
+    if formula.rounding_quantum is None:
+        return value
+    rounding_mode = ROUNDING_MODES.get(formula.rounding_mode)
+    if rounding_mode is None:
+        raise ValueError(f"Unsupported rounding mode: {formula.rounding_mode}")
+    return value.quantize(Decimal(formula.rounding_quantum), rounding=rounding_mode)
+
+
+def _number(value: Decimal) -> int | float:
     if value == value.to_integral_value():
         return int(value)
     return float(value)

--- a/comp/compiler_tool/profile_runner.py
+++ b/comp/compiler_tool/profile_runner.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from comp.compiler_tool.models import CompileReport, InterpretationHypothesis, ProofObligation
+from comp.compiler_tool.models import (
+    ClaimHypothesis,
+    CompileReport,
+    EvidenceWitness,
+    FailedClaim,
+    InterpretationHypothesis,
+    ProofObligation,
+)
 from comp.compiler_tool.profiles import CompilerProfile, active_rule_families, validate_compiler_profile
 from comp.compiler_tool.report_status import with_recomputed_status
 
@@ -10,24 +17,94 @@ def compile_with_profile(
     profile: CompilerProfile,
 ) -> CompileReport:
     validate_compiler_profile(profile)
+    failed_claims: list[FailedClaim] = []
     obligations: list[ProofObligation] = []
+    witnesses = {witness.witness_id: witness for witness in hypothesis.witnesses}
 
     for claim in hypothesis.claims:
+        witness_failure = _validate_core_witness(claim, witnesses)
+        if witness_failure is not None:
+            failed_claims.append(witness_failure)
+            _add_obligation(
+                obligations,
+                ProofObligation(
+                    kind="find_source_witness",
+                    field=claim.field,
+                    reason=witness_failure.reason,
+                ),
+            )
+
         for rule in active_rule_families(profile, validate=False):
             if rule.evaluate is None:
                 continue
             for result in rule.evaluate(claim, hypothesis, profile):
-                if isinstance(result, ProofObligation) and result not in obligations:
-                    obligations.append(result)
+                if isinstance(result, ProofObligation):
+                    _add_obligation(obligations, result)
 
     return with_recomputed_status(
         CompileReport(
             status="accepted",
             evidence_witnesses=hypothesis.witnesses,
+            failed_claims=tuple(failed_claims),
             obligations=tuple(obligations),
             can_project_public_row=False,
         )
     )
+
+
+def _validate_core_witness(
+    claim: ClaimHypothesis,
+    witnesses: dict[str, EvidenceWitness],
+) -> FailedClaim | None:
+    if claim.value is None:
+        return None
+
+    if claim.witness_id is None:
+        return FailedClaim(
+            field=claim.field,
+            value=claim.value,
+            reason="missing_source_witness",
+            origin=claim.origin,
+            witness_id=None,
+        )
+
+    witness = witnesses.get(claim.witness_id)
+    if witness is None:
+        return FailedClaim(
+            field=claim.field,
+            value=claim.value,
+            reason="missing_source_witness",
+            origin=claim.origin,
+            witness_id=claim.witness_id,
+        )
+
+    if witness.field != claim.field:
+        return FailedClaim(
+            field=claim.field,
+            value=claim.value,
+            reason="witness_field_mismatch",
+            origin=claim.origin,
+            witness_id=claim.witness_id,
+        )
+
+    if not witness.grounded:
+        return FailedClaim(
+            field=claim.field,
+            value=claim.value,
+            reason="ungrounded_source_witness",
+            origin=claim.origin,
+            witness_id=claim.witness_id,
+        )
+
+    return None
+
+
+def _add_obligation(
+    obligations: list[ProofObligation],
+    obligation: ProofObligation,
+) -> None:
+    if obligation not in obligations:
+        obligations.append(obligation)
 
 
 __all__ = ["compile_with_profile"]

--- a/comp/compiler_tool/profiles.py
+++ b/comp/compiler_tool/profiles.py
@@ -21,6 +21,8 @@ class RuleFamily:
     required_rubric_ids: tuple[str, ...] = field(default_factory=tuple)
     description: str = ""
     evaluate: RuleEvaluator | None = None
+    evaluator_id: str | None = None
+    implementation_version: str | None = None
 
 
 @dataclass(frozen=True)
@@ -130,6 +132,13 @@ def validate_compiler_profile(profile: CompilerProfile) -> None:
 
     active_rubrics = set(profile.active_rubric_ids)
     for rule in active_rule_families(profile, validate=False):
+        if rule.evaluate is not None and (
+            not rule.evaluator_id or not rule.implementation_version
+        ):
+            raise ProfileValidationError(
+                f"active rule {rule.rule_id} requires evaluator identity and "
+                "implementation version"
+            )
         for rubric_id in rule.required_rubric_ids:
             if rubric_id not in rubrics:
                 raise ProfileValidationError(
@@ -320,6 +329,8 @@ def _rule_family_fingerprint_payload(rule: RuleFamily) -> dict[str, Any]:
         "rule_id": rule.rule_id,
         "required_rubric_ids": rule.required_rubric_ids,
         "description": rule.description,
+        "evaluator_id": rule.evaluator_id,
+        "implementation_version": rule.implementation_version,
     }
 
 

--- a/comp/compiler_tool/reference_resolution.py
+++ b/comp/compiler_tool/reference_resolution.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from comp.compiler_tool.models import CompileReport, ProofObligation
 from comp.compiler_tool.reference_db import ReferenceCatalog
 from comp.compiler_tool.references import ReferenceCandidate
+from comp.compiler_tool.report_status import with_recomputed_status
 
 ReferenceSearchQuery = Callable[[ProofObligation], str | None]
 
@@ -54,12 +55,14 @@ def resolve_reference_search_obligations(
     if not changed:
         return report
 
-    return replace(
-        report,
-        obligations=tuple(obligations),
-        resolved_obligations=resolved_obligations,
-        reference_candidates=candidates,
-        can_project_public_row=False,
+    return with_recomputed_status(
+        replace(
+            report,
+            obligations=tuple(obligations),
+            resolved_obligations=resolved_obligations,
+            reference_candidates=candidates,
+            can_project_public_row=False,
+        )
     )
 
 

--- a/comp/compiler_tool/retrieval_resolution.py
+++ b/comp/compiler_tool/retrieval_resolution.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 
 from comp.compiler_tool.models import CompileReport, ProofObligation
 from comp.compiler_tool.references import ReferenceCandidate
+from comp.compiler_tool.report_status import with_recomputed_status
 from comp.compiler_tool.retrieval import ReferenceQuery, ReferenceResolver
 
 ReferenceRetrievalQuery = Callable[[ProofObligation], ReferenceQuery | None]
@@ -47,12 +48,14 @@ def resolve_reference_retrieval_obligations(
     if not changed:
         return report
 
-    return replace(
-        report,
-        obligations=tuple(obligations),
-        resolved_obligations=resolved_obligations,
-        reference_candidates=candidates,
-        can_project_public_row=False,
+    return with_recomputed_status(
+        replace(
+            report,
+            obligations=tuple(obligations),
+            resolved_obligations=resolved_obligations,
+            reference_candidates=candidates,
+            can_project_public_row=False,
+        )
     )
 
 

--- a/comp/judgment/core.py
+++ b/comp/judgment/core.py
@@ -39,6 +39,12 @@ class Fact:
     weight: float | None = None
     meta: tuple[tuple[str, Any], ...] = ()
 
+    def __post_init__(self) -> None:
+        _require_hashable("Fact value", self.value)
+        for key, value in self.meta:
+            _require_hashable("Fact meta key", key)
+            _require_hashable("Fact meta value", value)
+
 
 @dataclass
 class JudgmentState:
@@ -77,6 +83,13 @@ class JudgmentState:
             if fact.tag == "hazard_discharge" and fact.subject == subject
         }
         return opened - discharged
+
+
+def _require_hashable(label: str, value: Any) -> None:
+    try:
+        hash(value)
+    except TypeError as exc:
+        raise TypeError(f"{label} must be hashable.") from exc
 
 
 __all__ = [

--- a/tests/test_compiler_profile_contract.py
+++ b/tests/test_compiler_profile_contract.py
@@ -55,6 +55,10 @@ def _retrieval_policy(policy_id):
     )
 
 
+def _noop_rule_evaluator(claim, hypothesis, profile):
+    return ()
+
+
 def _domain(
     *,
     rules,
@@ -212,6 +216,26 @@ def test_domain_pack_cannot_disable_core_invariants():
     )
 
     with pytest.raises(ProfileValidationError, match="cannot disable core invariant"):
+        validate_compiler_profile(profile)
+
+
+def test_active_callable_rule_requires_evaluator_lock_identity():
+    profile = CompilerProfile(
+        profile_id="fixture-profile",
+        domain_packs=(
+            _domain(
+                rules=(
+                    RuleFamily(
+                        rule_id="fixture.callable_rule.v1",
+                        evaluate=_noop_rule_evaluator,
+                    ),
+                ),
+            ),
+        ),
+        active_rule_ids=("fixture.callable_rule.v1",),
+    )
+
+    with pytest.raises(ProfileValidationError, match="evaluator identity"):
         validate_compiler_profile(profile)
 
 

--- a/tests/test_declaration_fingerprints.py
+++ b/tests/test_declaration_fingerprints.py
@@ -52,6 +52,13 @@ def test_rule_and_rubric_declaration_fingerprints_pin_semantic_contracts():
         required_rubric_ids=("pcf.scope2_method_support.rubric.v2",),
         description="Opens a semantic judgment for Scope 2 method support.",
     )
+    changed_rule_evaluator = RuleFamily(
+        rule_id="pcf.scope2_method_support.v1",
+        required_rubric_ids=("pcf.scope2_method_support.rubric.v1",),
+        description="Opens a semantic judgment for Scope 2 method support.",
+        evaluator_id="pcf.scope2_method_support.evaluator",
+        implementation_version="2026.2",
+    )
     rubric = SemanticRubric(
         rubric_id="pcf.scope2_method_support.rubric.v1",
         acceptable_verdicts=("supports", "refutes", "ambiguous"),
@@ -71,6 +78,9 @@ def test_rule_and_rubric_declaration_fingerprints_pin_semantic_contracts():
     assert rule_fingerprint.dependency_kind == "rule_family"
     assert rule_fingerprint.dependency_id == "pcf.scope2_method_support.v1"
     assert rule_fingerprint != rule_family_declaration_fingerprint(changed_rule)
+    assert rule_fingerprint != rule_family_declaration_fingerprint(
+        changed_rule_evaluator
+    )
     assert rubric_fingerprint.dependency_kind == "semantic_rubric"
     assert rubric_fingerprint.dependency_id == "pcf.scope2_method_support.rubric.v1"
     assert rubric_fingerprint != semantic_rubric_declaration_fingerprint(

--- a/tests/test_deterministic_calculator.py
+++ b/tests/test_deterministic_calculator.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from comp.compiler_tool import (
     CalculationFormula,
     CalculationInput,
@@ -85,6 +87,54 @@ def test_calculator_generates_derived_claim_from_binding_and_formula():
     )
     assert result.derived_claim.trace.steps[0].output_value == 0.48
     assert result.derived_claim.trace.steps[0].output_unit == "tCO2e"
+    assert result.derived_claim.trace.steps[0].exact_output_value == Decimal("0.4800")
+
+
+def test_calculator_records_rounding_policy_in_trace_when_formula_declares_it():
+    catalog = ReferenceCatalog(
+        records=(
+            ReferenceRecord(
+                reference_id="factor.rounding",
+                reference_type="emission_factor",
+                attributes=(("factor_value", 2.345),),
+            ),
+        )
+    )
+    formula = CalculationFormula(
+        formula_id="fixture.rounded_multiplication.v1",
+        output_field="rounded_output",
+        output_unit="kgCO2e",
+        rounding_quantum="0.01",
+        rounding_mode="ROUND_HALF_UP",
+    )
+
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:rounded_output",
+        input_claim=_input(value=1, unit=None),
+        reference_binding=_binding(reference_id="factor.rounding"),
+        catalog=catalog,
+        formula=formula,
+    )
+
+    assert result.status == "calculated"
+    assert result.derived_claim.value == 2.35
+    assert result.derived_claim.trace.steps[0].exact_output_value == Decimal("2.35")
+    assert result.derived_claim.trace.steps[0].rounding_quantum == "0.01"
+    assert result.derived_claim.trace.steps[0].rounding_mode == "ROUND_HALF_UP"
+
+
+def test_calculator_blocks_boolean_numeric_inputs():
+    result = calculate_derived_claim(
+        output_claim_id="hyp-1:co2e_emission",
+        input_claim=_input(value=True),
+        reference_binding=_binding(),
+        catalog=_catalog(),
+        formula=_formula(),
+    )
+
+    assert result.status == "blocked"
+    assert result.reason == "non_numeric_input"
+    assert result.derived_claim is None
 
 
 def test_calculator_blocks_unit_mismatch():

--- a/tests/test_judgment_core.py
+++ b/tests/test_judgment_core.py
@@ -29,6 +29,24 @@ def test_judgment_state_append_only_and_versions():
     assert state.version_of(subject) == 1
 
 
+def test_fact_rejects_unhashable_value_at_construction():
+    subject = SubjectRef("claim", "c1")
+
+    import pytest
+
+    with pytest.raises(TypeError, match="Fact value must be hashable"):
+        Fact("evidence", subject, "payload", {"amount": 100})
+
+
+def test_fact_rejects_unhashable_meta_at_construction():
+    subject = SubjectRef("claim", "c1")
+
+    import pytest
+
+    with pytest.raises(TypeError, match="Fact meta value must be hashable"):
+        Fact("evidence", subject, "amount", 100, meta=(("source_ids", ["w1"]),))
+
+
 def test_active_hazards_respect_discharge_facts():
     subject = SubjectRef("draft", "d1")
     state = JudgmentState()

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -136,6 +136,14 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert resolve_reference_retrieval_obligations is not None
 
 
+def test_readme_tracks_persistence_active_surface():
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    assert "comp.persistence" in readme
+    assert "ArtifactEnvelope" in readme
+    assert "replay_public_projection" in readme
+
+
 def test_working_theory_status_section_tracks_current_rebuild_state():
     working_theory = Path(
         "docs/architecture/obligation-kernel-working-theory.md"

--- a/tests/test_reference_search_resolution.py
+++ b/tests/test_reference_search_resolution.py
@@ -105,6 +105,21 @@ def test_reference_search_resolution_adds_candidates_and_resolves_followup():
     ]
 
 
+def test_reference_search_resolution_recomputes_status_after_resolving_only_blocker():
+    obligation = _planned_unknown_reference_report().obligations[1]
+    report = CompileReport(status="blocked", obligations=(obligation,))
+
+    resolved = resolve_reference_search_obligations(
+        report,
+        _catalog(),
+        query_for_obligation=lambda obligation: "korea electricity grid factor",
+        reference_type="emission_factor",
+    )
+
+    assert resolved.obligations == ()
+    assert resolved.status == "accepted"
+
+
 def test_reference_search_resolution_leaves_followup_open_without_query():
     planned = _planned_unknown_reference_report()
 

--- a/tests/test_resolver_retrieval.py
+++ b/tests/test_resolver_retrieval.py
@@ -137,6 +137,31 @@ def test_reference_query_builder_from_tasks_feeds_retrieval_bridge():
     assert resolved.derived_claims == ()
 
 
+def test_reference_retrieval_resolution_recomputes_status_after_resolving_only_blocker():
+    report = CompileReport(
+        status="blocked",
+        obligations=(_reference_search_obligation(),),
+    )
+
+    resolved = resolve_reference_retrieval_obligations(
+        report,
+        _resolver(),
+        query_for_obligation=reference_query_for_obligation_from_resolver_tasks(
+            resolver_tasks_from_report(report),
+            query_texts={
+                "resolve:formula-v1:claim-co2e:reference_search_required": (
+                    "Korea grid electricity factor 2024"
+                )
+            },
+            lens="factor",
+            reference_type="emission_factor",
+        ),
+    )
+
+    assert resolved.obligations == ()
+    assert resolved.status == "accepted"
+
+
 def test_reference_query_builder_from_tasks_leaves_missing_query_open():
     report = CompileReport(
         status="blocked",

--- a/tests/test_tiny_domain_fixture.py
+++ b/tests/test_tiny_domain_fixture.py
@@ -51,6 +51,8 @@ def _tiny_domain():
                 rule_id=SCOPE2_RULE_ID,
                 required_rubric_ids=(SCOPE2_RUBRIC_ID,),
                 evaluate=_scope2_method_rule,
+                evaluator_id="fixture.ghg.scope2_method_support_rule.evaluator",
+                implementation_version="2026.1",
             ),
             RuleFamily(rule_id="fixture.inactive_rule.v1"),
         ),
@@ -103,6 +105,22 @@ def _hypothesis():
     )
 
 
+def _hypothesis_without_source_witness():
+    return InterpretationHypothesis(
+        hypothesis_id="hyp-scope2",
+        subject_id="claim-scope2",
+        claims=(
+            ClaimHypothesis(
+                field="scope2_method",
+                value="market_based",
+                witness_id=None,
+                origin="llm_inferred",
+            ),
+        ),
+        witnesses=(),
+    )
+
+
 def _judgment(obligation_id):
     return SemanticJudgment(
         judgment_id="judgment-scope2",
@@ -130,6 +148,19 @@ def test_tiny_domain_profile_opens_scope2_semantic_obligation():
         "llm/model@policy-v1",
     )
     assert report.can_project_public_row is False
+
+
+def test_profile_runner_blocks_claim_without_source_witness():
+    report = compile_with_profile(_hypothesis_without_source_witness(), _profile())
+
+    assert report.status == "blocked"
+    assert report.failed_claims[0].field == "scope2_method"
+    assert report.failed_claims[0].reason == "missing_source_witness"
+    assert any(
+        obligation.kind == "find_source_witness"
+        and obligation.field == "scope2_method"
+        for obligation in report.obligations
+    )
 
 
 def test_tiny_domain_semantic_judgment_discharges_obligation():


### PR DESCRIPTION
## Summary

- Recompute report status after reference search/retrieval mutators resolve obligations.
- Add persistence/replay to the README active surface and harden profile locks with explicit evaluator identity/version metadata.
- Add profile-runner witness grounding, calculation trace exact/rounding metadata with boolean numeric rejection, and hash-safe Fact validation.

## Why

External review identified trust-kernel hardening gaps around stale report status, profile behavior locks, baseline source witness checks, numeric traceability, and Fact canonical safety. This PR closes those gaps while preserving the existing receipt-gated authority model.

## Validation

- `python -m pytest -q` -> `325 passed in 5.34s`