### PR TITLE
[codex] add synthetic run harness

### DIFF
--- a/tests/support/synthetic/__init__.py
+++ b/tests/support/synthetic/__init__.py
@@ -2,5 +2,14 @@ from tests.support.synthetic.oracle_assertions import (
     assert_synthetic_oracle_matches_report,
     load_synthetic_oracle,
 )
+from tests.support.synthetic.run_harness import (
+    MaterializedSyntheticRun,
+    materialize_synthetic_run,
+)
 
-__all__ = ["assert_synthetic_oracle_matches_report", "load_synthetic_oracle"]
+__all__ = [
+    "MaterializedSyntheticRun",
+    "assert_synthetic_oracle_matches_report",
+    "load_synthetic_oracle",
+    "materialize_synthetic_run",
+]

--- a/tests/support/synthetic/run_harness.py
+++ b/tests/support/synthetic/run_harness.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from comp import ProjectionSpec, project_public_row
+from comp.compiler_tool import (
+    CommitPreparation,
+    CompileReport,
+    prepare_commit,
+    resolve_reference_grounded_calculation,
+)
+from comp.scenarios.synthetic import (
+    SyntheticOracle,
+    SyntheticPcfAdapter,
+    SyntheticRun,
+    SyntheticScenarioConfig,
+    generate_synthetic_pcf_run,
+    write_synthetic_run,
+)
+from tests.support.synthetic.oracle_assertions import (
+    assert_synthetic_oracle_matches_report,
+    load_synthetic_oracle,
+)
+
+
+@dataclass(frozen=True)
+class MaterializedSyntheticRun:
+    run: SyntheticRun
+    run_dir: Path
+    oracle: SyntheticOracle
+    adapter: SyntheticPcfAdapter
+    report: CompileReport
+    preparation: CommitPreparation
+    projection: dict[str, Any] | None
+    oracle_checked: bool
+
+
+def materialize_synthetic_run(
+    config: SyntheticScenarioConfig,
+    base_dir: Path,
+) -> MaterializedSyntheticRun:
+    run = generate_synthetic_pcf_run(config)
+    run_dir = write_synthetic_run(
+        run,
+        base_dir / f"{config.scenario_id}-seed-{config.seed}",
+    )
+    oracle = load_synthetic_oracle(run_dir / "oracle")
+    adapter = SyntheticPcfAdapter(run)
+    report = _compile_report(adapter)
+    preparation = prepare_commit(
+        report,
+        subject_id=adapter.subject_id,
+        public_row_id=adapter.public_row_id,
+        projection_id=adapter.projection_id,
+        profile_id=adapter.profile_id,
+        dependency_fingerprints=adapter.dependency_fingerprints(),
+    )
+    projection = _project_if_authorized(adapter, report, preparation)
+
+    assert_synthetic_oracle_matches_report(oracle, report)
+
+    return MaterializedSyntheticRun(
+        run=run,
+        run_dir=run_dir,
+        oracle=oracle,
+        adapter=adapter,
+        report=report,
+        preparation=preparation,
+        projection=projection,
+        oracle_checked=True,
+    )
+
+
+def _compile_report(adapter: SyntheticPcfAdapter) -> CompileReport:
+    if adapter.config.anomalies:
+        return adapter.anomaly_report()
+    return resolve_reference_grounded_calculation(
+        adapter.blocked_report(),
+        adapter.reference_catalog(),
+        query_for_obligation=adapter.query_for_obligation,
+        criteria=adapter.reference_selection_criteria(),
+        input_claim=adapter.input_claim(),
+        formula=adapter.formula(),
+        output_claim_id=adapter.output_claim_id,
+    )
+
+
+def _project_if_authorized(
+    adapter: SyntheticPcfAdapter,
+    report: CompileReport,
+    preparation: CommitPreparation,
+) -> dict[str, Any] | None:
+    if preparation.receipt is None:
+        return None
+    return project_public_row(
+        adapter.projection_source(report),
+        ProjectionSpec(adapter.projection_id, adapter.projection_fields),
+        receipt=preparation.receipt,
+    )
+
+
+__all__ = ["MaterializedSyntheticRun", "materialize_synthetic_run"]

--- a/tests/test_synthetic_run_harness.py
+++ b/tests/test_synthetic_run_harness.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from comp.scenarios.synthetic import SyntheticScenarioConfig
+from tests.support.synthetic import materialize_synthetic_run
+
+
+def test_synthetic_run_harness_materializes_smoke_receipt_flow(tmp_path) -> None:
+    harness = materialize_synthetic_run(
+        SyntheticScenarioConfig.pcf_smoke(seed=7),
+        tmp_path,
+    )
+
+    assert harness.run_dir.name == "synthetic_pcf.smoke.v1-seed-7"
+    assert (harness.run_dir / "raw_sources" / "erp_electricity.csv").is_file()
+    assert (harness.run_dir / "oracle" / "expected_derived_claims.csv").is_file()
+    assert harness.oracle_checked is True
+    assert harness.report.status == "accepted"
+    assert harness.preparation.decision.status == "commit"
+    assert harness.preparation.receipt is not None
+    assert harness.projection == {
+        "electricity_kwh": 1200,
+        "co2e_kg": 504.0,
+    }
+
+
+def test_synthetic_run_harness_materializes_anomaly_hold_flow(tmp_path) -> None:
+    harness = materialize_synthetic_run(
+        SyntheticScenarioConfig.pcf_anomaly(seed=11),
+        tmp_path,
+    )
+
+    assert harness.run_dir.name == "synthetic_pcf.anomaly.v1-seed-11"
+    assert (harness.run_dir / "oracle" / "injected_anomalies.csv").is_file()
+    assert (harness.run_dir / "oracle" / "expected_failed_claims.csv").is_file()
+    assert harness.oracle_checked is True
+    assert harness.report.status == "blocked"
+    assert harness.preparation.decision.status == "hold"
+    assert harness.preparation.receipt is None
+    assert harness.projection is None


### PR DESCRIPTION
## Summary
- Add `materialize_synthetic_run()` under `tests/support/synthetic` to execute the full synthetic validation loop in one helper.
- The harness generates the run, writes `master/`, `raw_sources/`, and `oracle/`, reloads oracle CSVs, adapts raw inputs into a comp report, prepares governance, projects only when receipt-authorized, and asserts oracle/report consistency.
- Add smoke and anomaly tests covering commit/projection and blocked/hold flows through the harness.

## Notes
- This remains test-support code only; production `comp` packages do not import the synthetic harness.
- The harness gives future synthetic scenarios one path for generator -> oracle -> report validation instead of repeating setup in each test.

## Test Plan
- `python -m pytest tests\test_synthetic_run_harness.py -q` -> `2 passed`
- `python -m pytest tests\test_synthetic_run_harness.py tests\test_synthetic_oracle_assertions.py tests\test_synthetic_scenario_generator.py tests\test_package_smoke.py -q` -> `22 passed`
- `python -m pytest -q` -> `347 passed`
- `python -m tests.domain_scenarios run-all` -> `Passed: 13/13`
- `git diff --check`