### PR TITLE
[codex] Move receipt body codec out of MySQL

### DIFF
--- a/comp/explanation/receipt_graph_cli.py
+++ b/comp/explanation/receipt_graph_cli.py
@@ -16,8 +16,7 @@ from comp.persistence import (
     ProjectionReplayReport,
     ReceiptLedgerKey,
 )
-from comp.persistence.codec import decode_persistence_json
-from comp.persistence.mysql import commit_receipt_from_body
+from comp.persistence.codec import commit_receipt_from_body, decode_persistence_json
 from comp.views.receipt_graph import render_graphviz_dot, render_mermaid
 
 

--- a/comp/persistence/codec.py
+++ b/comp/persistence/codec.py
@@ -5,6 +5,13 @@ from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from typing import Any
 
+from comp.judgment.receipts import (
+    DependencyFingerprint,
+    PublicOutputValueCommitment,
+    PublicOutputReceipt,
+    PublicOutputReceiptCitations,
+)
+
 
 _TYPE_KEY = "__comp_type__"
 _VALUE_KEY = "value"
@@ -77,6 +84,183 @@ def decode_persistence_json(value: Any) -> Any:
     raise TypeError(f"Unsupported persistence JSON type: {kind}")
 
 
+def commit_receipt_to_body(receipt: PublicOutputReceipt) -> dict[str, Any]:
+    citations = None
+    if receipt.citations is not None:
+        citations = {
+            "governance_decision_id": receipt.citations.governance_decision_id,
+            "governance_status": receipt.citations.governance_status,
+            "governance_reasons": receipt.citations.governance_reasons,
+            "commit_package_id": receipt.citations.commit_package_id,
+            "commit_package_complete": receipt.citations.commit_package_complete,
+            "subject_id": receipt.citations.subject_id,
+            "projection_id": receipt.citations.projection_id,
+            "authorized_fields": receipt.citations.authorized_fields,
+            "profile_id": receipt.citations.profile_id,
+            "report_status": receipt.citations.report_status,
+            "checked_claim_fields": receipt.citations.checked_claim_fields,
+            "checked_claim_witness_ids": receipt.citations.checked_claim_witness_ids,
+            "semantic_judgment_ids": receipt.citations.semantic_judgment_ids,
+            "reference_binding_ids": receipt.citations.reference_binding_ids,
+            "derived_claim_fields": receipt.citations.derived_claim_fields,
+            "derived_claim_ids": receipt.citations.derived_claim_ids,
+            "calculation_trace_ids": receipt.citations.calculation_trace_ids,
+            "formula_ids": receipt.citations.formula_ids,
+            "resolved_obligation_ids": receipt.citations.resolved_obligation_ids,
+            "open_obligation_ids": receipt.citations.open_obligation_ids,
+            "hazard_ids": receipt.citations.hazard_ids,
+            "projection_value_commitments": tuple(
+                _projection_value_commitment_to_body(item)
+                for item in receipt.citations.projection_value_commitments
+            ),
+            "dependency_fingerprints": tuple(
+                _dependency_fingerprint_to_body(item)
+                for item in receipt.citations.dependency_fingerprints
+            ),
+        }
+    return {
+        "draft_id": receipt.draft_id,
+        "winner_receipt_ids": receipt.winner_receipt_ids,
+        "barrier_snapshot": _receipt_value_to_body(receipt.barrier_snapshot),
+        "public_row_id": receipt.public_row_id,
+        "projection_id": receipt.projection_id,
+        "authorized_fields": receipt.authorized_fields,
+        "citations": citations,
+    }
+
+
+def commit_receipt_from_body(body: Mapping[str, Any]) -> PublicOutputReceipt:
+    citations_body = body["citations"]
+    citations = None
+    if citations_body is not None:
+        citations = PublicOutputReceiptCitations(
+            governance_decision_id=citations_body["governance_decision_id"],
+            governance_status=citations_body["governance_status"],
+            governance_reasons=tuple(citations_body["governance_reasons"]),
+            commit_package_id=citations_body["commit_package_id"],
+            commit_package_complete=citations_body["commit_package_complete"],
+            subject_id=citations_body["subject_id"],
+            projection_id=citations_body["projection_id"],
+            authorized_fields=tuple(citations_body["authorized_fields"]),
+            profile_id=citations_body["profile_id"],
+            report_status=citations_body["report_status"],
+            checked_claim_fields=tuple(citations_body["checked_claim_fields"]),
+            checked_claim_witness_ids=tuple(
+                citations_body["checked_claim_witness_ids"]
+            ),
+            semantic_judgment_ids=tuple(citations_body["semantic_judgment_ids"]),
+            reference_binding_ids=tuple(citations_body["reference_binding_ids"]),
+            derived_claim_fields=tuple(citations_body["derived_claim_fields"]),
+            derived_claim_ids=tuple(citations_body["derived_claim_ids"]),
+            calculation_trace_ids=tuple(citations_body["calculation_trace_ids"]),
+            formula_ids=tuple(citations_body["formula_ids"]),
+            resolved_obligation_ids=tuple(citations_body["resolved_obligation_ids"]),
+            open_obligation_ids=tuple(citations_body["open_obligation_ids"]),
+            hazard_ids=tuple(citations_body["hazard_ids"]),
+            projection_value_commitments=tuple(
+                _projection_value_commitment_from_body(item)
+                for item in citations_body["projection_value_commitments"]
+            ),
+            dependency_fingerprints=tuple(
+                _dependency_fingerprint_from_body(item)
+                for item in citations_body["dependency_fingerprints"]
+            ),
+        )
+    return PublicOutputReceipt(
+        draft_id=body["draft_id"],
+        winner_receipt_ids=tuple(body["winner_receipt_ids"]),
+        barrier_snapshot=_receipt_value_from_body(body["barrier_snapshot"]),
+        public_row_id=body["public_row_id"],
+        projection_id=body["projection_id"],
+        authorized_fields=tuple(body["authorized_fields"]),
+        citations=citations,
+    )
+
+
+def _projection_value_commitment_to_body(
+    commitment: PublicOutputValueCommitment,
+) -> dict[str, Any]:
+    return {
+        "field": commitment.field,
+        "source_kind": commitment.source_kind,
+        "source_id": commitment.source_id,
+        "value_digest": commitment.value_digest,
+        "digest_alg": commitment.digest_alg,
+    }
+
+
+def _projection_value_commitment_from_body(
+    body: Mapping[str, Any],
+) -> PublicOutputValueCommitment:
+    return PublicOutputValueCommitment(
+        field=body["field"],
+        source_kind=body["source_kind"],
+        source_id=body["source_id"],
+        value_digest=body["value_digest"],
+        digest_alg=body["digest_alg"],
+    )
+
+
+def _dependency_fingerprint_to_body(
+    fingerprint: DependencyFingerprint,
+) -> dict[str, Any]:
+    return {
+        "dependency_kind": fingerprint.dependency_kind,
+        "dependency_id": fingerprint.dependency_id,
+        "fingerprint": fingerprint.fingerprint,
+        "digest_alg": fingerprint.digest_alg,
+    }
+
+
+def _dependency_fingerprint_from_body(
+    body: Mapping[str, Any],
+) -> DependencyFingerprint:
+    return DependencyFingerprint(
+        dependency_kind=body["dependency_kind"],
+        dependency_id=body["dependency_id"],
+        fingerprint=body["fingerprint"],
+        digest_alg=body["digest_alg"],
+    )
+
+
+def _receipt_value_to_body(value: Any) -> Any:
+    if isinstance(value, PublicOutputValueCommitment):
+        return {
+            "__receipt_type__": "projection_value_commitment",
+            "value": _projection_value_commitment_to_body(value),
+        }
+    if isinstance(value, DependencyFingerprint):
+        return {
+            "__receipt_type__": "dependency_fingerprint",
+            "value": _dependency_fingerprint_to_body(value),
+        }
+    if isinstance(value, Mapping):
+        return {
+            str(key): _receipt_value_to_body(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, tuple):
+        return tuple(_receipt_value_to_body(item) for item in value)
+    if isinstance(value, list):
+        return [_receipt_value_to_body(item) for item in value]
+    return value
+
+
+def _receipt_value_from_body(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        receipt_type = value.get("__receipt_type__")
+        if receipt_type == "projection_value_commitment":
+            return _projection_value_commitment_from_body(value["value"])
+        if receipt_type == "dependency_fingerprint":
+            return _dependency_fingerprint_from_body(value["value"])
+        return {key: _receipt_value_from_body(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_receipt_value_from_body(item) for item in value)
+    if isinstance(value, list):
+        return [_receipt_value_from_body(item) for item in value]
+    return value
+
+
 def _string_key_items(value: Mapping[Any, Any]) -> tuple[tuple[str, Any], ...]:
     items: list[tuple[str, Any]] = []
     for key, item in value.items():
@@ -86,4 +270,9 @@ def _string_key_items(value: Mapping[Any, Any]) -> tuple[tuple[str, Any], ...]:
     return tuple(items)
 
 
-__all__ = ["decode_persistence_json", "encode_persistence_json"]
+__all__ = [
+    "commit_receipt_from_body",
+    "commit_receipt_to_body",
+    "decode_persistence_json",
+    "encode_persistence_json",
+]

--- a/comp/persistence/mysql.py
+++ b/comp/persistence/mysql.py
@@ -2,16 +2,15 @@ from __future__ import annotations
 
 import json
 import hashlib
-from collections.abc import Mapping
 from typing import Any
 
-from comp.judgment.receipts import (
-    DependencyFingerprint,
-    PublicOutputValueCommitment,
-    PublicOutputReceipt,
-    PublicOutputReceiptCitations,
+from comp.judgment.receipts import PublicOutputReceipt
+from comp.persistence.codec import (
+    commit_receipt_from_body,
+    commit_receipt_to_body,
+    decode_persistence_json,
+    encode_persistence_json,
 )
-from comp.persistence.codec import decode_persistence_json, encode_persistence_json
 from comp.persistence.envelope import ArtifactEnvelope
 from comp.persistence.ledger import (
     ArtifactConflict,
@@ -256,99 +255,6 @@ def receipt_id(receipt: PublicOutputReceipt) -> str:
     return f"receipt:sha256:{digest}"
 
 
-def commit_receipt_to_body(receipt: PublicOutputReceipt) -> dict[str, Any]:
-    citations = None
-    if receipt.citations is not None:
-        citations = {
-            "governance_decision_id": receipt.citations.governance_decision_id,
-            "governance_status": receipt.citations.governance_status,
-            "governance_reasons": receipt.citations.governance_reasons,
-            "commit_package_id": receipt.citations.commit_package_id,
-            "commit_package_complete": receipt.citations.commit_package_complete,
-            "subject_id": receipt.citations.subject_id,
-            "projection_id": receipt.citations.projection_id,
-            "authorized_fields": receipt.citations.authorized_fields,
-            "profile_id": receipt.citations.profile_id,
-            "report_status": receipt.citations.report_status,
-            "checked_claim_fields": receipt.citations.checked_claim_fields,
-            "checked_claim_witness_ids": receipt.citations.checked_claim_witness_ids,
-            "semantic_judgment_ids": receipt.citations.semantic_judgment_ids,
-            "reference_binding_ids": receipt.citations.reference_binding_ids,
-            "derived_claim_fields": receipt.citations.derived_claim_fields,
-            "derived_claim_ids": receipt.citations.derived_claim_ids,
-            "calculation_trace_ids": receipt.citations.calculation_trace_ids,
-            "formula_ids": receipt.citations.formula_ids,
-            "resolved_obligation_ids": receipt.citations.resolved_obligation_ids,
-            "open_obligation_ids": receipt.citations.open_obligation_ids,
-            "hazard_ids": receipt.citations.hazard_ids,
-            "projection_value_commitments": tuple(
-                _projection_value_commitment_to_body(item)
-                for item in receipt.citations.projection_value_commitments
-            ),
-            "dependency_fingerprints": tuple(
-                _dependency_fingerprint_to_body(item)
-                for item in receipt.citations.dependency_fingerprints
-            ),
-        }
-    return {
-        "draft_id": receipt.draft_id,
-        "winner_receipt_ids": receipt.winner_receipt_ids,
-        "barrier_snapshot": _receipt_value_to_body(receipt.barrier_snapshot),
-        "public_row_id": receipt.public_row_id,
-        "projection_id": receipt.projection_id,
-        "authorized_fields": receipt.authorized_fields,
-        "citations": citations,
-    }
-
-
-def commit_receipt_from_body(body: Mapping[str, Any]) -> PublicOutputReceipt:
-    citations_body = body["citations"]
-    citations = None
-    if citations_body is not None:
-        citations = PublicOutputReceiptCitations(
-            governance_decision_id=citations_body["governance_decision_id"],
-            governance_status=citations_body["governance_status"],
-            governance_reasons=tuple(citations_body["governance_reasons"]),
-            commit_package_id=citations_body["commit_package_id"],
-            commit_package_complete=citations_body["commit_package_complete"],
-            subject_id=citations_body["subject_id"],
-            projection_id=citations_body["projection_id"],
-            authorized_fields=tuple(citations_body["authorized_fields"]),
-            profile_id=citations_body["profile_id"],
-            report_status=citations_body["report_status"],
-            checked_claim_fields=tuple(citations_body["checked_claim_fields"]),
-            checked_claim_witness_ids=tuple(
-                citations_body["checked_claim_witness_ids"]
-            ),
-            semantic_judgment_ids=tuple(citations_body["semantic_judgment_ids"]),
-            reference_binding_ids=tuple(citations_body["reference_binding_ids"]),
-            derived_claim_fields=tuple(citations_body["derived_claim_fields"]),
-            derived_claim_ids=tuple(citations_body["derived_claim_ids"]),
-            calculation_trace_ids=tuple(citations_body["calculation_trace_ids"]),
-            formula_ids=tuple(citations_body["formula_ids"]),
-            resolved_obligation_ids=tuple(citations_body["resolved_obligation_ids"]),
-            open_obligation_ids=tuple(citations_body["open_obligation_ids"]),
-            hazard_ids=tuple(citations_body["hazard_ids"]),
-            projection_value_commitments=tuple(
-                _projection_value_commitment_from_body(item)
-                for item in citations_body["projection_value_commitments"]
-            ),
-            dependency_fingerprints=tuple(
-                _dependency_fingerprint_from_body(item)
-                for item in citations_body["dependency_fingerprints"]
-            ),
-        )
-    return PublicOutputReceipt(
-        draft_id=body["draft_id"],
-        winner_receipt_ids=tuple(body["winner_receipt_ids"]),
-        barrier_snapshot=_receipt_value_from_body(body["barrier_snapshot"]),
-        public_row_id=body["public_row_id"],
-        projection_id=body["projection_id"],
-        authorized_fields=tuple(body["authorized_fields"]),
-        citations=citations,
-    )
-
-
 def _insert_receipt_indexes(
     cursor: Any,
     rid: str,
@@ -415,90 +321,6 @@ def _artifact_envelope_from_row(row: Any) -> ArtifactEnvelope:
 
 def _commit_receipt_from_row(row: Any) -> PublicOutputReceipt:
     return commit_receipt_from_body(decode_persistence_json(_json_load(row[0])))
-
-
-def _projection_value_commitment_to_body(
-    commitment: PublicOutputValueCommitment,
-) -> dict[str, Any]:
-    return {
-        "field": commitment.field,
-        "source_kind": commitment.source_kind,
-        "source_id": commitment.source_id,
-        "value_digest": commitment.value_digest,
-        "digest_alg": commitment.digest_alg,
-    }
-
-
-def _projection_value_commitment_from_body(
-    body: Mapping[str, Any],
-) -> PublicOutputValueCommitment:
-    return PublicOutputValueCommitment(
-        field=body["field"],
-        source_kind=body["source_kind"],
-        source_id=body["source_id"],
-        value_digest=body["value_digest"],
-        digest_alg=body["digest_alg"],
-    )
-
-
-def _dependency_fingerprint_to_body(
-    fingerprint: DependencyFingerprint,
-) -> dict[str, Any]:
-    return {
-        "dependency_kind": fingerprint.dependency_kind,
-        "dependency_id": fingerprint.dependency_id,
-        "fingerprint": fingerprint.fingerprint,
-        "digest_alg": fingerprint.digest_alg,
-    }
-
-
-def _dependency_fingerprint_from_body(
-    body: Mapping[str, Any],
-) -> DependencyFingerprint:
-    return DependencyFingerprint(
-        dependency_kind=body["dependency_kind"],
-        dependency_id=body["dependency_id"],
-        fingerprint=body["fingerprint"],
-        digest_alg=body["digest_alg"],
-    )
-
-
-def _receipt_value_to_body(value: Any) -> Any:
-    if isinstance(value, PublicOutputValueCommitment):
-        return {
-            "__receipt_type__": "projection_value_commitment",
-            "value": _projection_value_commitment_to_body(value),
-        }
-    if isinstance(value, DependencyFingerprint):
-        return {
-            "__receipt_type__": "dependency_fingerprint",
-            "value": _dependency_fingerprint_to_body(value),
-        }
-    if isinstance(value, Mapping):
-        return {
-            str(key): _receipt_value_to_body(item)
-            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
-        }
-    if isinstance(value, tuple):
-        return tuple(_receipt_value_to_body(item) for item in value)
-    if isinstance(value, list):
-        return [_receipt_value_to_body(item) for item in value]
-    return value
-
-
-def _receipt_value_from_body(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        receipt_type = value.get("__receipt_type__")
-        if receipt_type == "projection_value_commitment":
-            return _projection_value_commitment_from_body(value["value"])
-        if receipt_type == "dependency_fingerprint":
-            return _dependency_fingerprint_from_body(value["value"])
-        return {key: _receipt_value_from_body(item) for key, item in value.items()}
-    if isinstance(value, tuple):
-        return tuple(_receipt_value_from_body(item) for item in value)
-    if isinstance(value, list):
-        return [_receipt_value_from_body(item) for item in value]
-    return value
 
 
 def _json_dump(value: Any) -> str:

--- a/comp/scenario_contracts/case.py
+++ b/comp/scenario_contracts/case.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any
 
 from comp.judgment import PublicOutputReceipt, PublicOutputSpec
+from comp.persistence.codec import commit_receipt_from_body, commit_receipt_to_body
 from comp.persistence.ledger import ReceiptLedgerKey
-from comp.persistence.mysql import commit_receipt_from_body, commit_receipt_to_body
 from comp.scenario_contracts.manifest import ScenarioManifestError
 
 

--- a/tests/test_receipt_proof_graph_cli.py
+++ b/tests/test_receipt_proof_graph_cli.py
@@ -1,8 +1,8 @@
 import json
+from pathlib import Path
 
 from comp.explanation import export_receipt_proof_graph
-from comp.persistence.mysql import commit_receipt_to_body
-from comp.persistence.codec import encode_persistence_json
+from comp.persistence.codec import commit_receipt_to_body, encode_persistence_json
 from comp.persistence.replay import ProjectionReplayReport
 from comp.explanation.receipt_graph_cli import main
 from tests.support.persistence_cases import (
@@ -10,6 +10,31 @@ from tests.support.persistence_cases import (
     receipt_projection_case,
 )
 from comp.persistence import replay_public_projection
+
+
+def test_receipt_body_codec_is_backend_neutral():
+    from comp.persistence.codec import (
+        commit_receipt_from_body,
+        commit_receipt_to_body,
+    )
+
+    case = receipt_projection_case(amount=100)
+    body = commit_receipt_to_body(case.receipt)
+    roundtripped = commit_receipt_from_body(body)
+
+    assert roundtripped == case.receipt
+
+
+def test_receipt_graph_cli_does_not_import_mysql_backend():
+    source = Path("comp/explanation/receipt_graph_cli.py").read_text(encoding="utf-8")
+
+    assert "comp.persistence.mysql" not in source
+
+
+def test_scenario_contract_runtime_case_does_not_import_mysql_backend():
+    source = Path("comp/scenario_contracts/case.py").read_text(encoding="utf-8")
+
+    assert "comp.persistence.mysql" not in source
 
 
 def test_receipt_graph_cli_exports_graph_json_from_replay_inputs(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- move public-output receipt body encode/decode helpers from `comp.persistence.mysql` into backend-neutral `comp.persistence.codec`
- update receipt graph CLI and scenario runtime-case serialization to use the neutral codec
- keep MySQL module compatibility by re-exporting the moved helpers through its existing imports

## Validation
- `python -m pytest tests/test_receipt_proof_graph_cli.py tests/test_scenario_contracts.py tests/test_mysql_persistence_spine.py::test_persistence_codec_roundtrips_tuple_and_decimal_body tests/test_package_smoke.py -q` -> 47 passed
- `python -m pytest -q` -> 452 passed, 9 skipped
- `git diff --check HEAD~1..HEAD` -> passed
- source grep for `comp.persistence.mysql` in `comp/explanation` and `comp/scenario_contracts` -> no matches