### PR TITLE
[codex] Attach proof graph to scenario JSON

### DIFF
--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -165,6 +165,11 @@ python -m tests.domain_scenarios run l_energy_pcf_governance.v1 --json
 python -m tests.domain_scenarios run-all --json
 ```
 
+When a scenario has a commit receipt and replayable projection, the JSON payload
+includes `proof_graph`. The graph is explanation-only: it is derived after
+replay succeeds, hides raw committed values by default, and cannot authorize a
+projection.
+
 The runner is intentionally generic. It only knows about `ScenarioDefinition`,
 `registered_scenarios()`, `run_scenario()`, and `DomainScenarioResult`; scenario
 packs own their domain fixtures and expected contracts.

--- a/tests/domain_scenarios/views.py
+++ b/tests/domain_scenarios/views.py
@@ -13,6 +13,7 @@ def scenario_result_view(result) -> dict[str, Any]:
             result.preparation.receipt,
         ),
         "replay_trace": replay_trace_view(result),
+        "proof_graph": proof_graph_view(result),
         "facts": {
             "report_count": len(result.report_facts),
             "commit_count": len(result.commit_facts),
@@ -172,6 +173,36 @@ def replay_trace_view(result) -> dict[str, Any] | None:
     }
 
 
+def proof_graph_view(result) -> dict[str, Any] | None:
+    receipt = result.preparation.receipt
+    if receipt is None or result.projection is None:
+        return None
+
+    from comp import ProjectionSpec
+    from comp.explanation import export_receipt_proof_graph
+    from comp.persistence import ProjectionReplayBlocked
+    from tests.domain_scenarios.persistence import (
+        replay_scenario_projection,
+        scenario_replay_bundle,
+    )
+
+    bundle = scenario_replay_bundle(result)
+    try:
+        replay = replay_scenario_projection(
+            result,
+            ProjectionSpec(receipt.projection_id, tuple(result.projection.keys())),
+            bundle=bundle,
+        )
+    except ProjectionReplayBlocked:
+        return None
+
+    return export_receipt_proof_graph(
+        receipt=receipt,
+        replay=replay,
+        artifacts=bundle.artifacts,
+    ).to_payload()
+
+
 def _dependency_manifests_view(fingerprints, artifacts) -> dict[str, list[dict[str, Any]]]:
     profile_locks = []
     catalog_snapshots = []
@@ -234,6 +265,7 @@ def _obligation_view(obligation) -> dict[str, str | None]:
 
 __all__ = [
     "commit_view",
+    "proof_graph_view",
     "receipt_trace_view",
     "replay_trace_view",
     "report_view",

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -98,9 +98,12 @@ def test_domain_scenario_cli_runs_json_view(capsys):
     exit_code = main(["run", "tiny_pcf.location_based_electricity.v1", "--json"])
 
     captured = capsys.readouterr()
+    payload = json.loads(captured.out)
     assert exit_code == 0
     assert '"scenario_id": "tiny_pcf.location_based_electricity.v1"' in captured.out
     assert '"projection": {' in captured.out
+    assert payload["proof_graph"]["authority"] == "explanation_only"
+    assert payload["proof_graph"]["can_authorize_public_projection"] is False
     assert captured.err == ""
 
 
@@ -496,6 +499,41 @@ def test_scenario_result_view_exposes_replay_trace_manifest_summary():
     assert "value" not in str(replay_trace["artifact_digests"])
 
 
+def test_scenario_result_view_exposes_proof_graph_from_successful_replay():
+    result = run_canonical_working_loop_scenario()
+
+    view = scenario_result_view(result)
+
+    proof_graph = view["proof_graph"]
+    assert proof_graph["authority"] == "explanation_only"
+    assert proof_graph["can_authorize_public_projection"] is False
+    assert proof_graph["receipt_node_id"] == (
+        "commit_receipt:"
+        "public-row:canonical-raw-pcf-1:"
+        "canonical-pcf-public-row:"
+        "commit-package:product:canonical-raw-pcf-1"
+    )
+    assert any(
+        node["node_kind"] == "public_projection"
+        for node in proof_graph["nodes"]
+    )
+    assert any(
+        edge["edge_kind"] == "authorized_by"
+        for edge in proof_graph["edges"]
+    )
+    assert not _payload_has_key(proof_graph, "value")
+    assert not _payload_has_key(proof_graph, "text")
+
+
+def test_scenario_result_view_omits_proof_graph_when_replay_is_absent():
+    result = run_synthetic_pcf_anomaly_scenario()
+
+    view = scenario_result_view(result)
+
+    assert view["replay_trace"] is None
+    assert view["proof_graph"] is None
+
+
 def test_tiny_pcf_scenario_exports_json_ready_viewer_payload():
     exported = run_tiny_pcf_scenario().to_dict()
 
@@ -517,3 +555,12 @@ def test_tiny_pcf_scenario_exports_json_ready_viewer_payload():
     assert exported["commit"]["governance_status"] == "commit"
     assert exported["commit"]["receipt_id"] == "public-row:tiny-pcf-1"
     assert exported["projection"] == EXPECTED_PROJECTION
+    assert exported["proof_graph"]["authority"] == "explanation_only"
+
+
+def _payload_has_key(value, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_payload_has_key(item, key) for item in value.values())
+    if isinstance(value, (tuple, list)):
+        return any(_payload_has_key(item, key) for item in value)
+    return False


### PR DESCRIPTION
## Summary
- attach `proof_graph` to `DomainScenarioResult` viewer payloads when replay succeeds
- keep `proof_graph` absent as `None` when scenarios lack a receipt/projection replay path
- cover scenario CLI JSON output and document the new payload field

## Why
This makes receipt proof graph export part of actual scenario run results while keeping it downstream of replay and explanation-only.

## Validation
- `python -m pytest tests/test_domain_scenario_lab.py tests/test_receipt_proof_graph.py -q`
- `python -m tests.domain_scenarios run tiny_pcf.location_based_electricity.v1 --json`
- `python -m pytest -q`
- `git diff --check --cached`

Note: local working tree still has unrelated unstaged changes in `docs/index.md`, `docs/architecture/friendly-authority-vocabulary.md`, and `tests/test_package_smoke.py`; they are intentionally excluded from this PR.