### PR TITLE
[codex] add manifest-based synthetic input loaders

### DIFF
--- a/comp/scenarios/synthetic/__init__.py
+++ b/comp/scenarios/synthetic/__init__.py
@@ -27,6 +27,11 @@ from comp.scenarios.synthetic.generator import (
     generate_synthetic_pcf_run,
     write_synthetic_run,
 )
+from comp.scenarios.synthetic.loaders import (
+    SyntheticInputLoadError,
+    SyntheticSourceDescriptor,
+    load_synthetic_input_bundle,
+)
 
 __all__ = [
     "ExpectedClaim",
@@ -42,12 +47,15 @@ __all__ = [
     "MasterReferenceRecord",
     "RawElectricityRow",
     "SyntheticInputBundle",
+    "SyntheticInputLoadError",
     "SyntheticMaster",
     "SyntheticOracle",
     "SyntheticPcfAdapter",
     "SyntheticRawSources",
     "SyntheticRun",
     "SyntheticScenarioConfig",
+    "SyntheticSourceDescriptor",
     "generate_synthetic_pcf_run",
+    "load_synthetic_input_bundle",
     "write_synthetic_run",
 ]

--- a/comp/scenarios/synthetic/loaders.py
+++ b/comp/scenarios/synthetic/loaders.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Callable
+
+from comp.scenarios.synthetic.config import SyntheticScenarioConfig
+from comp.scenarios.synthetic.generator import (
+    MasterReferenceRecord,
+    RawElectricityRow,
+    SyntheticInputBundle,
+    SyntheticMaster,
+    SyntheticRawSources,
+)
+
+
+class SyntheticInputLoadError(ValueError):
+    """Raised when a synthetic input directory cannot be loaded from manifest."""
+
+
+@dataclass(frozen=True)
+class SyntheticSourceDescriptor:
+    source_ref: str
+    role: str
+    path: str
+    media_type: str
+    schema_id: str
+
+    @classmethod
+    def from_manifest(cls, payload: dict[str, Any]) -> "SyntheticSourceDescriptor":
+        try:
+            return cls(
+                source_ref=str(payload["source_ref"]),
+                role=str(payload["role"]),
+                path=str(payload["path"]),
+                media_type=str(payload["media_type"]),
+                schema_id=str(payload["schema_id"]),
+            )
+        except KeyError as exc:
+            raise SyntheticInputLoadError(
+                f"synthetic source descriptor missing field: {exc.args[0]}"
+            ) from exc
+
+
+Loader = Callable[[Path, SyntheticSourceDescriptor], object]
+
+
+def load_synthetic_input_bundle(run_dir: Path) -> SyntheticInputBundle:
+    manifest = _read_manifest(run_dir)
+    config = _config_from_manifest(manifest)
+    descriptors = _source_descriptors(manifest)
+    loaded = _load_sources(run_dir, descriptors)
+
+    return SyntheticInputBundle(
+        config=config,
+        manifest=manifest,
+        master=SyntheticMaster(
+            reference_catalog=tuple(
+                loaded.get("master_reference_catalog", ())
+            ),
+            sites=tuple(loaded.get("master_sites", ())),
+            products=tuple(loaded.get("master_products", ())),
+        ),
+        raw_sources=SyntheticRawSources(
+            electricity_rows=tuple(loaded.get("raw_source", ())),
+        ),
+        output_contract=tuple(manifest.get("output_contract", ())),
+    )
+
+
+def _read_manifest(run_dir: Path) -> dict[str, Any]:
+    path = run_dir / "manifest.json"
+    if not path.is_file():
+        raise SyntheticInputLoadError(f"missing synthetic manifest: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SyntheticInputLoadError("synthetic manifest must be a JSON object")
+    return payload
+
+
+def _config_from_manifest(manifest: dict[str, Any]) -> SyntheticScenarioConfig:
+    payload = manifest.get("config")
+    if not isinstance(payload, dict):
+        raise SyntheticInputLoadError("synthetic manifest missing config object")
+    return SyntheticScenarioConfig(
+        **{
+            **payload,
+            "anomalies": tuple(payload.get("anomalies", ())),
+        }
+    )
+
+
+def _source_descriptors(
+    manifest: dict[str, Any],
+) -> tuple[SyntheticSourceDescriptor, ...]:
+    sources = manifest.get("sources")
+    if not isinstance(sources, list):
+        raise SyntheticInputLoadError("synthetic manifest missing sources list")
+    return tuple(
+        SyntheticSourceDescriptor.from_manifest(source)
+        for source in sources
+        if isinstance(source, dict)
+    )
+
+
+def _load_sources(
+    run_dir: Path,
+    descriptors: tuple[SyntheticSourceDescriptor, ...],
+) -> dict[str, tuple[object, ...]]:
+    loaded: dict[str, tuple[object, ...]] = {}
+    for descriptor in descriptors:
+        loader = _LOADER_REGISTRY.get((descriptor.media_type, descriptor.schema_id))
+        if loader is None:
+            raise SyntheticInputLoadError(
+                "unsupported synthetic source loader: "
+                f"{descriptor.media_type} {descriptor.schema_id}"
+            )
+        loaded_items = tuple(loader(run_dir / descriptor.path, descriptor))
+        loaded[descriptor.role] = loaded.get(descriptor.role, ()) + loaded_items
+    return loaded
+
+
+def _load_reference_catalog_csv(
+    path: Path,
+    descriptor: SyntheticSourceDescriptor,
+) -> tuple[MasterReferenceRecord, ...]:
+    return tuple(
+        MasterReferenceRecord(
+            reference_id=row["reference_id"],
+            reference_type=row["reference_type"],
+            label=row["label"],
+            geography=row["geography"],
+            valid_period=row["valid_period"],
+            method=row["method"],
+            factor_value=_number(row["factor_value"]),
+            input_unit=row["input_unit"],
+            output_unit=row["output_unit"],
+            source=row["source"],
+            witness_id=row["witness_id"],
+        )
+        for row in _read_csv(path, descriptor)
+    )
+
+
+def _load_sites_csv(
+    path: Path,
+    descriptor: SyntheticSourceDescriptor,
+) -> tuple[dict[str, Any], ...]:
+    return tuple(dict(row) for row in _read_csv(path, descriptor))
+
+
+def _load_products_csv(
+    path: Path,
+    descriptor: SyntheticSourceDescriptor,
+) -> tuple[dict[str, Any], ...]:
+    return tuple(dict(row) for row in _read_csv(path, descriptor))
+
+
+def _load_electricity_csv(
+    path: Path,
+    descriptor: SyntheticSourceDescriptor,
+) -> tuple[RawElectricityRow, ...]:
+    return tuple(
+        RawElectricityRow(
+            source_row_id=row["source_row_id"],
+            source_ref=row["source_ref"],
+            period=row["period"],
+            site_id=row["site_id"],
+            site_name=row["site_name"],
+            product_id=row["product_id"],
+            activity_type=row["activity_type"],
+            amount=_number(row["amount"]),
+            unit=row["unit"],
+        )
+        for row in _read_csv(path, descriptor)
+    )
+
+
+def _read_csv(
+    path: Path,
+    descriptor: SyntheticSourceDescriptor,
+) -> tuple[dict[str, str], ...]:
+    if not path.is_file():
+        raise SyntheticInputLoadError(
+            f"missing synthetic source file for {descriptor.source_ref}: {path}"
+        )
+    with path.open(encoding="utf-8", newline="") as handle:
+        return tuple(csv.DictReader(handle))
+
+
+def _number(value: str) -> int | float:
+    number = Decimal(value)
+    if number == number.to_integral_value():
+        return int(number)
+    return float(number)
+
+
+_LOADER_REGISTRY: dict[tuple[str, str], Loader] = {
+    ("text/csv", "synthetic.master_reference_catalog.v1"): _load_reference_catalog_csv,
+    ("text/csv", "synthetic.master_sites.v1"): _load_sites_csv,
+    ("text/csv", "synthetic.master_products.v1"): _load_products_csv,
+    ("text/csv", "synthetic.erp_electricity.v1"): _load_electricity_csv,
+}
+
+
+__all__ = [
+    "SyntheticInputLoadError",
+    "SyntheticSourceDescriptor",
+    "load_synthetic_input_bundle",
+]

--- a/comp/scenarios/synthetic/manifest.py
+++ b/comp/scenarios/synthetic/manifest.py
@@ -40,6 +40,36 @@ def build_manifest(
             "config_hash": build_config_hash(payload),
         },
         "config": payload,
+        "sources": [
+            {
+                "source_ref": "reference_catalog.csv",
+                "role": "master_reference_catalog",
+                "path": "master/reference_catalog.csv",
+                "media_type": "text/csv",
+                "schema_id": "synthetic.master_reference_catalog.v1",
+            },
+            {
+                "source_ref": "sites.csv",
+                "role": "master_sites",
+                "path": "master/sites.csv",
+                "media_type": "text/csv",
+                "schema_id": "synthetic.master_sites.v1",
+            },
+            {
+                "source_ref": "products.csv",
+                "role": "master_products",
+                "path": "master/products.csv",
+                "media_type": "text/csv",
+                "schema_id": "synthetic.master_products.v1",
+            },
+            {
+                "source_ref": config.source_ref,
+                "role": "raw_source",
+                "path": f"raw_sources/{config.source_ref}",
+                "media_type": "text/csv",
+                "schema_id": "synthetic.erp_electricity.v1",
+            },
+        ],
     }
 
 

--- a/docs/architecture/domain-scenario-pack-generation.md
+++ b/docs/architecture/domain-scenario-pack-generation.md
@@ -186,6 +186,21 @@ SourceRef(
 Source refs are trace metadata. They are not runtime dependencies. The `comp`
 test suite should not need to clone `minntcho/esg-platform` to run.
 
+Synthetic or generated scenario packs should describe disk inputs through a
+manifest source descriptor rather than by file extension alone:
+
+```text
+source_ref
+role
+path
+media_type
+schema_id
+```
+
+Loader dispatch should use `media_type` plus `schema_id`; path suffixes are only
+storage hints. Oracle files remain test expectations and must not be required to
+build the compiler input bundle.
+
 For the first L-Energy PCF scenario, copy only the minimal values required for
 the scenario contract into the pack and keep source refs to the original
 platform documents:

--- a/tests/support/synthetic/run_harness.py
+++ b/tests/support/synthetic/run_harness.py
@@ -18,6 +18,7 @@ from comp.scenarios.synthetic import (
     SyntheticRun,
     SyntheticScenarioConfig,
     generate_synthetic_pcf_run,
+    load_synthetic_input_bundle,
     write_synthetic_run,
 )
 from tests.support.synthetic.oracle_assertions import (
@@ -55,7 +56,7 @@ def materialize_synthetic_run(
         base_dir / f"{config.scenario_id}-seed-{config.seed}",
     )
     oracle = load_synthetic_oracle(run_dir / "oracle")
-    adapter = SyntheticPcfAdapter(run.input_bundle)
+    adapter = SyntheticPcfAdapter(load_synthetic_input_bundle(run_dir))
     report = _compile_report(adapter)
     preparation = prepare_commit(
         report,

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -195,6 +195,9 @@ def test_domain_scenario_generation_guide_tracks_swappable_pack_contract():
     assert "ScenarioDefinition" in guide
     assert "ScenarioContract" in guide
     assert "SourceRef" in guide
+    assert "media_type" in guide
+    assert "schema_id" in guide
+    assert "Oracle files remain test expectations" in guide
     assert "registered_scenarios()" in guide
     assert "Do not assert one huge exported JSON blob" in guide
     assert "minntcho/esg-platform" in guide

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import csv
+import json
+import shutil
 from pathlib import Path
 
 import pytest
 
+from comp.compiler_tool import resolve_reference_grounded_calculation
 from comp.scenarios.synthetic import (
+    SyntheticInputLoadError,
     SyntheticPcfAdapter,
     SyntheticScenarioConfig,
     generate_synthetic_pcf_run,
+    load_synthetic_input_bundle,
     write_synthetic_run,
 )
 from tests.support.synthetic.oracle_assertions import (
@@ -27,6 +32,36 @@ def test_synthetic_pcf_generator_writes_oracle_not_truth(tmp_path: Path) -> None
     assert run.manifest["reproducibility"]["seed"] == 7
     assert run.manifest["reproducibility"]["config_hash"].startswith("sha256:")
     assert run.output_contract == ("master", "raw_sources", "oracle")
+    assert run.manifest["sources"] == [
+        {
+            "source_ref": "reference_catalog.csv",
+            "role": "master_reference_catalog",
+            "path": "master/reference_catalog.csv",
+            "media_type": "text/csv",
+            "schema_id": "synthetic.master_reference_catalog.v1",
+        },
+        {
+            "source_ref": "sites.csv",
+            "role": "master_sites",
+            "path": "master/sites.csv",
+            "media_type": "text/csv",
+            "schema_id": "synthetic.master_sites.v1",
+        },
+        {
+            "source_ref": "products.csv",
+            "role": "master_products",
+            "path": "master/products.csv",
+            "media_type": "text/csv",
+            "schema_id": "synthetic.master_products.v1",
+        },
+        {
+            "source_ref": "erp_electricity.csv",
+            "role": "raw_source",
+            "path": "raw_sources/erp_electricity.csv",
+            "media_type": "text/csv",
+            "schema_id": "synthetic.erp_electricity.v1",
+        },
+    ]
 
     assert (run_dir / "manifest.json").is_file()
     assert (run_dir / "master" / "reference_catalog.csv").is_file()
@@ -139,6 +174,65 @@ def test_synthetic_pcf_adapter_rejects_oracle_bearing_run() -> None:
         SyntheticPcfAdapter(run)  # type: ignore[arg-type]
 
 
+def test_synthetic_input_loader_roundtrips_disk_sources_without_oracle(
+    tmp_path: Path,
+) -> None:
+    run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_smoke(seed=7))
+    run_dir = write_synthetic_run(run, tmp_path / "synthetic-pcf-smoke")
+    shutil.rmtree(run_dir / "oracle")
+
+    input_bundle = load_synthetic_input_bundle(run_dir)
+    adapter = SyntheticPcfAdapter(input_bundle)
+    report = resolve_reference_grounded_calculation(
+        adapter.blocked_report(),
+        adapter.reference_catalog(),
+        query_for_obligation=adapter.query_for_obligation,
+        criteria=adapter.reference_selection_criteria(),
+        input_claim=adapter.input_claim(),
+        formula=adapter.formula(),
+        output_claim_id=adapter.output_claim_id,
+    )
+
+    assert input_bundle.raw_sources == run.input_bundle.raw_sources
+    assert input_bundle.master == run.input_bundle.master
+    assert report.status == "accepted"
+    assert {witness.source for witness in report.evidence_witnesses} == {
+        "raw_sources/erp_electricity.csv",
+    }
+
+
+def test_synthetic_input_loader_uses_manifest_media_type_not_file_extension(
+    tmp_path: Path,
+) -> None:
+    run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_smoke(seed=7))
+    run_dir = write_synthetic_run(run, tmp_path / "synthetic-pcf-smoke")
+    alternate_path = run_dir / "raw_sources" / "erp_electricity.raw"
+    (run_dir / "raw_sources" / "erp_electricity.csv").replace(alternate_path)
+    manifest = _read_json(run_dir / "manifest.json")
+    manifest["sources"][-1]["path"] = "raw_sources/erp_electricity.raw"
+    _write_json(run_dir / "manifest.json", manifest)
+
+    input_bundle = load_synthetic_input_bundle(run_dir)
+
+    assert input_bundle.raw_sources == run.input_bundle.raw_sources
+
+
+def test_synthetic_input_loader_rejects_unsupported_manifest_source(
+    tmp_path: Path,
+) -> None:
+    run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_smoke(seed=7))
+    run_dir = write_synthetic_run(run, tmp_path / "synthetic-pcf-smoke")
+    manifest = _read_json(run_dir / "manifest.json")
+    manifest["sources"][-1]["media_type"] = "application/parquet"
+    _write_json(run_dir / "manifest.json", manifest)
+
+    with pytest.raises(
+        SyntheticInputLoadError,
+        match="unsupported synthetic source loader",
+    ):
+        load_synthetic_input_bundle(run_dir)
+
+
 def test_comp_core_does_not_import_synthetic_scenario_generator() -> None:
     root = Path(__file__).resolve().parents[1] / "comp"
     core_dirs = (
@@ -160,3 +254,14 @@ def test_comp_core_does_not_import_synthetic_scenario_generator() -> None:
 def _read_csv(path: Path) -> list[dict[str, str]]:
     with path.open(encoding="utf-8", newline="") as handle:
         return list(csv.DictReader(handle))
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary
- Add manifest source descriptors for synthetic master and raw input files with `source_ref`, `role`, `path`, `media_type`, and `schema_id`.
- Introduce `load_synthetic_input_bundle()` and a media-type/schema-id loader registry so disk inputs become `SyntheticInputBundle` without reading oracle files.
- Move the synthetic run harness onto the disk-loaded input bundle path.
- Document the manifest source descriptor contract for scenario packs.

## Why
This keeps synthetic compiler inputs independent from oracle expectations while avoiding CSV-specific architecture. The current implementation registers CSV loaders, but dispatch is keyed by manifest `media_type` and `schema_id`, so JSON/JSONL or other source encodings can be added without changing `SyntheticPcfAdapter`.

## Validation
- `python -m pytest -q` (`361 passed`)
- `python -m tests.domain_scenarios list`
- `python -m tests.domain_scenarios run-all` (`Passed: 14/14`)