### PR TITLE
[codex] add friendly user messages

### DIFF
--- a/comp/user_messages.py
+++ b/comp/user_messages.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class UserMessage:
+    key: str
+    ko: str
+    action_ko: str | None = None
+
+
+class UnknownUserMessage(KeyError):
+    """Raised when no user-facing message is registered for a key or reason."""
+
+
+_USER_MESSAGES = {
+    "missing_evidence": UserMessage(
+        key="missing_evidence",
+        ko="근거자료가 연결되지 않아 이 값을 검증할 수 없습니다.",
+        action_ko="값이 나온 문서, 엑셀, 인증서 등의 위치를 연결해 주세요.",
+    ),
+    "ambiguous_reference": UserMessage(
+        key="ambiguous_reference",
+        ko="사용할 기준이 여러 개라 선택이 필요합니다.",
+        action_ko="계산에 사용할 확정 기준을 선택해 주세요.",
+    ),
+    "unsupported_unit": UserMessage(
+        key="unsupported_unit",
+        ko="지원하지 않는 단위입니다. 단위를 확인해 주세요.",
+        action_ko="지원되는 단위로 변환하거나 단위 변환 근거를 추가해 주세요.",
+    ),
+    "public_output_receipt_required": UserMessage(
+        key="public_output_receipt_required",
+        ko="공개 결과를 만들려면 공개 승인 증표가 필요합니다.",
+        action_ko="검증 결과를 승인 검토한 뒤 공개 승인 증표를 발급해 주세요.",
+    ),
+    "source_fingerprint_mismatch": UserMessage(
+        key="source_fingerprint_mismatch",
+        ko="원본자료가 변경되어 감사 재검증에 실패했습니다.",
+        action_ko="변경된 원본자료로 다시 검증해 주세요.",
+    ),
+}
+
+_REASON_MESSAGE_KEYS = {
+    "missing_source_witness": "missing_evidence",
+    "missing_evidence": "missing_evidence",
+    "ambiguous_reference": "ambiguous_reference",
+    "multiple_reference_candidates": "ambiguous_reference",
+    "unsupported_unit": "unsupported_unit",
+    "public_output_receipt_required": "public_output_receipt_required",
+    "public_output_requires_receipt": "public_output_receipt_required",
+    "source_fingerprint_mismatch": "source_fingerprint_mismatch",
+    "dependency_fingerprint_mismatch": "source_fingerprint_mismatch",
+}
+
+USER_MESSAGES: Mapping[str, UserMessage] = MappingProxyType(_USER_MESSAGES)
+REASON_MESSAGE_KEYS: Mapping[str, str] = MappingProxyType(_REASON_MESSAGE_KEYS)
+
+
+def user_message(message_key: str) -> UserMessage:
+    try:
+        return USER_MESSAGES[message_key]
+    except KeyError as exc:
+        raise UnknownUserMessage(
+            f"No user message registered for {message_key!r}."
+        ) from exc
+
+
+def user_message_ko(message_key: str) -> str:
+    return user_message(message_key).ko
+
+
+def user_message_for_reason(reason: str) -> UserMessage:
+    try:
+        message_key = REASON_MESSAGE_KEYS[reason]
+    except KeyError as exc:
+        raise UnknownUserMessage(
+            f"No user message registered for reason {reason!r}."
+        ) from exc
+    return user_message(message_key)
+
+
+__all__ = [
+    "REASON_MESSAGE_KEYS",
+    "USER_MESSAGES",
+    "UnknownUserMessage",
+    "UserMessage",
+    "user_message",
+    "user_message_for_reason",
+    "user_message_ko",
+]

--- a/docs/architecture/friendly-authority-vocabulary.md
+++ b/docs/architecture/friendly-authority-vocabulary.md
@@ -144,6 +144,22 @@ Prefer:
 원본자료가 변경되어 감사 재검증에 실패했습니다.
 ```
 
+The first helper lives in `comp.user_messages`:
+
+```python
+from comp.user_messages import user_message_for_reason, user_message_ko
+
+user_message_for_reason("unsupported_unit").ko
+# "지원하지 않는 단위입니다. 단위를 확인해 주세요."
+
+user_message_ko("public_output_receipt_required")
+# "공개 결과를 만들려면 공개 승인 증표가 필요합니다."
+```
+
+Like `comp.schema_labels`, this helper is display-only. It can be used by docs,
+CLI output, UI adapters, and downstream product surfaces. It must not decide
+validation, calculation, receipt issuance, replay, or public-output authority.
+
 Internal exception types may remain English. Their messages should be suitable
 for CLI and product display unless the exception is explicitly developer-only.
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -494,6 +494,8 @@ def test_friendly_authority_vocabulary_names_rename_path_without_moving_authorit
     assert "PublicOutput is available as the public-row return type." in vocabulary
     assert "comp.schema_labels provides frozen display metadata" in vocabulary
     assert "schema_label_ko(\"ClaimCandidate\")" in vocabulary
+    assert "The first helper lives in `comp.user_messages`" in vocabulary
+    assert "user_message_for_reason(\"unsupported_unit\")" in vocabulary
     assert "ProofObligation remains a compatibility alias." in vocabulary
     assert "CommitReceipt remains a compatibility alias." in vocabulary
     assert "Only a clean public-output receipt can authorize public output." in vocabulary

--- a/tests/test_user_messages.py
+++ b/tests/test_user_messages.py
@@ -1,0 +1,74 @@
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+
+def test_user_messages_translate_common_kernel_reasons_to_korean_actions():
+    from comp.user_messages import (
+        USER_MESSAGES,
+        user_message_for_reason,
+        user_message_ko,
+    )
+
+    expected_messages = {
+        "missing_evidence": "근거자료가 연결되지 않아 이 값을 검증할 수 없습니다.",
+        "ambiguous_reference": "사용할 기준이 여러 개라 선택이 필요합니다.",
+        "unsupported_unit": "지원하지 않는 단위입니다. 단위를 확인해 주세요.",
+        "public_output_receipt_required": (
+            "공개 결과를 만들려면 공개 승인 증표가 필요합니다."
+        ),
+        "source_fingerprint_mismatch": (
+            "원본자료가 변경되어 감사 재검증에 실패했습니다."
+        ),
+    }
+
+    blocked_terms = (
+        "ClaimHypothesis",
+        "EvidenceWitness",
+        "ReferenceCandidate",
+        "ReferenceBinding",
+        "CommitReceipt",
+        "Projection",
+        "PublicOutputReceipt",
+    )
+    assert expected_messages.keys() <= USER_MESSAGES.keys()
+    for message_key, ko in expected_messages.items():
+        assert user_message_ko(message_key) == ko
+        assert not any(term in ko for term in blocked_terms)
+
+    assert user_message_for_reason("missing_source_witness").key == "missing_evidence"
+    assert user_message_for_reason("unsupported_unit").key == "unsupported_unit"
+    assert (
+        user_message_for_reason("public_output_receipt_required").key
+        == "public_output_receipt_required"
+    )
+
+
+def test_user_messages_are_display_metadata_not_authority_state():
+    from comp.user_messages import USER_MESSAGES, user_message
+
+    message = user_message("public_output_receipt_required")
+
+    assert not hasattr(message, "can_authorize_public_output")
+    assert not hasattr(message, "can_project_public_row")
+    with pytest.raises(FrozenInstanceError):
+        message.ko = "다른 메시지"
+    with pytest.raises(TypeError):
+        USER_MESSAGES["public_output_receipt_required"] = message
+
+    authority_paths = (
+        Path("comp/judgment/commit.py"),
+        Path("comp/compiler_tool/receipt_builder.py"),
+        Path("comp/persistence/ledger.py"),
+        Path("comp/persistence/replay.py"),
+    )
+    for path in authority_paths:
+        assert "user_messages" not in path.read_text(encoding="utf-8")
+
+
+def test_unknown_user_message_fails_explicitly():
+    from comp.user_messages import UnknownUserMessage, user_message
+
+    with pytest.raises(UnknownUserMessage, match="No user message registered"):
+        user_message("missing_product_surface")


### PR DESCRIPTION
## Summary

- add `comp.user_messages` with frozen Korean user-facing messages for common validation, reference, unit, public-output, and replay reasons
- map kernel reason codes such as `missing_source_witness` and `unsupported_unit` to action-oriented Korean messages
- document the helper in the friendly authority vocabulary error-message policy
- add tests that prevent hard kernel names leaking into these Korean messages and keep authority modules from importing the helper

## Validation

- `python -m pytest -q` -> `430 passed, 9 skipped`
- `python -m tests.domain_scenarios list`
- `python -m tests.domain_scenarios run-all` -> `Passed: 18/18`
- `git diff --cached --check`
