### PR TITLE
[codex] show friendly validation summary in scenario cli

### DIFF
--- a/tests/domain_scenarios/cli.py
+++ b/tests/domain_scenarios/cli.py
@@ -112,6 +112,9 @@ def render_scenario_summary(
     scenario: ScenarioDefinition,
     result: DomainScenarioResult,
 ) -> str:
+    from comp.views import validation_summary_view
+
+    validation_summary = validation_summary_view(result.report)
     lines = [
         f"Scenario: {scenario.scenario_id}",
         f"Title: {scenario.title}",
@@ -119,8 +122,9 @@ def render_scenario_summary(
         f"Commit: {result.preparation.decision.status}",
         f"Projection: {'present' if result.projection is not None else 'absent'}",
         "",
-        "Resolver steps:",
     ]
+    lines.extend(_render_validation_summary_lines(validation_summary))
+    lines.append("Resolver steps:")
     lines.extend(f"- {step}" for step in result.resolver_steps)
     lines.extend(
         (
@@ -163,6 +167,25 @@ def render_scenario_summary(
             )
         )
     return "\n".join(lines)
+
+
+def _render_validation_summary_lines(summary: dict[str, Any]) -> list[str]:
+    public_output = summary["public_output"]
+    open_requirements = summary["open_requirements"]
+    lines = [
+        "Validation summary:",
+        f"- {summary['label_ko']}: {summary['status_ko']}",
+        f"- {public_output['label_ko']}: {public_output['state_ko']}",
+    ]
+    lines.extend(
+        f"- {section['label_ko']}: {section['count']}"
+        for section in summary["sections"]
+    )
+    lines.append(f"- 보완 필요 항목: {len(open_requirements)}")
+    for requirement in open_requirements:
+        lines.append(f"  - {requirement['field']}: {requirement['message_ko']}")
+    lines.append("")
+    return lines
 
 
 def _dependency_manifest_count(replay_trace: dict[str, object]) -> int:

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -84,6 +84,17 @@ def test_domain_scenario_cli_runs_human_summary(capsys):
     assert "Status: accepted" in captured.out
     assert "Commit: commit" in captured.out
     assert "Projection: present" in captured.out
+    assert "Validation summary:" in captured.out
+    assert "- 검증 결과: 검증됨" in captured.out
+    assert "- 공개 결과:" in captured.out
+    assert "- 근거자료 위치:" in captured.out
+    assert "- 확정 기준: 1" in captured.out
+    assert "- 계산값: 1" in captured.out
+    assert "- 보완 필요 항목: 0" in captured.out
+    assert captured.out.index("Validation summary:") < captured.out.index(
+        "Resolver steps:"
+    )
+    assert "\nResolver steps:\n- plan_calculation_resolution" in captured.out
     assert "Resolver steps:" in captured.out
     assert "- deterministic_reference_selection" in captured.out
     assert "Receipt trace:" in captured.out


### PR DESCRIPTION
## Summary
- Show the Korean-friendly validation summary in the human-readable domain scenario CLI output.
- Reuse the presentation-only `comp.views.validation_summary_view()` helper instead of adding display metadata to authority modules.
- Keep resolver, receipt, and replay details unchanged below the new summary block.

## Tests
- `python -m pytest -q`