### PR TITLE
[codex] Guard scenario init overwrites

### DIFF
--- a/comp/cli/scenario.py
+++ b/comp/cli/scenario.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Sequence
 
 from comp.scenario_contracts import load_manifest, run_scenario
+from comp.scenario_contracts import ScenarioBundleExistsError
 from comp.scenario_contracts import write_public_projection_smoke_bundle
 
 
@@ -23,7 +24,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"{result.scenario_id}: {result.status}")
         return 0 if result.status == "passed" else 1
     if args.scenario_command == "init":
-        manifest_path = write_public_projection_smoke_bundle(args.target)
+        try:
+            manifest_path = write_public_projection_smoke_bundle(
+                args.target,
+                force=args.force,
+            )
+        except ScenarioBundleExistsError as exc:
+            print(str(exc), file=sys.stderr)
+            print("Use --force to regenerate the smoke bundle.", file=sys.stderr)
+            return 2
         print(f"created {manifest_path}")
         return 0
     parser.print_help(sys.stderr)
@@ -53,6 +62,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "init",
         help="Create a runnable public-projection smoke scenario bundle.",
     )
+    init.add_argument("--force", action="store_true")
     init.add_argument("target")
     return parser
 

--- a/comp/scenario_contracts/__init__.py
+++ b/comp/scenario_contracts/__init__.py
@@ -15,7 +15,10 @@ from comp.scenario_contracts.artifacts import (
     load_artifact_envelopes,
     write_artifact_envelopes,
 )
-from comp.scenario_contracts.examples import write_public_projection_smoke_bundle
+from comp.scenario_contracts.examples import (
+    ScenarioBundleExistsError,
+    write_public_projection_smoke_bundle,
+)
 from comp.scenario_contracts.manifest import (
     ScenarioManifest,
     ScenarioManifestError,
@@ -29,6 +32,7 @@ __all__ = [
     "InvariantResult",
     "RuntimeCase",
     "RuntimeProjection",
+    "ScenarioBundleExistsError",
     "ScenarioManifest",
     "ScenarioManifestError",
     "ScenarioResult",

--- a/comp/scenario_contracts/examples.py
+++ b/comp/scenario_contracts/examples.py
@@ -17,8 +17,17 @@ from comp.scenario_contracts.case import (
 )
 
 
-def write_public_projection_smoke_bundle(path: str | Path) -> Path:
+class ScenarioBundleExistsError(FileExistsError):
+    """Raised when scenario init would overwrite an existing bundle."""
+
+
+def write_public_projection_smoke_bundle(
+    path: str | Path,
+    *,
+    force: bool = False,
+) -> Path:
     target = Path(path)
+    _ensure_can_write_bundle(target, force=force)
     prepared = target / "prepared"
     prepared.mkdir(parents=True, exist_ok=True)
 
@@ -132,6 +141,15 @@ def write_public_projection_smoke_bundle(path: str | Path) -> Path:
     return manifest_path
 
 
+def _ensure_can_write_bundle(target: Path, *, force: bool) -> None:
+    if force or not target.exists():
+        return
+    if any(target.iterdir()):
+        raise ScenarioBundleExistsError(
+            f"Scenario bundle target already exists: {target}."
+        )
+
+
 def _manifest() -> dict[str, object]:
     return {
         "id": "public_projection_smoke",
@@ -154,4 +172,4 @@ def _manifest() -> dict[str, object]:
     }
 
 
-__all__ = ["write_public_projection_smoke_bundle"]
+__all__ = ["ScenarioBundleExistsError", "write_public_projection_smoke_bundle"]

--- a/docs/examples/scenario_contracts/README.md
+++ b/docs/examples/scenario_contracts/README.md
@@ -85,6 +85,13 @@ comp scenario init public_projection_smoke
 comp scenario run public_projection_smoke/scenario.json
 ```
 
+`comp scenario init` refuses to overwrite an existing target. To regenerate the
+neutral smoke bundle explicitly:
+
+```bash
+comp scenario init --force public_projection_smoke
+```
+
 That command writes:
 
 ```text

--- a/docs/examples/scenario_pack_repo/README.md
+++ b/docs/examples/scenario_pack_repo/README.md
@@ -28,6 +28,10 @@ comp scenario init packs/public_projection_smoke
 comp scenario run packs/public_projection_smoke/scenario.json
 ```
 
+`comp scenario init` refuses to overwrite an existing pack target. Use
+`comp scenario init --force packs/public_projection_smoke` only when you intend
+to regenerate the neutral smoke bundle.
+
 After that, replace the prepared files with pack-produced trust inputs. Keep the
 same public contract:
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -614,6 +614,7 @@ def test_downstream_scenario_pack_skeleton_documents_ci_contract():
 
     assert "comp-scenario-packs" in readme
     assert "comp scenario init packs/public_projection_smoke" in readme
+    assert "comp scenario init --force packs/public_projection_smoke" in readme
     assert "comp scenario run packs/public_projection_smoke/scenario.json" in readme
     assert "Do not import `tests.*`" in readme
     assert "comp @ git+https://github.com/minntcho/comp@main" in pyproject

--- a/tests/test_scenario_contracts.py
+++ b/tests/test_scenario_contracts.py
@@ -126,11 +126,13 @@ def test_public_contract_exports_bundle_loaders_and_writers():
         runtime_case_from_mapping,
         runtime_case_to_mapping,
         runtime_projection_to_mapping,
+        ScenarioBundleExistsError,
         write_artifact_envelopes,
         write_public_projection_smoke_bundle,
         write_runtime_case,
     )
 
+    assert ScenarioBundleExistsError is not None
     assert artifact_envelope_from_mapping is not None
     assert artifact_envelope_to_mapping is not None
     assert load_artifact_envelopes is not None
@@ -152,6 +154,8 @@ def test_scenario_contract_examples_document_public_bundle_writer():
     assert "write_runtime_case" in examples
     assert "write_artifact_envelopes" in examples
     assert "comp scenario init" in examples
+    assert "comp scenario init --force" in examples
+    assert "refuses to overwrite" in examples
     assert "comp scenario run" in examples
     assert "pre-trust" in examples
 
@@ -220,6 +224,42 @@ def test_comp_scenario_cli_initializes_runnable_smoke_bundle(tmp_path, capsys):
     assert "passed" in run_output
     assert report["scenario_id"] == "public_projection_smoke"
     assert report["status"] == "passed"
+
+
+def test_comp_scenario_cli_init_refuses_to_overwrite_existing_bundle(
+    tmp_path,
+    capsys,
+):
+    from comp.cli.scenario import main
+
+    target = tmp_path / "public_projection_smoke"
+    assert main(["scenario", "init", str(target)]) == 0
+    capsys.readouterr()
+    marker = target / "prepared" / "runtime_case.json"
+    marker.write_text("external pack data", encoding="utf-8")
+
+    assert main(["scenario", "init", str(target)]) == 2
+    output = capsys.readouterr()
+
+    assert "already exists" in output.err
+    assert marker.read_text(encoding="utf-8") == "external pack data"
+
+
+def test_comp_scenario_cli_init_force_regenerates_existing_bundle(tmp_path, capsys):
+    from comp.cli.scenario import main
+
+    target = tmp_path / "public_projection_smoke"
+    assert main(["scenario", "init", str(target)]) == 0
+    capsys.readouterr()
+    marker = target / "prepared" / "runtime_case.json"
+    marker.write_text("external pack data", encoding="utf-8")
+
+    assert main(["scenario", "init", "--force", str(target)]) == 0
+    output = capsys.readouterr()
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+
+    assert "created" in output.out
+    assert payload["case_id"] == "public_projection_smoke"
 
 
 def test_comp_scenario_cli_validates_and_runs_prepared_bundle(tmp_path, capsys):


### PR DESCRIPTION
## What changed

- Added overwrite protection for `comp scenario init`: existing non-empty bundle targets now return 2 instead of silently replacing files.
- Added `comp scenario init --force <target>` for explicit smoke bundle regeneration.
- Exposed `ScenarioBundleExistsError` from `comp.scenario_contracts`.
- Updated scenario contract and downstream skeleton docs to explain default preservation and explicit `--force` regeneration.

## Boundary

This keeps `init` as a bootstrap helper for neutral prepared bundles. It does not add raw adapter execution, benchmark generation, or product workflow behavior to `comp`.

## Validation

- `python -m pytest tests/test_scenario_contracts.py tests/test_package_smoke.py -q` -> 38 passed
- `python -m pytest -q` -> 451 passed, 9 skipped