### PR TITLE
[codex] Render receipt proof graphs

### DIFF
--- a/comp/explanation/receipt_graph_cli.py
+++ b/comp/explanation/receipt_graph_cli.py
@@ -18,23 +18,31 @@ from comp.persistence import (
 )
 from comp.persistence.codec import decode_persistence_json
 from comp.persistence.mysql import commit_receipt_from_body
+from comp.views.receipt_graph import render_graphviz_dot, render_mermaid
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    if args.command == "export-json":
-        graph = export_receipt_proof_graph(
-            receipt=commit_receipt_from_body(_load_mapping(args.receipt)),
-            replay=_replay_from_payload(_load_mapping(args.replay)),
-            artifacts=_artifact_store_from_payload(_load_mapping(args.artifacts)),
-        )
-        output = graph.to_json() + "\n"
-        if args.output is None:
-            sys.stdout.write(output)
+    if args.command in {"export-json", "export-mermaid", "export-dot"}:
+        graph = _export_graph(args)
+        if args.command == "export-json":
+            output = graph.to_json() + "\n"
+        elif args.command == "export-mermaid":
+            output = render_mermaid(graph.to_payload())
         else:
-            Path(args.output).write_text(output, encoding="utf-8")
+            output = render_graphviz_dot(graph.to_payload())
+        _write_output(output, args.output)
+        return 0
+
+    if args.command in {"render-mermaid", "render-dot"}:
+        graph_payload = _graph_payload_from_file(args.graph)
+        if args.command == "render-mermaid":
+            output = render_mermaid(graph_payload)
+        else:
+            output = render_graphviz_dot(graph_payload)
+        _write_output(output, args.output)
         return 0
 
     parser.print_help(sys.stderr)
@@ -44,13 +52,43 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="comp-receipt-graph",
-        description="Export receipt proof graphs as explanation-only JSON.",
+        description="Export receipt proof graphs as explanation-only JSON or diagrams.",
     )
     subparsers = parser.add_subparsers(dest="command")
-    export = subparsers.add_parser(
+    _add_export_parser(
+        subparsers,
         "export-json",
-        help="Export a ReceiptProofGraph from receipt, replay, and artifact JSON.",
+        "Export a ReceiptProofGraph from receipt, replay, and artifact JSON.",
     )
+    _add_export_parser(
+        subparsers,
+        "export-mermaid",
+        "Export a Mermaid flowchart from receipt, replay, and artifact JSON.",
+    )
+    _add_export_parser(
+        subparsers,
+        "export-dot",
+        "Export a Graphviz DOT graph from receipt, replay, and artifact JSON.",
+    )
+    _add_render_parser(
+        subparsers,
+        "render-mermaid",
+        "Render Mermaid from a proof graph JSON payload.",
+    )
+    _add_render_parser(
+        subparsers,
+        "render-dot",
+        "Render Graphviz DOT from a proof graph JSON payload.",
+    )
+    return parser
+
+
+def _add_export_parser(
+    subparsers: argparse._SubParsersAction,
+    name: str,
+    help_text: str,
+) -> argparse.ArgumentParser:
+    export = subparsers.add_parser(name, help=help_text)
     export.add_argument("--receipt", required=True, help="CommitReceipt body JSON path.")
     export.add_argument("--replay", required=True, help="ProjectionReplayReport JSON path.")
     export.add_argument(
@@ -60,18 +98,73 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     export.add_argument(
         "--output",
-        help="Optional output JSON path. Defaults to stdout.",
+        help="Optional output path. Defaults to stdout.",
     )
-    return parser
+    return export
+
+
+def _add_render_parser(
+    subparsers: argparse._SubParsersAction,
+    name: str,
+    help_text: str,
+) -> argparse.ArgumentParser:
+    render = subparsers.add_parser(name, help=help_text)
+    render.add_argument(
+        "--graph",
+        required=True,
+        help="ReceiptProofGraph JSON path, or scenario JSON containing proof_graph.",
+    )
+    render.add_argument(
+        "--output",
+        help="Optional output path. Defaults to stdout.",
+    )
+    return render
+
+
+def _export_graph(args: argparse.Namespace):
+    return export_receipt_proof_graph(
+        receipt=commit_receipt_from_body(_load_mapping(args.receipt)),
+        replay=_replay_from_payload(_load_mapping(args.replay)),
+        artifacts=_artifact_store_from_payload(_load_mapping(args.artifacts)),
+    )
+
+
+def _graph_payload_from_file(path: str) -> Mapping[str, Any]:
+    payload = _load_mapping(path)
+    if "proof_graph" in payload:
+        graph_payload = payload["proof_graph"]
+        if not isinstance(graph_payload, Mapping):
+            raise TypeError(f"Expected proof_graph object in {path}.")
+        return graph_payload
+    if "nodes" in payload and "edges" in payload:
+        return payload
+    raise TypeError(f"Expected ReceiptProofGraph payload: {path}.")
+
+
+def _write_output(output: str, output_path: str | None) -> None:
+    if output_path is None:
+        sys.stdout.write(output)
+    else:
+        Path(output_path).write_text(output, encoding="utf-8")
 
 
 def _load_mapping(path: str) -> Mapping[str, Any]:
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    payload = json.loads(_read_json_text(path))
     if isinstance(payload, Mapping) and "__comp_type__" in payload:
         payload = decode_persistence_json(payload)
     if not isinstance(payload, Mapping):
         raise TypeError(f"Expected JSON object: {path}.")
     return payload
+
+
+def _read_json_text(path: str) -> str:
+    data = Path(path).read_bytes()
+    for encoding in ("utf-8-sig", "utf-16", "utf-16-le", "utf-16-be"):
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8")
 
 
 def _replay_from_payload(payload: Mapping[str, Any]) -> ProjectionReplayReport:

--- a/comp/views/receipt_graph.py
+++ b/comp/views/receipt_graph.py
@@ -5,4 +5,95 @@ consume `ReceiptProofGraph.to_payload()`. It must not export graphs, replay
 projections, or authorize public rows.
 """
 
-__all__: list[str] = []
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def render_mermaid(graph_payload: Mapping[str, Any]) -> str:
+    """Render a receipt proof graph payload as Mermaid flowchart text."""
+
+    aliases: dict[str, str] = {}
+    lines = ["flowchart TD"]
+    for node in _nodes(graph_payload):
+        node_id = _required_text(node, "node_id")
+        alias = _alias_for(node_id, aliases)
+        label = _node_label(node)
+        lines.append(f'  {alias}["{_mermaid_text(label)}"]')
+    for edge in _edges(graph_payload):
+        source_alias = _alias_for(_required_text(edge, "source_id"), aliases)
+        target_alias = _alias_for(_required_text(edge, "target_id"), aliases)
+        edge_kind = _required_text(edge, "edge_kind")
+        lines.append(
+            f'  {source_alias} -- "{_mermaid_text(edge_kind)}" --> {target_alias}'
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_graphviz_dot(graph_payload: Mapping[str, Any]) -> str:
+    """Render a receipt proof graph payload as Graphviz DOT text."""
+
+    aliases: dict[str, str] = {}
+    lines = ["digraph ReceiptProofGraph {", "  rankdir=LR;"]
+    for node in _nodes(graph_payload):
+        node_id = _required_text(node, "node_id")
+        alias = _alias_for(node_id, aliases)
+        label = _node_label(node)
+        lines.append(f'  {alias} [label="{_dot_text(label)}"];')
+    for edge in _edges(graph_payload):
+        source_alias = _alias_for(_required_text(edge, "source_id"), aliases)
+        target_alias = _alias_for(_required_text(edge, "target_id"), aliases)
+        edge_kind = _required_text(edge, "edge_kind")
+        lines.append(
+            f'  {source_alias} -> {target_alias} [label="{_dot_text(edge_kind)}"];'
+        )
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def _nodes(graph_payload: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+    return _mapping_sequence(graph_payload.get("nodes", ()), "nodes")
+
+
+def _edges(graph_payload: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+    return _mapping_sequence(graph_payload.get("edges", ()), "edges")
+
+
+def _mapping_sequence(value: Any, name: str) -> Sequence[Mapping[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise TypeError(f"Expected array for {name}.")
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise TypeError(f"Expected object items for {name}.")
+    return value
+
+
+def _required_text(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"Expected non-empty string for {key}.")
+    return value
+
+
+def _alias_for(node_id: str, aliases: dict[str, str]) -> str:
+    alias = aliases.get(node_id)
+    if alias is None:
+        alias = f"n{len(aliases)}"
+        aliases[node_id] = alias
+    return alias
+
+
+def _node_label(node: Mapping[str, Any]) -> str:
+    return f"{_required_text(node, 'node_kind')}: {_required_text(node, 'label')}"
+
+
+def _mermaid_text(value: str) -> str:
+    return value.replace("&", "&amp;").replace('"', "&quot;").replace("\n", "<br/>")
+
+
+def _dot_text(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+__all__ = ["render_graphviz_dot", "render_mermaid"]

--- a/docs/architecture/receipt-proof-graph.md
+++ b/docs/architecture/receipt-proof-graph.md
@@ -356,8 +356,9 @@ than reconstructing graph semantics independently. Renderer code belongs in
 compiler, resolver, calculator, governance gate, projection gate, or replay
 function.
 
-The initial CLI is file-based and exports a graph from an already materialized
-receipt, replay report, and artifact envelope set:
+The CLI is file-based and exports a graph from an already materialized receipt,
+replay report, and artifact envelope set. JSON remains the stable payload; the
+Mermaid and Graphviz outputs are render-only views derived from that same graph:
 
 ```text
 comp-receipt-graph export-json \
@@ -365,12 +366,41 @@ comp-receipt-graph export-json \
   --replay replay.json \
   --artifacts artifacts.json \
   --output proof-graph.json
+
+comp-receipt-graph export-mermaid \
+  --receipt receipt.json \
+  --replay replay.json \
+  --artifacts artifacts.json \
+  --output proof-graph.mmd
+
+comp-receipt-graph export-dot \
+  --receipt receipt.json \
+  --replay replay.json \
+  --artifacts artifacts.json \
+  --output proof-graph.dot
+```
+
+Existing graph payloads can also be rendered directly. This is the path for a
+scenario JSON export that already contains `proof_graph`:
+
+```text
+python -m tests.domain_scenarios run synthetic_pcf.smoke.v1 \
+  --json > scenario.json
+
+comp-receipt-graph render-mermaid \
+  --graph scenario.json \
+  --output proof-graph.mmd
+
+comp-receipt-graph render-dot \
+  --graph proof-graph.json \
+  --output proof-graph.dot
 ```
 
 The CLI consumes replay outputs; it does not replay projections itself.
 Artifact envelope bodies should use the persistence JSON codec so tuple, list,
 decimal, and scalar values keep the same digest material they had at replay
-time.
+time. Diagram renderers omit raw values and metadata by default; they are for
+inspection, not for policy or projection decisions.
 
 MySQLArtifactStore is an ArtifactStore implementation. It stores and
 retrieves replay artifacts; it does not become a graph backend or a policy

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -170,6 +170,14 @@ includes `proof_graph`. The graph is explanation-only: it is derived after
 replay succeeds, hides raw committed values by default, and cannot authorize a
 projection.
 
+To inspect that graph visually, render the exported scenario payload:
+
+```bash
+python -m tests.domain_scenarios run synthetic_pcf.smoke.v1 --json > scenario.json
+comp-receipt-graph render-mermaid --graph scenario.json --output proof-graph.mmd
+comp-receipt-graph render-dot --graph scenario.json --output proof-graph.dot
+```
+
 The runner is intentionally generic. It only knows about `ScenarioDefinition`,
 `registered_scenarios()`, `run_scenario()`, and `DomainScenarioResult`; scenario
 packs own their domain fixtures and expected contracts.

--- a/tests/test_receipt_graph_views.py
+++ b/tests/test_receipt_graph_views.py
@@ -1,0 +1,54 @@
+from comp.explanation import export_receipt_proof_graph
+from comp.persistence import replay_public_projection
+from comp.views.receipt_graph import render_graphviz_dot, render_mermaid
+from tests.support.persistence_cases import (
+    artifact_store_for_receipt,
+    receipt_projection_case,
+)
+
+
+def test_receipt_graph_view_renders_mermaid_without_raw_values():
+    graph = _sample_graph()
+
+    output = render_mermaid(graph.to_payload())
+
+    assert output.startswith("flowchart TD\n")
+    assert "commit_receipt" in output
+    assert "public_projection" in output
+    assert "-- \"authorized_by\" -->" in output
+    assert "plant-a" not in output
+    assert "value" not in output
+    assert graph.receipt_node_id not in output
+
+
+def test_receipt_graph_view_renders_graphviz_dot_without_raw_values():
+    graph = _sample_graph()
+
+    output = render_graphviz_dot(graph.to_payload())
+
+    assert output.startswith("digraph ReceiptProofGraph {\n")
+    assert "rankdir=LR;" in output
+    assert "commit_receipt" in output
+    assert "public_projection" in output
+    assert "[label=\"authorized_by\"]" in output
+    assert "plant-a" not in output
+    assert "value" not in output
+
+
+def _sample_graph():
+    case = receipt_projection_case(amount=100, site="plant-a")
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+    return export_receipt_proof_graph(
+        receipt=case.receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )

--- a/tests/test_receipt_proof_graph_cli.py
+++ b/tests/test_receipt_proof_graph_cli.py
@@ -1,5 +1,6 @@
 import json
 
+from comp.explanation import export_receipt_proof_graph
 from comp.persistence.mysql import commit_receipt_to_body
 from comp.persistence.codec import encode_persistence_json
 from comp.persistence.replay import ProjectionReplayReport
@@ -109,6 +110,175 @@ def test_receipt_graph_cli_can_write_graph_json_to_file(tmp_path, capsys):
     assert exit_code == 0
     assert captured.out == ""
     assert payload["authority"] == "explanation_only"
+
+
+def test_receipt_graph_cli_exports_mermaid_from_replay_inputs(tmp_path, capsys):
+    receipt_path, replay_path, artifacts_path = _write_graph_inputs(
+        tmp_path,
+        site="plant-a",
+    )
+
+    exit_code = main(
+        [
+            "export-mermaid",
+            "--receipt",
+            str(receipt_path),
+            "--replay",
+            str(replay_path),
+            "--artifacts",
+            str(artifacts_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert captured.out.startswith("flowchart TD\n")
+    assert "-- \"authorized_by\" -->" in captured.out
+    assert "plant-a" not in captured.out
+    assert "value" not in captured.out
+
+
+def test_receipt_graph_cli_exports_graphviz_dot_to_file(tmp_path, capsys):
+    receipt_path, replay_path, artifacts_path = _write_graph_inputs(
+        tmp_path,
+        site="plant-a",
+    )
+    output_path = tmp_path / "graph.dot"
+
+    exit_code = main(
+        [
+            "export-dot",
+            "--receipt",
+            str(receipt_path),
+            "--replay",
+            str(replay_path),
+            "--artifacts",
+            str(artifacts_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    output = output_path.read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert captured.out == ""
+    assert output.startswith("digraph ReceiptProofGraph {\n")
+    assert "[label=\"authorized_by\"]" in output
+    assert "plant-a" not in output
+    assert "value" not in output
+
+
+def test_receipt_graph_cli_renders_mermaid_from_scenario_proof_graph_payload(
+    tmp_path,
+    capsys,
+):
+    graph_payload = _sample_graph_payload(site="plant-a")
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text(
+        json.dumps({"scenario_id": "synthetic.demo", "proof_graph": graph_payload}),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["render-mermaid", "--graph", str(scenario_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.startswith("flowchart TD\n")
+    assert "-- \"authorized_by\" -->" in captured.out
+    assert "plant-a" not in captured.out
+
+
+def test_receipt_graph_cli_renders_graphviz_dot_from_graph_payload_file(
+    tmp_path,
+    capsys,
+):
+    graph_path = tmp_path / "proof-graph.json"
+    graph_path.write_text(
+        json.dumps(_sample_graph_payload(site="plant-a")),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["render-dot", "--graph", str(graph_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.startswith("digraph ReceiptProofGraph {\n")
+    assert "[label=\"authorized_by\"]" in captured.out
+    assert "plant-a" not in captured.out
+
+
+def test_receipt_graph_cli_reads_utf16_json_from_windows_redirect(
+    tmp_path,
+    capsys,
+):
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text(
+        json.dumps(
+            {
+                "scenario_id": "synthetic.demo",
+                "proof_graph": _sample_graph_payload(site="plant-a"),
+            }
+        ),
+        encoding="utf-16",
+    )
+
+    exit_code = main(["render-mermaid", "--graph", str(scenario_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.startswith("flowchart TD\n")
+    assert "plant-a" not in captured.out
+
+
+def _sample_graph_payload(*, site: str = "plant-a") -> dict[str, object]:
+    case = receipt_projection_case(amount=100, site=site)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+    graph = export_receipt_proof_graph(
+        receipt=case.receipt,
+        replay=replay,
+        artifacts=artifacts,
+    )
+    return graph.to_payload()
+
+
+def _write_graph_inputs(tmp_path, *, site: str = "plant-a"):
+    case = receipt_projection_case(amount=100, site=site)
+    artifacts = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=artifacts,
+    )
+    receipt_path = tmp_path / "receipt.json"
+    replay_path = tmp_path / "replay.json"
+    artifacts_path = tmp_path / "artifacts.json"
+    receipt_path.write_text(
+        json.dumps(commit_receipt_to_body(case.receipt)),
+        encoding="utf-8",
+    )
+    replay_path.write_text(json.dumps(_replay_payload(replay)), encoding="utf-8")
+    artifacts_path.write_text(
+        json.dumps(
+            {"artifacts": [_artifact_payload(item) for item in artifacts.envelopes()]}
+        ),
+        encoding="utf-8",
+    )
+    return receipt_path, replay_path, artifacts_path
 
 
 def _replay_payload(replay: ProjectionReplayReport) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- add render-only Mermaid and Graphviz DOT formatters for `ReceiptProofGraph.to_payload()` in `comp.views.receipt_graph`
- extend `comp-receipt-graph` with `export-mermaid`, `export-dot`, `render-mermaid`, and `render-dot`
- document scenario JSON `proof_graph` rendering and keep diagrams explanation-only with raw values/metadata omitted
- support UTF-16 JSON reads so Windows PowerShell `--json > scenario.json` outputs can be rendered directly

## Validation
- python -m pytest tests/test_receipt_graph_views.py tests/test_receipt_proof_graph_cli.py tests/test_package_smoke.py::test_receipt_graph_renderers_have_non_authority_module_boundary tests/test_package_smoke.py::test_receipt_proof_graph_contract_names_prework_boundaries -q
- python -m pytest -q
- git diff --check HEAD~1..HEAD
- manual: `python -m tests.domain_scenarios run synthetic_pcf.smoke.v1 --json > scenario.json`, then `python -m comp.explanation.receipt_graph_cli render-mermaid --graph scenario.json --output proof-graph.mmd` and `render-dot --graph scenario.json --output proof-graph.dot`

## Notes
- This PR stays in the render/view layer. JSON remains the stable proof graph payload; Mermaid/DOT are derived inspection formats and do not authorize projection.