### PR TITLE
[codex] add friendly validation summary view

### DIFF
--- a/comp/views/__init__.py
+++ b/comp/views/__init__.py
@@ -1,1 +1,5 @@
 """Projection and explanation view helpers."""
+
+from comp.views.validation_summary import validation_summary_view
+
+__all__ = ["validation_summary_view"]

--- a/comp/views/validation_summary.py
+++ b/comp/views/validation_summary.py
@@ -1,0 +1,100 @@
+"""Render-only Korean validation summary helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from comp.compiler_tool import Hazard, ValidationReport, ValidationRequirement
+from comp.schema_labels import schema_label, schema_label_ko
+from comp.user_messages import (
+    UnknownUserMessage,
+    UserMessage,
+    user_message_for_reason,
+)
+
+_STATUS_KO = {
+    "accepted": "검증됨",
+    "blocked": "차단됨",
+    "review_required": "검토 필요",
+    "underconstrained": "정보 부족",
+    "unchecked": "미검증",
+}
+
+_FALLBACK_REQUIREMENT_MESSAGE = UserMessage(
+    key="additional_review_required",
+    ko="추가 확인이 필요한 항목입니다.",
+    action_ko="담당자가 근거자료와 기준을 확인해 주세요.",
+)
+
+
+def validation_summary_view(report: ValidationReport) -> dict[str, Any]:
+    """Build a display-only Korean summary for a validation report."""
+
+    return {
+        "label_ko": schema_label_ko("ValidationReport"),
+        "status": report.status,
+        "status_ko": _STATUS_KO.get(report.status, "상태 확인 필요"),
+        "authority_ko": schema_label("ValidationReport").authority_ko,
+        "can_make_public_output": report.can_project_public_row,
+        "public_output": _public_output_view(report),
+        "sections": [
+            _count_section("EvidenceRef", len(report.evidence_witnesses)),
+            _count_section("CanonicalReference", len(report.reference_bindings)),
+            _count_section("CalculatedClaim", len(report.derived_claims)),
+        ],
+        "open_requirements": [
+            _requirement_view(requirement)
+            for requirement in report.obligations
+        ],
+        "resolved_requirements": [
+            _requirement_view(requirement)
+            for requirement in report.resolved_obligations
+        ],
+        "review_items": [_review_item_view(hazard) for hazard in report.hazards],
+    }
+
+
+def _public_output_view(report: ValidationReport) -> dict[str, str]:
+    return {
+        "label_ko": schema_label_ko("PublicOutput"),
+        "state_ko": "공개 가능" if report.can_project_public_row else "공개 승인 전",
+        "authority_ko": schema_label("PublicOutput").authority_ko,
+    }
+
+
+def _count_section(schema_name: str, count: int) -> dict[str, int | str]:
+    return {
+        "label_ko": schema_label_ko(schema_name),
+        "count": count,
+    }
+
+
+def _requirement_view(requirement: ValidationRequirement) -> dict[str, Any]:
+    message = _message_for_requirement(requirement)
+    return {
+        "label_ko": schema_label_ko("ValidationRequirement"),
+        "requirement_id": requirement.obligation_id,
+        "field": requirement.field,
+        "blocking": requirement.blocking,
+        "message_ko": message.ko,
+        "action_ko": message.action_ko,
+    }
+
+
+def _message_for_requirement(requirement: ValidationRequirement) -> UserMessage:
+    try:
+        return user_message_for_reason(requirement.reason)
+    except UnknownUserMessage:
+        return _FALLBACK_REQUIREMENT_MESSAGE
+
+
+def _review_item_view(hazard: Hazard) -> dict[str, str]:
+    return {
+        "label_ko": "검토 필요 항목",
+        "field": hazard.field,
+        "message_ko": "검토가 필요한 항목입니다.",
+        "severity": hazard.severity,
+    }
+
+
+__all__ = ["validation_summary_view"]

--- a/tests/domain_scenarios/views.py
+++ b/tests/domain_scenarios/views.py
@@ -23,8 +23,11 @@ def scenario_result_view(result) -> dict[str, Any]:
 
 
 def report_view(report) -> dict[str, Any]:
+    from comp.views import validation_summary_view
+
     return {
         "status": report.status,
+        "friendly_summary": validation_summary_view(report),
         "open_obligations": [
             _obligation_view(obligation)
             for obligation in report.obligations

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -481,6 +481,43 @@ def test_scenario_result_view_exposes_receipt_trace_without_raw_values():
     assert all("value" not in commitment for commitment in commitments)
 
 
+def test_scenario_result_view_exposes_friendly_validation_summary():
+    result = run_tiny_pcf_scenario()
+
+    view = scenario_result_view(result)
+
+    friendly = view["report"]["friendly_summary"]
+    assert friendly["label_ko"] == "검증 결과"
+    assert friendly["status_ko"] == "검증됨"
+    assert friendly["open_requirements"] == []
+    assert friendly["public_output"]["label_ko"] == "공개 결과"
+    assert friendly["sections"] == [
+        {
+            "label_ko": "근거자료 위치",
+            "count": len(result.report.evidence_witnesses),
+        },
+        {
+            "label_ko": "확정 기준",
+            "count": len(result.report.reference_bindings),
+        },
+        {
+            "label_ko": "계산값",
+            "count": len(result.report.derived_claims),
+        },
+    ]
+
+    blocked_terms = (
+        "ClaimHypothesis",
+        "EvidenceWitness",
+        "ReferenceCandidate",
+        "ReferenceBinding",
+        "CommitReceipt",
+        "Projection",
+        "ProofObligation",
+    )
+    assert not any(term in str(friendly) for term in blocked_terms)
+
+
 def test_scenario_result_view_exposes_replay_trace_manifest_summary():
     result = run_canonical_working_loop_scenario()
 

--- a/tests/test_validation_summary_view.py
+++ b/tests/test_validation_summary_view.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+from comp.compiler_tool import Hazard, ValidationReport, ValidationRequirement
+
+
+def test_validation_summary_view_uses_korean_labels_and_messages():
+    from comp.views.validation_summary import validation_summary_view
+
+    report = ValidationReport(
+        status="blocked",
+        obligations=(
+            ValidationRequirement(
+                kind="find_source_witness",
+                field="co2e_kg",
+                reason="missing_source_witness",
+                obligation_id="obl-1",
+            ),
+        ),
+        resolved_obligations=(
+            ValidationRequirement(
+                kind="unit_check",
+                field="electricity_mwh",
+                reason="unsupported_unit",
+                obligation_id="obl-2",
+                blocking=False,
+            ),
+        ),
+        hazards=(Hazard(kind="conflict", field="scope2_method", severity="review"),),
+    )
+
+    view = validation_summary_view(report)
+
+    assert view["label_ko"] == "검증 결과"
+    assert view["status_ko"] == "차단됨"
+    assert view["public_output"] == {
+        "label_ko": "공개 결과",
+        "state_ko": "공개 승인 전",
+        "authority_ko": "증표로 검증된 보기, 자체 승인 권한 없음",
+    }
+    assert view["sections"] == [
+        {"label_ko": "근거자료 위치", "count": 0},
+        {"label_ko": "확정 기준", "count": 0},
+        {"label_ko": "계산값", "count": 0},
+    ]
+    assert view["open_requirements"] == [
+        {
+            "label_ko": "보완 필요 항목",
+            "requirement_id": "obl-1",
+            "field": "co2e_kg",
+            "blocking": True,
+            "message_ko": "근거자료가 연결되지 않아 이 값을 검증할 수 없습니다.",
+            "action_ko": "값이 나온 문서, 엑셀, 인증서 등의 위치를 연결해 주세요.",
+        }
+    ]
+    assert view["resolved_requirements"] == [
+        {
+            "label_ko": "보완 필요 항목",
+            "requirement_id": "obl-2",
+            "field": "electricity_mwh",
+            "blocking": False,
+            "message_ko": "지원하지 않는 단위입니다. 단위를 확인해 주세요.",
+            "action_ko": (
+                "지원되는 단위로 변환하거나 단위 변환 근거를 추가해 주세요."
+            ),
+        }
+    ]
+    assert view["review_items"] == [
+        {
+            "label_ko": "검토 필요 항목",
+            "field": "scope2_method",
+            "message_ko": "검토가 필요한 항목입니다.",
+            "severity": "review",
+        }
+    ]
+
+
+def test_validation_summary_view_falls_back_without_leaking_kernel_terms():
+    from comp.views.validation_summary import validation_summary_view
+
+    report = ValidationReport(
+        status="review_required",
+        obligations=(
+            ValidationRequirement(
+                kind="reference_search_required",
+                field="co2e_kg",
+                reason="unknown_reference",
+                obligation_id="obl-reference",
+            ),
+        ),
+    )
+
+    view = validation_summary_view(report)
+
+    assert view["open_requirements"][0]["message_ko"] == (
+        "추가 확인이 필요한 항목입니다."
+    )
+    blocked_terms = (
+        "ClaimHypothesis",
+        "EvidenceWitness",
+        "ReferenceCandidate",
+        "ReferenceBinding",
+        "CommitReceipt",
+        "Projection",
+        "PublicOutputReceipt",
+        "ProofObligation",
+    )
+    assert not any(term in str(view) for term in blocked_terms)
+
+
+def test_validation_summary_view_is_presentation_not_authority_state():
+    import comp.views.validation_summary as validation_summary
+    from comp.views import validation_summary_view
+
+    assert validation_summary_view is validation_summary.validation_summary_view
+
+    source = Path("comp/views/validation_summary.py").read_text(encoding="utf-8")
+    assert "comp.schema_labels" in source
+    assert "comp.user_messages" in source
+
+    authority_paths = (
+        Path("comp/judgment/commit.py"),
+        Path("comp/compiler_tool/receipt_builder.py"),
+        Path("comp/persistence/ledger.py"),
+        Path("comp/persistence/replay.py"),
+    )
+    for path in authority_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "validation_summary" not in text
+        assert "schema_labels" not in text
+        assert "user_messages" not in text


### PR DESCRIPTION
## Summary
- Add a render-only `comp.views.validation_summary_view()` for Korean validation summaries.
- Reuse `comp.schema_labels` and `comp.user_messages` without moving display metadata into authority modules.
- Expose the friendly summary in the domain scenario report viewer payload.

## Tests
- `python -m pytest -q`