### PR TITLE
[codex] Add scenario bundle writer examples

### DIFF
--- a/comp/scenario_contracts/__init__.py
+++ b/comp/scenario_contracts/__init__.py
@@ -4,6 +4,16 @@ from comp.scenario_contracts.case import (
     RuntimeCase,
     RuntimeProjection,
     load_runtime_case,
+    runtime_case_from_mapping,
+    runtime_case_to_mapping,
+    runtime_projection_to_mapping,
+    write_runtime_case,
+)
+from comp.scenario_contracts.artifacts import (
+    artifact_envelope_from_mapping,
+    artifact_envelope_to_mapping,
+    load_artifact_envelopes,
+    write_artifact_envelopes,
 )
 from comp.scenario_contracts.manifest import (
     ScenarioManifest,
@@ -21,8 +31,16 @@ __all__ = [
     "ScenarioManifest",
     "ScenarioManifestError",
     "ScenarioResult",
+    "artifact_envelope_from_mapping",
+    "artifact_envelope_to_mapping",
+    "load_artifact_envelopes",
     "load_manifest",
     "load_runtime_case",
     "run_scenario",
+    "runtime_case_from_mapping",
+    "runtime_case_to_mapping",
+    "runtime_projection_to_mapping",
+    "write_artifact_envelopes",
     "write_report",
+    "write_runtime_case",
 ]

--- a/comp/scenario_contracts/artifacts.py
+++ b/comp/scenario_contracts/artifacts.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
-from comp.persistence.codec import decode_persistence_json
+from comp.persistence.codec import decode_persistence_json, encode_persistence_json
 from comp.persistence.envelope import ArtifactEnvelope
 from comp.scenario_contracts.manifest import ScenarioManifestError
 
@@ -23,6 +23,32 @@ def load_artifact_envelopes(path: str | Path) -> tuple[ArtifactEnvelope, ...]:
             )
         envelopes.append(artifact_envelope_from_mapping(payload))
     return tuple(envelopes)
+
+
+def write_artifact_envelopes(
+    envelopes: Iterable[ArtifactEnvelope],
+    path: str | Path,
+) -> Path:
+    artifact_path = Path(path)
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps(artifact_envelope_to_mapping(envelope), sort_keys=True)
+        for envelope in envelopes
+    ]
+    artifact_path.write_text("\n".join(lines), encoding="utf-8")
+    return artifact_path
+
+
+def artifact_envelope_to_mapping(envelope: ArtifactEnvelope) -> dict[str, object]:
+    return {
+        "artifact_id": envelope.artifact_id,
+        "artifact_kind": envelope.artifact_kind,
+        "schema_version": envelope.schema_version,
+        "body_digest": envelope.body_digest,
+        "body": encode_persistence_json(envelope.body),
+        "source_refs": encode_persistence_json(envelope.source_refs),
+        "meta": encode_persistence_json(envelope.meta),
+    }
 
 
 def artifact_envelope_from_mapping(payload: Mapping[str, Any]) -> ArtifactEnvelope:
@@ -67,4 +93,9 @@ def _required_str(payload: Mapping[str, Any], key: str) -> str:
     return value
 
 
-__all__ = ["artifact_envelope_from_mapping", "load_artifact_envelopes"]
+__all__ = [
+    "artifact_envelope_from_mapping",
+    "artifact_envelope_to_mapping",
+    "load_artifact_envelopes",
+    "write_artifact_envelopes",
+]

--- a/comp/scenario_contracts/case.py
+++ b/comp/scenario_contracts/case.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from comp.judgment import PublicOutputReceipt, PublicOutputSpec
 from comp.persistence.ledger import ReceiptLedgerKey
-from comp.persistence.mysql import commit_receipt_from_body
+from comp.persistence.mysql import commit_receipt_from_body, commit_receipt_to_body
 from comp.scenario_contracts.manifest import ScenarioManifestError
 
 
@@ -45,6 +45,41 @@ def load_runtime_case(path: str | Path) -> RuntimeCase:
     if not isinstance(payload, Mapping):
         raise ScenarioManifestError("RuntimeCase file must contain an object.")
     return runtime_case_from_mapping(payload)
+
+
+def write_runtime_case(runtime_case: RuntimeCase, path: str | Path) -> Path:
+    runtime_case_path = Path(path)
+    runtime_case_path.parent.mkdir(parents=True, exist_ok=True)
+    runtime_case_path.write_text(
+        json.dumps(runtime_case_to_mapping(runtime_case), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return runtime_case_path
+
+
+def runtime_case_to_mapping(runtime_case: RuntimeCase) -> dict[str, object]:
+    return {
+        "case_id": runtime_case.case_id,
+        "receipts": [
+            commit_receipt_to_body(receipt) for receipt in runtime_case.receipts
+        ],
+        "projections": [
+            runtime_projection_to_mapping(projection)
+            for projection in runtime_case.projections
+        ],
+    }
+
+
+def runtime_projection_to_mapping(
+    projection: RuntimeProjection,
+) -> dict[str, object]:
+    return {
+        "public_row_id": projection.public_row_id,
+        "projection_id": projection.projection_id,
+        "draft_id": projection.draft_id,
+        "output_fields": list(projection.output_fields),
+        "row": dict(projection.row),
+    }
 
 
 def runtime_case_from_mapping(payload: Mapping[str, Any]) -> RuntimeCase:
@@ -104,4 +139,7 @@ __all__ = [
     "RuntimeProjection",
     "load_runtime_case",
     "runtime_case_from_mapping",
+    "runtime_case_to_mapping",
+    "runtime_projection_to_mapping",
+    "write_runtime_case",
 ]

--- a/docs/architecture/scenario-trust-runtime-bridge.md
+++ b/docs/architecture/scenario-trust-runtime-bridge.md
@@ -384,6 +384,8 @@ The first public bridge slice is implemented:
 comp.scenario_contracts
   loads canonical_bundle JSON manifests, prepared RuntimeCase JSON, and
   ArtifactEnvelope JSONL bundles.
+  exposes write_runtime_case and write_artifact_envelopes helpers so external
+  packs do not need private tests.* helpers or backend-specific JSON encoders.
 
 comp.runtime.TrustRuntime
   records prepared artifacts and receipts into in-memory stores, replays declared
@@ -401,4 +403,10 @@ YAML manifests require PyYAML if used; JSON manifests work without extra deps.
 Only input_mode=canonical_bundle is accepted.
 No raw pack adapter execution exists inside comp.
 No benchmark runner, MySQL query profiling, or migration rehearsal is included.
+```
+
+The public bundle example lives at:
+
+```text
+docs/examples/scenario_contracts/README.md
 ```

--- a/docs/examples/scenario_contracts/README.md
+++ b/docs/examples/scenario_contracts/README.md
@@ -1,0 +1,87 @@
+# Scenario Contract Example
+
+This example shows the prepared-bundle shape external scenario packs should
+produce before invoking `comp`.
+
+The boundary is intentionally narrow:
+
+```text
+raw pack data
+  -> pre-trust pack adapter outside comp
+  -> prepared RuntimeCase and ArtifactEnvelope bundle
+  -> comp scenario run
+```
+
+`comp` runs only the trust path. It does not parse raw CSV, email, OCR, LLM, UI,
+or supplier workflow inputs.
+
+## Manifest
+
+The first public bridge accepts only `input_mode: canonical_bundle`.
+
+```json
+{
+  "id": "fixture_public_projection",
+  "input_mode": "canonical_bundle",
+  "runtime_case": {
+    "path": "prepared/runtime_case.json"
+  },
+  "artifact_envelopes": {
+    "path": "prepared/artifact_envelopes.jsonl"
+  },
+  "expected": {
+    "invariants": [
+      "receipt_exists",
+      "replay_succeeds",
+      "all_public_rows_have_receipts",
+      "projection_values_are_committed",
+      "blocking_hazards_absent"
+    ]
+  },
+  "report": {
+    "format": "json",
+    "path": "reports/latest.json"
+  }
+}
+```
+
+## Writing A Bundle
+
+External packs should use the public writer helpers instead of importing test
+helpers or persistence backend encoders directly.
+
+```python
+from comp.scenario_contracts import (
+    RuntimeCase,
+    RuntimeProjection,
+    write_artifact_envelopes,
+    write_runtime_case,
+)
+
+runtime_case = RuntimeCase(
+    case_id="fixture-case",
+    receipts=(receipt,),
+    projections=(
+        RuntimeProjection(
+            public_row_id="public-row-1",
+            projection_id="public-row",
+            draft_id="draft-1",
+            output_fields=("site", "amount"),
+            row={"site": "plant-a", "amount": 100},
+        ),
+    ),
+)
+
+write_runtime_case(runtime_case, "prepared/runtime_case.json")
+write_artifact_envelopes(artifact_envelopes, "prepared/artifact_envelopes.jsonl")
+```
+
+## Running The Bundle
+
+```bash
+comp scenario validate scenario.json
+comp scenario run scenario.json --report reports/latest.json
+```
+
+The resulting report is operational evidence for the scenario run. The report is
+not authority; receipts and replay remain the authority path.

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -119,6 +119,27 @@ nightly downstream runs
 release-candidate downstream runs
 ```
 
+## Prepared Bundle Contract
+
+Downstream packs should prepare trust inputs before invoking `comp`:
+
+```text
+raw domain/product data
+  -> downstream pre-trust adapter
+  -> RuntimeCase JSON + ArtifactEnvelope JSONL
+  -> comp scenario run
+```
+
+Use the public scenario contract helpers:
+
+```python
+from comp.scenario_contracts import write_artifact_envelopes, write_runtime_case
+```
+
+Do not import `tests.*` or backend-specific JSON codecs from a downstream pack.
+See `docs/examples/scenario_contracts/README.md` for the minimal prepared bundle
+shape.
+
 ## Review Rule
 
 Before adding a large scenario to `comp`, ask:

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,13 @@ block PRs by themselves.
 2. `architecture/legacy-archive-cutover-plan.md`
 3. `architecture/llm-orchestrated-compiler-tool-loop.md`
 
+## Examples
+
+Examples are runnable or copyable guides for public surfaces. They are not
+authority contracts unless an active contract explicitly references them.
+
+1. `examples/scenario_contracts/README.md`
+
 ## Compiler Tool Layers
 
 Use this layer map when adding code or reviewing PRs:

--- a/tests/test_scenario_contracts.py
+++ b/tests/test_scenario_contracts.py
@@ -1,9 +1,10 @@
 import json
+from pathlib import Path
 
 import pytest
 
-from comp.persistence.codec import encode_persistence_json
-from comp.persistence.mysql import commit_receipt_to_body
+from comp.scenario_contracts import RuntimeCase, RuntimeProjection
+from comp.scenario_contracts import write_artifact_envelopes, write_runtime_case
 from tests.support.persistence_cases import artifact_store_for_receipt
 from tests.support.persistence_cases import receipt_projection_case
 
@@ -59,6 +60,99 @@ def test_run_scenario_writes_json_report(tmp_path):
     }
 
 
+def test_writer_helpers_round_trip_prepared_bundle(tmp_path):
+    from comp.scenario_contracts import run_scenario
+
+    case = receipt_projection_case(amount=125, site="plant-b")
+    store = artifact_store_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+    prepared = tmp_path / "prepared"
+    prepared.mkdir()
+    runtime_case_path = prepared / "runtime_case.json"
+    artifact_path = prepared / "artifact_envelopes.jsonl"
+
+    write_runtime_case(
+        RuntimeCase(
+            case_id="writer-round-trip",
+            receipts=(case.receipt,),
+            projections=(
+                RuntimeProjection(
+                    public_row_id="public-row-1",
+                    projection_id="public-row",
+                    draft_id="draft-1",
+                    output_fields=("site", "amount"),
+                    row=case.public_row,
+                ),
+            ),
+        ),
+        runtime_case_path,
+    )
+    write_artifact_envelopes(store.envelopes(), artifact_path)
+
+    manifest_path = _write_manifest(
+        tmp_path,
+        report_path=tmp_path / "reports" / "latest.json",
+    )
+    result = run_scenario(manifest_path)
+
+    runtime_payload = json.loads(runtime_case_path.read_text(encoding="utf-8"))
+    first_artifact = json.loads(
+        artifact_path.read_text(encoding="utf-8").splitlines()[0]
+    )
+
+    assert result.status == "passed"
+    assert runtime_payload["case_id"] == "writer-round-trip"
+    assert len(runtime_payload["receipts"]) == 1
+    assert runtime_payload["projections"][0]["output_fields"] == ["site", "amount"]
+    assert {
+        "artifact_id",
+        "artifact_kind",
+        "schema_version",
+        "body_digest",
+        "body",
+        "source_refs",
+        "meta",
+    } == set(first_artifact)
+
+
+def test_public_contract_exports_bundle_loaders_and_writers():
+    from comp.scenario_contracts import (
+        artifact_envelope_from_mapping,
+        artifact_envelope_to_mapping,
+        load_artifact_envelopes,
+        load_runtime_case,
+        runtime_case_from_mapping,
+        runtime_case_to_mapping,
+        runtime_projection_to_mapping,
+        write_artifact_envelopes,
+        write_runtime_case,
+    )
+
+    assert artifact_envelope_from_mapping is not None
+    assert artifact_envelope_to_mapping is not None
+    assert load_artifact_envelopes is not None
+    assert load_runtime_case is not None
+    assert runtime_case_from_mapping is not None
+    assert runtime_case_to_mapping is not None
+    assert runtime_projection_to_mapping is not None
+    assert write_artifact_envelopes is not None
+    assert write_runtime_case is not None
+
+
+def test_scenario_contract_examples_document_public_bundle_writer():
+    examples = Path("docs/examples/scenario_contracts/README.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "input_mode: canonical_bundle" in examples
+    assert "write_runtime_case" in examples
+    assert "write_artifact_envelopes" in examples
+    assert "comp scenario run" in examples
+    assert "pre-trust" in examples
+
+
 def test_run_scenario_rejects_pack_adapter_mode(tmp_path):
     from comp.scenario_contracts import ScenarioManifestError, run_scenario
 
@@ -100,7 +194,10 @@ def test_comp_scenario_cli_validates_and_runs_prepared_bundle(tmp_path, capsys):
     assert main(["scenario", "validate", str(manifest_path)]) == 0
     assert "fixture_public_projection" in capsys.readouterr().out
 
-    assert main(["scenario", "run", str(manifest_path), "--report", str(report_path)]) == 0
+    assert (
+        main(["scenario", "run", str(manifest_path), "--report", str(report_path)])
+        == 0
+    )
     output = capsys.readouterr().out
 
     assert "passed" in output
@@ -120,30 +217,23 @@ def _write_prepared_scenario(tmp_path, *, report_path=None, report_format="json"
     artifact_path = prepared / "artifact_envelopes.jsonl"
     manifest_path = tmp_path / "scenario.json"
 
-    runtime_case_path.write_text(
-        json.dumps(
-            {
-                "case_id": "fixture-case",
-                "receipts": [commit_receipt_to_body(case.receipt)],
-                "projections": [
-                    {
-                        "public_row_id": "public-row-1",
-                        "projection_id": "public-row",
-                        "draft_id": "draft-1",
-                        "output_fields": ["site", "amount"],
-                        "row": case.public_row,
-                    }
-                ],
-            },
-            sort_keys=True,
+    write_runtime_case(
+        RuntimeCase(
+            case_id="fixture-case",
+            receipts=(case.receipt,),
+            projections=(
+                RuntimeProjection(
+                    public_row_id="public-row-1",
+                    projection_id="public-row",
+                    draft_id="draft-1",
+                    output_fields=("site", "amount"),
+                    row=case.public_row,
+                ),
+            ),
         ),
-        encoding="utf-8",
+        runtime_case_path,
     )
-
-    artifact_path.write_text(
-        "\n".join(_artifact_payload(envelope) for envelope in store.envelopes()),
-        encoding="utf-8",
-    )
+    write_artifact_envelopes(store.envelopes(), artifact_path)
 
     manifest = {
         "id": "fixture_public_projection",
@@ -169,16 +259,27 @@ def _write_prepared_scenario(tmp_path, *, report_path=None, report_format="json"
     return manifest_path
 
 
-def _artifact_payload(envelope):
-    return json.dumps(
-        {
-            "artifact_id": envelope.artifact_id,
-            "artifact_kind": envelope.artifact_kind,
-            "schema_version": envelope.schema_version,
-            "body_digest": envelope.body_digest,
-            "body": encode_persistence_json(envelope.body),
-            "source_refs": encode_persistence_json(envelope.source_refs),
-            "meta": encode_persistence_json(envelope.meta),
+def _write_manifest(tmp_path, *, report_path=None):
+    manifest_path = tmp_path / "scenario.json"
+    manifest = {
+        "id": "fixture_public_projection",
+        "input_mode": "canonical_bundle",
+        "runtime_case": {"path": "prepared/runtime_case.json"},
+        "artifact_envelopes": {"path": "prepared/artifact_envelopes.jsonl"},
+        "expected": {
+            "invariants": [
+                "receipt_exists",
+                "replay_succeeds",
+                "all_public_rows_have_receipts",
+                "projection_values_are_committed",
+                "blocking_hazards_absent",
+            ]
         },
-        sort_keys=True,
-    )
+    }
+    if report_path is not None:
+        manifest["report"] = {
+            "format": "json",
+            "path": str(report_path),
+        }
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+    return manifest_path


### PR DESCRIPTION
## What changed

- Added public scenario bundle writer helpers:
  - `write_runtime_case`
  - `write_artifact_envelopes`
  - mapping helpers and matching loader exports from `comp.scenario_contracts`.
- Updated internal scenario contract tests so prepared bundles are written through the same public helpers external packs should use.
- Added `docs/examples/scenario_contracts/README.md` with the minimal `canonical_bundle` manifest shape, writer helper usage, and CLI run commands.
- Updated the scenario bridge and external scenario pack docs to point downstream packs at the prepared bundle contract instead of tests or backend codecs.

## Boundary

This follows #251. It does not add raw pack adapter execution, CSV/email/OCR/LLM parsing, benchmark runners, or product workflow ownership inside `comp`.

## Validation

- `python -m pytest tests/test_scenario_contracts.py tests/test_package_smoke.py -q` -> 29 passed
- `python -m pytest -q` -> 438 passed, 9 skipped