### PR TITLE
[codex] Connect MySQL replay to proof graph export

### DIFF
--- a/comp/persistence/ledger.py
+++ b/comp/persistence/ledger.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 from comp.judgment import (
     CommitReceipt,
@@ -34,6 +34,7 @@ class ProjectionReplayBlocked(PersistenceError):
     """Raised when a materialized projection cannot be replayed from a receipt."""
 
 
+@runtime_checkable
 class ArtifactStore(Protocol):
     """Read boundary for replayable artifact envelopes."""
 

--- a/docs/architecture/production-trust-spine-database.md
+++ b/docs/architecture/production-trust-spine-database.md
@@ -412,6 +412,18 @@ ledger_receipt_artifact_refs
   authority.
 ```
 
+The replay and graph-export connection is intentionally one-way:
+
+```text
+MySQL receipt/artifact stores
+  -> replay_public_projection(...)
+  -> ReceiptProofGraph export
+  -> JSON / Mermaid / Graphviz views
+```
+
+The MySQL spine persists the replay inputs. It does not store a separate graph
+truth, run replay on its own, or authorize projection outside `CommitReceipt`.
+
 The implemented V1 slice intentionally does not include workflow, registry,
 projection cache, typed artifact index, or domain-specific view tables yet.
 Those remain provisional follow-on layers around the artifact/receipt spine.

--- a/docs/architecture/receipt-proof-graph.md
+++ b/docs/architecture/receipt-proof-graph.md
@@ -406,6 +406,18 @@ MySQLArtifactStore is an ArtifactStore implementation. It stores and
 retrieves replay artifacts; it does not become a graph backend or a policy
 authority.
 
+The durable-path check is:
+
+```text
+MySQLReceiptLedger.get(...)
+-> replay_public_projection(..., artifacts=MySQLArtifactStore)
+-> export_receipt_proof_graph(..., artifacts=MySQLArtifactStore)
+-> JSON / Mermaid / Graphviz renderer
+```
+
+This confirms MySQL can supply replay and graph-export inputs without moving
+replay, explanation, or rendering authority into the database layer.
+
 ## 12. Deferred Graphs
 
 Candidate and review graphs are important, but they are not V0.

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -1,6 +1,7 @@
 import os
 from dataclasses import replace
 from decimal import Decimal
+from typing import get_type_hints
 
 import pytest
 
@@ -62,6 +63,17 @@ def test_mysql_spine_module_exists():
     from comp.persistence.mysql import apply_trust_spine_schema
 
     assert apply_trust_spine_schema is not None
+
+
+def test_mysql_artifact_store_satisfies_graph_export_artifact_store_protocol():
+    from comp.explanation import export_receipt_proof_graph
+    from comp.persistence import ArtifactStore
+    from comp.persistence.mysql import MySQLArtifactStore
+
+    hints = get_type_hints(export_receipt_proof_graph)
+
+    assert hints["artifacts"] is ArtifactStore
+    assert isinstance(MySQLArtifactStore(object()), ArtifactStore)
 
 
 def test_persistence_codec_roundtrips_tuple_and_decimal_body():
@@ -271,3 +283,74 @@ def test_mysql_artifact_store_supports_replay_public_projection():
 
     assert report.public_row == case.public_row
     assert report.artifact_refs == receipt_artifact_refs(case.receipt)
+
+
+def test_mysql_spine_supports_replay_then_receipt_proof_graph_export():
+    from comp.explanation import export_receipt_proof_graph
+    from comp.persistence.mysql import (
+        MySQLArtifactStore,
+        MySQLReceiptLedger,
+        apply_trust_spine_schema,
+    )
+
+    case = receipt_projection_case(amount=100, site="plant-a")
+    memory_store = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        mysql_store = MySQLArtifactStore(connection)
+        mysql_ledger = MySQLReceiptLedger(connection)
+        for envelope in memory_store.envelopes():
+            mysql_store.record(envelope)
+        mysql_ledger.record(case.receipt)
+
+        persisted_receipt = mysql_ledger.get(
+            public_row_id=case.receipt.public_row_id,
+            projection_id=case.receipt.projection_id,
+            draft_id=case.receipt.draft_id,
+        )
+        replay = replay_public_projection(
+            case.source_values,
+            case.projection,
+            receipt=persisted_receipt,
+            artifacts=mysql_store,
+        )
+        graph = export_receipt_proof_graph(
+            receipt=persisted_receipt,
+            replay=replay,
+            artifacts=mysql_store,
+        )
+    finally:
+        connection.close()
+
+    payload = graph.to_payload()
+    node_kinds = {node["node_kind"] for node in payload["nodes"]}
+    edge_kinds = {edge["edge_kind"] for edge in payload["edges"]}
+
+    assert replay.public_row == case.public_row
+    assert graph.authority == "explanation_only"
+    assert graph.can_authorize_public_projection is False
+    assert graph.replay_receipt_key.public_row_id == case.receipt.public_row_id
+    assert {
+        "commit_receipt",
+        "public_projection",
+        "dependency_fingerprint",
+    } <= node_kinds
+    assert {"authorized_by", "pinned_dependency", "projected_as"} <= edge_kinds
+    assert "plant-a" not in repr(payload)
+    assert not _payload_has_key(payload, "value")
+
+
+def _payload_has_key(value, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(
+            _payload_has_key(item, key) for item in value.values()
+        )
+    if isinstance(value, (tuple, list)):
+        return any(_payload_has_key(item, key) for item in value)
+    return False


### PR DESCRIPTION
## Summary
- make `ArtifactStore` runtime-checkable so MySQL-backed stores can be asserted against the graph export boundary
- add a MySQL spine integration test for `MySQLReceiptLedger.get(...) -> replay_public_projection(..., artifacts=MySQLArtifactStore) -> export_receipt_proof_graph(...)`
- document that MySQL persists replay inputs but does not become a graph backend, replay authority, or projection authority

## Validation
- python -m pytest tests/test_mysql_persistence_spine.py -q
  - local result: 3 passed, 9 skipped because `COMP_TEST_MYSQL_HOST` is not configured
- python -m pytest tests/test_receipt_proof_graph.py tests/test_receipt_graph_views.py tests/test_package_smoke.py::test_production_database_north_star_tracks_v1_mysql_spine tests/test_package_smoke.py::test_receipt_proof_graph_contract_names_prework_boundaries -q
- git diff --check HEAD~1..HEAD
- python -m pytest -q

## Notes
- This keeps the boundary as: receipt authorizes, replay verifies, graph explains, MySQL persists inputs.