### PR TITLE
Fix synthetic run harness input boundary

### DIFF
--- a/tests/support/synthetic/run_harness.py
+++ b/tests/support/synthetic/run_harness.py
@@ -47,7 +47,7 @@ def materialize_synthetic_run(
         base_dir / f"{config.scenario_id}-seed-{config.seed}",
     )
     oracle = load_synthetic_oracle(run_dir / "oracle")
-    adapter = SyntheticPcfAdapter(run)
+    adapter = SyntheticPcfAdapter(run.input_bundle)
     report = _compile_report(adapter)
     preparation = prepare_commit(
         report,


### PR DESCRIPTION
## Summary
- pass the synthetic adapter the non-authoritative `SyntheticInputBundle` instead of the full `SyntheticRun` in the run harness
- restore compatibility with the hardened synthetic input boundary merged before the harness

## Root cause
The main push failed after #215 and #216 were both merged because #215 changed `SyntheticPcfAdapter` to reject full `SyntheticRun` objects, while #216's test harness still called `SyntheticPcfAdapter(run)`.

## Verification
- `python -m pytest tests\test_synthetic_run_harness.py -q`
- `python -m pytest tests\test_synthetic_scenario_generator.py tests\test_synthetic_oracle_assertions.py tests\test_package_smoke.py tests\test_compiler_profile_contract.py -q`
- `python -m pytest -q`