### PR TITLE
[codex] Export receipt proof graph JSON

### DIFF
--- a/comp/explanation/receipt_graph.py
+++ b/comp/explanation/receipt_graph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -124,6 +125,9 @@ class ReceiptProofGraph:
                 for field, node_ids in self.field_paths
             ),
         }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_payload(), indent=2, sort_keys=True)
 
 
 def export_receipt_proof_graph(

--- a/comp/explanation/receipt_graph_cli.py
+++ b/comp/explanation/receipt_graph_cli.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from comp.explanation import export_receipt_proof_graph
+from comp.judgment import DependencyFingerprint
+from comp.persistence import (
+    ArtifactEnvelope,
+    ArtifactRef,
+    InMemoryArtifactStore,
+    ProjectionReplayReport,
+    ReceiptLedgerKey,
+)
+from comp.persistence.codec import decode_persistence_json
+from comp.persistence.mysql import commit_receipt_from_body
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "export-json":
+        graph = export_receipt_proof_graph(
+            receipt=commit_receipt_from_body(_load_mapping(args.receipt)),
+            replay=_replay_from_payload(_load_mapping(args.replay)),
+            artifacts=_artifact_store_from_payload(_load_mapping(args.artifacts)),
+        )
+        output = graph.to_json() + "\n"
+        if args.output is None:
+            sys.stdout.write(output)
+        else:
+            Path(args.output).write_text(output, encoding="utf-8")
+        return 0
+
+    parser.print_help(sys.stderr)
+    return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="comp-receipt-graph",
+        description="Export receipt proof graphs as explanation-only JSON.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    export = subparsers.add_parser(
+        "export-json",
+        help="Export a ReceiptProofGraph from receipt, replay, and artifact JSON.",
+    )
+    export.add_argument("--receipt", required=True, help="CommitReceipt body JSON path.")
+    export.add_argument("--replay", required=True, help="ProjectionReplayReport JSON path.")
+    export.add_argument(
+        "--artifacts",
+        required=True,
+        help="JSON path containing an artifacts array of ArtifactEnvelope payloads.",
+    )
+    export.add_argument(
+        "--output",
+        help="Optional output JSON path. Defaults to stdout.",
+    )
+    return parser
+
+
+def _load_mapping(path: str) -> Mapping[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(payload, Mapping) and "__comp_type__" in payload:
+        payload = decode_persistence_json(payload)
+    if not isinstance(payload, Mapping):
+        raise TypeError(f"Expected JSON object: {path}.")
+    return payload
+
+
+def _replay_from_payload(payload: Mapping[str, Any]) -> ProjectionReplayReport:
+    receipt_key = _mapping(payload["receipt_key"], "receipt_key")
+    return ProjectionReplayReport(
+        receipt_key=ReceiptLedgerKey(
+            public_row_id=str(receipt_key["public_row_id"]),
+            projection_id=str(receipt_key["projection_id"]),
+            draft_id=str(receipt_key["draft_id"]),
+        ),
+        projection_id=str(payload["projection_id"]),
+        public_row=dict(_mapping(payload["public_row"], "public_row")),
+        artifact_refs=tuple(
+            ArtifactRef(
+                artifact_id=str(_mapping(item, "artifact_ref")["artifact_id"]),
+                artifact_kind=str(_mapping(item, "artifact_ref")["artifact_kind"]),
+            )
+            for item in _sequence(payload["artifact_refs"], "artifact_refs")
+        ),
+        artifact_digests=tuple(
+            (str(item[0]), str(item[1]))
+            for item in _sequence(payload["artifact_digests"], "artifact_digests")
+        ),
+        dependency_fingerprints=tuple(
+            _dependency_fingerprint_from_payload(item)
+            for item in _sequence(
+                payload.get("dependency_fingerprints", ()),
+                "dependency_fingerprints",
+            )
+        ),
+    )
+
+
+def _artifact_store_from_payload(payload: Mapping[str, Any]) -> InMemoryArtifactStore:
+    store = InMemoryArtifactStore()
+    for item in _sequence(payload["artifacts"], "artifacts"):
+        envelope_payload = _mapping(item, "artifact")
+        store.record(
+            ArtifactEnvelope(
+                artifact_id=str(envelope_payload["artifact_id"]),
+                artifact_kind=str(envelope_payload["artifact_kind"]),
+                schema_version=str(envelope_payload["schema_version"]),
+                body_digest=str(envelope_payload["body_digest"]),
+                body=_decode_field_mapping(envelope_payload["body"], "artifact.body"),
+                source_refs=tuple(
+                    _decode_field(envelope_payload.get("source_refs", ()))
+                ),
+                meta=tuple(_decode_field(envelope_payload.get("meta", ()))),
+            )
+        )
+    return store
+
+
+def _dependency_fingerprint_from_payload(value: Any) -> DependencyFingerprint:
+    payload = _mapping(value, "dependency_fingerprint")
+    return DependencyFingerprint(
+        dependency_kind=str(payload["dependency_kind"]),
+        dependency_id=str(payload["dependency_id"]),
+        fingerprint=str(payload["fingerprint"]),
+        digest_alg=str(payload.get("digest_alg", "sha256")),
+    )
+
+
+def _decode_field(value: Any) -> Any:
+    if isinstance(value, Mapping) and "__comp_type__" in value:
+        return decode_persistence_json(value)
+    return value
+
+
+def _decode_field_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    decoded = _decode_field(value)
+    return _mapping(decoded, name)
+
+
+def _mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Expected object for {name}.")
+    return value
+
+
+def _sequence(value: Any, name: str) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise TypeError(f"Expected array for {name}.")
+    return value
+
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture/receipt-proof-graph.md
+++ b/docs/architecture/receipt-proof-graph.md
@@ -356,6 +356,22 @@ than reconstructing graph semantics independently. Renderer code belongs in
 compiler, resolver, calculator, governance gate, projection gate, or replay
 function.
 
+The initial CLI is file-based and exports a graph from an already materialized
+receipt, replay report, and artifact envelope set:
+
+```text
+comp-receipt-graph export-json \
+  --receipt receipt.json \
+  --replay replay.json \
+  --artifacts artifacts.json \
+  --output proof-graph.json
+```
+
+The CLI consumes replay outputs; it does not replay projections itself.
+Artifact envelope bodies should use the persistence JSON codec so tuple, list,
+decimal, and scalar values keep the same digest material they had at replay
+time.
+
 MySQLArtifactStore is an ArtifactStore implementation. It stores and
 retrieves replay artifacts; it does not become a graph backend or a policy
 authority.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,4 @@ packages = [
 
 [project.scripts]
 minchoagnt = "minchoagnt.cli:main"
+comp-receipt-graph = "comp.explanation.receipt_graph_cli:main"

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -490,6 +490,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
 
     scripts = pyproject["project"].get("scripts", {})
     assert scripts["minchoagnt"] == "minchoagnt.cli:main"
+    assert scripts["comp-receipt-graph"] == "comp.explanation.receipt_graph_cli:main"
 
     dependencies = pyproject["project"].get("dependencies", [])
     assert not any(dependency.startswith("lark") for dependency in dependencies)

--- a/tests/test_receipt_proof_graph.py
+++ b/tests/test_receipt_proof_graph.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import replace
 from typing import get_type_hints
 
@@ -54,6 +55,34 @@ def test_receipt_proof_graph_exports_successful_replay_payload():
     assert graph.to_payload()["can_authorize_public_projection"] is False
     for artifact_ref in replay.artifact_refs:
         assert graph.artifact_node(artifact_ref) is not None
+
+
+def test_receipt_proof_graph_serializes_stable_json_payload():
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+    graph = export_receipt_proof_graph(
+        receipt=case.receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )
+
+    payload = json.loads(graph.to_json())
+
+    assert payload["authority"] == "explanation_only"
+    assert payload["can_authorize_public_projection"] is False
+    assert payload["receipt_node_id"] == receipt_node_id(case.receipt)
+    assert isinstance(payload["nodes"], list)
+    assert isinstance(payload["edges"], list)
+    assert payload["field_paths"][0]["field"] == "amount"
 
 
 def test_public_projection_fields_connect_to_receipt_and_value_sources():

--- a/tests/test_receipt_proof_graph_cli.py
+++ b/tests/test_receipt_proof_graph_cli.py
@@ -1,0 +1,160 @@
+import json
+
+from comp.persistence.mysql import commit_receipt_to_body
+from comp.persistence.codec import encode_persistence_json
+from comp.persistence.replay import ProjectionReplayReport
+from comp.explanation.receipt_graph_cli import main
+from tests.support.persistence_cases import (
+    artifact_store_for_receipt,
+    receipt_projection_case,
+)
+from comp.persistence import replay_public_projection
+
+
+def test_receipt_graph_cli_exports_graph_json_from_replay_inputs(tmp_path, capsys):
+    case = receipt_projection_case(amount=100, site="plant-a")
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+    receipt_path = tmp_path / "receipt.json"
+    replay_path = tmp_path / "replay.json"
+    artifacts_path = tmp_path / "artifacts.json"
+
+    receipt_path.write_text(
+        json.dumps(commit_receipt_to_body(case.receipt), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    replay_path.write_text(
+        json.dumps(_replay_payload(replay), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    artifacts_path.write_text(
+        json.dumps(
+            {"artifacts": [_artifact_payload(item) for item in artifacts.envelopes()]},
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "export-json",
+            "--receipt",
+            str(receipt_path),
+            "--replay",
+            str(replay_path),
+            "--artifacts",
+            str(artifacts_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["authority"] == "explanation_only"
+    assert payload["can_authorize_public_projection"] is False
+    assert payload["public_row_id"] == case.receipt.public_row_id
+    assert "plant-a" not in captured.out
+    assert not _payload_has_key(payload, "value")
+
+
+def test_receipt_graph_cli_can_write_graph_json_to_file(tmp_path, capsys):
+    case = receipt_projection_case(amount=100)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+    receipt_path = tmp_path / "receipt.json"
+    replay_path = tmp_path / "replay.json"
+    artifacts_path = tmp_path / "artifacts.json"
+    output_path = tmp_path / "graph.json"
+    receipt_path.write_text(json.dumps(commit_receipt_to_body(case.receipt)), encoding="utf-8")
+    replay_path.write_text(json.dumps(_replay_payload(replay)), encoding="utf-8")
+    artifacts_path.write_text(
+        json.dumps({"artifacts": [_artifact_payload(item) for item in artifacts.envelopes()]}),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "export-json",
+            "--receipt",
+            str(receipt_path),
+            "--replay",
+            str(replay_path),
+            "--artifacts",
+            str(artifacts_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert captured.out == ""
+    assert payload["authority"] == "explanation_only"
+
+
+def _replay_payload(replay: ProjectionReplayReport) -> dict[str, object]:
+    return {
+        "receipt_key": {
+            "public_row_id": replay.receipt_key.public_row_id,
+            "projection_id": replay.receipt_key.projection_id,
+            "draft_id": replay.receipt_key.draft_id,
+        },
+        "projection_id": replay.projection_id,
+        "public_row": replay.public_row,
+        "artifact_refs": [
+            {
+                "artifact_id": ref.artifact_id,
+                "artifact_kind": ref.artifact_kind,
+            }
+            for ref in replay.artifact_refs
+        ],
+        "artifact_digests": replay.artifact_digests,
+        "dependency_fingerprints": [
+            {
+                "dependency_kind": fingerprint.dependency_kind,
+                "dependency_id": fingerprint.dependency_id,
+                "fingerprint": fingerprint.fingerprint,
+                "digest_alg": fingerprint.digest_alg,
+            }
+            for fingerprint in replay.dependency_fingerprints
+        ],
+    }
+
+
+def _artifact_payload(envelope) -> dict[str, object]:
+    return {
+        "artifact_id": envelope.artifact_id,
+        "artifact_kind": envelope.artifact_kind,
+        "schema_version": envelope.schema_version,
+        "body_digest": envelope.body_digest,
+        "body": encode_persistence_json(envelope.body),
+        "source_refs": encode_persistence_json(envelope.source_refs),
+        "meta": encode_persistence_json(envelope.meta),
+    }
+
+
+def _payload_has_key(value, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_payload_has_key(item, key) for item in value.values())
+    if isinstance(value, list):
+        return any(_payload_has_key(item, key) for item in value)
+    return False


### PR DESCRIPTION
## Summary
- add stable `ReceiptProofGraph.to_json()` output for the existing graph payload
- add `comp-receipt-graph export-json` to export a graph from receipt, replay report, and artifact envelope JSON files
- document the file-based CLI and persistence JSON requirement for artifact envelope bodies

## Why
This exposes the receipt-scoped proof graph as a machine-readable artifact before scenario runners and viewers start consuming it.

## Validation
- `python -m pytest tests/test_receipt_proof_graph.py tests/test_receipt_proof_graph_cli.py tests/test_package_smoke.py -q`
- `python -m comp.explanation.receipt_graph_cli --help`
- `python -m pytest -q`
- `git diff --check`

Note: local working tree has unrelated unstaged changes in `docs/index.md`, `docs/architecture/friendly-authority-vocabulary.md`, and non-staged hunks of `tests/test_package_smoke.py`; they are intentionally excluded from this PR.