### PR TITLE
[codex] Add scenario trust runtime bridge implementation

### DIFF
--- a/comp/cli/__init__.py
+++ b/comp/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line entry points for public comp workflows."""

--- a/comp/cli/scenario.py
+++ b/comp/cli/scenario.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from comp.scenario_contracts import load_manifest, run_scenario
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command != "scenario":
+        parser.print_help(sys.stderr)
+        return 2
+    if args.scenario_command == "validate":
+        manifest = load_manifest(args.manifest)
+        print(f"{manifest.scenario_id}: valid")
+        return 0
+    if args.scenario_command == "run":
+        result = run_scenario(args.manifest, report_path=args.report)
+        print(f"{result.scenario_id}: {result.status}")
+        return 0 if result.status == "passed" else 1
+    parser.print_help(sys.stderr)
+    return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="comp")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    scenario = subparsers.add_parser("scenario", help="Run public scenario contracts.")
+    scenario_subparsers = scenario.add_subparsers(
+        dest="scenario_command",
+        required=True,
+    )
+    validate = scenario_subparsers.add_parser(
+        "validate",
+        help="Validate a prepared scenario manifest.",
+    )
+    validate.add_argument("manifest")
+    run = scenario_subparsers.add_parser(
+        "run",
+        help="Run a prepared scenario through the trust path.",
+    )
+    run.add_argument("manifest")
+    run.add_argument("--report")
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main"]

--- a/comp/runtime/__init__.py
+++ b/comp/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime primitives that execute the comp trust path without product ingestion."""
+
+from comp.runtime.trust_runtime import TrustRuntime
+
+__all__ = ["TrustRuntime"]

--- a/comp/runtime/trust_runtime.py
+++ b/comp/runtime/trust_runtime.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import time
+
+from comp.persistence import (
+    ArtifactEnvelope,
+    InMemoryArtifactStore,
+    InMemoryReceiptLedger,
+    ProjectionReplayBlocked,
+    ReceiptLedgerKey,
+    replay_public_projection,
+)
+from comp.scenario_contracts.case import RuntimeCase
+from comp.scenario_contracts.invariants import evaluate_invariants
+from comp.scenario_contracts.result import ScenarioResult
+
+
+class TrustRuntime:
+    """Narrow runtime for prepared trust inputs, not product ingestion."""
+
+    def __init__(
+        self,
+        *,
+        artifact_store: InMemoryArtifactStore | None = None,
+        receipt_ledger: InMemoryReceiptLedger | None = None,
+    ):
+        self.artifact_store = (
+            artifact_store if artifact_store is not None else InMemoryArtifactStore()
+        )
+        self.receipt_ledger = (
+            receipt_ledger if receipt_ledger is not None else InMemoryReceiptLedger()
+        )
+
+    def run(
+        self,
+        *,
+        scenario_id: str,
+        runtime_case: RuntimeCase,
+        artifact_envelopes: tuple[ArtifactEnvelope, ...],
+        invariants: tuple[str, ...],
+    ) -> ScenarioResult:
+        started = time.perf_counter()
+        for envelope in artifact_envelopes:
+            self.artifact_store.record(envelope)
+        receipt_keys: set[ReceiptLedgerKey] = set()
+        for receipt in runtime_case.receipts:
+            self.receipt_ledger.record(receipt)
+            receipt_keys.add(ReceiptLedgerKey.from_receipt(receipt))
+
+        replay_checked_count = 0
+        replay_failed_count = 0
+        for projection in runtime_case.projections:
+            try:
+                receipt = self.receipt_ledger.get(
+                    public_row_id=projection.public_row_id,
+                    projection_id=projection.projection_id,
+                    draft_id=projection.draft_id,
+                )
+                replay_public_projection(
+                    projection.row,
+                    projection.projection_spec,
+                    receipt=receipt,
+                    artifacts=self.artifact_store,
+                )
+            except (KeyError, ProjectionReplayBlocked):
+                replay_failed_count += 1
+            else:
+                replay_checked_count += 1
+
+        invariant_results = evaluate_invariants(
+            invariants,
+            runtime_case=runtime_case,
+            receipt_keys=receipt_keys,
+            replay_checked_count=replay_checked_count,
+            replay_failed_count=replay_failed_count,
+        )
+        status = (
+            "passed"
+            if all(result.status == "passed" for result in invariant_results)
+            else "failed"
+        )
+        return ScenarioResult(
+            scenario_id=scenario_id,
+            status=status,
+            artifact_count=len(artifact_envelopes),
+            receipt_count=len(runtime_case.receipts),
+            public_row_count=len(runtime_case.projections),
+            replay_checked_count=replay_checked_count,
+            replay_failed_count=replay_failed_count,
+            invariant_results=invariant_results,
+            performance={"runtime_sec": round(time.perf_counter() - started, 6)},
+        )
+
+
+__all__ = ["TrustRuntime"]

--- a/comp/scenario_contracts/__init__.py
+++ b/comp/scenario_contracts/__init__.py
@@ -1,0 +1,28 @@
+"""Public scenario bridge contracts for external conformance packs."""
+
+from comp.scenario_contracts.case import (
+    RuntimeCase,
+    RuntimeProjection,
+    load_runtime_case,
+)
+from comp.scenario_contracts.manifest import (
+    ScenarioManifest,
+    ScenarioManifestError,
+    load_manifest,
+)
+from comp.scenario_contracts.report import write_report
+from comp.scenario_contracts.result import InvariantResult, ScenarioResult
+from comp.scenario_contracts.runner import run_scenario
+
+__all__ = [
+    "InvariantResult",
+    "RuntimeCase",
+    "RuntimeProjection",
+    "ScenarioManifest",
+    "ScenarioManifestError",
+    "ScenarioResult",
+    "load_manifest",
+    "load_runtime_case",
+    "run_scenario",
+    "write_report",
+]

--- a/comp/scenario_contracts/artifacts.py
+++ b/comp/scenario_contracts/artifacts.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from comp.persistence.codec import decode_persistence_json
+from comp.persistence.envelope import ArtifactEnvelope
+from comp.scenario_contracts.manifest import ScenarioManifestError
+
+
+def load_artifact_envelopes(path: str | Path) -> tuple[ArtifactEnvelope, ...]:
+    envelopes: list[ArtifactEnvelope] = []
+    artifact_lines = Path(path).read_text(encoding="utf-8").splitlines()
+    for line_number, line in enumerate(artifact_lines, 1):
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if not isinstance(payload, Mapping):
+            raise ScenarioManifestError(
+                f"artifact_envelopes line {line_number} must be an object."
+            )
+        envelopes.append(artifact_envelope_from_mapping(payload))
+    return tuple(envelopes)
+
+
+def artifact_envelope_from_mapping(payload: Mapping[str, Any]) -> ArtifactEnvelope:
+    return ArtifactEnvelope(
+        artifact_id=_required_str(payload, "artifact_id"),
+        artifact_kind=_required_str(payload, "artifact_kind"),
+        schema_version=_required_str(payload, "schema_version"),
+        body_digest=_required_str(payload, "body_digest"),
+        body=decode_persistence_json(payload["body"]),
+        source_refs=_tuple_value(decode_persistence_json(payload["source_refs"])),
+        meta=_tuple_pair_value(decode_persistence_json(payload["meta"])),
+    )
+
+
+def _tuple_value(value: Any) -> tuple[str, ...]:
+    if isinstance(value, tuple) and all(isinstance(item, str) for item in value):
+        return value
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return tuple(value)
+    raise ScenarioManifestError("ArtifactEnvelope.source_refs must be strings.")
+
+
+def _tuple_pair_value(value: Any) -> tuple[tuple[str, Any], ...]:
+    if not isinstance(value, tuple):
+        raise ScenarioManifestError("ArtifactEnvelope.meta must be a tuple.")
+    pairs: list[tuple[str, Any]] = []
+    for item in value:
+        if (
+            not isinstance(item, tuple)
+            or len(item) != 2
+            or not isinstance(item[0], str)
+        ):
+            raise ScenarioManifestError("ArtifactEnvelope.meta must contain pairs.")
+        pairs.append((item[0], item[1]))
+    return tuple(pairs)
+
+
+def _required_str(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ScenarioManifestError(f"{key} must be a non-empty string.")
+    return value
+
+
+__all__ = ["artifact_envelope_from_mapping", "load_artifact_envelopes"]

--- a/comp/scenario_contracts/case.py
+++ b/comp/scenario_contracts/case.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from comp.judgment import PublicOutputReceipt, PublicOutputSpec
+from comp.persistence.ledger import ReceiptLedgerKey
+from comp.persistence.mysql import commit_receipt_from_body
+from comp.scenario_contracts.manifest import ScenarioManifestError
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProjection:
+    public_row_id: str
+    projection_id: str
+    draft_id: str
+    output_fields: tuple[str, ...]
+    row: Mapping[str, Any]
+
+    @property
+    def receipt_key(self) -> ReceiptLedgerKey:
+        return ReceiptLedgerKey(
+            public_row_id=self.public_row_id,
+            projection_id=self.projection_id,
+            draft_id=self.draft_id,
+        )
+
+    @property
+    def projection_spec(self) -> PublicOutputSpec:
+        return PublicOutputSpec(self.projection_id, self.output_fields)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCase:
+    case_id: str
+    receipts: tuple[PublicOutputReceipt, ...]
+    projections: tuple[RuntimeProjection, ...]
+
+
+def load_runtime_case(path: str | Path) -> RuntimeCase:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ScenarioManifestError("RuntimeCase file must contain an object.")
+    return runtime_case_from_mapping(payload)
+
+
+def runtime_case_from_mapping(payload: Mapping[str, Any]) -> RuntimeCase:
+    case_id = _required_str(payload, "case_id")
+    receipts = payload.get("receipts")
+    projections = payload.get("projections")
+    if not isinstance(receipts, list):
+        raise ScenarioManifestError("RuntimeCase.receipts must be a list.")
+    if not isinstance(projections, list):
+        raise ScenarioManifestError("RuntimeCase.projections must be a list.")
+    return RuntimeCase(
+        case_id=case_id,
+        receipts=tuple(
+            commit_receipt_from_body(_required_mapping(item, "receipt"))
+            for item in receipts
+        ),
+        projections=tuple(
+            _projection_from_mapping(_required_mapping(item, "projection"))
+            for item in projections
+        ),
+    )
+
+
+def _projection_from_mapping(payload: Mapping[str, Any]) -> RuntimeProjection:
+    output_fields = payload.get("output_fields")
+    row = payload.get("row")
+    if not isinstance(output_fields, list) or not all(
+        isinstance(field, str) for field in output_fields
+    ):
+        raise ScenarioManifestError("RuntimeProjection.output_fields must be strings.")
+    if not isinstance(row, Mapping):
+        raise ScenarioManifestError("RuntimeProjection.row must be an object.")
+    return RuntimeProjection(
+        public_row_id=_required_str(payload, "public_row_id"),
+        projection_id=_required_str(payload, "projection_id"),
+        draft_id=_required_str(payload, "draft_id"),
+        output_fields=tuple(output_fields),
+        row=dict(row),
+    )
+
+
+def _required_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ScenarioManifestError(f"{label} must be an object.")
+    return value
+
+
+def _required_str(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ScenarioManifestError(f"{key} must be a non-empty string.")
+    return value
+
+
+__all__ = [
+    "RuntimeCase",
+    "RuntimeProjection",
+    "load_runtime_case",
+    "runtime_case_from_mapping",
+]

--- a/comp/scenario_contracts/invariants.py
+++ b/comp/scenario_contracts/invariants.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from comp.persistence.ledger import ReceiptLedgerKey
+from comp.scenario_contracts.case import RuntimeCase
+from comp.scenario_contracts.result import InvariantResult
+
+
+def evaluate_invariants(
+    names: tuple[str, ...],
+    *,
+    runtime_case: RuntimeCase,
+    receipt_keys: set[ReceiptLedgerKey],
+    replay_checked_count: int,
+    replay_failed_count: int,
+) -> tuple[InvariantResult, ...]:
+    evaluators = {
+        "receipt_exists": _receipt_exists,
+        "all_public_rows_have_receipts": _all_public_rows_have_receipts,
+        "replay_succeeds": _replay_succeeds,
+        "projection_values_are_committed": _replay_succeeds,
+        "blocking_hazards_absent": _blocking_hazards_absent,
+    }
+    context = {
+        "runtime_case": runtime_case,
+        "receipt_keys": receipt_keys,
+        "replay_checked_count": replay_checked_count,
+        "replay_failed_count": replay_failed_count,
+    }
+    results: list[InvariantResult] = []
+    for name in names:
+        evaluator = evaluators.get(name)
+        if evaluator is None:
+            results.append(
+                InvariantResult(name=name, status="failed", message="unknown invariant")
+            )
+            continue
+        results.append(evaluator(name, context))
+    return tuple(results)
+
+
+def _receipt_exists(name: str, context: Mapping[str, object]) -> InvariantResult:
+    runtime_case = _runtime_case(context)
+    receipt_keys = _receipt_keys(context)
+    missing = [
+        projection.receipt_key
+        for projection in runtime_case.projections
+        if projection.receipt_key not in receipt_keys
+    ]
+    if missing:
+        return InvariantResult(name=name, status="failed", message="missing receipt")
+    return InvariantResult(name=name, status="passed")
+
+
+def _all_public_rows_have_receipts(
+    name: str,
+    context: Mapping[str, object],
+) -> InvariantResult:
+    return _receipt_exists(name, context)
+
+
+def _replay_succeeds(name: str, context: Mapping[str, object]) -> InvariantResult:
+    replay_checked_count = int(context["replay_checked_count"])
+    replay_failed_count = int(context["replay_failed_count"])
+    runtime_case = _runtime_case(context)
+    if replay_failed_count:
+        return InvariantResult(name=name, status="failed", message="replay failed")
+    if replay_checked_count != len(runtime_case.projections):
+        return InvariantResult(name=name, status="failed", message="replay incomplete")
+    return InvariantResult(name=name, status="passed")
+
+
+def _blocking_hazards_absent(
+    name: str,
+    context: Mapping[str, object],
+) -> InvariantResult:
+    runtime_case = _runtime_case(context)
+    for receipt in runtime_case.receipts:
+        citations = receipt.citations
+        if citations is not None and citations.hazard_ids:
+            return InvariantResult(
+                name=name,
+                status="failed",
+                message="blocking hazards present",
+            )
+    return InvariantResult(name=name, status="passed")
+
+
+def _runtime_case(context: Mapping[str, object]) -> RuntimeCase:
+    runtime_case = context["runtime_case"]
+    assert isinstance(runtime_case, RuntimeCase)
+    return runtime_case
+
+
+def _receipt_keys(context: Mapping[str, object]) -> set[ReceiptLedgerKey]:
+    receipt_keys = context["receipt_keys"]
+    assert isinstance(receipt_keys, set)
+    return receipt_keys
+
+
+__all__ = ["evaluate_invariants"]

--- a/comp/scenario_contracts/manifest.py
+++ b/comp/scenario_contracts/manifest.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ScenarioManifestError(ValueError):
+    """Raised when a scenario manifest cannot use the public trust bridge."""
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioManifest:
+    scenario_id: str
+    input_mode: str
+    runtime_case_path: Path
+    artifact_envelopes_path: Path
+    invariants: tuple[str, ...]
+    report_format: str = "json"
+    report_path: Path | None = None
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        base_path: Path,
+    ) -> "ScenarioManifest":
+        scenario_id = _required_str(payload, "id")
+        input_mode = _required_str(payload, "input_mode")
+        if input_mode != "canonical_bundle":
+            raise ScenarioManifestError(
+                "Scenario manifests must use input_mode='canonical_bundle' "
+                "before comp can run the trust path."
+            )
+
+        runtime_case = _required_mapping(payload, "runtime_case")
+        artifact_envelopes = _required_mapping(payload, "artifact_envelopes")
+        expected = _required_mapping(payload, "expected")
+        invariants = tuple(_required_sequence(expected, "invariants"))
+        if not invariants:
+            raise ScenarioManifestError("expected.invariants must not be empty.")
+
+        report = payload.get("report", {})
+        if report is None:
+            report = {}
+        if not isinstance(report, Mapping):
+            raise ScenarioManifestError("report must be an object when provided.")
+
+        report_format = str(report.get("format", "json"))
+        if report_format != "json":
+            raise ScenarioManifestError("report.format must be 'json'.")
+        report_path = report.get("path")
+        return cls(
+            scenario_id=scenario_id,
+            input_mode=input_mode,
+            runtime_case_path=_resolve_path(
+                base_path,
+                _required_str(runtime_case, "path"),
+            ),
+            artifact_envelopes_path=_resolve_path(
+                base_path,
+                _required_str(artifact_envelopes, "path"),
+            ),
+            invariants=invariants,
+            report_format=report_format,
+            report_path=(
+                None
+                if report_path is None
+                else _resolve_path(base_path, str(report_path))
+            ),
+        )
+
+
+def load_manifest(path: str | Path) -> ScenarioManifest:
+    manifest_path = Path(path)
+    payload = _load_mapping(manifest_path)
+    return ScenarioManifest.from_mapping(payload, base_path=manifest_path.parent)
+
+
+def _load_mapping(path: Path) -> Mapping[str, Any]:
+    if path.suffix.lower() == ".json":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    elif path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise ScenarioManifestError(
+                "YAML scenario manifests require PyYAML; use JSON or install PyYAML."
+            ) from exc
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    else:
+        raise ScenarioManifestError(
+            "Scenario manifest path must end with .json, .yaml, or .yml."
+        )
+    if not isinstance(payload, Mapping):
+        raise ScenarioManifestError("Scenario manifest must be a JSON/YAML object.")
+    return payload
+
+
+def _required_mapping(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, Mapping):
+        raise ScenarioManifestError(f"{key} must be an object.")
+    return value
+
+
+def _required_sequence(payload: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = payload.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ScenarioManifestError(f"{key} must be a list of strings.")
+    return tuple(value)
+
+
+def _required_str(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ScenarioManifestError(f"{key} must be a non-empty string.")
+    return value
+
+
+def _resolve_path(base_path: Path, value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return base_path / path
+
+
+__all__ = ["ScenarioManifest", "ScenarioManifestError", "load_manifest"]

--- a/comp/scenario_contracts/report.py
+++ b/comp/scenario_contracts/report.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from comp.scenario_contracts.result import ScenarioResult
+
+
+def write_report(result: ScenarioResult, path: str | Path) -> Path:
+    report_path = Path(path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(result.to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return report_path
+
+
+__all__ = ["write_report"]

--- a/comp/scenario_contracts/result.py
+++ b/comp/scenario_contracts/result.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class InvariantResult:
+    name: str
+    status: str
+    message: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioResult:
+    scenario_id: str
+    status: str
+    artifact_count: int
+    receipt_count: int
+    public_row_count: int
+    replay_checked_count: int
+    replay_failed_count: int
+    invariant_results: tuple[InvariantResult, ...]
+    performance: dict[str, float] = field(default_factory=dict)
+    report_path: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scenario_id": self.scenario_id,
+            "status": self.status,
+            "counts": {
+                "artifacts": self.artifact_count,
+                "receipts": self.receipt_count,
+                "public_rows": self.public_row_count,
+            },
+            "replay": {
+                "checked": self.replay_checked_count,
+                "failed": self.replay_failed_count,
+            },
+            "invariants": [
+                invariant.to_dict() for invariant in self.invariant_results
+            ],
+            "performance": self.performance,
+        }
+
+
+__all__ = ["InvariantResult", "ScenarioResult"]

--- a/comp/scenario_contracts/runner.py
+++ b/comp/scenario_contracts/runner.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from comp.runtime import TrustRuntime
+from comp.scenario_contracts.artifacts import load_artifact_envelopes
+from comp.scenario_contracts.case import load_runtime_case
+from comp.scenario_contracts.manifest import ScenarioManifest, load_manifest
+from comp.scenario_contracts.report import write_report
+from comp.scenario_contracts.result import ScenarioResult
+
+
+def run_scenario(
+    manifest: str | Path | ScenarioManifest,
+    *,
+    runtime: TrustRuntime | None = None,
+    report_path: str | Path | None = None,
+) -> ScenarioResult:
+    scenario_manifest = (
+        load_manifest(manifest)
+        if not isinstance(manifest, ScenarioManifest)
+        else manifest
+    )
+    runtime_case = load_runtime_case(scenario_manifest.runtime_case_path)
+    artifact_envelopes = load_artifact_envelopes(
+        scenario_manifest.artifact_envelopes_path
+    )
+    trust_runtime = runtime if runtime is not None else TrustRuntime()
+    result = trust_runtime.run(
+        scenario_id=scenario_manifest.scenario_id,
+        runtime_case=runtime_case,
+        artifact_envelopes=artifact_envelopes,
+        invariants=scenario_manifest.invariants,
+    )
+    selected_report_path = (
+        Path(report_path) if report_path is not None else scenario_manifest.report_path
+    )
+    if selected_report_path is None:
+        return result
+    report_path = write_report(result, selected_report_path)
+    return ScenarioResult(
+        scenario_id=result.scenario_id,
+        status=result.status,
+        artifact_count=result.artifact_count,
+        receipt_count=result.receipt_count,
+        public_row_count=result.public_row_count,
+        replay_checked_count=result.replay_checked_count,
+        replay_failed_count=result.replay_failed_count,
+        invariant_results=result.invariant_results,
+        performance=result.performance,
+        report_path=str(report_path),
+    )
+
+
+__all__ = ["run_scenario"]

--- a/docs/architecture/scenario-trust-runtime-bridge.md
+++ b/docs/architecture/scenario-trust-runtime-bridge.md
@@ -9,8 +9,9 @@ This document sketches the public bridge that external scenario packs should use
 when they need to pressure-test `comp` without importing `tests.*` or turning the
 trust kernel into a product workflow engine.
 
-It is not an implemented API contract yet. It is a direction document for the
-next scenario-runtime slice.
+It is a direction document for the scenario-runtime bridge. The first
+implementation slice is intentionally small and should not be treated as a final
+scenario pack API.
 
 The stable boundary is:
 
@@ -373,4 +374,31 @@ Are expected results invariant-based instead of exact JSON blobs?
 Does at least one internal smoke scenario exercise the public bridge?
 Can reports show performance without making performance data authoritative?
 Does any new scenario code avoid importing tests.* from external packages?
+```
+
+## 13. Current Implementation Status
+
+The first public bridge slice is implemented:
+
+```text
+comp.scenario_contracts
+  loads canonical_bundle JSON manifests, prepared RuntimeCase JSON, and
+  ArtifactEnvelope JSONL bundles.
+
+comp.runtime.TrustRuntime
+  records prepared artifacts and receipts into in-memory stores, replays declared
+  projections, evaluates invariant results, and emits ScenarioResult.
+
+comp scenario validate
+comp scenario run
+  expose the prepared-bundle trust path through a public CLI.
+```
+
+Current limits:
+
+```text
+YAML manifests require PyYAML if used; JSON manifests work without extra deps.
+Only input_mode=canonical_bundle is accepted.
+No raw pack adapter execution exists inside comp.
+No benchmark runner, MySQL query profiling, or migration rehearsal is included.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,13 @@ db = ["PyMySQL>=1.1"]
 [tool.setuptools]
 packages = [
   "comp",
+  "comp.cli",
   "comp.compiler_tool",
   "comp.explanation",
   "comp.judgment",
   "comp.persistence",
+  "comp.runtime",
+  "comp.scenario_contracts",
   "comp.scenarios",
   "comp.scenarios.synthetic",
   "comp.views",
@@ -30,5 +33,6 @@ packages = [
 "comp.scenarios.synthetic" = ["profiles/*.yaml"]
 
 [project.scripts]
+comp = "comp.cli.scenario:main"
 minchoagnt = "minchoagnt.cli:main"
 comp-receipt-graph = "comp.explanation.receipt_graph_cli:main"

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -573,10 +573,13 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     setuptools_config = pyproject["tool"]["setuptools"]
     assert setuptools_config["packages"] == [
         "comp",
+        "comp.cli",
         "comp.compiler_tool",
         "comp.explanation",
         "comp.judgment",
         "comp.persistence",
+        "comp.runtime",
+        "comp.scenario_contracts",
         "comp.scenarios",
         "comp.scenarios.synthetic",
         "comp.views",
@@ -588,6 +591,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert "py-modules" not in setuptools_config
 
     scripts = pyproject["project"].get("scripts", {})
+    assert scripts["comp"] == "comp.cli.scenario:main"
     assert scripts["minchoagnt"] == "minchoagnt.cli:main"
     assert scripts["comp-receipt-graph"] == "comp.explanation.receipt_graph_cli:main"
 

--- a/tests/test_scenario_contracts.py
+++ b/tests/test_scenario_contracts.py
@@ -1,0 +1,184 @@
+import json
+
+import pytest
+
+from comp.persistence.codec import encode_persistence_json
+from comp.persistence.mysql import commit_receipt_to_body
+from tests.support.persistence_cases import artifact_store_for_receipt
+from tests.support.persistence_cases import receipt_projection_case
+
+
+def test_run_scenario_accepts_prepared_canonical_bundle(tmp_path):
+    from comp.scenario_contracts import run_scenario
+
+    manifest_path = _write_prepared_scenario(tmp_path)
+
+    result = run_scenario(manifest_path)
+
+    assert result.scenario_id == "fixture_public_projection"
+    assert result.status == "passed"
+    assert result.artifact_count == 9
+    assert result.receipt_count == 1
+    assert result.public_row_count == 1
+    assert result.replay_checked_count == 1
+    assert result.replay_failed_count == 0
+    assert {item.name: item.status for item in result.invariant_results} == {
+        "receipt_exists": "passed",
+        "replay_succeeds": "passed",
+        "all_public_rows_have_receipts": "passed",
+        "projection_values_are_committed": "passed",
+        "blocking_hazards_absent": "passed",
+    }
+
+
+def test_run_scenario_writes_json_report(tmp_path):
+    from comp.scenario_contracts import run_scenario
+
+    report_path = tmp_path / "reports" / "latest.json"
+    manifest_path = _write_prepared_scenario(tmp_path, report_path=report_path)
+
+    result = run_scenario(manifest_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+
+    assert result.report_path == str(report_path)
+    assert payload["scenario_id"] == "fixture_public_projection"
+    assert payload["status"] == "passed"
+    assert payload["counts"] == {
+        "artifacts": 9,
+        "receipts": 1,
+        "public_rows": 1,
+    }
+    assert payload["replay"] == {
+        "checked": 1,
+        "failed": 0,
+    }
+    assert payload["invariants"][0] == {
+        "name": "receipt_exists",
+        "status": "passed",
+        "message": "",
+    }
+
+
+def test_run_scenario_rejects_pack_adapter_mode(tmp_path):
+    from comp.scenario_contracts import ScenarioManifestError, run_scenario
+
+    manifest_path = tmp_path / "scenario.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "id": "adapter_mode",
+                "input_mode": "pack_adapter",
+                "adapter": {"command": "python -m packs.example.prepare"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ScenarioManifestError, match="canonical_bundle"):
+        run_scenario(manifest_path)
+
+
+def test_run_scenario_rejects_unsupported_report_format(tmp_path):
+    from comp.scenario_contracts import ScenarioManifestError, run_scenario
+
+    manifest_path = _write_prepared_scenario(
+        tmp_path,
+        report_path=tmp_path / "reports" / "latest.html",
+        report_format="html",
+    )
+
+    with pytest.raises(ScenarioManifestError, match="report.format"):
+        run_scenario(manifest_path)
+
+
+def test_comp_scenario_cli_validates_and_runs_prepared_bundle(tmp_path, capsys):
+    from comp.cli.scenario import main
+
+    report_path = tmp_path / "reports" / "cli.json"
+    manifest_path = _write_prepared_scenario(tmp_path)
+
+    assert main(["scenario", "validate", str(manifest_path)]) == 0
+    assert "fixture_public_projection" in capsys.readouterr().out
+
+    assert main(["scenario", "run", str(manifest_path), "--report", str(report_path)]) == 0
+    output = capsys.readouterr().out
+
+    assert "passed" in output
+    assert report_path.exists()
+
+
+def _write_prepared_scenario(tmp_path, *, report_path=None, report_format="json"):
+    case = receipt_projection_case(amount=100, site="plant-a")
+    store = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+
+    prepared = tmp_path / "prepared"
+    prepared.mkdir()
+    runtime_case_path = prepared / "runtime_case.json"
+    artifact_path = prepared / "artifact_envelopes.jsonl"
+    manifest_path = tmp_path / "scenario.json"
+
+    runtime_case_path.write_text(
+        json.dumps(
+            {
+                "case_id": "fixture-case",
+                "receipts": [commit_receipt_to_body(case.receipt)],
+                "projections": [
+                    {
+                        "public_row_id": "public-row-1",
+                        "projection_id": "public-row",
+                        "draft_id": "draft-1",
+                        "output_fields": ["site", "amount"],
+                        "row": case.public_row,
+                    }
+                ],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    artifact_path.write_text(
+        "\n".join(_artifact_payload(envelope) for envelope in store.envelopes()),
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "id": "fixture_public_projection",
+        "input_mode": "canonical_bundle",
+        "runtime_case": {"path": "prepared/runtime_case.json"},
+        "artifact_envelopes": {"path": "prepared/artifact_envelopes.jsonl"},
+        "expected": {
+            "invariants": [
+                "receipt_exists",
+                "replay_succeeds",
+                "all_public_rows_have_receipts",
+                "projection_values_are_committed",
+                "blocking_hazards_absent",
+            ]
+        },
+    }
+    if report_path is not None:
+        manifest["report"] = {
+            "format": report_format,
+            "path": str(report_path),
+        }
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+    return manifest_path
+
+
+def _artifact_payload(envelope):
+    return json.dumps(
+        {
+            "artifact_id": envelope.artifact_id,
+            "artifact_kind": envelope.artifact_kind,
+            "schema_version": envelope.schema_version,
+            "body_digest": envelope.body_digest,
+            "body": encode_persistence_json(envelope.body),
+            "source_refs": encode_persistence_json(envelope.source_refs),
+            "meta": encode_persistence_json(envelope.meta),
+        },
+        sort_keys=True,
+    )


### PR DESCRIPTION
## What changed

- Added `comp.scenario_contracts` as the public bridge external scenario packs can call without importing `tests.*`.
- Added a narrow `TrustRuntime` that accepts prepared canonical bundles, records artifact envelopes and receipts, replays public projections, evaluates invariants, and returns `ScenarioResult`.
- Added `comp scenario validate/run` CLI plus package metadata for the public entrypoint.
- Updated the scenario trust runtime bridge design doc with current implementation status.
- Added scenario contract tests and package smoke coverage for the new public API/script surface.

## Boundary

This slice intentionally accepts only `input_mode: canonical_bundle`. It rejects `pack_adapter` mode and does not run raw CSV/email/OCR/LLM/product ingestion inside `comp`.

## Validation

- `python -m pytest tests/test_scenario_contracts.py tests/test_package_smoke.py -q` -> 26 passed
- `python -m pytest -q` -> 435 passed, 9 skipped