### PR TITLE
[codex] Add scenario init smoke bundle

### DIFF
--- a/comp/cli/scenario.py
+++ b/comp/cli/scenario.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Sequence
 
 from comp.scenario_contracts import load_manifest, run_scenario
+from comp.scenario_contracts import write_public_projection_smoke_bundle
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -21,6 +22,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         result = run_scenario(args.manifest, report_path=args.report)
         print(f"{result.scenario_id}: {result.status}")
         return 0 if result.status == "passed" else 1
+    if args.scenario_command == "init":
+        manifest_path = write_public_projection_smoke_bundle(args.target)
+        print(f"created {manifest_path}")
+        return 0
     parser.print_help(sys.stderr)
     return 2
 
@@ -44,6 +49,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     run.add_argument("manifest")
     run.add_argument("--report")
+    init = scenario_subparsers.add_parser(
+        "init",
+        help="Create a runnable public-projection smoke scenario bundle.",
+    )
+    init.add_argument("target")
     return parser
 
 

--- a/comp/scenario_contracts/__init__.py
+++ b/comp/scenario_contracts/__init__.py
@@ -15,6 +15,7 @@ from comp.scenario_contracts.artifacts import (
     load_artifact_envelopes,
     write_artifact_envelopes,
 )
+from comp.scenario_contracts.examples import write_public_projection_smoke_bundle
 from comp.scenario_contracts.manifest import (
     ScenarioManifest,
     ScenarioManifestError,
@@ -41,6 +42,7 @@ __all__ = [
     "runtime_case_to_mapping",
     "runtime_projection_to_mapping",
     "write_artifact_envelopes",
+    "write_public_projection_smoke_bundle",
     "write_report",
     "write_runtime_case",
 ]

--- a/comp/scenario_contracts/examples.py
+++ b/comp/scenario_contracts/examples.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from comp.judgment import (
+    CommitReceipt,
+    CommitReceiptCitations,
+    ProjectionValueCommitment,
+)
+from comp.persistence import ArtifactEnvelope
+from comp.scenario_contracts.artifacts import write_artifact_envelopes
+from comp.scenario_contracts.case import (
+    RuntimeCase,
+    RuntimeProjection,
+    write_runtime_case,
+)
+
+
+def write_public_projection_smoke_bundle(path: str | Path) -> Path:
+    target = Path(path)
+    prepared = target / "prepared"
+    prepared.mkdir(parents=True, exist_ok=True)
+
+    public_row = {"site": "plant-a", "amount": 100}
+    commitments = (
+        ProjectionValueCommitment.from_value(
+            field="site",
+            source_kind="checked_claim",
+            source_id="checked_claim:site:smoke",
+            value=public_row["site"],
+        ),
+        ProjectionValueCommitment.from_value(
+            field="amount",
+            source_kind="checked_claim",
+            source_id="checked_claim:amount:smoke",
+            value=public_row["amount"],
+        ),
+    )
+    citations = CommitReceiptCitations(
+        governance_decision_id="governance_decision:smoke",
+        governance_status="commit",
+        governance_reasons=("ready",),
+        commit_package_id="commit_package:smoke",
+        commit_package_complete=True,
+        subject_id="facility:smoke",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        profile_id=None,
+        report_status="accepted",
+        checked_claim_fields=("site", "amount"),
+        checked_claim_witness_ids=(),
+        semantic_judgment_ids=(),
+        reference_binding_ids=(),
+        derived_claim_fields=(),
+        derived_claim_ids=(),
+        calculation_trace_ids=(),
+        formula_ids=(),
+        resolved_obligation_ids=(),
+        open_obligation_ids=(),
+        hazard_ids=(),
+        projection_value_commitments=commitments,
+        dependency_fingerprints=(),
+    )
+    receipt = CommitReceipt(
+        draft_id="draft:smoke",
+        winner_receipt_ids=("governance_decision:smoke",),
+        barrier_snapshot=citations.to_barrier_snapshot(),
+        public_row_id="public-row:smoke",
+        projection_id="public-row",
+        authorized_fields=("site", "amount"),
+        citations=citations,
+    )
+    write_runtime_case(
+        RuntimeCase(
+            case_id="public_projection_smoke",
+            receipts=(receipt,),
+            projections=(
+                RuntimeProjection(
+                    public_row_id="public-row:smoke",
+                    projection_id="public-row",
+                    draft_id="draft:smoke",
+                    output_fields=("site", "amount"),
+                    row=public_row,
+                ),
+            ),
+        ),
+        prepared / "runtime_case.json",
+    )
+    write_artifact_envelopes(
+        (
+            ArtifactEnvelope.from_body(
+                artifact_id="commit_package:smoke",
+                artifact_kind="commit_package",
+                schema_version="v1",
+                body={"package_id": "commit_package:smoke", "complete": True},
+            ),
+            ArtifactEnvelope.from_body(
+                artifact_id="governance_decision:smoke",
+                artifact_kind="governance_decision",
+                schema_version="v1",
+                body={"decision_id": "governance_decision:smoke", "status": "commit"},
+            ),
+            ArtifactEnvelope.from_body(
+                artifact_id="checked_claim:site:smoke",
+                artifact_kind="checked_claim",
+                schema_version="v1",
+                body={
+                    "claim_id": "checked_claim:site:smoke",
+                    "field": "site",
+                    "value": public_row["site"],
+                },
+            ),
+            ArtifactEnvelope.from_body(
+                artifact_id="checked_claim:amount:smoke",
+                artifact_kind="checked_claim",
+                schema_version="v1",
+                body={
+                    "claim_id": "checked_claim:amount:smoke",
+                    "field": "amount",
+                    "value": public_row["amount"],
+                },
+            ),
+        ),
+        prepared / "artifact_envelopes.jsonl",
+    )
+    manifest_path = target / "scenario.json"
+    manifest_path.write_text(
+        json.dumps(_manifest(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "id": "public_projection_smoke",
+        "input_mode": "canonical_bundle",
+        "runtime_case": {"path": "prepared/runtime_case.json"},
+        "artifact_envelopes": {"path": "prepared/artifact_envelopes.jsonl"},
+        "expected": {
+            "invariants": [
+                "receipt_exists",
+                "replay_succeeds",
+                "all_public_rows_have_receipts",
+                "projection_values_are_committed",
+                "blocking_hazards_absent",
+            ]
+        },
+        "report": {
+            "format": "json",
+            "path": "reports/latest.json",
+        },
+    }
+
+
+__all__ = ["write_public_projection_smoke_bundle"]

--- a/docs/architecture/scenario-trust-runtime-bridge.md
+++ b/docs/architecture/scenario-trust-runtime-bridge.md
@@ -394,6 +394,10 @@ comp.runtime.TrustRuntime
 comp scenario validate
 comp scenario run
   expose the prepared-bundle trust path through a public CLI.
+
+comp scenario init
+  writes a neutral public_projection_smoke bundle that external pack authors can
+  run before replacing the prepared files with pack-produced trust inputs.
 ```
 
 Current limits:

--- a/docs/examples/scenario_contracts/README.md
+++ b/docs/examples/scenario_contracts/README.md
@@ -78,6 +78,24 @@ write_artifact_envelopes(artifact_envelopes, "prepared/artifact_envelopes.jsonl"
 
 ## Running The Bundle
 
+To create a neutral runnable smoke bundle:
+
+```bash
+comp scenario init public_projection_smoke
+comp scenario run public_projection_smoke/scenario.json
+```
+
+That command writes:
+
+```text
+public_projection_smoke/
+  scenario.json
+  prepared/runtime_case.json
+  prepared/artifact_envelopes.jsonl
+```
+
+To run a bundle prepared by an external pack:
+
 ```bash
 comp scenario validate scenario.json
 comp scenario run scenario.json --report reports/latest.json

--- a/tests/test_scenario_contracts.py
+++ b/tests/test_scenario_contracts.py
@@ -127,6 +127,7 @@ def test_public_contract_exports_bundle_loaders_and_writers():
         runtime_case_to_mapping,
         runtime_projection_to_mapping,
         write_artifact_envelopes,
+        write_public_projection_smoke_bundle,
         write_runtime_case,
     )
 
@@ -138,6 +139,7 @@ def test_public_contract_exports_bundle_loaders_and_writers():
     assert runtime_case_to_mapping is not None
     assert runtime_projection_to_mapping is not None
     assert write_artifact_envelopes is not None
+    assert write_public_projection_smoke_bundle is not None
     assert write_runtime_case is not None
 
 
@@ -149,6 +151,7 @@ def test_scenario_contract_examples_document_public_bundle_writer():
     assert "input_mode: canonical_bundle" in examples
     assert "write_runtime_case" in examples
     assert "write_artifact_envelopes" in examples
+    assert "comp scenario init" in examples
     assert "comp scenario run" in examples
     assert "pre-trust" in examples
 
@@ -183,6 +186,40 @@ def test_run_scenario_rejects_unsupported_report_format(tmp_path):
 
     with pytest.raises(ScenarioManifestError, match="report.format"):
         run_scenario(manifest_path)
+
+
+def test_comp_scenario_cli_initializes_runnable_smoke_bundle(tmp_path, capsys):
+    from comp.cli.scenario import main
+
+    target = tmp_path / "public_projection_smoke"
+    report_path = target / "reports" / "latest.json"
+
+    assert main(["scenario", "init", str(target)]) == 0
+    init_output = capsys.readouterr().out
+
+    assert "scenario.json" in init_output
+    assert (target / "scenario.json").exists()
+    assert (target / "prepared" / "runtime_case.json").exists()
+    assert (target / "prepared" / "artifact_envelopes.jsonl").exists()
+
+    assert (
+        main(
+            [
+                "scenario",
+                "run",
+                str(target / "scenario.json"),
+                "--report",
+                str(report_path),
+            ]
+        )
+        == 0
+    )
+    run_output = capsys.readouterr().out
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+
+    assert "passed" in run_output
+    assert report["scenario_id"] == "public_projection_smoke"
+    assert report["status"] == "passed"
 
 
 def test_comp_scenario_cli_validates_and_runs_prepared_bundle(tmp_path, capsys):


### PR DESCRIPTION
## What changed

- Added `comp scenario init <target>` to write a neutral `public_projection_smoke` scenario bundle.
- Added `comp.scenario_contracts.write_public_projection_smoke_bundle` as the public helper behind the CLI.
- The generated bundle includes `scenario.json`, `prepared/runtime_case.json`, and `prepared/artifact_envelopes.jsonl`, and can be run immediately with `comp scenario run`.
- Updated the scenario contract example doc and bridge status text to include the init flow.

## Boundary

This remains a prepared canonical bundle flow. It does not run raw pack adapters, parse CSV/email/OCR/LLM inputs, or add product workflow ownership to `comp`.

## Validation

- `python -m pytest tests/test_scenario_contracts.py -q` -> 9 passed
- `python -m pytest tests/test_scenario_contracts.py tests/test_package_smoke.py -q` -> 30 passed
- `python -m pytest -q` -> 439 passed, 9 skipped