### PR TITLE
Fix domain scenario run-all totals

### DIFF
--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -121,7 +121,7 @@ def test_domain_scenario_cli_runs_all_registered_scenarios(capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Domain Scenario Run" in captured.out
-    assert "Passed: 16/16" in captured.out
+    assert "Passed: 17/17" in captured.out
     assert "- canonical_working_loop.raw_text_pcf.v1: pass" in captured.out
     assert "- tiny_pcf.location_based_electricity.v1: pass" in captured.out
     assert "- l_energy.alpha_invalid_allocation_rfi.v1: pass" in captured.out
@@ -153,8 +153,9 @@ def test_domain_scenario_cli_runs_all_as_json(capsys):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert exit_code == 0
-    assert payload["summary"] == {"total": 16, "passed": 16, "failed": 0}
+    assert payload["summary"] == {"total": 17, "passed": 17, "failed": 0}
     assert tuple(item["status"] for item in payload["scenarios"]) == (
+        "pass",
         "pass",
         "pass",
         "pass",


### PR DESCRIPTION
## Summary
- update domain scenario `run-all` expectations from 16 to 17 after the raw claim conflict scenario was merged
- keep this as a tiny follow-up PR: no scenario behavior changes, just the aggregate count/status assertion

## Verification
- RED on `origin/main`: `python -m pytest tests\\test_domain_scenario_lab.py::test_domain_scenario_cli_runs_all_registered_scenarios tests\\test_domain_scenario_lab.py::test_domain_scenario_cli_runs_all_as_json -q` failed because output was `Passed: 17/17` while tests expected `16/16`
- `python -m pytest tests\\test_domain_scenario_lab.py::test_domain_scenario_cli_runs_all_registered_scenarios tests\\test_domain_scenario_lab.py::test_domain_scenario_cli_runs_all_as_json -q` -> 2 passed
- `python -m pytest tests\\test_domain_scenario_lab.py tests\\test_synthetic_raw_claim_conflict.py -q` -> 25 passed
- `python -m pytest -q` -> 381 passed
- `git diff --check HEAD~1..HEAD` -> exit 0