### PR TITLE
Add synthetic receipt replay oracle

### DIFF
--- a/comp/scenarios/synthetic/__init__.py
+++ b/comp/scenarios/synthetic/__init__.py
@@ -7,11 +7,14 @@ claims, issue receipts, or authorize public projection.
 from comp.scenarios.synthetic.adapters import SyntheticPcfAdapter
 from comp.scenarios.synthetic.config import SyntheticScenarioConfig
 from comp.scenarios.synthetic.generator import (
+    ExpectedArtifactRef,
     ExpectedClaim,
+    ExpectedDependencyRef,
     ExpectedDerivedClaim,
     ExpectedFailedClaim,
     ExpectedHazard,
     ExpectedObligation,
+    ExpectedReceipt,
     ExpectedSourceMap,
     InjectedAnomaly,
     MasterReferenceRecord,
@@ -27,10 +30,13 @@ from comp.scenarios.synthetic.generator import (
 
 __all__ = [
     "ExpectedClaim",
+    "ExpectedArtifactRef",
+    "ExpectedDependencyRef",
     "ExpectedDerivedClaim",
     "ExpectedFailedClaim",
     "ExpectedHazard",
     "ExpectedObligation",
+    "ExpectedReceipt",
     "ExpectedSourceMap",
     "InjectedAnomaly",
     "MasterReferenceRecord",

--- a/comp/scenarios/synthetic/generator.py
+++ b/comp/scenarios/synthetic/generator.py
@@ -202,6 +202,107 @@ class ExpectedHazard:
 
 
 @dataclass(frozen=True)
+class ExpectedArtifactRef:
+    artifact_id: str
+    artifact_kind: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "artifact_id": self.artifact_id,
+            "artifact_kind": self.artifact_kind,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ExpectedArtifactRef":
+        return cls(
+            artifact_id=str(payload["artifact_id"]),
+            artifact_kind=str(payload["artifact_kind"]),
+        )
+
+
+@dataclass(frozen=True)
+class ExpectedDependencyRef:
+    dependency_kind: str
+    dependency_id: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "dependency_kind": self.dependency_kind,
+            "dependency_id": self.dependency_id,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ExpectedDependencyRef":
+        return cls(
+            dependency_kind=str(payload["dependency_kind"]),
+            dependency_id=str(payload["dependency_id"]),
+        )
+
+
+@dataclass(frozen=True)
+class ExpectedReceipt:
+    public_row_id: str
+    projection_id: str
+    authorized_fields: tuple[str, ...]
+    public_row: dict[str, Any]
+    governance_status: str
+    commit_package_id: str
+    governance_decision_id: str
+    checked_claim_witness_ids: tuple[str, ...]
+    reference_binding_ids: tuple[str, ...]
+    derived_claim_ids: tuple[str, ...]
+    calculation_trace_ids: tuple[str, ...]
+    formula_ids: tuple[str, ...]
+    dependency_refs: tuple[ExpectedDependencyRef, ...]
+    artifact_refs: tuple[ExpectedArtifactRef, ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "public_row_id": self.public_row_id,
+            "projection_id": self.projection_id,
+            "authorized_fields": list(self.authorized_fields),
+            "public_row": self.public_row,
+            "governance_status": self.governance_status,
+            "commit_package_id": self.commit_package_id,
+            "governance_decision_id": self.governance_decision_id,
+            "checked_claim_witness_ids": list(self.checked_claim_witness_ids),
+            "reference_binding_ids": list(self.reference_binding_ids),
+            "derived_claim_ids": list(self.derived_claim_ids),
+            "calculation_trace_ids": list(self.calculation_trace_ids),
+            "formula_ids": list(self.formula_ids),
+            "dependency_refs": [
+                ref.to_payload() for ref in self.dependency_refs
+            ],
+            "artifact_refs": [ref.to_payload() for ref in self.artifact_refs],
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "ExpectedReceipt":
+        return cls(
+            public_row_id=str(payload["public_row_id"]),
+            projection_id=str(payload["projection_id"]),
+            authorized_fields=tuple(payload["authorized_fields"]),
+            public_row=dict(payload["public_row"]),
+            governance_status=str(payload["governance_status"]),
+            commit_package_id=str(payload["commit_package_id"]),
+            governance_decision_id=str(payload["governance_decision_id"]),
+            checked_claim_witness_ids=tuple(payload["checked_claim_witness_ids"]),
+            reference_binding_ids=tuple(payload["reference_binding_ids"]),
+            derived_claim_ids=tuple(payload["derived_claim_ids"]),
+            calculation_trace_ids=tuple(payload["calculation_trace_ids"]),
+            formula_ids=tuple(payload["formula_ids"]),
+            dependency_refs=tuple(
+                ExpectedDependencyRef.from_payload(ref)
+                for ref in payload["dependency_refs"]
+            ),
+            artifact_refs=tuple(
+                ExpectedArtifactRef.from_payload(ref)
+                for ref in payload["artifact_refs"]
+            ),
+        )
+
+
+@dataclass(frozen=True)
 class SyntheticMaster:
     reference_catalog: tuple[MasterReferenceRecord, ...]
     sites: tuple[dict[str, Any], ...]
@@ -231,6 +332,7 @@ class SyntheticOracle:
     expected_failed_claims: tuple[ExpectedFailedClaim, ...]
     injected_anomalies: tuple[InjectedAnomaly, ...]
     source_to_expected_claim_map: tuple[ExpectedSourceMap, ...]
+    expected_receipt: ExpectedReceipt | None = None
 
 
 @dataclass(frozen=True)
@@ -334,6 +436,11 @@ def generate_synthetic_pcf_run(config: SyntheticScenarioConfig) -> SyntheticRun:
                     expected_field="electricity_kwh",
                     witness_id=source_witness_id,
                 ),
+            ),
+            expected_receipt=_expected_smoke_receipt(
+                config,
+                source_witness_id=source_witness_id,
+                derived_value=derived_value,
             ),
         ),
     )
@@ -690,6 +797,11 @@ def write_synthetic_run(run: SyntheticRun, run_dir: Path) -> Path:
         ],
         (item.to_row() for item in run.oracle.source_to_expected_claim_map),
     )
+    if run.oracle.expected_receipt is not None:
+        _write_json(
+            run_dir / "oracle" / "expected_receipt.json",
+            run.oracle.expected_receipt.to_payload(),
+        )
     return run_dir
 
 
@@ -718,12 +830,70 @@ def _multiply(left: int | float, right: int | float) -> int | float:
     return float(value)
 
 
+def _expected_smoke_receipt(
+    config: SyntheticScenarioConfig,
+    *,
+    source_witness_id: str,
+    derived_value: int | float,
+) -> ExpectedReceipt:
+    commit_package_id = f"commit-package:{config.subject_id}"
+    governance_decision_id = f"governance-decision:{commit_package_id}"
+    manifest_dependency_id = _synthetic_manifest_dependency_id(config)
+    return ExpectedReceipt(
+        public_row_id=config.public_row_id,
+        projection_id=config.projection_id,
+        authorized_fields=("electricity_kwh", "co2e_kg"),
+        public_row={
+            "electricity_kwh": config.electricity_kwh,
+            "co2e_kg": derived_value,
+        },
+        governance_status="commit",
+        commit_package_id=commit_package_id,
+        governance_decision_id=governance_decision_id,
+        checked_claim_witness_ids=(source_witness_id,),
+        reference_binding_ids=(config.binding_id,),
+        derived_claim_ids=(config.output_claim_id,),
+        calculation_trace_ids=(f"trace:{config.output_claim_id}",),
+        formula_ids=(config.formula_id,),
+        dependency_refs=(
+            ExpectedDependencyRef(
+                dependency_kind="synthetic_manifest",
+                dependency_id=manifest_dependency_id,
+            ),
+        ),
+        artifact_refs=(
+            ExpectedArtifactRef(commit_package_id, "commit_package"),
+            ExpectedArtifactRef(governance_decision_id, "governance_decision"),
+            ExpectedArtifactRef(
+                f"checked_claim:electricity_kwh:{source_witness_id}",
+                "checked_claim",
+            ),
+            ExpectedArtifactRef(config.output_claim_id, "derived_claim"),
+            ExpectedArtifactRef(source_witness_id, "evidence_witness"),
+            ExpectedArtifactRef(config.binding_id, "reference_binding"),
+            ExpectedArtifactRef(
+                f"trace:{config.output_claim_id}",
+                "calculation_trace",
+            ),
+            ExpectedArtifactRef(config.formula_id, "formula"),
+            ExpectedArtifactRef(manifest_dependency_id, "synthetic_manifest"),
+        ),
+    )
+
+
+def _synthetic_manifest_dependency_id(config: SyntheticScenarioConfig) -> str:
+    return f"synthetic_manifest:{config.scenario_id}:seed-{config.seed}"
+
+
 __all__ = [
     "ExpectedClaim",
     "ExpectedDerivedClaim",
     "ExpectedFailedClaim",
     "ExpectedHazard",
     "ExpectedObligation",
+    "ExpectedArtifactRef",
+    "ExpectedDependencyRef",
+    "ExpectedReceipt",
     "ExpectedSourceMap",
     "InjectedAnomaly",
     "MasterReferenceRecord",

--- a/tests/support/synthetic/__init__.py
+++ b/tests/support/synthetic/__init__.py
@@ -1,5 +1,6 @@
 from tests.support.synthetic.oracle_assertions import (
     assert_synthetic_oracle_matches_report,
+    assert_synthetic_receipt_oracle_matches,
     load_synthetic_oracle,
 )
 from tests.support.synthetic.run_harness import (
@@ -10,6 +11,7 @@ from tests.support.synthetic.run_harness import (
 __all__ = [
     "MaterializedSyntheticRun",
     "assert_synthetic_oracle_matches_report",
+    "assert_synthetic_receipt_oracle_matches",
     "load_synthetic_oracle",
     "materialize_synthetic_run",
 ]

--- a/tests/support/synthetic/oracle_assertions.py
+++ b/tests/support/synthetic/oracle_assertions.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import csv
+import json
 from pathlib import Path
 from typing import Any
 
 from comp.compiler_tool import CompileReport
+from comp.judgment import CommitReceipt
+from comp.persistence import ProjectionReplayReport
 from comp.scenarios.synthetic import (
     ExpectedClaim,
     ExpectedDerivedClaim,
     ExpectedFailedClaim,
     ExpectedHazard,
     ExpectedObligation,
+    ExpectedReceipt,
     ExpectedSourceMap,
     InjectedAnomaly,
     SyntheticOracle,
@@ -88,6 +92,9 @@ def load_synthetic_oracle(oracle_dir: Path) -> SyntheticOracle:
             )
             for row in _read_csv(oracle_dir / "source_to_expected_claim_map.csv")
         ),
+        expected_receipt=_read_expected_receipt(
+            oracle_dir / "expected_receipt.json"
+        ),
     )
 
 
@@ -111,6 +118,58 @@ def assert_synthetic_oracle_matches_report(
         oracle
     ), "expected hazards did not match report.hazards"
     _assert_source_map_matches_witnesses(oracle, report)
+
+
+def assert_synthetic_receipt_oracle_matches(
+    oracle: SyntheticOracle,
+    receipt: CommitReceipt | None,
+    replay_report: ProjectionReplayReport | None,
+) -> None:
+    expected = oracle.expected_receipt
+    if expected is None:
+        assert receipt is None, "synthetic oracle expected no commit receipt"
+        assert replay_report is None, "synthetic oracle expected no replay report"
+        return
+
+    assert receipt is not None, "synthetic oracle expected a commit receipt"
+    assert replay_report is not None, "synthetic oracle expected replay output"
+    assert receipt.citations is not None, "synthetic receipt must carry citations"
+
+    citations = receipt.citations
+    assert receipt.public_row_id == expected.public_row_id
+    assert receipt.projection_id == expected.projection_id
+    assert tuple(receipt.authorized_fields) == expected.authorized_fields
+    assert replay_report.public_row == expected.public_row
+    assert replay_report.projection_id == expected.projection_id
+
+    assert citations.governance_status == expected.governance_status
+    assert citations.commit_package_id == expected.commit_package_id
+    assert citations.governance_decision_id == expected.governance_decision_id
+    assert citations.checked_claim_witness_ids == expected.checked_claim_witness_ids
+    assert citations.reference_binding_ids == expected.reference_binding_ids
+    assert citations.derived_claim_ids == expected.derived_claim_ids
+    assert citations.calculation_trace_ids == expected.calculation_trace_ids
+    assert citations.formula_ids == expected.formula_ids
+    assert (
+        tuple(
+            (fingerprint.dependency_kind, fingerprint.dependency_id)
+            for fingerprint in citations.dependency_fingerprints
+        )
+        == tuple(
+            (dependency.dependency_kind, dependency.dependency_id)
+            for dependency in expected.dependency_refs
+        )
+    )
+    assert (
+        tuple(
+            (artifact.artifact_id, artifact.artifact_kind)
+            for artifact in replay_report.artifact_refs
+        )
+        == tuple(
+            (artifact.artifact_id, artifact.artifact_kind)
+            for artifact in expected.artifact_refs
+        )
+    )
 
 
 def _expected_claim_rows(oracle: SyntheticOracle) -> tuple[tuple[Any, ...], ...]:
@@ -243,6 +302,14 @@ def _read_csv(path: Path) -> tuple[dict[str, str], ...]:
         return tuple(csv.DictReader(handle))
 
 
+def _read_expected_receipt(path: Path) -> ExpectedReceipt | None:
+    if not path.exists():
+        return None
+    return ExpectedReceipt.from_payload(
+        json.loads(path.read_text(encoding="utf-8"))
+    )
+
+
 def _parse_scalar(value: str) -> str | int | float:
     try:
         integer = int(value)
@@ -257,4 +324,8 @@ def _parse_scalar(value: str) -> str | int | float:
         return value
 
 
-__all__ = ["assert_synthetic_oracle_matches_report", "load_synthetic_oracle"]
+__all__ = [
+    "assert_synthetic_oracle_matches_report",
+    "assert_synthetic_receipt_oracle_matches",
+    "load_synthetic_oracle",
+]

--- a/tests/support/synthetic/replay.py
+++ b/tests/support/synthetic/replay.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from comp.compiler_tool import (
+    CommitPreparation,
+    CompileReport,
+    evidence_witness_fingerprint,
+)
+from comp.judgment import ProjectionSpec
+from comp.persistence import (
+    ArtifactEnvelope,
+    ArtifactRef,
+    InMemoryArtifactStore,
+    InMemoryReceiptLedger,
+    ProjectionReplayReport,
+    receipt_artifact_refs,
+    replay_public_projection,
+)
+
+
+@dataclass(frozen=True)
+class SyntheticReplayBundle:
+    artifacts: InMemoryArtifactStore
+    receipt_ledger: InMemoryReceiptLedger
+
+
+def synthetic_replay_bundle(
+    report: CompileReport,
+    preparation: CommitPreparation,
+    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> SyntheticReplayBundle:
+    receipt = preparation.receipt
+    if receipt is None:
+        raise AssertionError("Synthetic replay requires a commit receipt.")
+
+    artifacts = InMemoryArtifactStore()
+    for ref in receipt_artifact_refs(receipt):
+        artifacts.record(
+            _artifact_envelope_for_ref(
+                report,
+                preparation,
+                dependency_artifact_bodies,
+                ref,
+            )
+        )
+
+    receipt_ledger = InMemoryReceiptLedger()
+    receipt_ledger.record(receipt)
+    return SyntheticReplayBundle(
+        artifacts=artifacts,
+        receipt_ledger=receipt_ledger,
+    )
+
+
+def replay_synthetic_projection(
+    row: Mapping[str, Any],
+    projection: ProjectionSpec,
+    preparation: CommitPreparation,
+    *,
+    bundle: SyntheticReplayBundle,
+) -> ProjectionReplayReport:
+    receipt = preparation.receipt
+    if receipt is None:
+        raise AssertionError("Synthetic replay requires a commit receipt.")
+
+    ledger_receipt = bundle.receipt_ledger.get(
+        public_row_id=receipt.public_row_id,
+        projection_id=receipt.projection_id,
+        draft_id=receipt.draft_id,
+    )
+    return replay_public_projection(
+        row,
+        projection,
+        receipt=ledger_receipt,
+        artifacts=bundle.artifacts,
+    )
+
+
+def _artifact_envelope_for_ref(
+    report: CompileReport,
+    preparation: CommitPreparation,
+    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+    ref: ArtifactRef,
+) -> ArtifactEnvelope:
+    return ArtifactEnvelope.from_body(
+        artifact_id=ref.artifact_id,
+        artifact_kind=ref.artifact_kind,
+        schema_version="synthetic-scenario-v1",
+        body=_artifact_body_for_ref(
+            report,
+            preparation,
+            dependency_artifact_bodies,
+            ref,
+        ),
+    )
+
+
+def _artifact_body_for_ref(
+    report: CompileReport,
+    preparation: CommitPreparation,
+    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+    ref: ArtifactRef,
+) -> dict[str, Any]:
+    dependency_body = dependency_artifact_bodies.get(
+        (ref.artifact_kind, ref.artifact_id)
+    )
+    if dependency_body is not None:
+        return dict(dependency_body)
+
+    if ref.artifact_kind == "commit_package":
+        package = preparation.package
+        return {
+            "package_id": package.package_id,
+            "subject_id": package.subject_id,
+            "report_status": package.report_status,
+            "complete": package.complete,
+            "reference_binding_ids": package.reference_binding_ids,
+            "derived_claim_ids": package.derived_claim_ids,
+            "calculation_trace_ids": package.calculation_trace_ids,
+            "formula_ids": package.formula_ids,
+            "open_obligation_ids": package.open_obligation_ids,
+            "hazard_ids": package.hazard_ids,
+        }
+    if ref.artifact_kind == "governance_decision":
+        decision = preparation.decision
+        return {
+            "decision_id": decision.decision_id,
+            "package_id": decision.package_id,
+            "subject_id": decision.subject_id,
+            "status": decision.status,
+            "reasons": decision.reasons,
+            "profile_id": decision.profile_id,
+        }
+    if ref.artifact_kind == "checked_claim":
+        claim = _checked_claim_by_source_id(report, ref.artifact_id)
+        return {
+            "claim_id": ref.artifact_id,
+            "field": claim.field,
+            "value": claim.value,
+            "witness_id": claim.witness_id,
+            "origin": claim.origin,
+        }
+    if ref.artifact_kind == "evidence_witness":
+        witness = _evidence_witness_by_id(report, ref.artifact_id)
+        fingerprint = evidence_witness_fingerprint(witness)
+        return {
+            "dependency_kind": fingerprint.dependency_kind,
+            "dependency_id": fingerprint.dependency_id,
+            "witness_id": witness.witness_id,
+            "field": witness.field,
+            "source": witness.source,
+            "span": witness.span,
+            "text": witness.text,
+            "fingerprint": fingerprint.fingerprint,
+            "digest_alg": fingerprint.digest_alg,
+        }
+    if ref.artifact_kind == "reference_binding":
+        binding = _by_id(report.reference_bindings, ref.artifact_id, "binding_id")
+        return {
+            "binding_id": binding.binding_id,
+            "claim_id": binding.claim_id,
+            "reference_id": binding.reference_id,
+            "reference_type": binding.reference_type,
+            "selected_candidate_id": binding.selected_candidate_id,
+            "selector_rule_id": binding.selector_rule_id,
+            "source_witness_ids": binding.source_witness_ids,
+            "rejected_candidates": tuple(
+                {
+                    "candidate_id": candidate.candidate_id,
+                    "reference_id": candidate.reference_id,
+                    "reason": candidate.reason,
+                    "selector_rule_id": candidate.selector_rule_id,
+                }
+                for candidate in binding.rejected_candidates
+            ),
+            "authority": binding.authority,
+        }
+    if ref.artifact_kind == "derived_claim":
+        claim = _by_id(report.derived_claims, ref.artifact_id, "claim_id")
+        return {
+            "claim_id": claim.claim_id,
+            "field": claim.field,
+            "value": claim.value,
+            "unit": claim.unit,
+            "formula_id": claim.formula_id,
+            "trace_id": claim.trace.trace_id,
+            "origin": claim.origin,
+        }
+    if ref.artifact_kind == "calculation_trace":
+        trace = _trace_by_id(report, ref.artifact_id)
+        return {
+            "trace_id": trace.trace_id,
+            "formula_id": trace.formula_id,
+            "input_claim_ids": trace.input_claim_ids,
+            "reference_binding_ids": trace.reference_binding_ids,
+            "steps": tuple(
+                {
+                    "step_id": step.step_id,
+                    "operation": step.operation,
+                    "input_ids": step.input_ids,
+                    "output_value": step.output_value,
+                    "output_unit": step.output_unit,
+                }
+                for step in trace.steps
+            ),
+        }
+    if ref.artifact_kind == "formula":
+        return {"formula_id": ref.artifact_id}
+
+    raise AssertionError(f"Unsupported synthetic artifact ref: {ref}.")
+
+
+def _checked_claim_by_source_id(report: CompileReport, source_id: str):
+    for claim in report.checked_claims:
+        if source_id == f"checked_claim:{claim.field}:{claim.witness_id}":
+            return claim
+    raise AssertionError(f"Synthetic checked claim not found: {source_id}.")
+
+
+def _evidence_witness_by_id(report: CompileReport, witness_id: str):
+    for witness in report.evidence_witnesses:
+        if witness.witness_id == witness_id:
+            return witness
+    raise AssertionError(f"Synthetic evidence witness not found: {witness_id}.")
+
+
+def _trace_by_id(report: CompileReport, trace_id: str):
+    for claim in report.derived_claims:
+        if claim.trace.trace_id == trace_id:
+            return claim.trace
+    raise AssertionError(f"Synthetic calculation trace not found: {trace_id}.")
+
+
+def _by_id(items, item_id: str, field: str):
+    for item in items:
+        if getattr(item, field) == item_id:
+            return item
+    raise AssertionError(f"Synthetic artifact not found: {item_id}.")
+
+
+__all__ = [
+    "SyntheticReplayBundle",
+    "replay_synthetic_projection",
+    "synthetic_replay_bundle",
+]

--- a/tests/support/synthetic/run_harness.py
+++ b/tests/support/synthetic/run_harness.py
@@ -11,6 +11,7 @@ from comp.compiler_tool import (
     prepare_commit,
     resolve_reference_grounded_calculation,
 )
+from comp.persistence import ProjectionReplayReport
 from comp.scenarios.synthetic import (
     SyntheticOracle,
     SyntheticPcfAdapter,
@@ -21,7 +22,12 @@ from comp.scenarios.synthetic import (
 )
 from tests.support.synthetic.oracle_assertions import (
     assert_synthetic_oracle_matches_report,
+    assert_synthetic_receipt_oracle_matches,
     load_synthetic_oracle,
+)
+from tests.support.synthetic.replay import (
+    replay_synthetic_projection,
+    synthetic_replay_bundle,
 )
 
 
@@ -34,7 +40,9 @@ class MaterializedSyntheticRun:
     report: CompileReport
     preparation: CommitPreparation
     projection: dict[str, Any] | None
+    replay_report: ProjectionReplayReport | None
     oracle_checked: bool
+    receipt_oracle_checked: bool
 
 
 def materialize_synthetic_run(
@@ -57,9 +65,22 @@ def materialize_synthetic_run(
         profile_id=adapter.profile_id,
         dependency_fingerprints=adapter.dependency_fingerprints(),
     )
-    projection = _project_if_authorized(adapter, report, preparation)
+    projection_spec = ProjectionSpec(adapter.projection_id, adapter.projection_fields)
+    projection = _project_if_authorized(adapter, report, preparation, projection_spec)
+    replay_report = _replay_if_authorized(
+        adapter,
+        report,
+        preparation,
+        projection,
+        projection_spec,
+    )
 
     assert_synthetic_oracle_matches_report(oracle, report)
+    assert_synthetic_receipt_oracle_matches(
+        oracle,
+        preparation.receipt,
+        replay_report,
+    )
 
     return MaterializedSyntheticRun(
         run=run,
@@ -69,7 +90,9 @@ def materialize_synthetic_run(
         report=report,
         preparation=preparation,
         projection=projection,
+        replay_report=replay_report,
         oracle_checked=True,
+        receipt_oracle_checked=oracle.expected_receipt is not None,
     )
 
 
@@ -91,13 +114,36 @@ def _project_if_authorized(
     adapter: SyntheticPcfAdapter,
     report: CompileReport,
     preparation: CommitPreparation,
+    projection_spec: ProjectionSpec,
 ) -> dict[str, Any] | None:
     if preparation.receipt is None:
         return None
     return project_public_row(
         adapter.projection_source(report),
-        ProjectionSpec(adapter.projection_id, adapter.projection_fields),
+        projection_spec,
         receipt=preparation.receipt,
+    )
+
+
+def _replay_if_authorized(
+    adapter: SyntheticPcfAdapter,
+    report: CompileReport,
+    preparation: CommitPreparation,
+    projection: dict[str, Any] | None,
+    projection_spec: ProjectionSpec,
+) -> ProjectionReplayReport | None:
+    if preparation.receipt is None or projection is None:
+        return None
+    bundle = synthetic_replay_bundle(
+        report,
+        preparation,
+        adapter.dependency_artifact_bodies(),
+    )
+    return replay_synthetic_projection(
+        projection,
+        projection_spec,
+        preparation,
+        bundle=bundle,
     )
 
 

--- a/tests/test_synthetic_run_harness.py
+++ b/tests/test_synthetic_run_harness.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+
+from comp.persistence import ArtifactRef
 from comp.scenarios.synthetic import SyntheticScenarioConfig
 from tests.support.synthetic import materialize_synthetic_run
 
@@ -13,7 +16,9 @@ def test_synthetic_run_harness_materializes_smoke_receipt_flow(tmp_path) -> None
     assert harness.run_dir.name == "synthetic_pcf.smoke.v1-seed-7"
     assert (harness.run_dir / "raw_sources" / "erp_electricity.csv").is_file()
     assert (harness.run_dir / "oracle" / "expected_derived_claims.csv").is_file()
+    assert (harness.run_dir / "oracle" / "expected_receipt.json").is_file()
     assert harness.oracle_checked is True
+    assert harness.receipt_oracle_checked is True
     assert harness.report.status == "accepted"
     assert harness.preparation.decision.status == "commit"
     assert harness.preparation.receipt is not None
@@ -21,6 +26,34 @@ def test_synthetic_run_harness_materializes_smoke_receipt_flow(tmp_path) -> None
         "electricity_kwh": 1200,
         "co2e_kg": 504.0,
     }
+    assert harness.replay_report is not None
+    assert harness.replay_report.public_row == harness.projection
+    assert (
+        ArtifactRef("commit-package:product:synthetic-pcf-smoke-1", "commit_package")
+        in harness.replay_report.artifact_refs
+    )
+    assert (
+        ArtifactRef(
+            "governance-decision:commit-package:product:synthetic-pcf-smoke-1",
+            "governance_decision",
+        )
+        in harness.replay_report.artifact_refs
+    )
+    assert (
+        ArtifactRef(
+            "synthetic_manifest:synthetic_pcf.smoke.v1:seed-7",
+            "synthetic_manifest",
+        )
+        in harness.replay_report.artifact_refs
+    )
+    expected_receipt = json.loads(
+        (harness.run_dir / "oracle" / "expected_receipt.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert expected_receipt["public_row_id"] == "public-row:synthetic-pcf-smoke-1"
+    assert expected_receipt["projection_id"] == "synthetic-pcf-public-row"
+    assert expected_receipt["authorized_fields"] == ["electricity_kwh", "co2e_kg"]
 
 
 def test_synthetic_run_harness_materializes_anomaly_hold_flow(tmp_path) -> None:
@@ -32,8 +65,11 @@ def test_synthetic_run_harness_materializes_anomaly_hold_flow(tmp_path) -> None:
     assert harness.run_dir.name == "synthetic_pcf.anomaly.v1-seed-11"
     assert (harness.run_dir / "oracle" / "injected_anomalies.csv").is_file()
     assert (harness.run_dir / "oracle" / "expected_failed_claims.csv").is_file()
+    assert not (harness.run_dir / "oracle" / "expected_receipt.json").exists()
     assert harness.oracle_checked is True
+    assert harness.receipt_oracle_checked is False
     assert harness.report.status == "blocked"
     assert harness.preparation.decision.status == "hold"
     assert harness.preparation.receipt is None
     assert harness.projection is None
+    assert harness.replay_report is None


### PR DESCRIPTION
## Summary
- add `oracle/expected_receipt.json` for the synthetic PCF smoke run
- assert the smoke `CommitReceipt` matches expected receipt authority fields and citation ids
- add a synthetic replay bundle so the harness replays the receipt-authorized projection from receipt-cited artifacts
- keep anomaly runs receipt-free: no expected receipt oracle, no replay report

## Verification
- RED: `python -m pytest tests\test_synthetic_run_harness.py -q` failed before implementation because `expected_receipt.json` and replay fields were missing
- GREEN targeted: `python -m pytest tests\test_synthetic_run_harness.py tests\test_synthetic_oracle_assertions.py tests\test_synthetic_scenario_generator.py -q`
- Full: `python -m pytest -q` -> 351 passed
- `git diff --check`