### PR TITLE
[codex] add receipt proof graph core exporter

### DIFF
--- a/comp/explanation/__init__.py
+++ b/comp/explanation/__init__.py
@@ -1,0 +1,27 @@
+"""Explanation-only receipt proof graph exports."""
+
+from comp.explanation.receipt_graph import (
+    ProofEdge,
+    ProofGraphExportError,
+    ProofNode,
+    ReceiptProofGraph,
+    artifact_node_id,
+    dependency_fingerprint_node_id,
+    export_receipt_proof_graph,
+    public_field_node_id,
+    public_projection_node_id,
+    receipt_node_id,
+)
+
+__all__ = [
+    "ProofEdge",
+    "ProofGraphExportError",
+    "ProofNode",
+    "ReceiptProofGraph",
+    "artifact_node_id",
+    "dependency_fingerprint_node_id",
+    "export_receipt_proof_graph",
+    "public_field_node_id",
+    "public_projection_node_id",
+    "receipt_node_id",
+]

--- a/comp/explanation/receipt_graph.py
+++ b/comp/explanation/receipt_graph.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from comp.judgment import CommitReceipt
+from comp.persistence import (
+    ArtifactRef,
+    InMemoryArtifactStore,
+    ProjectionReplayReport,
+    ReceiptLedgerKey,
+)
+from comp.persistence.envelope import ArtifactEnvelope
+
+
+class ProofGraphExportError(RuntimeError):
+    """Raised when a replay report cannot be normalized into a proof graph."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProofNode:
+    node_id: str
+    node_kind: str
+    label: str
+    digest: str | None = None
+    metadata: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("node_id", self.node_id)
+        _require_non_empty("node_kind", self.node_kind)
+        _require_non_empty("label", self.label)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "node_kind": self.node_kind,
+            "label": self.label,
+            "digest": self.digest,
+            "metadata": _metadata_payload(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProofEdge:
+    source_id: str
+    target_id: str
+    edge_kind: str
+    metadata: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("source_id", self.source_id)
+        _require_non_empty("target_id", self.target_id)
+        _require_non_empty("edge_kind", self.edge_kind)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "target_id": self.target_id,
+            "edge_kind": self.edge_kind,
+            "metadata": _metadata_payload(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptProofGraph:
+    public_row_id: str
+    projection_id: str
+    receipt_node_id: str
+    replay_receipt_key: ReceiptLedgerKey
+    nodes: tuple[ProofNode, ...]
+    edges: tuple[ProofEdge, ...]
+    field_paths: tuple[tuple[str, tuple[str, ...]], ...] = field(default_factory=tuple)
+    authority: str = "explanation_only"
+    can_authorize_public_projection: bool = False
+
+    def node(self, node_id: str) -> ProofNode | None:
+        for graph_node in self.nodes:
+            if graph_node.node_id == node_id:
+                return graph_node
+        return None
+
+    def artifact_node(self, artifact_ref: ArtifactRef) -> ProofNode | None:
+        return self.node(
+            artifact_node_id(artifact_ref.artifact_kind, artifact_ref.artifact_id)
+        )
+
+    def field_node(self, field: str) -> ProofNode | None:
+        return self.node(
+            public_field_node_id(self.public_row_id, self.projection_id, field)
+        )
+
+    def edges_between(
+        self,
+        source_id: str,
+        target_id: str,
+        *,
+        edge_kind: str | None = None,
+    ) -> tuple[ProofEdge, ...]:
+        return tuple(
+            edge
+            for edge in self.edges
+            if edge.source_id == source_id
+            and edge.target_id == target_id
+            and (edge_kind is None or edge.edge_kind == edge_kind)
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "public_row_id": self.public_row_id,
+            "projection_id": self.projection_id,
+            "receipt_node_id": self.receipt_node_id,
+            "replay_receipt_key": {
+                "public_row_id": self.replay_receipt_key.public_row_id,
+                "projection_id": self.replay_receipt_key.projection_id,
+                "draft_id": self.replay_receipt_key.draft_id,
+            },
+            "authority": self.authority,
+            "can_authorize_public_projection": self.can_authorize_public_projection,
+            "nodes": tuple(node.to_payload() for node in self.nodes),
+            "edges": tuple(edge.to_payload() for edge in self.edges),
+            "field_paths": tuple(
+                {"field": field, "node_ids": node_ids}
+                for field, node_ids in self.field_paths
+            ),
+        }
+
+
+def export_receipt_proof_graph(
+    *,
+    receipt: CommitReceipt,
+    replay: ProjectionReplayReport,
+    artifacts: InMemoryArtifactStore,
+) -> ReceiptProofGraph:
+    """Export an explanation-only graph from an already successful replay.
+
+    The exporter is read-only. It consumes the receipt, replay report, and
+    replayed artifact envelopes; it does not call the compiler, projection gate,
+    governance gate, resolver, calculator, or replay function.
+    """
+
+    _validate_replay_scope(receipt, replay)
+    builder = _ReceiptProofGraphBuilder(
+        receipt=receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )
+    return builder.export()
+
+
+def receipt_node_id(receipt: CommitReceipt) -> str:
+    return (
+        "commit_receipt:"
+        f"{receipt.public_row_id}:{receipt.projection_id}:{receipt.draft_id}"
+    )
+
+
+def public_projection_node_id(public_row_id: str, projection_id: str) -> str:
+    return f"public_projection:{public_row_id}:{projection_id}"
+
+
+def public_field_node_id(public_row_id: str, projection_id: str, field: str) -> str:
+    return f"public_field:{public_row_id}:{projection_id}:{field}"
+
+
+def artifact_node_id(artifact_kind: str, artifact_id: str) -> str:
+    return f"{artifact_kind}:{artifact_id}"
+
+
+def dependency_fingerprint_node_id(
+    dependency_kind: str,
+    dependency_id: str,
+) -> str:
+    return f"dependency_fingerprint:{dependency_kind}:{dependency_id}"
+
+
+class _ReceiptProofGraphBuilder:
+    def __init__(
+        self,
+        *,
+        receipt: CommitReceipt,
+        replay: ProjectionReplayReport,
+        artifacts: InMemoryArtifactStore,
+    ) -> None:
+        self._receipt = receipt
+        self._replay = replay
+        self._artifacts = artifacts
+        self._nodes: dict[str, ProofNode] = {}
+        self._edges: dict[tuple[str, str, str, tuple[tuple[str, Any], ...]], ProofEdge] = {}
+        self._artifact_envelopes: dict[tuple[str, str], ArtifactEnvelope] = {}
+        self._field_paths: dict[str, tuple[str, ...]] = {}
+
+    def export(self) -> ReceiptProofGraph:
+        self._add_receipt_node()
+        self._add_public_projection_nodes()
+        self._add_artifact_nodes()
+        self._add_dependency_fingerprint_nodes()
+        self._add_receipt_citation_edges()
+        self._add_public_projection_edges()
+        return ReceiptProofGraph(
+            public_row_id=self._receipt.public_row_id,
+            projection_id=self._receipt.projection_id,
+            receipt_node_id=receipt_node_id(self._receipt),
+            replay_receipt_key=self._replay.receipt_key,
+            nodes=tuple(self._nodes.values()),
+            edges=tuple(self._edges.values()),
+            field_paths=tuple(sorted(self._field_paths.items())),
+        )
+
+    def _add_receipt_node(self) -> None:
+        self._add_node(
+            ProofNode(
+                node_id=receipt_node_id(self._receipt),
+                node_kind="commit_receipt",
+                label=f"Commit receipt: {self._receipt.public_row_id}",
+                metadata=_metadata(
+                    public_row_id=self._receipt.public_row_id,
+                    projection_id=self._receipt.projection_id,
+                    draft_id=self._receipt.draft_id,
+                    authorized_fields=self._receipt.authorized_fields,
+                ),
+            )
+        )
+
+    def _add_public_projection_nodes(self) -> None:
+        projection_node_id = public_projection_node_id(
+            self._receipt.public_row_id,
+            self._receipt.projection_id,
+        )
+        self._add_node(
+            ProofNode(
+                node_id=projection_node_id,
+                node_kind="public_projection",
+                label=f"Public projection: {self._receipt.projection_id}",
+                metadata=_metadata(
+                    public_row_id=self._receipt.public_row_id,
+                    projection_id=self._receipt.projection_id,
+                    field_count=len(self._replay.public_row),
+                ),
+            )
+        )
+        for field in self._replay.public_row:
+            self._add_node(
+                ProofNode(
+                    node_id=public_field_node_id(
+                        self._receipt.public_row_id,
+                        self._receipt.projection_id,
+                        field,
+                    ),
+                    node_kind="public_field",
+                    label=f"Public field: {field}",
+                    metadata=_metadata(
+                        field=field,
+                        projection_id=self._receipt.projection_id,
+                        has_value_commitment=field in _commitments_by_field(
+                            self._receipt
+                        ),
+                    ),
+                )
+            )
+
+    def _add_artifact_nodes(self) -> None:
+        for ref in self._replay.artifact_refs:
+            envelope = self._artifact_envelope(ref)
+            self._add_node(
+                ProofNode(
+                    node_id=artifact_node_id(ref.artifact_kind, ref.artifact_id),
+                    node_kind=ref.artifact_kind,
+                    label=_artifact_label(ref, envelope),
+                    digest=envelope.body_digest,
+                    metadata=_artifact_metadata(ref, envelope),
+                )
+            )
+
+    def _add_dependency_fingerprint_nodes(self) -> None:
+        for fingerprint in self._replay.dependency_fingerprints:
+            self._add_node(
+                ProofNode(
+                    node_id=dependency_fingerprint_node_id(
+                        fingerprint.dependency_kind,
+                        fingerprint.dependency_id,
+                    ),
+                    node_kind="dependency_fingerprint",
+                    label=(
+                        "Dependency fingerprint: "
+                        f"{fingerprint.dependency_kind}:{fingerprint.dependency_id}"
+                    ),
+                    digest=fingerprint.fingerprint,
+                    metadata=_metadata(
+                        dependency_kind=fingerprint.dependency_kind,
+                        dependency_id=fingerprint.dependency_id,
+                        digest_alg=fingerprint.digest_alg,
+                    ),
+                )
+            )
+
+    def _add_receipt_citation_edges(self) -> None:
+        citations = self._receipt.citations
+        if citations is None:
+            return
+        receipt_id = receipt_node_id(self._receipt)
+        package_node_id = artifact_node_id("commit_package", citations.commit_package_id)
+        self._add_edge(package_node_id, receipt_id, "committed_in")
+        self._add_edge(
+            artifact_node_id("governance_decision", citations.governance_decision_id),
+            receipt_id,
+            "decided_by",
+            governance_status=citations.governance_status,
+        )
+        for commitment in citations.projection_value_commitments:
+            self._add_edge(
+                artifact_node_id(commitment.source_kind, commitment.source_id),
+                package_node_id,
+                "committed_in",
+                field=commitment.field,
+                source_kind=commitment.source_kind,
+            )
+        for fingerprint in citations.dependency_fingerprints:
+            self._add_edge(
+                receipt_id,
+                dependency_fingerprint_node_id(
+                    fingerprint.dependency_kind,
+                    fingerprint.dependency_id,
+                ),
+                "pinned_dependency",
+                dependency_kind=fingerprint.dependency_kind,
+                dependency_id=fingerprint.dependency_id,
+            )
+
+    def _add_public_projection_edges(self) -> None:
+        projection_node_id = public_projection_node_id(
+            self._receipt.public_row_id,
+            self._receipt.projection_id,
+        )
+        receipt_id = receipt_node_id(self._receipt)
+        self._add_edge(projection_node_id, receipt_id, "authorized_by")
+        commitments = _commitments_by_field(self._receipt)
+        for field in self._replay.public_row:
+            field_node_id = public_field_node_id(
+                self._receipt.public_row_id,
+                self._receipt.projection_id,
+                field,
+            )
+            path = [field_node_id, projection_node_id, receipt_id]
+            self._add_edge(field_node_id, projection_node_id, "projected_as", field=field)
+            self._add_edge(field_node_id, receipt_id, "authorized_by", field=field)
+            commitment = commitments.get(field)
+            if commitment is not None:
+                source_node_id = artifact_node_id(
+                    commitment.source_kind,
+                    commitment.source_id,
+                )
+                if source_node_id in self._nodes:
+                    self._add_edge(
+                        source_node_id,
+                        field_node_id,
+                        "projected_as",
+                        field=field,
+                        value_digest=commitment.value_digest,
+                        digest_alg=commitment.digest_alg,
+                    )
+                    path.insert(0, source_node_id)
+            self._field_paths[field] = tuple(path)
+
+    def _artifact_envelope(self, ref: ArtifactRef) -> ArtifactEnvelope:
+        key = (ref.artifact_kind, ref.artifact_id)
+        envelope = self._artifact_envelopes.get(key)
+        if envelope is not None:
+            return envelope
+        try:
+            envelope = self._artifacts.get(ref.artifact_id)
+        except KeyError as exc:
+            raise ProofGraphExportError(
+                f"Proof graph missing replay artifact: {ref.artifact_id}."
+            ) from exc
+        if envelope.artifact_kind != ref.artifact_kind:
+            raise ProofGraphExportError(
+                f"Proof graph artifact kind mismatch: {ref.artifact_id}."
+            )
+        self._artifact_envelopes[key] = envelope
+        return envelope
+
+    def _add_node(self, node: ProofNode) -> None:
+        existing = self._nodes.get(node.node_id)
+        if existing is None:
+            self._nodes[node.node_id] = node
+            return
+        if existing != node:
+            raise ProofGraphExportError(
+                f"Proof graph node id conflict: {node.node_id}."
+            )
+
+    def _add_edge(
+        self,
+        source_id: str,
+        target_id: str,
+        edge_kind: str,
+        **metadata: Any,
+    ) -> None:
+        if source_id not in self._nodes or target_id not in self._nodes:
+            return
+        edge_metadata = _metadata(**metadata)
+        edge = ProofEdge(
+            source_id=source_id,
+            target_id=target_id,
+            edge_kind=edge_kind,
+            metadata=edge_metadata,
+        )
+        self._edges[(source_id, target_id, edge_kind, edge_metadata)] = edge
+
+
+def _validate_replay_scope(
+    receipt: CommitReceipt,
+    replay: ProjectionReplayReport,
+) -> None:
+    expected = ReceiptLedgerKey.from_receipt(receipt)
+    if replay.receipt_key != expected:
+        raise ProofGraphExportError("Proof graph receipt key does not match replay report.")
+    if replay.projection_id != receipt.projection_id:
+        raise ProofGraphExportError("Proof graph projection id does not match receipt.")
+
+
+def _artifact_label(ref: ArtifactRef, envelope: ArtifactEnvelope) -> str:
+    body = envelope.body
+    field = body.get("field")
+    if isinstance(field, str):
+        return f"{ref.artifact_kind}: {field}"
+    for key in (
+        "claim_id",
+        "decision_id",
+        "package_id",
+        "dependency_id",
+        "snapshot_id",
+        "witness_id",
+    ):
+        value = body.get(key)
+        if isinstance(value, str):
+            return f"{ref.artifact_kind}: {value}"
+    return f"{ref.artifact_kind}: {ref.artifact_id}"
+
+
+def _artifact_metadata(
+    ref: ArtifactRef,
+    envelope: ArtifactEnvelope,
+) -> tuple[tuple[str, Any], ...]:
+    metadata: dict[str, Any] = {
+        "artifact_id": ref.artifact_id,
+        "artifact_kind": ref.artifact_kind,
+        "schema_version": envelope.schema_version,
+    }
+    metadata.update(_safe_body_metadata(envelope.body))
+    return tuple(sorted(metadata.items()))
+
+
+def _safe_body_metadata(body: Mapping[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for key, value in body.items():
+        if key in _SENSITIVE_BODY_KEYS:
+            metadata[f"has_{key}"] = value is not None
+            continue
+        if key == "steps":
+            metadata["step_count"] = len(_sequence_or_empty(value))
+            continue
+        if key == "record_fingerprints":
+            metadata["record_fingerprint_count"] = len(_sequence_or_empty(value))
+            continue
+        if key == "profile_lock":
+            metadata["has_profile_lock"] = value is not None
+            continue
+        if _is_safe_metadata_value(value):
+            metadata[key] = value
+    return metadata
+
+
+def _is_safe_metadata_value(value: Any) -> bool:
+    if value is None or isinstance(value, str | int | float | bool):
+        return True
+    if isinstance(value, tuple):
+        return all(_is_safe_metadata_value(item) for item in value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return all(_is_safe_metadata_value(item) for item in value)
+    if isinstance(value, Mapping):
+        return all(
+            isinstance(key, str) and _is_safe_metadata_value(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _commitments_by_field(receipt: CommitReceipt):
+    if receipt.citations is None:
+        return {}
+    return {
+        commitment.field: commitment
+        for commitment in receipt.citations.projection_value_commitments
+    }
+
+
+def _metadata(**items: Any) -> tuple[tuple[str, Any], ...]:
+    return tuple(
+        (key, value)
+        for key, value in sorted(items.items())
+        if value is not None
+    )
+
+
+def _metadata_payload(metadata: tuple[tuple[str, Any], ...]) -> dict[str, Any]:
+    return {key: _jsonable(value) for key, value in metadata}
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, tuple):
+        return tuple(_jsonable(item) for item in value)
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(_jsonable(item) for item in value)
+    return value
+
+
+def _sequence_or_empty(value: Any) -> tuple[Any, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(value)
+    return ()
+
+
+def _require_non_empty(field: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{field} is required.")
+
+
+_SENSITIVE_BODY_KEYS = frozenset({"value", "output_value", "text"})
+
+
+__all__ = [
+    "ProofEdge",
+    "ProofGraphExportError",
+    "ProofNode",
+    "ReceiptProofGraph",
+    "artifact_node_id",
+    "dependency_fingerprint_node_id",
+    "export_receipt_proof_graph",
+    "public_field_node_id",
+    "public_projection_node_id",
+    "receipt_node_id",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ test = ["pytest>=8"]
 packages = [
   "comp",
   "comp.compiler_tool",
+  "comp.explanation",
   "comp.judgment",
   "comp.persistence",
   "comp.scenarios",

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -427,6 +427,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert setuptools_config["packages"] == [
         "comp",
         "comp.compiler_tool",
+        "comp.explanation",
         "comp.judgment",
         "comp.persistence",
         "comp.scenarios",
@@ -443,6 +444,11 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
 
     dependencies = pyproject["project"].get("dependencies", [])
     assert not any(dependency.startswith("lark") for dependency in dependencies)
+
+    from comp.explanation import ReceiptProofGraph, export_receipt_proof_graph
+
+    assert ReceiptProofGraph is not None
+    assert export_receipt_proof_graph is not None
     assert ArtifactEnvelope is not None
     assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None

--- a/tests/test_receipt_proof_graph.py
+++ b/tests/test_receipt_proof_graph.py
@@ -1,0 +1,194 @@
+from dataclasses import replace
+
+from comp.explanation import (
+    ProofGraphExportError,
+    ReceiptProofGraph,
+    artifact_node_id,
+    dependency_fingerprint_node_id,
+    export_receipt_proof_graph,
+    public_field_node_id,
+    public_projection_node_id,
+    receipt_node_id,
+)
+from comp.persistence import replay_public_projection
+from tests.support.persistence_cases import (
+    artifact_store_for_receipt,
+    receipt_projection_case,
+)
+
+
+def test_receipt_proof_graph_exports_successful_replay_payload():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+
+    graph = export_receipt_proof_graph(
+        receipt=case.receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )
+
+    assert isinstance(graph, ReceiptProofGraph)
+    assert graph.authority == "explanation_only"
+    assert graph.can_authorize_public_projection is False
+    assert graph.receipt_node_id == receipt_node_id(case.receipt)
+    assert graph.to_payload()["authority"] == "explanation_only"
+    assert graph.to_payload()["can_authorize_public_projection"] is False
+    for artifact_ref in replay.artifact_refs:
+        assert graph.artifact_node(artifact_ref) is not None
+
+
+def test_public_projection_fields_connect_to_receipt_and_value_sources():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+
+    graph = export_receipt_proof_graph(
+        receipt=case.receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )
+
+    receipt_id = receipt_node_id(case.receipt)
+    projection_id = public_projection_node_id("public-row-1", "public-row")
+    amount_field_id = public_field_node_id("public-row-1", "public-row", "amount")
+    amount_claim_id = artifact_node_id(
+        "checked_claim",
+        "checked_claim:amount:span-amount",
+    )
+
+    assert graph.field_node("amount") is not None
+    assert _has_edge(graph, amount_field_id, projection_id, "projected_as")
+    assert _has_edge(graph, amount_field_id, receipt_id, "authorized_by")
+    assert _has_edge(graph, amount_claim_id, amount_field_id, "projected_as")
+    assert dict(graph.field_paths)["amount"] == (
+        amount_claim_id,
+        amount_field_id,
+        projection_id,
+        receipt_id,
+    )
+
+
+def test_dependency_fingerprints_are_explanation_nodes():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+
+    graph = export_receipt_proof_graph(
+        receipt=case.receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )
+
+    for fingerprint in replay.dependency_fingerprints:
+        node = graph.node(
+            dependency_fingerprint_node_id(
+                fingerprint.dependency_kind,
+                fingerprint.dependency_id,
+            )
+        )
+        assert node is not None
+        assert node.node_kind == "dependency_fingerprint"
+        assert node.digest == fingerprint.fingerprint
+        assert _has_edge(graph, graph.receipt_node_id, node.node_id, "pinned_dependency")
+
+
+def test_graph_payload_hides_raw_committed_values_by_default():
+    case = receipt_projection_case(amount=100, site="plant-a")
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+
+    graph = export_receipt_proof_graph(
+        receipt=case.receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )
+    payload = graph.to_payload()
+
+    assert "plant-a" not in repr(payload)
+    assert not _payload_has_key(payload, "value")
+    assert not _payload_has_key(payload, "output_value")
+    assert not _payload_has_key(payload, "text")
+
+
+def test_graph_export_rejects_replay_for_different_receipt_scope():
+    first = receipt_projection_case(amount=100)
+    second_receipt = replace(first.receipt, draft_id="draft-2")
+    artifacts = artifact_store_for_receipt(
+        first.receipt,
+        committed_values=first.source_values,
+    )
+    replay = replay_public_projection(
+        first.source_values,
+        first.projection,
+        receipt=first.receipt,
+        artifacts=artifacts,
+    )
+
+    try:
+        export_receipt_proof_graph(
+            receipt=second_receipt,
+            replay=replay,
+            artifacts=artifacts,
+        )
+    except ProofGraphExportError as exc:
+        assert "receipt key" in str(exc)
+    else:
+        raise AssertionError("Expected replay scope mismatch to block graph export.")
+
+
+def test_graph_export_does_not_import_authority_or_compiler_functions():
+    import comp.explanation.receipt_graph as receipt_graph
+
+    assert "replay_public_projection" not in receipt_graph.__dict__
+    assert "project_public_row" not in receipt_graph.__dict__
+    assert "CompilerTool" not in receipt_graph.__dict__
+
+
+def _has_edge(
+    graph: ReceiptProofGraph,
+    source_id: str,
+    target_id: str,
+    edge_kind: str,
+) -> bool:
+    return bool(graph.edges_between(source_id, target_id, edge_kind=edge_kind))
+
+
+def _payload_has_key(value, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_payload_has_key(item, key) for item in value.values())
+    if isinstance(value, (tuple, list)):
+        return any(_payload_has_key(item, key) for item in value)
+    return False


### PR DESCRIPTION
## Summary

Adds the first, smaller slice of the receipt proof graph work as an explanation-only package:

- adds `comp.explanation` with `ReceiptProofGraph`, `ProofNode`, `ProofEdge`, and `export_receipt_proof_graph`
- exports graph nodes/edges from an already successful `CommitReceipt` + `ProjectionReplayReport`
- covers receipt, public projection fields, replay artifact refs, dependency fingerprints, and field-level paths
- keeps the graph non-authoritative with `authority="explanation_only"` and `can_authorize_public_projection=False`
- hides raw committed body values/text from the default payload

This intentionally does not include the larger canonical scenario artifact-body walking from `receipt_proof_graph.patch`; claim/reference/calculation internal edges can be a follow-up PR.

## Validation

- `python -m pytest -q` -> `394 passed`
- `git diff --cached --check`