### PR TITLE
[codex] Add downstream scenario pack skeleton

### DIFF
--- a/docs/examples/scenario_pack_repo/.github/workflows/scenario-contracts.yml
+++ b/docs/examples/scenario_pack_repo/.github/workflows/scenario-contracts.yml
@@ -1,0 +1,18 @@
+name: scenario-contracts
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  public-scenario-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install -U pip
+      - run: python -m pip install -e .
+      - run: comp scenario init packs/public_projection_smoke
+      - run: comp scenario run packs/public_projection_smoke/scenario.json

--- a/docs/examples/scenario_pack_repo/README.md
+++ b/docs/examples/scenario_pack_repo/README.md
@@ -1,0 +1,69 @@
+# comp-scenario-packs Skeleton
+
+This is a copyable downstream repository shape for scenario packs that consume
+`comp` through the public scenario bridge.
+
+The downstream repo owns raw data, adapters, larger domain fixtures, benchmarks,
+and CI reports. `comp` owns the trust runtime and the receipt/replay contract.
+
+## Minimal Layout
+
+```text
+comp-scenario-packs/
+  pyproject.toml
+  README.md
+  .github/workflows/scenario-contracts.yml
+  packs/
+    public_projection_smoke/
+      scenario.json
+      prepared/runtime_case.json
+      prepared/artifact_envelopes.jsonl
+      reports/latest.json
+```
+
+Create the first smoke pack with:
+
+```bash
+comp scenario init packs/public_projection_smoke
+comp scenario run packs/public_projection_smoke/scenario.json
+```
+
+After that, replace the prepared files with pack-produced trust inputs. Keep the
+same public contract:
+
+```text
+raw domain/product input
+  -> downstream pre-trust adapter
+  -> prepared RuntimeCase + ArtifactEnvelope bundle
+  -> comp scenario run
+```
+
+## Rules
+
+Do not import `tests.*`.
+Do not import private `comp` modules.
+Do not make raw CSV, email, OCR, LLM, or product workflow execution part of
+`comp`.
+
+Allowed public surfaces:
+
+```text
+comp.scenario_contracts
+comp.runtime
+comp.persistence public interfaces
+comp.compiler_tool public interfaces
+comp.judgment public interfaces
+```
+
+## CI Command
+
+The minimal CI check should install the downstream pack and run the public
+scenario CLI:
+
+```bash
+python -m pip install -e .
+comp scenario run packs/public_projection_smoke/scenario.json
+```
+
+The report is compatibility evidence for the pack. It is not authority;
+receipts and replay remain the authority path.

--- a/docs/examples/scenario_pack_repo/pyproject.toml
+++ b/docs/examples/scenario_pack_repo/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "comp-scenario-packs"
+version = "0.0.0"
+description = "Downstream scenario packs for comp compatibility and operations rehearsals"
+requires-python = ">=3.11"
+dependencies = [
+  "comp @ git+https://github.com/minntcho/comp@main",
+]

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -140,6 +140,9 @@ Do not import `tests.*` or backend-specific JSON codecs from a downstream pack.
 See `docs/examples/scenario_contracts/README.md` for the minimal prepared bundle
 shape.
 
+See `docs/examples/scenario_pack_repo/README.md` for a copyable downstream repo
+skeleton with `pyproject.toml` and a GitHub Actions scenario-contract workflow.
+
 ## Review Rule
 
 Before adding a large scenario to `comp`, ask:

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,7 @@ Examples are runnable or copyable guides for public surfaces. They are not
 authority contracts unless an active contract explicitly references them.
 
 1. `examples/scenario_contracts/README.md`
+2. `examples/scenario_pack_repo/README.md`
 
 ## Compiler Tool Layers
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -509,6 +509,31 @@ def test_docs_index_groups_architecture_docs_by_governance_authority():
     assert "architecture/production-trust-spine-database.md" in docs_index
     assert "architecture/scenario-trust-runtime-bridge.md" in docs_index
     assert "docs/archive/plans/" in docs_index
+    assert "examples/scenario_pack_repo/README.md" in docs_index
+
+
+def test_downstream_scenario_pack_skeleton_documents_ci_contract():
+    readme = Path("docs/examples/scenario_pack_repo/README.md").read_text(
+        encoding="utf-8"
+    )
+    pyproject = Path("docs/examples/scenario_pack_repo/pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    workflow = Path(
+        "docs/examples/scenario_pack_repo/.github/workflows/scenario-contracts.yml"
+    ).read_text(encoding="utf-8")
+    extensions = Path("docs/extensions/scenario-packs.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "comp-scenario-packs" in readme
+    assert "comp scenario init packs/public_projection_smoke" in readme
+    assert "comp scenario run packs/public_projection_smoke/scenario.json" in readme
+    assert "Do not import `tests.*`" in readme
+    assert "comp @ git+https://github.com/minntcho/comp@main" in pyproject
+    assert "python -m pip install -e ." in workflow
+    assert "comp scenario run packs/public_projection_smoke/scenario.json" in workflow
+    assert "examples/scenario_pack_repo/README.md" in extensions
 
 
 def test_scenario_trust_runtime_bridge_keeps_public_runner_narrow():


### PR DESCRIPTION
## What changed

- Added `docs/examples/scenario_pack_repo/` as a copyable downstream `comp-scenario-packs` skeleton.
- Included a minimal downstream `pyproject.toml` that consumes `comp` from the public Git ref.
- Included a GitHub Actions workflow that installs the downstream pack, bootstraps a `public_projection_smoke` bundle, and runs `comp scenario run` through the public CLI.
- Linked the skeleton from `docs/index.md` and `docs/extensions/scenario-packs.md`.

## Boundary

This does not create or require an external repo. It documents the downstream shape while keeping raw adapters, large domain fixtures, benchmarks, and product workflows outside `comp`.

## Validation

- `python -m pytest tests/test_package_smoke.py -q` -> 24 passed
- `python -m pytest -q` -> 446 passed, 9 skipped