### PR TITLE
[codex] add friendly reference calculation names

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -1,6 +1,7 @@
 """Deterministic compiler-tool contract surface."""
 
 from comp.compiler_tool.calculations import (
+    CalculatedClaim,
     CalculationFormula,
     CalculationInput,
     CalculationRequirement,
@@ -38,6 +39,7 @@ from comp.compiler_tool.models import (
     UncheckedArea,
     UnknownClaim,
     ValidationRequirement,
+    ValidationReport,
     evidence_ref_fingerprint,
     evidence_witness_fingerprint,
 )
@@ -80,8 +82,10 @@ from comp.compiler_tool.reference_selector import (
     select_reference_binding,
 )
 from comp.compiler_tool.references import (
+    CanonicalReference,
     ReferenceBinding,
     ReferenceCandidate,
+    ReferenceOption,
     RejectedReferenceCandidate,
 )
 from comp.compiler_tool.receipt_builder import (
@@ -140,6 +144,7 @@ __all__ = [
     "EvidenceWitness",
     "evidence_ref_fingerprint",
     "evidence_witness_fingerprint",
+    "ValidationReport",
     "CompileReport",
     "CheckedClaim",
     "FailedClaim",
@@ -156,6 +161,7 @@ __all__ = [
     "CalculationResult",
     "CalculationStep",
     "CalculationTrace",
+    "CalculatedClaim",
     "DerivedClaim",
     "calculation_formula_declaration_fingerprint",
     "calculate_derived_claim",
@@ -170,8 +176,10 @@ __all__ = [
     "GovernanceDecision",
     "GovernanceStatus",
     "decide_governance",
+    "ReferenceOption",
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
+    "CanonicalReference",
     "ReferenceBinding",
     "ReceiptBuildBlocked",
     "CommitReceiptCitations",

--- a/comp/compiler_tool/calculations.py
+++ b/comp/compiler_tool/calculations.py
@@ -36,7 +36,7 @@ class CalculationTrace:
 
 
 @dataclass(frozen=True)
-class DerivedClaim:
+class CalculatedClaim:
     claim_id: str
     field: str
     value: Any
@@ -51,6 +51,9 @@ class DerivedClaim:
     @property
     def can_authorize_public_projection(self) -> bool:
         return False
+
+
+DerivedClaim = CalculatedClaim
 
 
 @dataclass(frozen=True)
@@ -297,6 +300,7 @@ def _number(value: Decimal) -> int | float:
 __all__ = [
     "CalculationStep",
     "CalculationTrace",
+    "CalculatedClaim",
     "DerivedClaim",
     "CalculationInput",
     "CalculationFormula",

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from comp.compiler_tool.calculations import CalculationRequirement, DerivedClaim
-from comp.compiler_tool.references import ReferenceBinding, ReferenceCandidate
+from comp.compiler_tool.calculations import CalculationRequirement, CalculatedClaim
+from comp.compiler_tool.references import CanonicalReference, ReferenceOption
 from comp.judgment.receipts import DependencyFingerprint
 
 CompileStatus = Literal[
@@ -143,7 +143,7 @@ class Hazard:
 
 
 @dataclass(frozen=True)
-class CompileReport:
+class ValidationReport:
     status: CompileStatus
     evidence_witnesses: tuple[EvidenceRef, ...] = field(default_factory=tuple)
     checked_claims: tuple[CheckedClaim, ...] = field(default_factory=tuple)
@@ -153,7 +153,10 @@ class CompileReport:
     obligations: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
     resolved_obligations: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
     hazards: tuple[Hazard, ...] = field(default_factory=tuple)
-    reference_candidates: tuple[ReferenceCandidate, ...] = field(default_factory=tuple)
-    reference_bindings: tuple[ReferenceBinding, ...] = field(default_factory=tuple)
-    derived_claims: tuple[DerivedClaim, ...] = field(default_factory=tuple)
+    reference_candidates: tuple[ReferenceOption, ...] = field(default_factory=tuple)
+    reference_bindings: tuple[CanonicalReference, ...] = field(default_factory=tuple)
+    derived_claims: tuple[CalculatedClaim, ...] = field(default_factory=tuple)
     can_project_public_row: bool = False
+
+
+CompileReport = ValidationReport

--- a/comp/compiler_tool/references.py
+++ b/comp/compiler_tool/references.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
-class ReferenceCandidate:
+class ReferenceOption:
     candidate_id: str
     reference_id: str
     reference_type: str
@@ -18,7 +18,7 @@ class ReferenceCandidate:
         _require_authority(
             actual=self.authority,
             expected="candidate_only",
-            artifact="ReferenceCandidate",
+            artifact="ReferenceOption",
         )
 
     @property
@@ -35,7 +35,7 @@ class RejectedReferenceCandidate:
 
 
 @dataclass(frozen=True)
-class ReferenceBinding:
+class CanonicalReference:
     binding_id: str
     claim_id: str
     reference_id: str
@@ -52,7 +52,7 @@ class ReferenceBinding:
         _require_authority(
             actual=self.authority,
             expected="canonical_binding",
-            artifact="ReferenceBinding",
+            artifact="CanonicalReference",
         )
 
     @property
@@ -65,8 +65,14 @@ def _require_authority(*, actual: str, expected: str, artifact: str) -> None:
         raise ValueError(f"{artifact} authority must be {expected!r}")
 
 
+ReferenceCandidate = ReferenceOption
+ReferenceBinding = CanonicalReference
+
+
 __all__ = [
+    "ReferenceOption",
     "ReferenceCandidate",
     "RejectedReferenceCandidate",
+    "CanonicalReference",
     "ReferenceBinding",
 ]

--- a/docs/architecture/friendly-authority-vocabulary.md
+++ b/docs/architecture/friendly-authority-vocabulary.md
@@ -235,8 +235,8 @@ PublicOutput is a receipt-verifiable view, not authority.
 
 ## 7. Current Implementation Status
 
-The first compiler-side intake and validation names are now available as
-canonical Python objects with deprecated aliases:
+The first compiler-side names are now available as canonical Python objects
+with deprecated aliases:
 
 ```text
 ClaimCandidate is canonical.
@@ -250,14 +250,27 @@ ProofObligation remains a compatibility alias.
 
 evidence_ref_fingerprint is canonical.
 evidence_witness_fingerprint remains a compatibility alias.
+
+ReferenceOption is canonical.
+ReferenceCandidate remains a compatibility alias.
+
+CanonicalReference is canonical.
+ReferenceBinding remains a compatibility alias.
+
+CalculatedClaim is canonical.
+DerivedClaim remains a compatibility alias.
+
+ValidationReport is canonical.
+CompileReport remains a compatibility alias.
 ```
 
 The underlying evidence fingerprint payload still uses
 `dependency_kind="evidence_witness"` so existing receipt and replay dependency
 digests stay stable during the rename window.
 
-This first step does not rename report fields such as `evidence_witnesses` or
-`obligations`; those are compatibility surfaces for a later, more careful PR.
+This step does not rename report fields such as `evidence_witnesses`,
+`reference_candidates`, `reference_bindings`, `derived_claims`, or
+`obligations`; those are compatibility surfaces for later, more careful PRs.
 
 ## 8. Non-Goals
 

--- a/tests/test_compiler_tool_contract.py
+++ b/tests/test_compiler_tool_contract.py
@@ -84,6 +84,58 @@ def test_friendly_intake_validation_names_are_canonical_with_legacy_aliases():
     assert evidence_ref_fingerprint(witness).dependency_kind == "evidence_witness"
 
 
+def test_friendly_reference_calculation_report_names_are_canonical_with_legacy_aliases():
+    from comp.compiler_tool import (
+        CalculatedClaim,
+        CanonicalReference,
+        CalculationTrace,
+        CompileReport,
+        DerivedClaim,
+        ReferenceBinding,
+        ReferenceCandidate,
+        ReferenceOption,
+        ValidationReport,
+    )
+
+    option = ReferenceCandidate(
+        candidate_id="candidate-1",
+        reference_id="factor.kr.2024",
+        reference_type="emission_factor",
+        retrieval_method="profile_rule",
+    )
+    reference = ReferenceBinding(
+        binding_id="binding-1",
+        claim_id="claim:electricity",
+        reference_id="factor.kr.2024",
+        reference_type="emission_factor",
+    )
+    calculated = DerivedClaim(
+        claim_id="claim:co2e",
+        field="co2e_kg",
+        value=1200,
+        unit="kg",
+        trace=CalculationTrace(trace_id="trace-1", formula_id="formula:co2e"),
+    )
+    report = CompileReport(
+        status="accepted",
+        reference_candidates=(option,),
+        reference_bindings=(reference,),
+        derived_claims=(calculated,),
+    )
+
+    assert ReferenceCandidate is ReferenceOption
+    assert ReferenceBinding is CanonicalReference
+    assert DerivedClaim is CalculatedClaim
+    assert CompileReport is ValidationReport
+    assert type(option).__name__ == "ReferenceOption"
+    assert type(reference).__name__ == "CanonicalReference"
+    assert type(calculated).__name__ == "CalculatedClaim"
+    assert type(report).__name__ == "ValidationReport"
+    assert option.can_authorize_calculation is False
+    assert reference.can_authorize_calculation is True
+    assert calculated.can_authorize_public_projection is False
+
+
 def test_compiler_tool_has_no_domain_known_fields_by_default():
     report = CompilerTool().compile_interpretation(
         _hypothesis(

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -76,6 +76,8 @@ def test_top_level_package_no_longer_exports_legacy_runner_surface():
 
 def test_readme_compiler_tool_import_surface_is_exported():
     from comp.compiler_tool import (
+        CalculatedClaim,
+        CanonicalReference,
         ClaimCandidate,
         CompileReport,
         CompilerTool,
@@ -102,16 +104,20 @@ def test_readme_compiler_tool_import_surface_is_exported():
         reference_query_for_obligation_from_resolver_tasks,
         reference_query_from_resolver_task,
         reference_record_fingerprint,
+        ReferenceOption,
         resolve_reference_retrieval_obligations,
         rule_family_declaration_fingerprint,
         semantic_rubric_declaration_fingerprint,
         ValidationRequirement,
+        ValidationReport,
         build_commit_receipt,
         compile_report_to_facts,
         prepare_commit,
         resolver_tasks_from_report,
     )
 
+    assert CalculatedClaim is not None
+    assert CanonicalReference is not None
     assert ClaimCandidate is not None
     assert CompilerTool is not None
     assert CompileReport is not None
@@ -140,11 +146,13 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert reference_query_for_obligation_from_policy is not None
     assert reference_query_from_resolver_task is not None
     assert reference_query_for_obligation_from_resolver_tasks is not None
+    assert ReferenceOption is not None
     assert reference_catalog_snapshot_fingerprint is not None
     assert reference_record_fingerprint is not None
     assert rule_family_declaration_fingerprint is not None
     assert semantic_rubric_declaration_fingerprint is not None
     assert ValidationRequirement is not None
+    assert ValidationReport is not None
     assert resolve_reference_retrieval_obligations is not None
 
 
@@ -432,6 +440,8 @@ def test_friendly_authority_vocabulary_names_rename_path_without_moving_authorit
     assert "감사 산출물 기록" in vocabulary
     assert "Canonical rename with deprecated aliases" in vocabulary
     assert "ClaimCandidate is canonical." in vocabulary
+    assert "CanonicalReference is canonical." in vocabulary
+    assert "ValidationReport is canonical." in vocabulary
     assert "ProofObligation remains a compatibility alias." in vocabulary
     assert "Only a clean public-output receipt can authorize public output." in vocabulary
 


### PR DESCRIPTION
## Summary

- Add `ReferenceOption`, `CanonicalReference`, `CalculatedClaim`, and `ValidationReport` as canonical compiler-tool names for the second friendly-vocabulary slice.
- Keep `ReferenceCandidate`, `ReferenceBinding`, `DerivedClaim`, and `CompileReport` as compatibility aliases so existing call sites continue to work.
- Update the friendly authority vocabulary doc and smoke coverage while leaving report field names and receipt/output authority untouched.

## Validation

- `python -m pytest -q` -> `412 passed, 8 skipped in 6.28s`

## Notes

This intentionally avoids renaming report fields such as `reference_candidates`, `reference_bindings`, and `derived_claims`. Those are compatibility surfaces for later, narrower PRs.