### PR TITLE
[codex] document downstream scenario pack boundary

### DIFF
--- a/docs/extensions/downstream-registry.json
+++ b/docs/extensions/downstream-registry.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "owner": "scenario-lab",
+  "description": "Downstream scenario-pack repositories that consume comp as a public authority kernel.",
+  "packs": [
+    {
+      "id": "comp-scenario-packs",
+      "repo": "minntcho/comp-scenario-packs",
+      "status": "planned",
+      "relationship": "downstream",
+      "scope": "large-domain-and-product-e2e",
+      "required_for_comp_pr_ci": false,
+      "recommended_for_release_candidate": true,
+      "authority_policy": "compatibility_signal_not_authority_source",
+      "dependency_direction": "downstream_consumes_comp",
+      "expected_comp_dependency_before_v1": "comp @ git+https://github.com/minntcho/comp@<ref>",
+      "expected_comp_dependency_after_v1": "comp>=1.0,<2.0",
+      "notes": [
+        "comp keeps only minimal kernel e2e scenarios internally.",
+        "Large domain, product, platform, importer, UI, and supplier workflow scenarios continue downstream.",
+        "Downstream packs must consume comp through public APIs after v1.0."
+      ]
+    }
+  ]
+}

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -1,0 +1,132 @@
+# External Scenario Packs
+
+Status: planning
+Owner: scenario-lab
+Can block PRs: no
+
+`comp` keeps a minimal set of internal scenarios that prove kernel contracts.
+Large domain, product, platform, importer, UI, and supplier workflow scenarios
+belong in downstream scenario-pack repositories.
+
+The first downstream repository is expected to be:
+
+```text
+https://github.com/minntcho/comp-scenario-packs
+```
+
+## Boundary
+
+```text
+comp
+  owns authority contracts
+  owns receipts
+  owns projection gates
+  owns replay validation
+  owns minimal kernel e2e scenarios
+
+external scenario packs
+  own large domain workflows
+  own product/platform fixtures
+  own importers and UI/viewer flows
+  consume comp through public APIs
+  report compatibility and regression signals
+```
+
+External scenario packs are compatibility signals, not authority sources.
+
+A downstream pack may submit artifacts, source refs, resolver outputs, fixtures,
+expected contracts, and viewer payloads. The compiler still decides whether
+obligations are discharged, whether references are canonical, whether derived
+claims remain non-public, whether receipts can be minted, and whether public
+projection is authorized.
+
+## What Stays Inside Comp
+
+Internal scenarios should stay small and should prove `comp` kernel invariants.
+
+Examples:
+
+```text
+raw_claim_hypothesis_gate
+raw_claim_acceptance
+raw_claim_conflict
+raw_claim_conflict_resolution
+tiny_pcf
+canonical_working_loop
+synthetic_pcf.smoke
+synthetic_pcf.anomaly
+minimal receipt/projection/replay cases
+```
+
+An internal scenario belongs in `comp` when a failure indicates a likely kernel
+contract regression.
+
+## What Moves Downstream
+
+Large scenarios should move to downstream scenario-pack repositories when they
+primarily test domain or product behavior.
+
+Examples:
+
+```text
+full L-Energy supplier workflow
+platform YAML import
+RFI workflow engine
+external certificate verification
+UI/viewer e2e
+large multi-actor orchestration
+real reference database integration
+product-specific persistence flows
+```
+
+A downstream scenario belongs outside `comp` when a failure is more likely to
+indicate a domain pack, platform, importer, UI, or workflow regression.
+
+## Dependency Direction
+
+Downstream repositories consume `comp`.
+
+Before `comp` v1.0, downstream repositories may install `comp` from a Git ref:
+
+```text
+comp @ git+https://github.com/minntcho/comp@main
+```
+
+After `comp` v1.0, downstream repositories should prefer version ranges:
+
+```text
+comp>=1.0,<2.0
+```
+
+`comp` must not require downstream repositories to pass its own test suite.
+
+Avoid:
+
+```text
+comp tests cloning downstream repositories
+git submodules for scenario packs
+production imports from downstream scenario code
+mandatory PR gates against large downstream scenarios before v1.0
+```
+
+Prefer:
+
+```text
+documentation links
+a downstream registry
+manual downstream runs
+nightly downstream runs
+release-candidate downstream runs
+```
+
+## Review Rule
+
+Before adding a large scenario to `comp`, ask:
+
+```text
+If this scenario fails, is the likely bug in comp's authority kernel?
+```
+
+If yes, keep it internal and small.
+
+If no, place it in a downstream scenario pack.

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -112,6 +112,31 @@ it bundles the canonical `ReferenceCatalog`, retrieval resolver/index, and their
 fixture version labels so larger domain packs can replace reference data without
 rewiring the scenario runner.
 
+## External Scenario Packs
+
+This directory keeps minimal scenarios that prove `comp` kernel contracts.
+
+Large domain/product e2e scenarios should continue in downstream scenario-pack
+repositories, starting with:
+
+```text
+https://github.com/minntcho/comp-scenario-packs
+```
+
+External scenario packs are compatibility signals, not authority sources.
+
+Use this directory for small scenarios where a failure indicates a likely
+`comp` authority-kernel regression. Use downstream scenario packs for full
+supplier workflows, platform importers, UI/viewer e2e, certificate verification,
+large multi-actor orchestration, and product-specific flows.
+
+See:
+
+```text
+docs/extensions/scenario-packs.md
+docs/extensions/downstream-registry.json
+```
+
 ## Local Runner
 
 The scenario registry can also be inspected without opening the pytest files:


### PR DESCRIPTION
## What changed

- Added `docs/extensions/scenario-packs.md` to define the boundary between minimal internal kernel scenarios and large downstream scenario packs.
- Added `docs/extensions/downstream-registry.json` with a planned `minntcho/comp-scenario-packs` downstream entry.
- Linked the Domain Scenario Lab README to the external scenario-pack boundary and registry.

## Why

`comp` should keep small scenario tests that prove authority-kernel contracts. Large domain, product, platform, importer, UI, and supplier workflow scenarios should continue in downstream scenario-pack repositories that consume `comp` through public APIs. Downstream packs are compatibility signals, not authority sources.

## Validation

- `python -m json.tool docs\extensions\downstream-registry.json > $null` -> exit 0
- `python -m pytest tests\test_package_smoke.py tests\test_domain_scenario_lab.py -q` -> `36 passed in 0.57s`
- `python -m pytest -q` -> `388 passed in 5.83s`
- `git diff --check origin/main..HEAD` -> exit 0
- `git merge-tree --write-tree origin/main HEAD` -> exit 0