### PR TITLE
[codex] Add scenario trust runtime bridge design

### DIFF
--- a/docs/architecture/scenario-trust-runtime-bridge.md
+++ b/docs/architecture/scenario-trust-runtime-bridge.md
@@ -1,0 +1,376 @@
+# Scenario Trust Runtime Bridge
+
+Status: north-star
+Owner: scenario-lab
+Last checked against code: 2026-05-22
+Can block PRs: limited
+
+This document sketches the public bridge that external scenario packs should use
+when they need to pressure-test `comp` without importing `tests.*` or turning the
+trust kernel into a product workflow engine.
+
+It is not an implemented API contract yet. It is a direction document for the
+next scenario-runtime slice.
+
+The stable boundary is:
+
+```text
+External packs prepare canonical or candidate trust inputs.
+comp runs those inputs through receipt, replay, projection, and persistence
+contracts.
+Product ingestion stays outside comp.
+```
+
+## 1. Goal
+
+`comp` should stay a small proof and authority kernel. Large domain scenarios,
+messy source inputs, operational benchmarks, and product rehearsals should live
+outside the core repository.
+
+External packs still need a first-class way to run `comp`. They should not copy
+private helpers from `tests/domain_scenarios`, import internal modules, or learn
+the shape of current pytest fixtures.
+
+The desired shape is:
+
+```text
+comp-scenario-packs
+  scenario manifest
+  prepared RuntimeCase
+  prepared ArtifactEnvelope bundle
+  expected invariants
+  benchmark budgets
+        |
+        v
+comp public scenario contracts / CLI
+        |
+        v
+narrow TrustRuntime
+        |
+        v
+artifact / receipt / replay / projection / persistence core
+```
+
+## 2. Non-Goal: Product Runtime
+
+The bridge must not make `comp` responsible for product ingestion.
+
+These belong outside `comp`:
+
+```text
+CSV parsing
+email parsing
+OCR
+LLM extraction
+supplier workflow
+worker orchestration
+UI query simulation
+benchmark dataset generation
+domain-specific adapter code
+```
+
+Those capabilities may exist in downstream products or external scenario packs.
+They may prepare inputs for `comp`, but they must not become responsibilities of
+the trust kernel.
+
+## 3. Proposed Public Surface
+
+The first public bridge can be small:
+
+```text
+comp/scenario_contracts/
+  manifest.py
+  case.py
+  result.py
+  invariants.py
+  runner.py
+  report.py
+
+comp/runtime/
+  trust_runtime.py
+
+comp/cli/
+  scenario.py
+```
+
+The intended user-facing imports are:
+
+```python
+from comp.scenario_contracts import ScenarioManifest, RuntimeCase
+from comp.scenario_contracts import ScenarioResult, run_scenario
+```
+
+The intended CLI shape is:
+
+```bash
+comp scenario validate path/to/scenario.yaml
+comp scenario run path/to/scenario.yaml --report reports/latest.json
+```
+
+`comp scenario run` should execute the trust path only. It should not execute
+external pack adapters by default.
+
+## 4. TrustRuntime Scope
+
+`TrustRuntime` should be narrow enough that it cannot grow into a product shell.
+
+Allowed responsibilities:
+
+```text
+validate RuntimeCase
+record ArtifactEnvelope objects
+record CommitReceipt roots
+materialize receipt-authorized projection rows
+verify materialized projection rows
+replay projection rows from receipt-cited artifacts
+emit ScenarioResult
+```
+
+Out-of-scope responsibilities:
+
+```text
+parse raw product files
+call LLM providers
+run OCR
+assign resolver workers
+own supplier workflow state
+render product UI
+decide product query semantics
+generate benchmark datasets
+```
+
+If a scenario requires raw data preparation, the external pack should run a
+pre-trust adapter before invoking `comp`.
+
+## 5. Manifest Modes
+
+The first manifest mode should accept prepared trust inputs:
+
+```yaml
+id: esg_energy_mvp
+input_mode: canonical_bundle
+
+runtime_case:
+  path: prepared/runtime_case.json
+
+artifact_envelopes:
+  path: prepared/artifact_envelopes.jsonl
+
+expected:
+  invariants:
+    - receipt_exists
+    - replay_succeeds
+    - all_public_rows_have_receipts
+    - projection_values_are_committed
+    - blocking_hazards_absent
+
+report:
+  format: json
+```
+
+External packs that start from messy inputs should prepare the bundle in a
+separate step:
+
+```bash
+python -m packs.esg_energy_mvp.prepare \
+  --input raw/ \
+  --output prepared/
+
+comp scenario run packs/esg_energy_mvp/scenario.yaml \
+  --report reports/esg_energy_mvp.json
+```
+
+This keeps extraction and product workflow in the pack while letting `comp`
+exercise the trust path through a stable public contract.
+
+## 6. RuntimeCase
+
+`RuntimeCase` should describe trust-relevant inputs, not raw product documents.
+
+Likely fields:
+
+```text
+case_id
+profile_id
+projection_spec
+candidate artifacts or canonical artifact refs
+receipt request metadata
+materialized projection request
+```
+
+`RuntimeCase` may reference artifact envelopes by id. It should not depend on
+the current `tests.domain_scenarios` dataclasses or fixture helpers.
+
+## 7. Invariants Instead Of Golden Blobs
+
+External packs should assert authority invariants instead of exact exported JSON
+snapshots.
+
+Healthy invariants:
+
+```text
+receipt_exists
+replay_succeeds
+all_public_rows_have_receipts
+projection_values_are_committed
+blocking_hazards_absent
+dependency_fingerprints_present
+```
+
+Avoid:
+
+```text
+exact receipt JSON equality
+exact viewer payload equality
+module path expectations
+helper function name expectations
+field order expectations
+```
+
+Exact snapshots can freeze implementation shape and create a second source of
+truth. Invariants should preserve the authority story while letting projection
+reports, views, and helper modules evolve.
+
+## 8. ScenarioResult And Reports
+
+`run_scenario()` should return a stable `ScenarioResult` and optionally write a
+JSON report.
+
+Suggested result shape:
+
+```text
+ScenarioResult
+  scenario_id
+  status
+  artifact_count
+  receipt_count
+  public_row_count
+  replay_checked_count
+  replay_failed_count
+  invariant_results
+  performance
+  report_path
+```
+
+Suggested JSON report shape:
+
+```json
+{
+  "scenario_id": "esg_energy_mvp",
+  "status": "passed",
+  "counts": {
+    "artifacts": 10000,
+    "receipts": 1200,
+    "public_rows": 5000
+  },
+  "invariants": [
+    {
+      "name": "replay_succeeds",
+      "status": "passed"
+    }
+  ],
+  "performance": {
+    "runtime_sec": 24.3,
+    "projection_query_ms": 83,
+    "replay_sec": 5.1
+  }
+}
+```
+
+Performance fields are measurements, not authority.
+
+## 9. Import Boundary
+
+External scenario packs must use public `comp` APIs or the public CLI.
+
+Allowed public areas:
+
+```text
+comp.scenario_contracts
+comp.runtime
+comp.persistence public interfaces
+comp.compiler_tool public interfaces
+comp.judgment public interfaces
+```
+
+Forbidden imports:
+
+```text
+tests
+tests.domain_scenarios
+comp.tests
+private helper modules
+legacy archived runner modules
+```
+
+The bridge should eventually be covered by import-boundary smoke tests so a pack
+can consume the same public surface that internal smoke scenarios use.
+
+## 10. Internal Smoke Path
+
+At least one internal canonical smoke scenario should use the public bridge.
+
+Bad shape:
+
+```text
+internal tests use tests.domain_scenarios helpers
+external packs use comp.scenario_contracts
+```
+
+Better shape:
+
+```text
+internal smoke uses comp.scenario_contracts.run_scenario
+external packs use comp.scenario_contracts.run_scenario or comp scenario run
+```
+
+This proves the bridge is real and prevents the public API from becoming a
+documentation-only facade.
+
+## 11. First Slice
+
+The first implementation slice should avoid benchmarks, raw ingestion, MySQL
+query profiling, and schema migration.
+
+Start with:
+
+```text
+ScenarioManifest
+RuntimeCase
+ScenarioResult
+InvariantResult
+run_scenario
+write_report
+comp scenario validate
+comp scenario run
+one internal smoke scenario using the public runner
+```
+
+The first invariants should be small:
+
+```text
+receipt_exists
+replay_succeeds
+all_public_rows_have_receipts
+projection_values_are_committed
+blocking_hazards_absent
+```
+
+Once the bridge is stable, external scenario packs can add large domain data,
+materialized projection benchmarks, migration rehearsal cases, and agent-produced
+candidate tests without loading that material into the core repository.
+
+## 12. Review Checklist
+
+Use this checklist when adding scenario runtime code or external-pack support:
+
+```text
+Does the change keep raw product ingestion outside comp?
+Does the external pack use public comp APIs or CLI only?
+Does the runner accept prepared RuntimeCase or ArtifactEnvelope inputs?
+Does TrustRuntime avoid parser, OCR, LLM, UI, and workflow ownership?
+Are expected results invariant-based instead of exact JSON blobs?
+Does at least one internal smoke scenario exercise the public bridge?
+Can reports show performance without making performance data authoritative?
+Does any new scenario code avoid importing tests.* from external packages?
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ override active contracts.
 2. `architecture/llm-worker-orchestration.md`
 3. `architecture/production-trust-spine-database.md`
 4. `architecture/friendly-authority-vocabulary.md`
+5. `architecture/scenario-trust-runtime-bridge.md`
 
 ### Historical Notes
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -394,6 +394,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "limited",
             "2026-05-20",
         ),
+        "scenario-trust-runtime-bridge.md": (
+            "north-star",
+            "scenario-lab",
+            "limited",
+            "2026-05-22",
+        ),
         "trust-kernel-extension-rings.md": (
             "active-contract",
             "trust-kernel",
@@ -445,6 +451,22 @@ def test_docs_index_groups_architecture_docs_by_governance_authority():
     assert "architecture/legacy-archive-cutover-plan.md" in docs_index
     assert "architecture/llm-orchestrated-compiler-tool-loop.md" in docs_index
     assert "architecture/production-trust-spine-database.md" in docs_index
+    assert "architecture/scenario-trust-runtime-bridge.md" in docs_index
+
+
+def test_scenario_trust_runtime_bridge_keeps_public_runner_narrow():
+    bridge = Path("docs/architecture/scenario-trust-runtime-bridge.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Status: north-star" in bridge
+    assert "External packs prepare canonical or candidate trust inputs." in bridge
+    assert "Product ingestion stays outside comp." in bridge
+    assert "TrustRuntime" in bridge
+    assert "input_mode: canonical_bundle" in bridge
+    assert "comp scenario run" in bridge
+    assert "tests.domain_scenarios" in bridge
+    assert "Does the change keep raw product ingestion outside comp?" in bridge
 
 
 def test_friendly_authority_vocabulary_names_rename_path_without_moving_authority():


### PR DESCRIPTION
## What changed

- Added `docs/architecture/scenario-trust-runtime-bridge.md` as a north-star design for the public scenario bridge external packs should use.
- Framed the bridge around prepared `RuntimeCase` / `ArtifactEnvelope` inputs, a narrow `TrustRuntime`, invariant-based checks, JSON reports, and `comp scenario` CLI direction.
- Updated `docs/index.md` and package smoke governance checks so the new architecture doc is classified and discoverable.

## Why

Recent production-readiness feedback pointed at a real gap between `comp` as a receipt/replay trust kernel and external scenario packs that need to run larger domain, performance, migration, and operational rehearsals. This doc keeps the boundary explicit: external packs prepare messy inputs into trust-ready bundles, while `comp` exposes a public runner without absorbing product ingestion.

## Validation

- `python -m pytest tests/test_package_smoke.py -q` -> 21 passed
- `python -m pytest -q` -> 424 passed, 9 skipped