### PR TITLE
[codex] add synthetic oracle assertion harness

### DIFF
--- a/tests/support/synthetic/__init__.py
+++ b/tests/support/synthetic/__init__.py
@@ -1,0 +1,6 @@
+from tests.support.synthetic.oracle_assertions import (
+    assert_synthetic_oracle_matches_report,
+    load_synthetic_oracle,
+)
+
+__all__ = ["assert_synthetic_oracle_matches_report", "load_synthetic_oracle"]

--- a/tests/support/synthetic/oracle_assertions.py
+++ b/tests/support/synthetic/oracle_assertions.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from comp.compiler_tool import CompileReport
+from comp.scenarios.synthetic import (
+    ExpectedClaim,
+    ExpectedDerivedClaim,
+    ExpectedFailedClaim,
+    ExpectedHazard,
+    ExpectedObligation,
+    ExpectedSourceMap,
+    InjectedAnomaly,
+    SyntheticOracle,
+)
+
+
+def load_synthetic_oracle(oracle_dir: Path) -> SyntheticOracle:
+    return SyntheticOracle(
+        expected_claims=tuple(
+            ExpectedClaim(
+                claim_id=row["claim_id"],
+                field=row["field"],
+                value=_parse_scalar(row["value"]),
+                unit=row["unit"] or None,
+                witness_id=row["witness_id"],
+                source_row_id=row["source_row_id"],
+            )
+            for row in _read_csv(oracle_dir / "expected_claims.csv")
+        ),
+        expected_derived_claims=tuple(
+            ExpectedDerivedClaim(
+                claim_id=row["claim_id"],
+                field=row["field"],
+                value=_parse_scalar(row["value"]),
+                unit=row["unit"],
+                formula_id=row["formula_id"],
+            )
+            for row in _read_csv(oracle_dir / "expected_derived_claims.csv")
+        ),
+        expected_obligations=tuple(
+            ExpectedObligation(
+                obligation_id=row["obligation_id"],
+                kind=row["kind"],
+                field=row["field"],
+                reason=row["reason"],
+            )
+            for row in _read_csv(oracle_dir / "expected_obligations.csv")
+        ),
+        expected_hazards=tuple(
+            ExpectedHazard(
+                hazard_id=row["hazard_id"],
+                kind=row["kind"],
+                field=row["field"],
+                severity=row["severity"],
+            )
+            for row in _read_csv(oracle_dir / "expected_hazards.csv")
+        ),
+        expected_failed_claims=tuple(
+            ExpectedFailedClaim(
+                failed_claim_id=row["failed_claim_id"],
+                field=row["field"],
+                value=_parse_scalar(row["value"]),
+                reason=row["reason"],
+                source_row_id=row["source_row_id"],
+            )
+            for row in _read_csv(oracle_dir / "expected_failed_claims.csv")
+        ),
+        injected_anomalies=tuple(
+            InjectedAnomaly(
+                anomaly_id=row["anomaly_id"],
+                anomaly_type=row["anomaly_type"],
+                source_row_id=row["source_row_id"],
+                field=row["field"],
+                description=row["description"],
+            )
+            for row in _read_csv(oracle_dir / "injected_anomalies.csv")
+        ),
+        source_to_expected_claim_map=tuple(
+            ExpectedSourceMap(
+                source_ref=row["source_ref"],
+                source_row_id=row["source_row_id"],
+                expected_claim_id=row["expected_claim_id"],
+                expected_field=row["expected_field"],
+                witness_id=row["witness_id"],
+            )
+            for row in _read_csv(oracle_dir / "source_to_expected_claim_map.csv")
+        ),
+    )
+
+
+def assert_synthetic_oracle_matches_report(
+    oracle: SyntheticOracle,
+    report: CompileReport,
+) -> None:
+    assert _checked_claim_rows(report) == _expected_claim_rows(
+        oracle
+    ), "expected checked claims did not match report.checked_claims"
+    assert _derived_claim_rows(report) == _expected_derived_claim_rows(
+        oracle
+    ), "expected derived claims did not match report.derived_claims"
+    assert _failed_claim_rows(report) == _expected_failed_claim_rows(
+        oracle
+    ), "expected failed claims did not match report.failed_claims"
+    assert _obligation_rows(report) == _expected_obligation_rows(
+        oracle
+    ), "expected obligations did not match report.obligations"
+    assert _hazard_rows(report) == _expected_hazard_rows(
+        oracle
+    ), "expected hazards did not match report.hazards"
+    _assert_source_map_matches_witnesses(oracle, report)
+
+
+def _expected_claim_rows(oracle: SyntheticOracle) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (claim.field, claim.value, claim.witness_id)
+        for claim in oracle.expected_claims
+    )
+
+
+def _checked_claim_rows(report: CompileReport) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (claim.field, claim.value, claim.witness_id)
+        for claim in report.checked_claims
+    )
+
+
+def _expected_derived_claim_rows(
+    oracle: SyntheticOracle,
+) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (claim.claim_id, claim.field, claim.value, claim.unit, claim.formula_id)
+        for claim in oracle.expected_derived_claims
+    )
+
+
+def _derived_claim_rows(report: CompileReport) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (claim.claim_id, claim.field, claim.value, claim.unit, claim.formula_id)
+        for claim in report.derived_claims
+    )
+
+
+def _expected_failed_claim_rows(
+    oracle: SyntheticOracle,
+) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (claim.field, claim.value, claim.reason)
+        for claim in oracle.expected_failed_claims
+    )
+
+
+def _failed_claim_rows(report: CompileReport) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (claim.field, claim.value, claim.reason)
+        for claim in report.failed_claims
+    )
+
+
+def _expected_obligation_rows(
+    oracle: SyntheticOracle,
+) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (
+            obligation.obligation_id,
+            obligation.kind,
+            obligation.field,
+            obligation.reason,
+        )
+        for obligation in oracle.expected_obligations
+    )
+
+
+def _obligation_rows(report: CompileReport) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (
+            obligation.obligation_id
+            or _stable_id(
+                "proof_obligation",
+                obligation.kind,
+                obligation.field,
+                obligation.reason,
+            ),
+            obligation.kind,
+            obligation.field,
+            obligation.reason,
+        )
+        for obligation in report.obligations
+    )
+
+
+def _expected_hazard_rows(oracle: SyntheticOracle) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (hazard.hazard_id, hazard.kind, hazard.field, hazard.severity)
+        for hazard in oracle.expected_hazards
+    )
+
+
+def _hazard_rows(report: CompileReport) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        (
+            _stable_id("hazard", hazard.kind, hazard.field, hazard.severity),
+            hazard.kind,
+            hazard.field,
+            hazard.severity,
+        )
+        for hazard in report.hazards
+    )
+
+
+def _assert_source_map_matches_witnesses(
+    oracle: SyntheticOracle,
+    report: CompileReport,
+) -> None:
+    actual = {
+        (witness.field, witness.witness_id, witness.source, witness.span)
+        for witness in report.evidence_witnesses
+    }
+    expected = {
+        (
+            source_map.expected_field,
+            source_map.witness_id,
+            f"raw_sources/{source_map.source_ref}",
+            source_map.source_row_id,
+        )
+        for source_map in oracle.source_to_expected_claim_map
+    }
+    missing = expected - actual
+    assert not missing, (
+        "source_to_expected_claim_map did not match report.evidence_witnesses: "
+        f"{sorted(missing)}"
+    )
+
+
+def _stable_id(*parts: str) -> str:
+    return ":".join(str(part) for part in parts)
+
+
+def _read_csv(path: Path) -> tuple[dict[str, str], ...]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return tuple(csv.DictReader(handle))
+
+
+def _parse_scalar(value: str) -> str | int | float:
+    try:
+        integer = int(value)
+    except ValueError:
+        pass
+    else:
+        return integer
+
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+__all__ = ["assert_synthetic_oracle_matches_report", "load_synthetic_oracle"]

--- a/tests/test_synthetic_oracle_assertions.py
+++ b/tests/test_synthetic_oracle_assertions.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from comp.compiler_tool import resolve_reference_grounded_calculation
+from comp.scenarios.synthetic import (
+    SyntheticPcfAdapter,
+    SyntheticScenarioConfig,
+    generate_synthetic_pcf_run,
+    write_synthetic_run,
+)
+from tests.support.synthetic.oracle_assertions import (
+    assert_synthetic_oracle_matches_report,
+    load_synthetic_oracle,
+)
+
+
+def test_oracle_assertions_match_smoke_report_outputs() -> None:
+    run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_smoke(seed=7))
+    adapter = SyntheticPcfAdapter(run)
+    report = resolve_reference_grounded_calculation(
+        adapter.blocked_report(),
+        adapter.reference_catalog(),
+        query_for_obligation=adapter.query_for_obligation,
+        criteria=adapter.reference_selection_criteria(),
+        input_claim=adapter.input_claim(),
+        formula=adapter.formula(),
+        output_claim_id=adapter.output_claim_id,
+    )
+
+    assert_synthetic_oracle_matches_report(run.oracle, report)
+
+
+def test_oracle_assertions_match_anomaly_report_outputs() -> None:
+    run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_anomaly(seed=11))
+    adapter = SyntheticPcfAdapter(run)
+
+    assert_synthetic_oracle_matches_report(run.oracle, adapter.anomaly_report())
+
+
+def test_oracle_assertions_can_load_written_oracle_files(tmp_path) -> None:
+    run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_anomaly(seed=11))
+    run_dir = write_synthetic_run(run, tmp_path / "synthetic-pcf-anomaly")
+    adapter = SyntheticPcfAdapter(run)
+
+    oracle = load_synthetic_oracle(run_dir / "oracle")
+
+    assert_synthetic_oracle_matches_report(oracle, adapter.anomaly_report())
+
+
+def test_oracle_assertions_fail_when_expected_obligation_is_missing() -> None:
+    run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_anomaly(seed=11))
+    adapter = SyntheticPcfAdapter(run)
+    report = adapter.anomaly_report()
+    report_without_site_alias = replace(report, obligations=report.obligations[:-1])
+
+    with pytest.raises(AssertionError, match="expected obligations"):
+        assert_synthetic_oracle_matches_report(
+            run.oracle,
+            report_without_site_alias,
+        )

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -9,6 +9,9 @@ from comp.scenarios.synthetic import (
     generate_synthetic_pcf_run,
     write_synthetic_run,
 )
+from tests.support.synthetic.oracle_assertions import (
+    assert_synthetic_oracle_matches_report,
+)
 
 
 def test_synthetic_pcf_generator_writes_oracle_not_truth(tmp_path: Path) -> None:
@@ -119,24 +122,8 @@ def test_synthetic_pcf_anomaly_adapter_reports_raw_source_pressure() -> None:
 
     report = adapter.anomaly_report()
 
+    assert_synthetic_oracle_matches_report(run.oracle, report)
     assert report.status == "blocked"
-    assert tuple((claim.field, claim.reason) for claim in report.failed_claims) == (
-        ("unit", "unsupported_unit"),
-        ("electricity_kwh", "negative_amount"),
-    )
-    assert tuple(obligation.obligation_id for obligation in report.obligations) == (
-        "synthetic-obligation:missing_unit",
-        "synthetic-obligation:wrong_unit",
-        "synthetic-obligation:period_mismatch",
-        "synthetic-obligation:negative_amount",
-        "synthetic-obligation:site_alias",
-    )
-    assert tuple((hazard.kind, hazard.field, hazard.severity) for hazard in report.hazards) == (
-        ("missing_unit", "unit", "review"),
-        ("period_mismatch", "period", "review"),
-        ("invalid_activity_amount", "electricity_kwh", "block"),
-        ("site_alias", "site_id", "review"),
-    )
     assert {witness.source for witness in report.evidence_witnesses} == {
         "raw_sources/erp_electricity.csv",
     }


### PR DESCRIPTION
## Summary
- Add a synthetic oracle assertion harness under `tests/support/synthetic` that compares generated oracle expectations against actual `CompileReport` outputs.
- Support both in-memory `SyntheticOracle` objects and written `oracle/` CSV directories via `load_synthetic_oracle`.
- Replace the anomaly adapter test's hand-coded failed-claim/obligation/hazard assertions with the shared oracle harness.

## Notes
- The harness remains test-only and keeps the production `comp` package independent of synthetic oracle assertions.
- The source map check verifies generated `source_to_expected_claim_map.csv` expectations against actual evidence witness source/span linkage.

## Test Plan
- `python -m pytest tests\test_synthetic_oracle_assertions.py tests\test_synthetic_scenario_generator.py -q` -> `8 passed`
- `python -m pytest tests\test_synthetic_oracle_assertions.py tests\test_synthetic_scenario_generator.py tests\test_domain_scenario_lab.py tests\test_package_smoke.py tests\test_final_bottom_up_rollup_scenario.py -q` -> `44 passed`
- `python -m pytest -q` -> `345 passed`
- `python -m tests.domain_scenarios run-all` -> `Passed: 13/13`
- `git diff --check`