### PR TITLE
[codex] Define document authority lifecycle

### DIFF
--- a/docs/architecture/document-governance.md
+++ b/docs/architecture/document-governance.md
@@ -2,7 +2,7 @@
 
 Status: active-contract
 Owner: trust-kernel
-Last checked against code: 2026-05-20
+Last checked against code: 2026-05-22
 Can block PRs: yes
 
 This document defines how architecture documents gain or lose authority in the
@@ -22,6 +22,23 @@ Some docs are historical context.
 
 Every architecture document that is used in review should declare its authority
 level near the top.
+
+## Metadata And Navigation
+
+Document headers are the metadata source of truth.
+
+```text
+Status
+Owner
+Last checked against code
+Can block PRs
+```
+
+`docs/index.md` is the navigation source of truth.
+
+The index groups documents for humans, but it must not become a second source
+of authority metadata. If the index and a document header disagree, fix the
+stale one in the same PR.
 
 ## Authority Levels
 
@@ -94,6 +111,31 @@ Can block PRs: yes | limited | no
 the code shape on that date. It is not a promise that the document will remain
 fresh forever.
 
+## Location Rules
+
+Status and location should agree.
+
+After the lifecycle migration, docs/architecture/ root is an entry surface. It
+may contain a README, governance entry point, or short routing document; the
+governed architecture body should live under the status-specific directories.
+
+```text
+active-contract -> docs/architecture/contracts/
+implementation-map -> docs/architecture/maps/
+north-star -> docs/architecture/north-stars/
+historical-note -> docs/archive/architecture/
+implementation plan -> docs/archive/plans/
+migration history -> docs/archive/migration/
+```
+
+The current repository may still contain documents that predate this physical
+layout. New documents should follow this layout immediately, and migration PRs
+should move obvious existing documents without changing their review meaning.
+
+Implementation plans, execution logs, and temporary PR plans should not be
+created under `docs/architecture/`. They may be useful, but they are not active
+architecture contracts.
+
 ## Review Checklist
 
 Before adding or promoting a document, answer:
@@ -119,6 +161,7 @@ implementation-map -> historical-note
 north-star -> historical-note
 ```
 
+After the lifecycle migration, demotion changes both status and location.
 Demotion is not deletion. It preserves useful reasoning while removing review
 authority.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,10 @@ Read `architecture/document-governance.md` first when deciding whether a
 document can block a PR. The rest of the architecture docs are grouped by that
 authority model.
 
+The document header is the metadata source of truth for `Status`, `Owner`,
+`Last checked against code`, and `Can block PRs`. For finding governed docs,
+this index is the navigation source of truth.
+
 ### Active Contracts
 
 These documents can block PRs when a change violates their authority boundary

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -302,6 +302,31 @@ def test_document_governance_classifies_architecture_doc_authority():
             assert line in text
 
 
+def test_document_governance_defines_authority_lifecycle_locations():
+    governance = Path(
+        "docs/architecture/document-governance.md"
+    ).read_text(encoding="utf-8")
+    docs_index = Path("docs/index.md").read_text(encoding="utf-8")
+
+    assert "Document headers are the metadata source of truth." in governance
+    assert "`docs/index.md` is the navigation source of truth." in governance
+    assert "docs/architecture/ root is an entry surface" in governance
+    assert "demotion changes both status and location" in governance
+
+    for lifecycle_rule in (
+        "active-contract -> docs/architecture/contracts/",
+        "implementation-map -> docs/architecture/maps/",
+        "north-star -> docs/architecture/north-stars/",
+        "historical-note -> docs/archive/architecture/",
+        "implementation plan -> docs/archive/plans/",
+        "migration history -> docs/archive/migration/",
+    ):
+        assert lifecycle_rule in governance
+
+    assert "The document header is the metadata source of truth" in docs_index
+    assert "this index is the navigation source of truth" in docs_index
+
+
 def test_architecture_docs_are_classified_by_governance_status():
     expected_status = {
         "active-surface-cutover.md": (
@@ -320,7 +345,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "trust-kernel",
             "yes",
-            "2026-05-20",
+            "2026-05-22",
         ),
         "domain-scenario-pack-generation.md": (
             "implementation-map",


### PR DESCRIPTION
## Summary
- define document header metadata as the authority source of truth and `docs/index.md` as the navigation source of truth
- add lifecycle location rules for active contracts, maps, north stars, historical notes, implementation plans, and migration history
- strengthen package smoke coverage for the new document authority lifecycle rules

## Notes
- This PR intentionally does not move files yet. Follow-up PRs can apply these rules to move obvious historical notes and plan logs.

## Validation
- `python -m pytest tests/test_package_smoke.py -q` -> 22 passed
- `python -m pytest -q` -> 436 passed, 9 skipped
- `git diff --check HEAD~1..HEAD` -> passed