### PR TITLE
[codex] Clarify receipt graph export boundaries

### DIFF
--- a/comp/explanation/receipt_graph.py
+++ b/comp/explanation/receipt_graph.py
@@ -7,7 +7,7 @@ from typing import Any
 from comp.judgment import CommitReceipt
 from comp.persistence import (
     ArtifactRef,
-    InMemoryArtifactStore,
+    ArtifactStore,
     ProjectionReplayReport,
     ReceiptLedgerKey,
 )
@@ -130,7 +130,7 @@ def export_receipt_proof_graph(
     *,
     receipt: CommitReceipt,
     replay: ProjectionReplayReport,
-    artifacts: InMemoryArtifactStore,
+    artifacts: ArtifactStore,
 ) -> ReceiptProofGraph:
     """Export an explanation-only graph from an already successful replay.
 
@@ -180,7 +180,7 @@ class _ReceiptProofGraphBuilder:
         *,
         receipt: CommitReceipt,
         replay: ProjectionReplayReport,
-        artifacts: InMemoryArtifactStore,
+        artifacts: ArtifactStore,
     ) -> None:
         self._receipt = receipt
         self._replay = replay

--- a/comp/persistence/__init__.py
+++ b/comp/persistence/__init__.py
@@ -5,6 +5,7 @@ from comp.persistence.envelope import ArtifactEnvelope
 from comp.persistence.ledger import (
     ArtifactConflict,
     ArtifactIntegrityError,
+    ArtifactStore,
     InMemoryArtifactStore,
     InMemoryReceiptLedger,
     PersistenceError,
@@ -31,6 +32,7 @@ __all__ = [
     "ArtifactEnvelope",
     "ArtifactRef",
     "ArtifactIntegrityError",
+    "ArtifactStore",
     "InMemoryArtifactStore",
     "InMemoryReceiptLedger",
     "MySQLArtifactStore",

--- a/comp/persistence/ledger.py
+++ b/comp/persistence/ledger.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
 
 from comp.judgment import (
     CommitReceipt,
@@ -32,6 +32,13 @@ class ReceiptConflict(PersistenceError):
 
 class ProjectionReplayBlocked(PersistenceError):
     """Raised when a materialized projection cannot be replayed from a receipt."""
+
+
+class ArtifactStore(Protocol):
+    """Read boundary for replayable artifact envelopes."""
+
+    def get(self, artifact_id: str) -> ArtifactEnvelope:
+        ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,6 +165,7 @@ __all__ = [
     "PersistenceError",
     "ArtifactIntegrityError",
     "ArtifactConflict",
+    "ArtifactStore",
     "ReceiptConflict",
     "ProjectionReplayBlocked",
     "ReceiptLedgerKey",

--- a/comp/persistence/replay.py
+++ b/comp/persistence/replay.py
@@ -8,7 +8,7 @@ from comp.judgment import CommitReceipt, ProjectionSpec
 from comp.judgment.receipts import DependencyFingerprint
 from comp.persistence.ledger import (
     ArtifactIntegrityError,
-    InMemoryArtifactStore,
+    ArtifactStore,
     ProjectionReplayBlocked,
     ReceiptLedgerKey,
     verify_artifact_envelope,
@@ -41,7 +41,7 @@ def replay_public_projection(
     projection: ProjectionSpec,
     *,
     receipt: CommitReceipt,
-    artifacts: InMemoryArtifactStore,
+    artifacts: ArtifactStore,
 ) -> ProjectionReplayReport:
     public_row = verify_materialized_public_projection(
         row,
@@ -110,7 +110,7 @@ def receipt_artifact_refs(receipt: CommitReceipt) -> tuple[ArtifactRef, ...]:
 
 def _verified_artifact_digests(
     refs: tuple[ArtifactRef, ...],
-    artifacts: InMemoryArtifactStore,
+    artifacts: ArtifactStore,
 ) -> tuple[tuple[str, str], ...]:
     digests: list[tuple[str, str]] = []
     for ref in refs:
@@ -136,7 +136,7 @@ def _verified_artifact_digests(
 
 def _verify_projection_value_sources(
     receipt: CommitReceipt,
-    artifacts: InMemoryArtifactStore,
+    artifacts: ArtifactStore,
 ) -> None:
     if receipt.citations is None:
         return
@@ -173,7 +173,7 @@ def _verify_projection_value_sources(
 
 def _verify_dependency_fingerprint_sources(
     receipt: CommitReceipt,
-    artifacts: InMemoryArtifactStore,
+    artifacts: ArtifactStore,
 ) -> None:
     if receipt.citations is None:
         return
@@ -241,7 +241,7 @@ def _verify_profile_lock_body(
 
 def _verify_source_evidence_span_fingerprints(
     receipt: CommitReceipt,
-    artifacts: InMemoryArtifactStore,
+    artifacts: ArtifactStore,
 ) -> None:
     if receipt.citations is None:
         return
@@ -276,7 +276,7 @@ def _evidence_witness_fingerprint_from_body(
 
 def _verify_reference_catalog_snapshot_coverage(
     receipt: CommitReceipt,
-    artifacts: InMemoryArtifactStore,
+    artifacts: ArtifactStore,
 ) -> None:
     if receipt.citations is None:
         return

--- a/comp/views/__init__.py
+++ b/comp/views/__init__.py
@@ -1,1 +1,1 @@
-"""Future projection/view package."""
+"""Projection and explanation view helpers."""

--- a/comp/views/receipt_graph.py
+++ b/comp/views/receipt_graph.py
@@ -1,0 +1,8 @@
+"""Render-only receipt proof graph view helpers.
+
+This module is reserved for Mermaid, Graphviz, and viewer formatters that
+consume `ReceiptProofGraph.to_payload()`. It must not export graphs, replay
+projections, or authorize public rows.
+"""
+
+__all__: list[str] = []

--- a/docs/architecture/receipt-proof-graph.md
+++ b/docs/architecture/receipt-proof-graph.md
@@ -344,11 +344,21 @@ Scenario viewer payloads may expose the graph alongside existing traces:
 ```text
 receipt_trace      receipt citation summary
 replay_trace       replay verification summary
-dependency_graph   explanation DAG
+proof_graph        receipt-scoped proof DAG
 ```
 
+Use `proof_graph`, not a generic dependency-graph name, because the payload
+explains receipt-gated proof paths rather than arbitrary dependency edges.
+
 CLI, Mermaid, Graphviz, and UI rendering should consume the graph payload rather
-than reconstructing graph semantics independently.
+than reconstructing graph semantics independently. Renderer code belongs in
+`comp.views.receipt_graph` or downstream viewer packages; it must not call the
+compiler, resolver, calculator, governance gate, projection gate, or replay
+function.
+
+MySQLArtifactStore is an ArtifactStore implementation. It stores and
+retrieves replay artifacts; it does not become a graph backend or a policy
+authority.
 
 ## 12. Deferred Graphs
 
@@ -399,7 +409,7 @@ dependency fingerprints appear as typed nodes
 public projection and public fields connect back to the receipt
 graph payload hides raw values by default
 graph explicitly cannot authorize public projection
-scenario JSON includes dependency_graph
+scenario JSON includes proof_graph
 ```
 
 Non-goals:

--- a/docs/superpowers/plans/2026-05-22-receipt-proof-graph-boundary-prework.md
+++ b/docs/superpowers/plans/2026-05-22-receipt-proof-graph-boundary-prework.md
@@ -1,0 +1,257 @@
+# Receipt Proof Graph Boundary Prework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare the receipt proof graph boundary so follow-up PRs can add CLI/JSON export, scenario attachment, and renderers without weakening the receipt/replay authority model.
+
+**Architecture:** Keep `ReceiptProofGraph` in `comp.explanation` as the explanation IR derived from a successful replay. Define an `ArtifactStore` read protocol at the persistence boundary, reserve `comp.views.receipt_graph` for render-only consumers, and update the active contract so payload names and renderer ownership are explicit before feature work begins.
+
+**Tech Stack:** Python dataclasses, typing `Protocol`, pytest, repository architecture docs.
+
+---
+
+### Task 1: Document Payload And Renderer Boundaries
+
+**Files:**
+- Modify: `docs/architecture/receipt-proof-graph.md`
+- Test: `tests/test_package_smoke.py`
+
+- [ ] **Step 1: Write the failing doc-boundary test**
+
+Add a smoke test that requires the active contract to name the stable scenario key, renderer module, and MySQL boundary:
+
+```python
+def test_receipt_proof_graph_contract_names_prework_boundaries():
+    graph_doc = Path("docs/architecture/receipt-proof-graph.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "proof_graph" in graph_doc
+    assert "dependency_graph" not in graph_doc
+    assert "comp.views.receipt_graph" in graph_doc
+    assert "MySQLArtifactStore is an ArtifactStore implementation" in graph_doc
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python -m pytest tests/test_package_smoke.py::test_receipt_proof_graph_contract_names_prework_boundaries -q
+```
+
+Expected: FAIL because the current document still mentions `dependency_graph` and does not reserve `comp.views.receipt_graph`.
+
+- [ ] **Step 3: Update the active contract**
+
+Modify `docs/architecture/receipt-proof-graph.md` so section 11 uses this shape:
+
+```text
+Scenario viewer payloads may expose the graph alongside existing traces:
+
+receipt_trace      receipt citation summary
+replay_trace       replay verification summary
+proof_graph        receipt-scoped proof DAG
+
+Use `proof_graph`, not `dependency_graph`, because the payload explains
+receipt-gated proof paths rather than arbitrary dependency edges.
+
+CLI, Mermaid, Graphviz, and UI rendering should consume the graph payload rather
+than reconstructing graph semantics independently. Renderer code belongs in
+`comp.views.receipt_graph` or downstream viewer packages; it must not call the
+compiler, resolver, calculator, governance gate, projection gate, or replay
+function.
+
+`MySQLArtifactStore` is an `ArtifactStore` implementation. It stores and
+retrieves replay artifacts; it does not become a graph backend or a policy
+authority.
+```
+
+Update the recommended first slice so it says `scenario JSON includes proof_graph`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+python -m pytest tests/test_package_smoke.py::test_receipt_proof_graph_contract_names_prework_boundaries -q
+```
+
+Expected: PASS.
+
+### Task 2: Define The ArtifactStore Read Boundary
+
+**Files:**
+- Modify: `comp/persistence/ledger.py`
+- Modify: `comp/persistence/__init__.py`
+- Modify: `comp/explanation/receipt_graph.py`
+- Test: `tests/test_receipt_proof_graph.py`
+- Test: `tests/test_package_smoke.py`
+
+- [ ] **Step 1: Write the failing type-boundary test**
+
+Add imports:
+
+```python
+from typing import get_type_hints
+
+import comp.explanation.receipt_graph as receipt_graph
+from comp.persistence import ArtifactStore
+```
+
+Add the test:
+
+```python
+def test_graph_export_depends_on_artifact_store_protocol():
+    hints = get_type_hints(receipt_graph.export_receipt_proof_graph)
+
+    assert hints["artifacts"] is ArtifactStore
+    assert getattr(ArtifactStore, "_is_protocol", False) is True
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python -m pytest tests/test_receipt_proof_graph.py::test_graph_export_depends_on_artifact_store_protocol -q
+```
+
+Expected: FAIL because `ArtifactStore` is not exported yet and the graph exporter is annotated with `InMemoryArtifactStore`.
+
+- [ ] **Step 3: Add the protocol**
+
+In `comp/persistence/ledger.py`, add:
+
+```python
+from typing import Protocol
+```
+
+Then add:
+
+```python
+class ArtifactStore(Protocol):
+    def get(self, artifact_id: str) -> ArtifactEnvelope:
+        ...
+```
+
+Export it in `__all__`.
+
+- [ ] **Step 4: Export and consume the protocol**
+
+In `comp/persistence/__init__.py`, import and export `ArtifactStore`.
+
+In `comp/explanation/receipt_graph.py`, replace the `InMemoryArtifactStore` import and annotations with `ArtifactStore`.
+
+- [ ] **Step 5: Add package smoke coverage**
+
+In `test_pyproject_packages_comp_core_scenarios_and_agent_layer`, import `ArtifactStore` from `comp.persistence` and assert it is not `None`.
+
+- [ ] **Step 6: Run the focused tests**
+
+Run:
+
+```bash
+python -m pytest tests/test_receipt_proof_graph.py tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer -q
+```
+
+Expected: PASS.
+
+### Task 3: Reserve The Renderer Module Without Adding Renderers
+
+**Files:**
+- Create: `comp/views/receipt_graph.py`
+- Modify: `comp/views/__init__.py`
+- Test: `tests/test_package_smoke.py`
+
+- [ ] **Step 1: Write the failing renderer-boundary test**
+
+Add:
+
+```python
+def test_receipt_graph_renderers_have_non_authority_module_boundary():
+    from comp.views import receipt_graph
+
+    assert "render-only" in (receipt_graph.__doc__ or "")
+    assert "export_receipt_proof_graph" not in receipt_graph.__dict__
+    assert "replay_public_projection" not in receipt_graph.__dict__
+    assert "project_public_row" not in receipt_graph.__dict__
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python -m pytest tests/test_package_smoke.py::test_receipt_graph_renderers_have_non_authority_module_boundary -q
+```
+
+Expected: FAIL because `comp.views.receipt_graph` does not exist yet.
+
+- [ ] **Step 3: Add the reserved module**
+
+Create `comp/views/receipt_graph.py`:
+
+```python
+"""Render-only receipt proof graph view helpers.
+
+This module is reserved for Mermaid, Graphviz, and viewer formatters that
+consume `ReceiptProofGraph.to_payload()`. It must not export graphs, replay
+projections, or authorize public rows.
+"""
+
+__all__: list[str] = []
+```
+
+Update `comp/views/__init__.py` to expose only the module:
+
+```python
+"""Projection and explanation view helpers."""
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+```bash
+python -m pytest tests/test_package_smoke.py::test_receipt_graph_renderers_have_non_authority_module_boundary -q
+```
+
+Expected: PASS.
+
+### Task 4: Verify The Boundary Prework
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run focused graph and package tests**
+
+Run:
+
+```bash
+python -m pytest tests/test_receipt_proof_graph.py tests/test_package_smoke.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Check the diff**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; changed files are limited to docs, persistence typing, explanation annotations, views boundary, and tests.
+
+- [ ] **Step 3: Commit the prework**
+
+Run:
+
+```bash
+git add docs/architecture/receipt-proof-graph.md docs/superpowers/plans/2026-05-22-receipt-proof-graph-boundary-prework.md comp/persistence/ledger.py comp/persistence/__init__.py comp/explanation/receipt_graph.py comp/views/__init__.py comp/views/receipt_graph.py tests/test_package_smoke.py tests/test_receipt_proof_graph.py
+git commit -m "chore: clarify receipt graph export boundaries"
+```
+
+Expected: one small prework commit ready for the first sequential PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ packages = [
   "comp.persistence",
   "comp.scenarios",
   "comp.scenarios.synthetic",
+  "comp.views",
   "minchoagnt",
 ]
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -432,9 +432,30 @@ def test_production_database_north_star_tracks_v1_mysql_spine():
     assert "MySQL trust spine" in persistence_doc
 
 
+def test_receipt_proof_graph_contract_names_prework_boundaries():
+    graph_doc = Path("docs/architecture/receipt-proof-graph.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "proof_graph" in graph_doc
+    assert "dependency_graph" not in graph_doc
+    assert "comp.views.receipt_graph" in graph_doc
+    assert "MySQLArtifactStore is an ArtifactStore implementation" in graph_doc
+
+
+def test_receipt_graph_renderers_have_non_authority_module_boundary():
+    from comp.views import receipt_graph
+
+    assert "render-only" in (receipt_graph.__doc__ or "").lower()
+    assert "export_receipt_proof_graph" not in receipt_graph.__dict__
+    assert "replay_public_projection" not in receipt_graph.__dict__
+    assert "project_public_row" not in receipt_graph.__dict__
+
+
 def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
     from comp.persistence import (
+        ArtifactStore,
         ArtifactEnvelope,
         ArtifactRef,
         InMemoryArtifactStore,
@@ -459,6 +480,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         "comp.persistence",
         "comp.scenarios",
         "comp.scenarios.synthetic",
+        "comp.views",
         "minchoagnt",
     ]
     assert pyproject["tool"]["setuptools"]["package-data"] == {
@@ -476,6 +498,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
 
     assert ReceiptProofGraph is not None
     assert export_receipt_proof_graph is not None
+    assert ArtifactStore is not None
     assert ArtifactEnvelope is not None
     assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None

--- a/tests/test_receipt_proof_graph.py
+++ b/tests/test_receipt_proof_graph.py
@@ -1,6 +1,8 @@
 from dataclasses import replace
+from typing import get_type_hints
 
 from comp import ProjectionSpec
+import comp.explanation.receipt_graph as receipt_graph
 from comp.explanation import (
     ProofGraphExportError,
     ReceiptProofGraph,
@@ -219,6 +221,15 @@ def test_graph_export_does_not_import_authority_or_compiler_functions():
     assert "replay_public_projection" not in receipt_graph.__dict__
     assert "project_public_row" not in receipt_graph.__dict__
     assert "CompilerTool" not in receipt_graph.__dict__
+
+
+def test_graph_export_depends_on_artifact_store_protocol():
+    from comp.persistence import ArtifactStore
+
+    hints = get_type_hints(receipt_graph.export_receipt_proof_graph)
+
+    assert hints["artifacts"] is ArtifactStore
+    assert getattr(ArtifactStore, "_is_protocol", False) is True
 
 
 def _has_edge(


### PR DESCRIPTION
## Summary
- clarify the receipt proof graph product surface around `proof_graph`, renderers, and MySQL storage boundaries
- add an `ArtifactStore` read protocol and use it for replay/graph export annotations
- reserve `comp.views.receipt_graph` as a render-only module for future Mermaid/Graphviz/viewer work

## Why
This keeps the next CLI/JSON, scenario attachment, and renderer PRs from pulling graph behavior back into projection authority or persistence policy.

## Validation
- `python -m pytest tests/test_receipt_proof_graph.py tests/test_package_smoke.py -q`
- `python -m pytest -q`
- `git diff --check`