### PR TITLE
[codex] add friendly intake validation names

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -24,8 +24,10 @@ from comp.compiler_tool.governance import (
 )
 from comp.compiler_tool.models import (
     CheckedClaim,
+    ClaimCandidate,
     ClaimHypothesis,
     CompileReport,
+    EvidenceRef,
     EvidenceWitness,
     FailedClaim,
     Hazard,
@@ -35,6 +37,8 @@ from comp.compiler_tool.models import (
     SemanticJudgmentRequirement,
     UncheckedArea,
     UnknownClaim,
+    ValidationRequirement,
+    evidence_ref_fingerprint,
     evidence_witness_fingerprint,
 )
 from comp.compiler_tool.profiles import (
@@ -130,14 +134,18 @@ from comp.compiler_tool.judgment_adapter import (
 
 __all__ = [
     "InterpretationHypothesis",
+    "ClaimCandidate",
     "ClaimHypothesis",
+    "EvidenceRef",
     "EvidenceWitness",
+    "evidence_ref_fingerprint",
     "evidence_witness_fingerprint",
     "CompileReport",
     "CheckedClaim",
     "FailedClaim",
     "UnknownClaim",
     "UncheckedArea",
+    "ValidationRequirement",
     "ProofObligation",
     "SemanticJudgmentRequirement",
     "SemanticJudgment",

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -17,15 +17,18 @@ CompileStatus = Literal[
 
 
 @dataclass(frozen=True)
-class ClaimHypothesis:
+class ClaimCandidate:
     field: str
     value: Any
     witness_id: str | None = None
     origin: str = "llm_inferred"
 
 
+ClaimHypothesis = ClaimCandidate
+
+
 @dataclass(frozen=True)
-class EvidenceWitness:
+class EvidenceRef:
     witness_id: str
     field: str
     source: str | None = None
@@ -37,7 +40,10 @@ class EvidenceWitness:
         return self.source is not None or self.span is not None
 
 
-def evidence_witness_fingerprint(witness: EvidenceWitness) -> DependencyFingerprint:
+EvidenceWitness = EvidenceRef
+
+
+def evidence_ref_fingerprint(witness: EvidenceRef) -> DependencyFingerprint:
     return DependencyFingerprint.from_payload(
         dependency_kind="evidence_witness",
         dependency_id=witness.witness_id,
@@ -51,12 +57,15 @@ def evidence_witness_fingerprint(witness: EvidenceWitness) -> DependencyFingerpr
     )
 
 
+evidence_witness_fingerprint = evidence_ref_fingerprint
+
+
 @dataclass(frozen=True)
 class InterpretationHypothesis:
     hypothesis_id: str
     subject_id: str
-    claims: tuple[ClaimHypothesis, ...] = field(default_factory=tuple)
-    witnesses: tuple[EvidenceWitness, ...] = field(default_factory=tuple)
+    claims: tuple[ClaimCandidate, ...] = field(default_factory=tuple)
+    witnesses: tuple[EvidenceRef, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -100,7 +109,7 @@ class SemanticJudgmentRequirement:
 
 
 @dataclass(frozen=True)
-class ProofObligation:
+class ValidationRequirement:
     kind: str
     field: str
     reason: str
@@ -109,6 +118,9 @@ class ProofObligation:
     blocking: bool = True
     semantic_requirement: SemanticJudgmentRequirement | None = None
     calculation_requirement: CalculationRequirement | None = None
+
+
+ProofObligation = ValidationRequirement
 
 
 @dataclass(frozen=True)
@@ -133,13 +145,13 @@ class Hazard:
 @dataclass(frozen=True)
 class CompileReport:
     status: CompileStatus
-    evidence_witnesses: tuple[EvidenceWitness, ...] = field(default_factory=tuple)
+    evidence_witnesses: tuple[EvidenceRef, ...] = field(default_factory=tuple)
     checked_claims: tuple[CheckedClaim, ...] = field(default_factory=tuple)
     failed_claims: tuple[FailedClaim, ...] = field(default_factory=tuple)
     unknowns: tuple[UnknownClaim, ...] = field(default_factory=tuple)
     unchecked_areas: tuple[UncheckedArea, ...] = field(default_factory=tuple)
-    obligations: tuple[ProofObligation, ...] = field(default_factory=tuple)
-    resolved_obligations: tuple[ProofObligation, ...] = field(default_factory=tuple)
+    obligations: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
+    resolved_obligations: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
     hazards: tuple[Hazard, ...] = field(default_factory=tuple)
     reference_candidates: tuple[ReferenceCandidate, ...] = field(default_factory=tuple)
     reference_bindings: tuple[ReferenceBinding, ...] = field(default_factory=tuple)

--- a/docs/architecture/friendly-authority-vocabulary.md
+++ b/docs/architecture/friendly-authority-vocabulary.md
@@ -233,7 +233,33 @@ PublicOutputReceipt is required for public output.
 PublicOutput is a receipt-verifiable view, not authority.
 ```
 
-## 7. Non-Goals
+## 7. Current Implementation Status
+
+The first compiler-side intake and validation names are now available as
+canonical Python objects with deprecated aliases:
+
+```text
+ClaimCandidate is canonical.
+ClaimHypothesis remains a compatibility alias.
+
+EvidenceRef is canonical.
+EvidenceWitness remains a compatibility alias.
+
+ValidationRequirement is canonical.
+ProofObligation remains a compatibility alias.
+
+evidence_ref_fingerprint is canonical.
+evidence_witness_fingerprint remains a compatibility alias.
+```
+
+The underlying evidence fingerprint payload still uses
+`dependency_kind="evidence_witness"` so existing receipt and replay dependency
+digests stay stable during the rename window.
+
+This first step does not rename report fields such as `evidence_witnesses` or
+`obligations`; those are compatibility surfaces for a later, more careful PR.
+
+## 8. Non-Goals
 
 Do not use Korean Python class names.
 
@@ -250,7 +276,7 @@ Do not rename persistence internals just to make them friendlier. Persistence
 names must continue to protect digest, schema-version, replay, and append-only
 ledger semantics.
 
-## 8. Promotion Rule
+## 9. Promotion Rule
 
 While this document is a north star, it can guide naming review and onboarding
 discussion, but it should not block unrelated PRs by itself.

--- a/tests/test_compiler_tool_contract.py
+++ b/tests/test_compiler_tool_contract.py
@@ -55,6 +55,35 @@ def test_compiler_tool_contract_model_set_is_exported():
     assert Hazard is not None
 
 
+def test_friendly_intake_validation_names_are_canonical_with_legacy_aliases():
+    from comp.compiler_tool import (
+        ClaimCandidate,
+        EvidenceRef,
+        ValidationRequirement,
+        evidence_ref_fingerprint,
+    )
+
+    claim = ClaimHypothesis(field="amount", value=1200, witness_id="w-amount")
+    witness = EvidenceWitness(
+        witness_id="w-amount",
+        field="amount",
+        source="invoice.csv",
+    )
+    requirement = ProofObligation(
+        kind="find_source_witness",
+        field="amount",
+        reason="missing_source_witness",
+    )
+
+    assert ClaimHypothesis is ClaimCandidate
+    assert EvidenceWitness is EvidenceRef
+    assert ProofObligation is ValidationRequirement
+    assert type(claim).__name__ == "ClaimCandidate"
+    assert type(witness).__name__ == "EvidenceRef"
+    assert type(requirement).__name__ == "ValidationRequirement"
+    assert evidence_ref_fingerprint(witness).dependency_kind == "evidence_witness"
+
+
 def test_compiler_tool_has_no_domain_known_fields_by_default():
     report = CompilerTool().compile_interpretation(
         _hypothesis(

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -76,8 +76,10 @@ def test_top_level_package_no_longer_exports_legacy_runner_surface():
 
 def test_readme_compiler_tool_import_surface_is_exported():
     from comp.compiler_tool import (
+        ClaimCandidate,
         CompileReport,
         CompilerTool,
+        EvidenceRef,
         EmbeddingResolverStub,
         ReferenceIndexEntry,
         ReferenceQuery,
@@ -88,6 +90,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
         active_retrieval_query_policies,
         calculation_formula_declaration_fingerprint,
         domain_pack_declaration_fingerprint,
+        evidence_ref_fingerprint,
         evidence_witness_fingerprint,
         profile_declaration_fingerprint,
         profile_allowed_units,
@@ -102,14 +105,17 @@ def test_readme_compiler_tool_import_surface_is_exported():
         resolve_reference_retrieval_obligations,
         rule_family_declaration_fingerprint,
         semantic_rubric_declaration_fingerprint,
+        ValidationRequirement,
         build_commit_receipt,
         compile_report_to_facts,
         prepare_commit,
         resolver_tasks_from_report,
     )
 
+    assert ClaimCandidate is not None
     assert CompilerTool is not None
     assert CompileReport is not None
+    assert EvidenceRef is not None
     assert resolver_tasks_from_report is not None
     assert prepare_commit is not None
     assert build_commit_receipt is not None
@@ -123,6 +129,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert RetrievalQueryRule is not None
     assert calculation_formula_declaration_fingerprint is not None
     assert domain_pack_declaration_fingerprint is not None
+    assert evidence_ref_fingerprint is not None
     assert evidence_witness_fingerprint is not None
     assert active_retrieval_query_policies is not None
     assert profile_declaration_fingerprint is not None
@@ -137,6 +144,7 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert reference_record_fingerprint is not None
     assert rule_family_declaration_fingerprint is not None
     assert semantic_rubric_declaration_fingerprint is not None
+    assert ValidationRequirement is not None
     assert resolve_reference_retrieval_obligations is not None
 
 
@@ -423,6 +431,8 @@ def test_friendly_authority_vocabulary_names_rename_path_without_moving_authorit
     assert "공개 승인 증표" in vocabulary
     assert "감사 산출물 기록" in vocabulary
     assert "Canonical rename with deprecated aliases" in vocabulary
+    assert "ClaimCandidate is canonical." in vocabulary
+    assert "ProofObligation remains a compatibility alias." in vocabulary
     assert "Only a clean public-output receipt can authorize public output." in vocabulary
 
 


### PR DESCRIPTION
## Summary

- Add `ClaimCandidate`, `EvidenceRef`, `ValidationRequirement`, and `evidence_ref_fingerprint` as canonical compiler-tool intake/validation names.
- Keep `ClaimHypothesis`, `EvidenceWitness`, `ProofObligation`, and `evidence_witness_fingerprint` as compatibility aliases so existing call sites continue to work.
- Update the friendly authority vocabulary doc and smoke coverage to record the first rename slice without moving receipt/public-output authority.

## Validation

- `python -m pytest -q` -> `411 passed, 8 skipped in 6.05s`

## Notes

This intentionally avoids receipt/output gate renames and report field renames. Those remain separate follow-up slices because they touch projection authority and broader downstream compatibility.