### PR TITLE
[codex] Strengthen synthetic proof graph assertions

### DIFF
--- a/tests/domain_scenarios/assertions.py
+++ b/tests/domain_scenarios/assertions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
@@ -55,7 +55,98 @@ def assert_receipt_trace(
         assert citations.formula_ids == formula_ids
 
 
+def assert_proof_graph_contract(
+    result,
+    *,
+    required_fields: Sequence[str] = (),
+    required_node_kinds: Sequence[str] = (),
+    required_node_ids: Sequence[str] = (),
+    required_edge_kinds: Sequence[str] = (),
+) -> None:
+    from tests.domain_scenarios.views import scenario_result_view
+
+    graph = scenario_result_view(result).get("proof_graph")
+    if graph is None:
+        raise AssertionError("scenario result has no proof graph")
+
+    assert graph["authority"] == "explanation_only"
+    assert graph["can_authorize_public_projection"] is False
+    assert not _payload_has_key(graph, "value")
+    assert not _payload_has_key(graph, "text")
+
+    nodes = tuple(graph["nodes"])
+    edges = tuple(graph["edges"])
+    node_ids = {node["node_id"] for node in nodes}
+    node_kinds = {node["node_kind"] for node in nodes}
+    edge_kinds = {edge["edge_kind"] for edge in edges}
+    field_paths = {
+        path["field"]: tuple(path["node_ids"])
+        for path in graph["field_paths"]
+    }
+
+    for field in required_fields:
+        if field not in field_paths:
+            raise AssertionError(f"proof graph missing field path: {field}")
+        path = field_paths[field]
+        assert path[-1] == graph["receipt_node_id"]
+        assert any(f":{field}" in node_id for node_id in path)
+
+    for node_kind in required_node_kinds:
+        if node_kind not in node_kinds:
+            raise AssertionError(f"proof graph missing node kind: {node_kind}")
+
+    for node_id in required_node_ids:
+        if node_id not in node_ids:
+            raise AssertionError(f"proof graph missing node id: {node_id}")
+
+    for edge_kind in required_edge_kinds:
+        if edge_kind not in edge_kinds:
+            raise AssertionError(f"proof graph missing edge kind: {edge_kind}")
+
+    for node in nodes:
+        if node["node_kind"] == "dependency_fingerprint":
+            assert _has_edge(
+                edges,
+                graph["receipt_node_id"],
+                node["node_id"],
+                "pinned_dependency",
+            )
+
+
+def assert_no_proof_graph(result) -> None:
+    from tests.domain_scenarios.views import scenario_result_view
+
+    assert scenario_result_view(result).get("proof_graph") is None
+
+
+def _has_edge(
+    edges: Sequence[Mapping[str, Any]],
+    source_id: str,
+    target_id: str,
+    edge_kind: str,
+) -> bool:
+    return any(
+        edge["source_id"] == source_id
+        and edge["target_id"] == target_id
+        and edge["edge_kind"] == edge_kind
+        for edge in edges
+    )
+
+
+def _payload_has_key(value, key: str) -> bool:
+    if isinstance(value, Mapping):
+        return key in value or any(
+            _payload_has_key(item, key)
+            for item in value.values()
+        )
+    if isinstance(value, (tuple, list)):
+        return any(_payload_has_key(item, key) for item in value)
+    return False
+
+
 __all__ = [
+    "assert_no_proof_graph",
+    "assert_proof_graph_contract",
     "assert_projection_tamper_blocked",
     "assert_receipt_trace",
 ]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -6,6 +6,8 @@ import pytest
 
 from comp import DependencyFingerprint, ProjectionSpec
 from tests.domain_scenarios.assertions import (
+    assert_no_proof_graph,
+    assert_proof_graph_contract,
     assert_projection_tamper_blocked,
     assert_receipt_trace,
 )
@@ -324,6 +326,16 @@ def test_synthetic_pcf_smoke_scenario_runs_generated_raw_to_receipt_flow():
             "seed-7:raw_source:erp_electricity.csv"
         ),
     )
+    assert_proof_graph_contract(
+        result,
+        required_fields=("electricity_kwh", "co2e_kg"),
+        required_node_kinds=(
+            "synthetic_manifest",
+            "synthetic_source_input",
+            "dependency_fingerprint",
+        ),
+        required_edge_kinds=("authorized_by", "pinned_dependency", "projected_as"),
+    )
 
 
 def test_synthetic_pcf_anomaly_scenario_blocks_generated_bad_rows():
@@ -351,6 +363,7 @@ def test_synthetic_pcf_anomaly_scenario_blocks_generated_bad_rows():
         ("unit", "unsupported_unit"),
         ("electricity_kwh", "negative_amount"),
     )
+    assert_no_proof_graph(result)
 
 
 def test_synthetic_pcf_resolution_scenario_commits_after_generated_fix():
@@ -363,6 +376,21 @@ def test_synthetic_pcf_resolution_scenario_commits_after_generated_fix():
     assert result.projection == EXPECTED_PROJECTION
     assert "synthetic-obligation:missing_unit" in (
         result.preparation.package.resolved_obligation_ids
+    )
+    assert_proof_graph_contract(
+        result,
+        required_fields=("electricity_kwh", "co2e_kg"),
+        required_node_kinds=(
+            "synthetic_manifest",
+            "synthetic_source_input",
+            "dependency_fingerprint",
+        ),
+        required_node_ids=(
+            "synthetic_source_input:"
+            "synthetic_source_input:synthetic_pcf.resolution.v1:"
+            "seed-17:resolution_unit_witness:unit_witnesses.csv",
+        ),
+        required_edge_kinds=("authorized_by", "pinned_dependency", "projected_as"),
     )
 
 


### PR DESCRIPTION
## Summary
- add reusable domain-scenario assertions for explanation-only receipt proof graph contracts
- require synthetic smoke/resolution scenarios to expose expected graph nodes, edges, field paths, and dependency pinning
- assert anomaly scenarios produce no proof graph when receipt generation is blocked

## Validation
- python -m pytest tests/test_domain_scenario_lab.py tests/test_receipt_proof_graph.py -q
- python -m pytest -q
- git diff --check

## Notes
- Built from a clean worktree so unrelated local documentation changes in the original checkout are excluded.