### PR TITLE
[codex] add mysql trust spine v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ jobs:
     name: Python contract suite
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: comp_test
+          MYSQL_USER: comp
+          MYSQL_PASSWORD: comp
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -ucomp -pcomp"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
@@ -27,9 +43,15 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
+          python -m pip install -e ".[test,db]"
 
       - name: Run unit and scenario tests
+        env:
+          COMP_TEST_MYSQL_HOST: 127.0.0.1
+          COMP_TEST_MYSQL_PORT: "3306"
+          COMP_TEST_MYSQL_USER: comp
+          COMP_TEST_MYSQL_PASSWORD: comp
+          COMP_TEST_MYSQL_DATABASE: comp_test
         run: python -m pytest -q
 
       - name: List registered domain scenarios

--- a/comp/persistence/__init__.py
+++ b/comp/persistence/__init__.py
@@ -14,6 +14,11 @@ from comp.persistence.ledger import (
     verify_artifact_envelope,
     verify_materialized_public_projection,
 )
+from comp.persistence.mysql import (
+    MySQLArtifactStore,
+    MySQLReceiptLedger,
+    apply_trust_spine_schema,
+)
 from comp.persistence.replay import (
     ArtifactRef,
     ProjectionReplayReport,
@@ -28,11 +33,14 @@ __all__ = [
     "ArtifactIntegrityError",
     "InMemoryArtifactStore",
     "InMemoryReceiptLedger",
+    "MySQLArtifactStore",
+    "MySQLReceiptLedger",
     "PersistenceError",
     "ProjectionReplayBlocked",
     "ProjectionReplayReport",
     "ReceiptConflict",
     "ReceiptLedgerKey",
+    "apply_trust_spine_schema",
     "artifact_digest",
     "receipt_artifact_refs",
     "replay_public_projection",

--- a/comp/persistence/codec.py
+++ b/comp/persistence/codec.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from typing import Any
+
+
+_TYPE_KEY = "__comp_type__"
+_VALUE_KEY = "value"
+
+
+def encode_persistence_json(value: Any) -> Any:
+    if value is None:
+        return {_TYPE_KEY: "none", _VALUE_KEY: None}
+    if isinstance(value, bool):
+        return {_TYPE_KEY: "bool", _VALUE_KEY: value}
+    if isinstance(value, int):
+        return {_TYPE_KEY: "int", _VALUE_KEY: str(value)}
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Persistence JSON requires a finite float.")
+        return {_TYPE_KEY: "float", _VALUE_KEY: repr(value)}
+    if isinstance(value, str):
+        return {_TYPE_KEY: "str", _VALUE_KEY: value}
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError("Persistence JSON requires a finite decimal.")
+        return {_TYPE_KEY: "decimal", _VALUE_KEY: str(value)}
+    if isinstance(value, Mapping):
+        return {
+            _TYPE_KEY: "mapping",
+            _VALUE_KEY: [
+                [key, encode_persistence_json(item)]
+                for key, item in sorted(
+                    _string_key_items(value),
+                    key=lambda pair: pair[0],
+                )
+            ],
+        }
+    if isinstance(value, tuple):
+        return {
+            _TYPE_KEY: "tuple",
+            _VALUE_KEY: [encode_persistence_json(item) for item in value],
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return {
+            _TYPE_KEY: "list",
+            _VALUE_KEY: [encode_persistence_json(item) for item in value],
+        }
+    raise TypeError(f"Unsupported persistence JSON value: {type(value).__name__}")
+
+
+def decode_persistence_json(value: Any) -> Any:
+    if not isinstance(value, Mapping) or _TYPE_KEY not in value:
+        raise TypeError("Persistence JSON value is missing __comp_type__.")
+    kind = value[_TYPE_KEY]
+    raw = value[_VALUE_KEY]
+    if kind == "none":
+        return None
+    if kind == "bool":
+        return bool(raw)
+    if kind == "int":
+        return int(raw)
+    if kind == "float":
+        return float(raw)
+    if kind == "str":
+        return str(raw)
+    if kind == "decimal":
+        return Decimal(str(raw))
+    if kind == "mapping":
+        return {str(key): decode_persistence_json(item) for key, item in raw}
+    if kind == "tuple":
+        return tuple(decode_persistence_json(item) for item in raw)
+    if kind == "list":
+        return [decode_persistence_json(item) for item in raw]
+    raise TypeError(f"Unsupported persistence JSON type: {kind}")
+
+
+def _string_key_items(value: Mapping[Any, Any]) -> tuple[tuple[str, Any], ...]:
+    items: list[tuple[str, Any]] = []
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise TypeError("Persistence JSON mappings require string keys.")
+        items.append((key, item))
+    return tuple(items)
+
+
+__all__ = ["decode_persistence_json", "encode_persistence_json"]

--- a/comp/persistence/mysql.py
+++ b/comp/persistence/mysql.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+TRUST_SPINE_SCHEMA_STATEMENTS = (
+    """
+    create table if not exists artifact_envelopes (
+      artifact_id varchar(255) primary key,
+      artifact_kind varchar(128) not null,
+      schema_version varchar(64) not null,
+      body_digest varchar(96) not null,
+      body json not null,
+      source_refs json not null,
+      meta json not null,
+      created_at timestamp(6) not null default current_timestamp(6),
+      unique key artifact_envelope_identity (
+        artifact_id, artifact_kind, schema_version, body_digest
+      )
+    ) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_0900_bin
+    """,
+    """
+    create table if not exists ledger_commit_receipts (
+      receipt_id varchar(255) primary key,
+      public_row_id varchar(255) not null,
+      projection_id varchar(255) not null,
+      draft_id varchar(255) not null,
+      receipt_digest varchar(96) not null,
+      receipt_body json not null,
+      issued_at timestamp(6) not null default current_timestamp(6),
+      unique key receipt_ledger_key (public_row_id, projection_id, draft_id)
+    ) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_0900_bin
+    """,
+    """
+    create table if not exists ledger_receipt_value_commitments (
+      receipt_id varchar(255) not null,
+      field varchar(255) not null,
+      source_kind varchar(128) not null,
+      source_id varchar(255) not null,
+      value_digest varchar(96) not null,
+      digest_alg varchar(32) not null,
+      primary key (receipt_id, field),
+      constraint fk_receipt_value_commitments_receipt
+        foreign key (receipt_id) references ledger_commit_receipts(receipt_id)
+    ) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_0900_bin
+    """,
+    """
+    create table if not exists ledger_receipt_dependency_fingerprints (
+      receipt_id varchar(255) not null,
+      dependency_kind varchar(128) not null,
+      dependency_id varchar(255) not null,
+      fingerprint varchar(96) not null,
+      digest_alg varchar(32) not null,
+      primary key (receipt_id, dependency_kind, dependency_id),
+      constraint fk_receipt_dependency_fingerprints_receipt
+        foreign key (receipt_id) references ledger_commit_receipts(receipt_id)
+    ) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_0900_bin
+    """,
+    """
+    create table if not exists ledger_receipt_artifact_refs (
+      receipt_id varchar(255) not null,
+      artifact_id varchar(255) not null,
+      artifact_kind varchar(128) not null,
+      role varchar(128) not null,
+      primary key (receipt_id, artifact_id, artifact_kind, role),
+      constraint fk_receipt_artifact_refs_receipt
+        foreign key (receipt_id) references ledger_commit_receipts(receipt_id)
+    ) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_0900_bin
+    """,
+)
+
+
+def apply_trust_spine_schema(connection: Any) -> None:
+    with connection.cursor() as cursor:
+        for statement in TRUST_SPINE_SCHEMA_STATEMENTS:
+            cursor.execute(statement)
+    connection.commit()
+
+
+__all__ = ["TRUST_SPINE_SCHEMA_STATEMENTS", "apply_trust_spine_schema"]

--- a/comp/persistence/mysql.py
+++ b/comp/persistence/mysql.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import json
 from typing import Any
+
+from comp.persistence.codec import decode_persistence_json, encode_persistence_json
+from comp.persistence.envelope import ArtifactEnvelope
+from comp.persistence.ledger import ArtifactConflict, verify_artifact_envelope
 
 
 TRUST_SPINE_SCHEMA_STATEMENTS = (
@@ -77,4 +82,112 @@ def apply_trust_spine_schema(connection: Any) -> None:
     connection.commit()
 
 
-__all__ = ["TRUST_SPINE_SCHEMA_STATEMENTS", "apply_trust_spine_schema"]
+class MySQLArtifactStore:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def record(self, envelope: ArtifactEnvelope) -> ArtifactEnvelope:
+        verify_artifact_envelope(envelope)
+        existing = self._get_optional(envelope.artifact_id)
+        if existing is None:
+            with self.connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into artifact_envelopes (
+                      artifact_id, artifact_kind, schema_version, body_digest,
+                      body, source_refs, meta
+                    )
+                    values (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        envelope.artifact_id,
+                        envelope.artifact_kind,
+                        envelope.schema_version,
+                        envelope.body_digest,
+                        _json_dump(encode_persistence_json(envelope.body)),
+                        _json_dump(encode_persistence_json(envelope.source_refs)),
+                        _json_dump(encode_persistence_json(envelope.meta)),
+                    ),
+                )
+            self.connection.commit()
+            return envelope
+        if (
+            existing.artifact_kind != envelope.artifact_kind
+            or existing.schema_version != envelope.schema_version
+            or existing.body_digest != envelope.body_digest
+        ):
+            raise ArtifactConflict(
+                f"Artifact already recorded with different content: "
+                f"{envelope.artifact_id}."
+            )
+        return existing
+
+    def get(self, artifact_id: str) -> ArtifactEnvelope:
+        existing = self._get_optional(artifact_id)
+        if existing is None:
+            raise KeyError(artifact_id)
+        return existing
+
+    def envelopes(self) -> tuple[ArtifactEnvelope, ...]:
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                select artifact_id, artifact_kind, schema_version, body_digest,
+                       body, source_refs, meta
+                from artifact_envelopes
+                order by artifact_id
+                """
+            )
+            return tuple(_artifact_envelope_from_row(row) for row in cursor.fetchall())
+
+    def _get_optional(self, artifact_id: str) -> ArtifactEnvelope | None:
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                select artifact_id, artifact_kind, schema_version, body_digest,
+                       body, source_refs, meta
+                from artifact_envelopes
+                where artifact_id = %s
+                """,
+                (artifact_id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return _artifact_envelope_from_row(row)
+
+
+def _artifact_envelope_from_row(row: Any) -> ArtifactEnvelope:
+    return ArtifactEnvelope(
+        artifact_id=row[0],
+        artifact_kind=row[1],
+        schema_version=row[2],
+        body_digest=row[3],
+        body=decode_persistence_json(_json_load(row[4])),
+        source_refs=decode_persistence_json(_json_load(row[5])),
+        meta=decode_persistence_json(_json_load(row[6])),
+    )
+
+
+def _json_dump(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _json_load(value: Any) -> Any:
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+__all__ = [
+    "MySQLArtifactStore",
+    "TRUST_SPINE_SCHEMA_STATEMENTS",
+    "apply_trust_spine_schema",
+]

--- a/comp/persistence/mysql.py
+++ b/comp/persistence/mysql.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
 import json
+import hashlib
+from collections.abc import Mapping
 from typing import Any
 
+from comp.judgment.receipts import (
+    CommitReceipt,
+    CommitReceiptCitations,
+    DependencyFingerprint,
+    ProjectionValueCommitment,
+)
 from comp.persistence.codec import decode_persistence_json, encode_persistence_json
 from comp.persistence.envelope import ArtifactEnvelope
-from comp.persistence.ledger import ArtifactConflict, verify_artifact_envelope
+from comp.persistence.ledger import (
+    ArtifactConflict,
+    ReceiptConflict,
+    ReceiptLedgerKey,
+    verify_artifact_envelope,
+)
+from comp.persistence.replay import receipt_artifact_refs
 
 
 TRUST_SPINE_SCHEMA_STATEMENTS = (
@@ -157,6 +171,232 @@ class MySQLArtifactStore:
         return _artifact_envelope_from_row(row)
 
 
+class MySQLReceiptLedger:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def record(self, receipt: CommitReceipt) -> CommitReceipt:
+        key = ReceiptLedgerKey.from_receipt(receipt)
+        existing = self._get_optional(key)
+        if existing is None:
+            rid = receipt_id(receipt)
+            body = commit_receipt_to_body(receipt)
+            with self.connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into ledger_commit_receipts (
+                      receipt_id, public_row_id, projection_id, draft_id,
+                      receipt_digest, receipt_body
+                    )
+                    values (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        rid,
+                        receipt.public_row_id,
+                        receipt.projection_id,
+                        receipt.draft_id,
+                        rid.removeprefix("receipt:"),
+                        _json_dump(encode_persistence_json(body)),
+                    ),
+                )
+                _insert_receipt_indexes(cursor, rid, receipt)
+            self.connection.commit()
+            return receipt
+        if existing != receipt:
+            raise ReceiptConflict(
+                f"CommitReceipt ledger root already recorded with different "
+                f"content: {key.public_row_id}."
+            )
+        return existing
+
+    def get(
+        self,
+        *,
+        public_row_id: str,
+        projection_id: str,
+        draft_id: str,
+    ) -> CommitReceipt:
+        key = ReceiptLedgerKey(public_row_id, projection_id, draft_id)
+        existing = self._get_optional(key)
+        if existing is None:
+            raise KeyError(key)
+        return existing
+
+    def receipts(self) -> tuple[CommitReceipt, ...]:
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                select receipt_body
+                from ledger_commit_receipts
+                order by public_row_id, projection_id, draft_id
+                """
+            )
+            return tuple(_commit_receipt_from_row(row) for row in cursor.fetchall())
+
+    def _get_optional(self, key: ReceiptLedgerKey) -> CommitReceipt | None:
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                select receipt_body
+                from ledger_commit_receipts
+                where public_row_id = %s and projection_id = %s and draft_id = %s
+                """,
+                (key.public_row_id, key.projection_id, key.draft_id),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return _commit_receipt_from_row(row)
+
+
+def receipt_id(receipt: CommitReceipt) -> str:
+    body = commit_receipt_to_body(receipt)
+    canonical = _json_dump(encode_persistence_json(body))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"receipt:sha256:{digest}"
+
+
+def commit_receipt_to_body(receipt: CommitReceipt) -> dict[str, Any]:
+    citations = None
+    if receipt.citations is not None:
+        citations = {
+            "governance_decision_id": receipt.citations.governance_decision_id,
+            "governance_status": receipt.citations.governance_status,
+            "governance_reasons": receipt.citations.governance_reasons,
+            "commit_package_id": receipt.citations.commit_package_id,
+            "commit_package_complete": receipt.citations.commit_package_complete,
+            "subject_id": receipt.citations.subject_id,
+            "projection_id": receipt.citations.projection_id,
+            "authorized_fields": receipt.citations.authorized_fields,
+            "profile_id": receipt.citations.profile_id,
+            "report_status": receipt.citations.report_status,
+            "checked_claim_fields": receipt.citations.checked_claim_fields,
+            "checked_claim_witness_ids": receipt.citations.checked_claim_witness_ids,
+            "semantic_judgment_ids": receipt.citations.semantic_judgment_ids,
+            "reference_binding_ids": receipt.citations.reference_binding_ids,
+            "derived_claim_fields": receipt.citations.derived_claim_fields,
+            "derived_claim_ids": receipt.citations.derived_claim_ids,
+            "calculation_trace_ids": receipt.citations.calculation_trace_ids,
+            "formula_ids": receipt.citations.formula_ids,
+            "resolved_obligation_ids": receipt.citations.resolved_obligation_ids,
+            "open_obligation_ids": receipt.citations.open_obligation_ids,
+            "hazard_ids": receipt.citations.hazard_ids,
+            "projection_value_commitments": tuple(
+                _projection_value_commitment_to_body(item)
+                for item in receipt.citations.projection_value_commitments
+            ),
+            "dependency_fingerprints": tuple(
+                _dependency_fingerprint_to_body(item)
+                for item in receipt.citations.dependency_fingerprints
+            ),
+        }
+    return {
+        "draft_id": receipt.draft_id,
+        "winner_receipt_ids": receipt.winner_receipt_ids,
+        "barrier_snapshot": _receipt_value_to_body(receipt.barrier_snapshot),
+        "public_row_id": receipt.public_row_id,
+        "projection_id": receipt.projection_id,
+        "authorized_fields": receipt.authorized_fields,
+        "citations": citations,
+    }
+
+
+def commit_receipt_from_body(body: Mapping[str, Any]) -> CommitReceipt:
+    citations_body = body["citations"]
+    citations = None
+    if citations_body is not None:
+        citations = CommitReceiptCitations(
+            governance_decision_id=citations_body["governance_decision_id"],
+            governance_status=citations_body["governance_status"],
+            governance_reasons=tuple(citations_body["governance_reasons"]),
+            commit_package_id=citations_body["commit_package_id"],
+            commit_package_complete=citations_body["commit_package_complete"],
+            subject_id=citations_body["subject_id"],
+            projection_id=citations_body["projection_id"],
+            authorized_fields=tuple(citations_body["authorized_fields"]),
+            profile_id=citations_body["profile_id"],
+            report_status=citations_body["report_status"],
+            checked_claim_fields=tuple(citations_body["checked_claim_fields"]),
+            checked_claim_witness_ids=tuple(
+                citations_body["checked_claim_witness_ids"]
+            ),
+            semantic_judgment_ids=tuple(citations_body["semantic_judgment_ids"]),
+            reference_binding_ids=tuple(citations_body["reference_binding_ids"]),
+            derived_claim_fields=tuple(citations_body["derived_claim_fields"]),
+            derived_claim_ids=tuple(citations_body["derived_claim_ids"]),
+            calculation_trace_ids=tuple(citations_body["calculation_trace_ids"]),
+            formula_ids=tuple(citations_body["formula_ids"]),
+            resolved_obligation_ids=tuple(citations_body["resolved_obligation_ids"]),
+            open_obligation_ids=tuple(citations_body["open_obligation_ids"]),
+            hazard_ids=tuple(citations_body["hazard_ids"]),
+            projection_value_commitments=tuple(
+                _projection_value_commitment_from_body(item)
+                for item in citations_body["projection_value_commitments"]
+            ),
+            dependency_fingerprints=tuple(
+                _dependency_fingerprint_from_body(item)
+                for item in citations_body["dependency_fingerprints"]
+            ),
+        )
+    return CommitReceipt(
+        draft_id=body["draft_id"],
+        winner_receipt_ids=tuple(body["winner_receipt_ids"]),
+        barrier_snapshot=_receipt_value_from_body(body["barrier_snapshot"]),
+        public_row_id=body["public_row_id"],
+        projection_id=body["projection_id"],
+        authorized_fields=tuple(body["authorized_fields"]),
+        citations=citations,
+    )
+
+
+def _insert_receipt_indexes(cursor: Any, rid: str, receipt: CommitReceipt) -> None:
+    if receipt.citations is None:
+        return
+    for commitment in receipt.citations.projection_value_commitments:
+        cursor.execute(
+            """
+            insert into ledger_receipt_value_commitments (
+              receipt_id, field, source_kind, source_id, value_digest, digest_alg
+            )
+            values (%s, %s, %s, %s, %s, %s)
+            """,
+            (
+                rid,
+                commitment.field,
+                commitment.source_kind,
+                commitment.source_id,
+                commitment.value_digest,
+                commitment.digest_alg,
+            ),
+        )
+    for fingerprint in receipt.citations.dependency_fingerprints:
+        cursor.execute(
+            """
+            insert into ledger_receipt_dependency_fingerprints (
+              receipt_id, dependency_kind, dependency_id, fingerprint, digest_alg
+            )
+            values (%s, %s, %s, %s, %s)
+            """,
+            (
+                rid,
+                fingerprint.dependency_kind,
+                fingerprint.dependency_id,
+                fingerprint.fingerprint,
+                fingerprint.digest_alg,
+            ),
+        )
+    for ref in receipt_artifact_refs(receipt):
+        cursor.execute(
+            """
+            insert into ledger_receipt_artifact_refs (
+              receipt_id, artifact_id, artifact_kind, role
+            )
+            values (%s, %s, %s, %s)
+            """,
+            (rid, ref.artifact_id, ref.artifact_kind, "receipt_artifact_ref"),
+        )
+
+
 def _artifact_envelope_from_row(row: Any) -> ArtifactEnvelope:
     return ArtifactEnvelope(
         artifact_id=row[0],
@@ -167,6 +407,94 @@ def _artifact_envelope_from_row(row: Any) -> ArtifactEnvelope:
         source_refs=decode_persistence_json(_json_load(row[5])),
         meta=decode_persistence_json(_json_load(row[6])),
     )
+
+
+def _commit_receipt_from_row(row: Any) -> CommitReceipt:
+    return commit_receipt_from_body(decode_persistence_json(_json_load(row[0])))
+
+
+def _projection_value_commitment_to_body(
+    commitment: ProjectionValueCommitment,
+) -> dict[str, Any]:
+    return {
+        "field": commitment.field,
+        "source_kind": commitment.source_kind,
+        "source_id": commitment.source_id,
+        "value_digest": commitment.value_digest,
+        "digest_alg": commitment.digest_alg,
+    }
+
+
+def _projection_value_commitment_from_body(
+    body: Mapping[str, Any],
+) -> ProjectionValueCommitment:
+    return ProjectionValueCommitment(
+        field=body["field"],
+        source_kind=body["source_kind"],
+        source_id=body["source_id"],
+        value_digest=body["value_digest"],
+        digest_alg=body["digest_alg"],
+    )
+
+
+def _dependency_fingerprint_to_body(
+    fingerprint: DependencyFingerprint,
+) -> dict[str, Any]:
+    return {
+        "dependency_kind": fingerprint.dependency_kind,
+        "dependency_id": fingerprint.dependency_id,
+        "fingerprint": fingerprint.fingerprint,
+        "digest_alg": fingerprint.digest_alg,
+    }
+
+
+def _dependency_fingerprint_from_body(
+    body: Mapping[str, Any],
+) -> DependencyFingerprint:
+    return DependencyFingerprint(
+        dependency_kind=body["dependency_kind"],
+        dependency_id=body["dependency_id"],
+        fingerprint=body["fingerprint"],
+        digest_alg=body["digest_alg"],
+    )
+
+
+def _receipt_value_to_body(value: Any) -> Any:
+    if isinstance(value, ProjectionValueCommitment):
+        return {
+            "__receipt_type__": "projection_value_commitment",
+            "value": _projection_value_commitment_to_body(value),
+        }
+    if isinstance(value, DependencyFingerprint):
+        return {
+            "__receipt_type__": "dependency_fingerprint",
+            "value": _dependency_fingerprint_to_body(value),
+        }
+    if isinstance(value, Mapping):
+        return {
+            str(key): _receipt_value_to_body(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, tuple):
+        return tuple(_receipt_value_to_body(item) for item in value)
+    if isinstance(value, list):
+        return [_receipt_value_to_body(item) for item in value]
+    return value
+
+
+def _receipt_value_from_body(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        receipt_type = value.get("__receipt_type__")
+        if receipt_type == "projection_value_commitment":
+            return _projection_value_commitment_from_body(value["value"])
+        if receipt_type == "dependency_fingerprint":
+            return _dependency_fingerprint_from_body(value["value"])
+        return {key: _receipt_value_from_body(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_receipt_value_from_body(item) for item in value)
+    if isinstance(value, list):
+        return [_receipt_value_from_body(item) for item in value]
+    return value
 
 
 def _json_dump(value: Any) -> str:
@@ -187,7 +515,11 @@ def _json_load(value: Any) -> Any:
 
 
 __all__ = [
+    "MySQLReceiptLedger",
     "MySQLArtifactStore",
     "TRUST_SPINE_SCHEMA_STATEMENTS",
     "apply_trust_spine_schema",
+    "commit_receipt_from_body",
+    "commit_receipt_to_body",
+    "receipt_id",
 ]

--- a/docs/architecture/persistence-ledger-boundary.md
+++ b/docs/architecture/persistence-ledger-boundary.md
@@ -2,7 +2,7 @@
 
 Status: active-contract
 Owner: persistence
-Last checked against code: 2026-05-20
+Last checked against code: 2026-05-21
 Can block PRs: yes
 
 CommitReceipt as the durable explanation root.
@@ -26,8 +26,8 @@ Fingerprints pin the world that made the receipt meaningful.
 envelope set required by receipt replay.
 
 `production-trust-spine-database.md` sketches the production database direction
-for carrying this boundary into Postgres. It is a north-star working model, not
-a final migration schema.
+for carrying this boundary into MySQL. It is a north-star working model, not a
+final migration schema.
 
 The current implementation now has the first in-memory replay substrate:
 
@@ -50,10 +50,17 @@ comp.persistence
   InMemoryArtifactStore
   InMemoryReceiptLedger
   replay_public_projection(...)
+
+MySQL trust spine
+  apply_trust_spine_schema(...)
+  MySQLArtifactStore
+  MySQLReceiptLedger
+  receipt-derived indexes for value commitments, dependency fingerprints, and
+  artifact refs
 ```
 
-This document describes how that in-memory authority boundary should become a
-durable explanation boundary.
+This document describes how the memory and MySQL substrates preserve the same
+artifact/receipt authority boundary.
 
 ---
 

--- a/docs/architecture/production-trust-spine-database.md
+++ b/docs/architecture/production-trust-spine-database.md
@@ -388,3 +388,30 @@ Does the PR avoid treating JSONB convenience bodies as untyped truth?
 Does any schema change explain whether it updates this provisional model?
 ```
 
+## 12. Current Implementation Status
+
+The first durable spine slice is implemented for MySQL. This is still not a
+final product database schema; it is the V1 persistence adapter that proves the
+artifact/receipt authority path can survive outside memory.
+
+```text
+comp/persistence/mysql.py
+  provides apply_trust_spine_schema, MySQLArtifactStore, and MySQLReceiptLedger.
+
+artifact_envelopes
+  stores encoded ArtifactEnvelope bodies with digest-preserving persistence
+  JSON.
+
+ledger_commit_receipts
+  stores append-only CommitReceipt roots keyed by receipt id and ledger key.
+
+ledger_receipt_value_commitments
+ledger_receipt_dependency_fingerprints
+ledger_receipt_artifact_refs
+  provide receipt-derived query indexes. They are indexes, not independent
+  authority.
+```
+
+The implemented V1 slice intentionally does not include workflow, registry,
+projection cache, typed artifact index, or domain-specific view tables yet.
+Those remain provisional follow-on layers around the artifact/receipt spine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 
 [project.optional-dependencies]
 test = ["pytest>=8"]
+db = ["PyMySQL>=1.1"]
 
 [tool.setuptools]
 packages = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 xfail_strict = true
+markers =
+    mysql: tests that require COMP_TEST_MYSQL_* connection settings
 testpaths =
     tests
 norecursedirs =

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -1,9 +1,16 @@
 import os
+from dataclasses import replace
 from decimal import Decimal
 
 import pytest
 
-from comp.persistence import ArtifactEnvelope, verify_artifact_envelope
+from comp.persistence import (
+    ArtifactConflict,
+    ArtifactEnvelope,
+    ArtifactIntegrityError,
+    verify_artifact_envelope,
+)
+from tests.support.persistence_cases import claim_envelope
 
 
 pytestmark = pytest.mark.mysql
@@ -22,6 +29,26 @@ def _database_config() -> dict[str, object]:
         "charset": "utf8mb4",
         "autocommit": False,
     }
+
+
+def _connect_mysql():
+    pymysql = pytest.importorskip("pymysql")
+    return pymysql.connect(**_database_config())
+
+
+def _reset_spine(connection):
+    with connection.cursor() as cursor:
+        cursor.execute("set foreign_key_checks = 0")
+        for table in (
+            "ledger_receipt_artifact_refs",
+            "ledger_receipt_dependency_fingerprints",
+            "ledger_receipt_value_commitments",
+            "ledger_commit_receipts",
+            "artifact_envelopes",
+        ):
+            cursor.execute(f"truncate table {table}")
+        cursor.execute("set foreign_key_checks = 1")
+    connection.commit()
 
 
 def test_mysql_spine_module_exists():
@@ -89,3 +116,54 @@ def test_apply_trust_spine_schema_creates_v1_tables():
     assert "ledger_receipt_value_commitments" in tables
     assert "ledger_receipt_dependency_fingerprints" in tables
     assert "ledger_receipt_artifact_refs" in tables
+
+
+def test_mysql_artifact_store_records_envelopes_idempotently():
+    from comp.persistence.mysql import MySQLArtifactStore, apply_trust_spine_schema
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        store = MySQLArtifactStore(connection)
+        envelope = claim_envelope(value=1200)
+
+        assert store.record(envelope) == envelope
+        assert store.record(envelope) == envelope
+        assert store.get("artifact:claim:1") == envelope
+        assert store.envelopes() == (envelope,)
+    finally:
+        connection.close()
+
+
+def test_mysql_artifact_store_rejects_conflicting_content():
+    from comp.persistence.mysql import MySQLArtifactStore, apply_trust_spine_schema
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        store = MySQLArtifactStore(connection)
+        store.record(claim_envelope(value=1200))
+
+        with pytest.raises(ArtifactConflict, match="artifact:claim:1"):
+            store.record(claim_envelope(value=1201))
+    finally:
+        connection.close()
+
+
+def test_mysql_artifact_store_rejects_invalid_digest():
+    from comp.persistence.mysql import MySQLArtifactStore, apply_trust_spine_schema
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        store = MySQLArtifactStore(connection)
+        envelope = claim_envelope(value=1200)
+        tampered = replace(envelope, body={"field": "amount", "value": 999})
+
+        with pytest.raises(ArtifactIntegrityError, match="body digest"):
+            store.record(tampered)
+    finally:
+        connection.close()

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.mysql
+
+
+def _database_config() -> dict[str, object]:
+    host = os.environ.get("COMP_TEST_MYSQL_HOST")
+    if not host:
+        pytest.skip("COMP_TEST_MYSQL_HOST is required for MySQL spine tests")
+    return {
+        "host": host,
+        "port": int(os.environ.get("COMP_TEST_MYSQL_PORT", "3306")),
+        "user": os.environ.get("COMP_TEST_MYSQL_USER", "comp"),
+        "password": os.environ.get("COMP_TEST_MYSQL_PASSWORD", "comp"),
+        "database": os.environ.get("COMP_TEST_MYSQL_DATABASE", "comp_test"),
+        "charset": "utf8mb4",
+        "autocommit": False,
+    }
+
+
+def test_mysql_spine_module_exists():
+    from comp.persistence.mysql import apply_trust_spine_schema
+
+    assert apply_trust_spine_schema is not None

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -1,6 +1,9 @@
 import os
+from decimal import Decimal
 
 import pytest
+
+from comp.persistence import ArtifactEnvelope, verify_artifact_envelope
 
 
 pytestmark = pytest.mark.mysql
@@ -25,3 +28,37 @@ def test_mysql_spine_module_exists():
     from comp.persistence.mysql import apply_trust_spine_schema
 
     assert apply_trust_spine_schema is not None
+
+
+def test_persistence_codec_roundtrips_tuple_and_decimal_body():
+    from comp.persistence.codec import decode_persistence_json, encode_persistence_json
+
+    envelope = ArtifactEnvelope.from_body(
+        artifact_id="artifact:codec:1",
+        artifact_kind="codec_fixture",
+        schema_version="v1",
+        body={
+            "tuple_value": ("a", "b"),
+            "list_value": ["a", "b"],
+            "decimal_value": Decimal("1.25"),
+        },
+    )
+
+    encoded = encode_persistence_json(envelope.body)
+    decoded = decode_persistence_json(encoded)
+
+    assert decoded == envelope.body
+    assert isinstance(decoded["tuple_value"], tuple)
+    assert isinstance(decoded["list_value"], list)
+    assert isinstance(decoded["decimal_value"], Decimal)
+
+    roundtripped = ArtifactEnvelope(
+        artifact_id=envelope.artifact_id,
+        artifact_kind=envelope.artifact_kind,
+        schema_version=envelope.schema_version,
+        body_digest=envelope.body_digest,
+        body=decoded,
+        source_refs=envelope.source_refs,
+        meta=envelope.meta,
+    )
+    verify_artifact_envelope(roundtripped)

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -9,9 +9,15 @@ from comp.persistence import (
     ArtifactEnvelope,
     ArtifactIntegrityError,
     ReceiptConflict,
+    receipt_artifact_refs,
+    replay_public_projection,
     verify_artifact_envelope,
 )
-from tests.support.persistence_cases import claim_envelope, receipt_projection_case
+from tests.support.persistence_cases import (
+    artifact_store_for_receipt,
+    claim_envelope,
+    receipt_projection_case,
+)
 
 
 pytestmark = pytest.mark.mysql
@@ -208,3 +214,60 @@ def test_mysql_receipt_ledger_rejects_conflicting_receipt_root():
             ledger.record(changed)
     finally:
         connection.close()
+
+
+def test_mysql_receipt_ledger_populates_receipt_indexes():
+    from comp.persistence.mysql import MySQLReceiptLedger, apply_trust_spine_schema
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        receipt = receipt_projection_case(amount=100).receipt
+        ledger = MySQLReceiptLedger(connection)
+        ledger.record(receipt)
+
+        with connection.cursor() as cursor:
+            cursor.execute("select count(*) from ledger_receipt_value_commitments")
+            value_commitments = cursor.fetchone()[0]
+            cursor.execute("select count(*) from ledger_receipt_dependency_fingerprints")
+            dependencies = cursor.fetchone()[0]
+            cursor.execute("select count(*) from ledger_receipt_artifact_refs")
+            refs = cursor.fetchone()[0]
+    finally:
+        connection.close()
+
+    assert receipt.citations is not None
+    assert value_commitments == len(receipt.citations.projection_value_commitments)
+    assert dependencies == len(receipt.citations.dependency_fingerprints)
+    assert refs == len(set(receipt_artifact_refs(receipt)))
+
+
+def test_mysql_artifact_store_supports_replay_public_projection():
+    from comp.persistence.mysql import MySQLArtifactStore, apply_trust_spine_schema
+
+    case = receipt_projection_case(amount=100)
+    memory_store = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        mysql_store = MySQLArtifactStore(connection)
+        for envelope in memory_store.envelopes():
+            mysql_store.record(envelope)
+
+        report = replay_public_projection(
+            case.source_values,
+            case.projection,
+            receipt=case.receipt,
+            artifacts=mysql_store,
+        )
+    finally:
+        connection.close()
+
+    assert report.public_row == case.public_row
+    assert report.artifact_refs == receipt_artifact_refs(case.receipt)

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -62,3 +62,30 @@ def test_persistence_codec_roundtrips_tuple_and_decimal_body():
         meta=envelope.meta,
     )
     verify_artifact_envelope(roundtripped)
+
+
+def test_apply_trust_spine_schema_creates_v1_tables():
+    pymysql = pytest.importorskip("pymysql")
+    from comp.persistence.mysql import apply_trust_spine_schema
+
+    connection = pymysql.connect(**_database_config())
+    try:
+        apply_trust_spine_schema(connection)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                select table_name
+                from information_schema.tables
+                where table_schema = database()
+                order by table_name
+                """
+            )
+            tables = {row[0] for row in cursor.fetchall()}
+    finally:
+        connection.close()
+
+    assert "artifact_envelopes" in tables
+    assert "ledger_commit_receipts" in tables
+    assert "ledger_receipt_value_commitments" in tables
+    assert "ledger_receipt_dependency_fingerprints" in tables
+    assert "ledger_receipt_artifact_refs" in tables

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -8,9 +8,10 @@ from comp.persistence import (
     ArtifactConflict,
     ArtifactEnvelope,
     ArtifactIntegrityError,
+    ReceiptConflict,
     verify_artifact_envelope,
 )
-from tests.support.persistence_cases import claim_envelope
+from tests.support.persistence_cases import claim_envelope, receipt_projection_case
 
 
 pytestmark = pytest.mark.mysql
@@ -165,5 +166,45 @@ def test_mysql_artifact_store_rejects_invalid_digest():
 
         with pytest.raises(ArtifactIntegrityError, match="body digest"):
             store.record(tampered)
+    finally:
+        connection.close()
+
+
+def test_mysql_receipt_ledger_records_receipts_idempotently():
+    from comp.persistence.mysql import MySQLReceiptLedger, apply_trust_spine_schema
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        ledger = MySQLReceiptLedger(connection)
+        receipt = receipt_projection_case(amount=100).receipt
+
+        assert ledger.record(receipt) == receipt
+        assert ledger.record(receipt) == receipt
+        assert ledger.get(
+            public_row_id="public-row-1",
+            projection_id="public-row",
+            draft_id="draft-1",
+        ) == receipt
+        assert ledger.receipts() == (receipt,)
+    finally:
+        connection.close()
+
+
+def test_mysql_receipt_ledger_rejects_conflicting_receipt_root():
+    from comp.persistence.mysql import MySQLReceiptLedger, apply_trust_spine_schema
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        ledger = MySQLReceiptLedger(connection)
+        receipt = receipt_projection_case(amount=100).receipt
+        changed = replace(receipt, authorized_fields=("site",))
+
+        ledger.record(receipt)
+        with pytest.raises(ReceiptConflict, match="public-row-1"):
+            ledger.record(changed)
     finally:
         connection.close()

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -330,7 +330,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "persistence",
             "yes",
-            "2026-05-20",
+            "2026-05-21",
         ),
         "production-trust-spine-database.md": (
             "north-star",
@@ -415,6 +415,21 @@ def test_production_database_north_star_is_provisional_and_discoverable():
     assert "intentionally provisional" in db_north_star
     assert "Expected to evolve" in db_north_star
     assert "production-trust-spine-database.md" in persistence_boundary
+
+
+def test_production_database_north_star_tracks_v1_mysql_spine():
+    db_doc = Path(
+        "docs/architecture/production-trust-spine-database.md"
+    ).read_text(encoding="utf-8")
+    persistence_doc = Path(
+        "docs/architecture/persistence-ledger-boundary.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## 12. Current Implementation Status" in db_doc
+    assert "MySQLArtifactStore" in db_doc
+    assert "MySQLReceiptLedger" in db_doc
+    assert "ledger_receipt_artifact_refs" in db_doc
+    assert "MySQL trust spine" in persistence_doc
 
 
 def test_pyproject_packages_comp_core_scenarios_and_agent_layer():

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -148,6 +148,18 @@ def test_readme_tracks_persistence_active_surface():
     assert "replay_public_projection" in readme
 
 
+def test_persistence_exports_mysql_backend_surface():
+    from comp.persistence import (
+        MySQLArtifactStore,
+        MySQLReceiptLedger,
+        apply_trust_spine_schema,
+    )
+
+    assert MySQLArtifactStore is not None
+    assert MySQLReceiptLedger is not None
+    assert apply_trust_spine_schema is not None
+
+
 def test_trust_kernel_hardening_documents_projection_numeric_policy():
     hardening = Path("docs/architecture/trust-kernel-hardening.md").read_text(
         encoding="utf-8"


### PR DESCRIPTION
﻿## Summary

- Add a MySQL-backed V1 trust spine for `ArtifactEnvelope` and `CommitReceipt` persistence.
- Add digest-preserving persistence JSON codec, MySQL schema creation, artifact store, receipt ledger, and receipt-derived indexes.
- Wire optional `db` dependency, CI MySQL service, package exports, and architecture docs/status tests.

## Notes

- This intentionally implements only the artifact/receipt spine, not workflow, registry, projection cache, typed artifact indexes, or domain-specific views.
- MySQL JSON is treated as storage only; authority-bearing values are encoded/decoded through `comp.persistence.codec` before replay/digest checks.
- The branch has been merged with latest `origin/main` after PR #233.

## Validation

- `COMP_TEST_MYSQL_HOST=127.0.0.1 COMP_TEST_MYSQL_PORT=3307 COMP_TEST_MYSQL_USER=comp COMP_TEST_MYSQL_PASSWORD=comp COMP_TEST_MYSQL_DATABASE=comp_test python -m pytest tests/test_mysql_persistence_spine.py -q` -> 10 passed
- `COMP_TEST_MYSQL_HOST=127.0.0.1 COMP_TEST_MYSQL_PORT=3307 COMP_TEST_MYSQL_USER=comp COMP_TEST_MYSQL_PASSWORD=comp COMP_TEST_MYSQL_DATABASE=comp_test python -m pytest -q` -> 407 passed
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `git diff --check origin/main..HEAD` -> no errors
