### PR TITLE
[codex] add friendly review names

### DIFF
--- a/comp/compiler_tool/__init__.py
+++ b/comp/compiler_tool/__init__.py
@@ -17,10 +17,15 @@ from comp.compiler_tool.calculation_report import apply_calculation_result
 from comp.compiler_tool.calculation_resolution import plan_calculation_resolution
 from comp.compiler_tool.calculation_retry import retry_blocked_calculation
 from comp.compiler_tool.commit_flow import CommitPreparation, prepare_commit
-from comp.compiler_tool.commit_package import CommitPackage, build_commit_package
+from comp.compiler_tool.commit_package import (
+    CommitPackage,
+    ReviewPackage,
+    build_commit_package,
+)
 from comp.compiler_tool.governance import (
     GovernanceDecision,
     GovernanceStatus,
+    ReviewDecision,
     decide_governance,
 )
 from comp.compiler_tool.models import (
@@ -172,8 +177,10 @@ __all__ = [
     "CommitPreparation",
     "prepare_commit",
     "CommitPackage",
+    "ReviewPackage",
     "build_commit_package",
     "GovernanceDecision",
+    "ReviewDecision",
     "GovernanceStatus",
     "decide_governance",
     "ReferenceOption",

--- a/comp/compiler_tool/commit_package.py
+++ b/comp/compiler_tool/commit_package.py
@@ -9,7 +9,7 @@ from comp.judgment.receipts import DependencyFingerprint, ProjectionValueCommitm
 
 
 @dataclass(frozen=True)
-class CommitPackage:
+class ReviewPackage:
     package_id: str
     subject_id: str
     report_status: str
@@ -38,6 +38,9 @@ class CommitPackage:
         return False
 
 
+CommitPackage = ReviewPackage
+
+
 def build_commit_package(
     report: CompileReport,
     *,
@@ -46,7 +49,7 @@ def build_commit_package(
     profile_id: str | None = None,
     semantic_judgment_ids: Iterable[str] = (),
     dependency_fingerprints: Iterable[DependencyFingerprint] = (),
-) -> CommitPackage:
+) -> ReviewPackage:
     report_status = recompute_report_status(report)
     open_obligation_ids = tuple(
         _obligation_id(obligation) for obligation in report.obligations
@@ -56,7 +59,7 @@ def build_commit_package(
     )
     hazard_ids = tuple(_hazard_id(hazard) for hazard in report.hazards)
 
-    return CommitPackage(
+    return ReviewPackage(
         package_id=package_id or f"commit-package:{subject_id}",
         subject_id=subject_id,
         report_status=report_status,
@@ -147,4 +150,4 @@ def _unique(values: Iterable[str]) -> tuple[str, ...]:
     return tuple(unique_values)
 
 
-__all__ = ["CommitPackage", "build_commit_package"]
+__all__ = ["ReviewPackage", "CommitPackage", "build_commit_package"]

--- a/comp/compiler_tool/governance.py
+++ b/comp/compiler_tool/governance.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from comp.compiler_tool.commit_package import CommitPackage
+from comp.compiler_tool.commit_package import ReviewPackage
 
 GovernanceStatus = Literal["commit", "hold", "reject"]
 
 
 @dataclass(frozen=True)
-class GovernanceDecision:
+class ReviewDecision:
     decision_id: str
     package_id: str
     subject_id: str
@@ -26,13 +26,16 @@ class GovernanceDecision:
         return False
 
 
+GovernanceDecision = ReviewDecision
+
+
 def decide_governance(
-    package: CommitPackage,
+    package: ReviewPackage,
     *,
     decision_id: str | None = None,
-) -> GovernanceDecision:
+) -> ReviewDecision:
     status, reasons = _evaluate_package(package)
-    return GovernanceDecision(
+    return ReviewDecision(
         decision_id=decision_id or f"governance-decision:{package.package_id}",
         package_id=package.package_id,
         subject_id=package.subject_id,
@@ -43,7 +46,7 @@ def decide_governance(
 
 
 def _evaluate_package(
-    package: CommitPackage,
+    package: ReviewPackage,
 ) -> tuple[GovernanceStatus, tuple[str, ...]]:
     if package.complete:
         return "commit", ("commit_package_complete",)
@@ -56,7 +59,7 @@ def _evaluate_package(
     return "hold", reasons
 
 
-def _incomplete_reasons(package: CommitPackage) -> tuple[str, ...]:
+def _incomplete_reasons(package: ReviewPackage) -> tuple[str, ...]:
     reasons = []
     if package.report_status != "accepted":
         reasons.append(f"report_status:{package.report_status}")
@@ -70,4 +73,9 @@ def _incomplete_reasons(package: CommitPackage) -> tuple[str, ...]:
     return tuple(reasons)
 
 
-__all__ = ["GovernanceDecision", "GovernanceStatus", "decide_governance"]
+__all__ = [
+    "ReviewDecision",
+    "GovernanceDecision",
+    "GovernanceStatus",
+    "decide_governance",
+]

--- a/docs/architecture/friendly-authority-vocabulary.md
+++ b/docs/architecture/friendly-authority-vocabulary.md
@@ -262,6 +262,12 @@ DerivedClaim remains a compatibility alias.
 
 ValidationReport is canonical.
 CompileReport remains a compatibility alias.
+
+ReviewPackage is canonical.
+CommitPackage remains a compatibility alias.
+
+ReviewDecision is canonical.
+GovernanceDecision remains a compatibility alias.
 ```
 
 The underlying evidence fingerprint payload still uses
@@ -271,6 +277,10 @@ digests stay stable during the rename window.
 This step does not rename report fields such as `evidence_witnesses`,
 `reference_candidates`, `reference_bindings`, `derived_claims`, or
 `obligations`; those are compatibility surfaces for later, more careful PRs.
+
+This step also does not rename receipt, citation, projection, or projection
+error types. `CommitReceipt` remains the active public-output authority name
+until the receipt-gate slice can update that boundary independently.
 
 ## 8. Non-Goals
 

--- a/tests/test_commit_package.py
+++ b/tests/test_commit_package.py
@@ -6,7 +6,10 @@ from comp.compiler_tool import (
     Hazard,
     ProofObligation,
     ReferenceBinding,
+    ReviewDecision,
+    ReviewPackage,
     build_commit_package,
+    decide_governance,
 )
 
 
@@ -76,6 +79,26 @@ def test_commit_package_collects_report_artifacts_without_receipt_authority():
     assert package.hazard_ids == ()
     assert package.complete is True
     assert package.can_authorize_public_projection is False
+
+
+def test_friendly_review_names_are_canonical_with_legacy_aliases():
+    from comp.compiler_tool import CommitPackage, GovernanceDecision
+
+    package = CommitPackage(
+        package_id="package-1",
+        subject_id="facility-1",
+        report_status="accepted",
+        complete=True,
+    )
+    decision = decide_governance(package)
+
+    assert CommitPackage is ReviewPackage
+    assert GovernanceDecision is ReviewDecision
+    assert type(package).__name__ == "ReviewPackage"
+    assert type(decision).__name__ == "ReviewDecision"
+    assert package.can_authorize_public_projection is False
+    assert decision.can_authorize_public_projection is False
+    assert decision.can_issue_commit_receipt is True
 
 
 def test_commit_package_is_incomplete_with_open_blocking_obligation():

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -87,6 +87,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
         ReferenceQuery,
         ReferenceResolver,
         ReferenceCatalogSnapshot,
+        ReviewDecision,
+        ReviewPackage,
         RetrievalQueryPolicy,
         RetrievalQueryRule,
         active_retrieval_query_policies,
@@ -130,6 +132,8 @@ def test_readme_compiler_tool_import_surface_is_exported():
     assert ReferenceIndexEntry is not None
     assert ReferenceResolver is not None
     assert ReferenceCatalogSnapshot is not None
+    assert ReviewDecision is not None
+    assert ReviewPackage is not None
     assert EmbeddingResolverStub is not None
     assert RetrievalQueryPolicy is not None
     assert RetrievalQueryRule is not None
@@ -442,6 +446,8 @@ def test_friendly_authority_vocabulary_names_rename_path_without_moving_authorit
     assert "ClaimCandidate is canonical." in vocabulary
     assert "CanonicalReference is canonical." in vocabulary
     assert "ValidationReport is canonical." in vocabulary
+    assert "ReviewPackage is canonical." in vocabulary
+    assert "ReviewDecision is canonical." in vocabulary
     assert "ProofObligation remains a compatibility alias." in vocabulary
     assert "Only a clean public-output receipt can authorize public output." in vocabulary
 


### PR DESCRIPTION
## Summary

- rename the review-stage canonical types to `ReviewPackage` and `ReviewDecision`
- keep `CommitPackage` and `GovernanceDecision` as compatibility aliases
- document this rename slice while leaving receipt/projection authority names for a later PR
- add smoke and authority-boundary coverage for the new names

## Validation

- `python -m pytest -q` -> `413 passed, 8 skipped`
- `git diff --check` -> no whitespace errors; only Windows CRLF working-copy warnings
