### PR TITLE
[codex] Classify domain scenario residency

### DIFF
--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -61,6 +61,19 @@ minimal receipt/projection/replay cases
 An internal scenario belongs in `comp` when a failure indicates a likely kernel
 contract regression.
 
+The internal registry exposes residency metadata:
+
+```text
+core-kernel
+  internal authority-kernel regression scenario
+
+downstream-candidate
+  currently internal scenario that should move once a downstream pack owns it
+```
+
+This metadata is not a runtime authority source. It is a maintenance signal for
+reviewing whether a scenario still belongs in the `comp` repo.
+
 ## What Moves Downstream
 
 Large scenarios should move to downstream scenario-pack repositories when they

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -53,8 +53,6 @@ raw_claim_conflict
 raw_claim_conflict_resolution
 tiny_pcf
 canonical_working_loop
-synthetic_pcf.smoke
-synthetic_pcf.anomaly
 minimal receipt/projection/replay cases
 ```
 
@@ -74,6 +72,16 @@ downstream-candidate
 This metadata is not a runtime authority source. It is a maintenance signal for
 reviewing whether a scenario still belongs in the `comp` repo.
 
+`downstream-candidate` does not mean immediate deletion. Candidate scenarios
+should move through this sequence:
+
+```text
+copy/reconstruct -> external run -> parallel validation -> internal shrink/remove
+```
+
+Until the downstream pack can run the same trust meaning through public `comp`
+APIs, the internal scenario remains as regression coverage.
+
 ## What Moves Downstream
 
 Large scenarios should move to downstream scenario-pack repositories when they
@@ -83,6 +91,13 @@ Examples:
 
 ```text
 full L-Energy supplier workflow
+synthetic PCF smoke/anomaly/resolution scenarios
+large generated datasets
+messy source adapter rehearsals
+projection query benchmarks
+replay performance benchmarks
+migration rehearsal cases
+agent-produced candidate ingestion tests
 platform YAML import
 RFI workflow engine
 external certificate verification
@@ -94,6 +109,11 @@ product-specific persistence flows
 
 A downstream scenario belongs outside `comp` when a failure is more likely to
 indicate a domain pack, platform, importer, UI, or workflow regression.
+
+The first external run should stay smaller than the large domain packs. Start
+with `public_projection_smoke`, because it proves a downstream repository can
+install `comp`, use prepared `RuntimeCase` and `ArtifactEnvelope` files, run the
+public scenario bridge, and emit a report without importing `tests.*`.
 
 ## Dependency Direction
 

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -147,13 +147,16 @@ core-kernel
   small scenarios where failure likely means a comp authority-kernel regression
 
 downstream-candidate
-  larger domain workflows retained temporarily until comp-scenario-packs owns them
+  currently internal scenarios retained until comp-scenario-packs owns them
 ```
 
 Current core-kernel scenarios include `canonical_working_loop`, `tiny_pcf`,
-synthetic PCF smoke/anomaly/resolution, and the raw-claim boundary scenarios.
-Current downstream-candidate scenarios are the `l_energy.*` family and
-`l_energy_pcf_governance.v1`.
+and the raw-claim boundary scenarios. Current downstream-candidate scenarios
+are the `l_energy.*` family, `l_energy_pcf_governance.v1`, and synthetic PCF smoke/anomaly/resolution.
+
+Downstream-candidate is not a removal instruction. Keep the internal scenario
+until a downstream pack has copied or reconstructed the same trust meaning, run
+it through public `comp` APIs, and passed parallel validation.
 
 ## Local Runner
 

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -137,6 +137,24 @@ docs/extensions/scenario-packs.md
 docs/extensions/downstream-registry.json
 ```
 
+## Scenario Residency
+
+The registry exposes residency metadata so internal scenario sprawl is visible
+before it becomes package shape.
+
+```text
+core-kernel
+  small scenarios where failure likely means a comp authority-kernel regression
+
+downstream-candidate
+  larger domain workflows retained temporarily until comp-scenario-packs owns them
+```
+
+Current core-kernel scenarios include `canonical_working_loop`, `tiny_pcf`,
+synthetic PCF smoke/anomaly/resolution, and the raw-claim boundary scenarios.
+Current downstream-candidate scenarios are the `l_energy.*` family and
+`l_energy_pcf_governance.v1`.
+
 ## Local Runner
 
 The scenario registry can also be inspected without opening the pytest files:
@@ -144,6 +162,8 @@ The scenario registry can also be inspected without opening the pytest files:
 ```bash
 python -m tests.domain_scenarios list
 ```
+
+The list output includes scenario id, residency tier, and title.
 
 Run one scenario as a human-readable trace summary:
 

--- a/tests/domain_scenarios/cli.py
+++ b/tests/domain_scenarios/cli.py
@@ -13,7 +13,7 @@ from tests.domain_scenarios.core import (
     assert_scenario_contract,
     run_scenario,
 )
-from tests.domain_scenarios.registry import registered_scenarios
+from tests.domain_scenarios.registry import registered_scenarios, scenario_residency
 
 
 @dataclass(frozen=True)
@@ -230,7 +230,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _render_scenario_list(scenarios: Iterable[ScenarioDefinition]) -> str:
     return "\n".join(
-        f"{scenario.scenario_id}\t{scenario.title}"
+        f"{scenario.scenario_id}\t{scenario_residency(scenario.scenario_id).tier}"
+        f"\t{scenario.title}"
         for scenario in scenarios
     )
 

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -84,7 +84,7 @@ _REGISTERED_SCENARIOS = (
     SYNTHETIC_PCF_ANOMALY_SCENARIO,
     SYNTHETIC_PCF_RESOLUTION_SCENARIO,
 )
-_DOWNSTREAM_CANDIDATE_IDS = frozenset(
+_LARGE_DOMAIN_DOWNSTREAM_IDS = frozenset(
     scenario.scenario_id
     for scenario in (
         ALPHA_INVALID_ALLOCATION_SCENARIO,
@@ -98,20 +98,46 @@ _DOWNSTREAM_CANDIDATE_IDS = frozenset(
         L_ENERGY_PCF_GOVERNANCE_SCENARIO,
     )
 )
-_SCENARIO_RESIDENCY = {
-    scenario.scenario_id: ScenarioResidency(
-        tier="downstream-candidate",
-        target_pack="comp-scenario-packs",
-        reason=(
-            "large domain workflow fixture retained temporarily until the "
-            "downstream scenario pack owns it"
-        ),
+_SYNTHETIC_PCF_DOWNSTREAM_IDS = frozenset(
+    scenario.scenario_id
+    for scenario in (
+        SYNTHETIC_PCF_SMOKE_SCENARIO,
+        SYNTHETIC_PCF_ANOMALY_SCENARIO,
+        SYNTHETIC_PCF_RESOLUTION_SCENARIO,
     )
-    if scenario.scenario_id in _DOWNSTREAM_CANDIDATE_IDS
-    else ScenarioResidency(
+)
+_DOWNSTREAM_CANDIDATE_IDS = (
+    _LARGE_DOMAIN_DOWNSTREAM_IDS | _SYNTHETIC_PCF_DOWNSTREAM_IDS
+)
+
+
+def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
+    if scenario_id in _LARGE_DOMAIN_DOWNSTREAM_IDS:
+        return ScenarioResidency(
+            tier="downstream-candidate",
+            target_pack="comp-scenario-packs",
+            reason=(
+                "large domain workflow fixture retained temporarily until the "
+                "downstream scenario pack owns it"
+            ),
+        )
+    if scenario_id in _SYNTHETIC_PCF_DOWNSTREAM_IDS:
+        return ScenarioResidency(
+            tier="downstream-candidate",
+            target_pack="comp-scenario-packs",
+            reason=(
+                "synthetic generator fixture retained temporarily until the "
+                "downstream scenario pack owns generated replay checks"
+            ),
+        )
+    return ScenarioResidency(
         tier="core-kernel",
         reason="small authority boundary scenario for comp kernel regression",
     )
+
+
+_SCENARIO_RESIDENCY = {
+    scenario.scenario_id: _scenario_residency_for(scenario.scenario_id)
     for scenario in _REGISTERED_SCENARIOS
 }
 

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from tests.domain_scenarios.core import ScenarioDefinition
 from tests.domain_scenarios.canonical_working_loop.scenario import (
     SCENARIO as CANONICAL_WORKING_LOOP_SCENARIO,
@@ -55,10 +57,36 @@ from tests.domain_scenarios.synthetic_pcf_smoke.scenario import (
 from tests.domain_scenarios.tiny_pcf.scenario import SCENARIO as TINY_PCF_SCENARIO
 
 
-def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
-    return (
-        CANONICAL_WORKING_LOOP_SCENARIO,
-        TINY_PCF_SCENARIO,
+@dataclass(frozen=True)
+class ScenarioResidency:
+    tier: str
+    reason: str
+    target_pack: str | None = None
+
+
+_REGISTERED_SCENARIOS = (
+    CANONICAL_WORKING_LOOP_SCENARIO,
+    TINY_PCF_SCENARIO,
+    ALPHA_INVALID_ALLOCATION_SCENARIO,
+    ALPHA_PHYSICAL_ALLOCATION_SCENARIO,
+    STEEL_FRAME_PROXY_SCENARIO,
+    CARBON_TECH_CERTIFICATE_SCENARIO,
+    L_MATERIALS_COMPOSITION_SCENARIO,
+    C_PACK_YIELD_ROLLUP_SCENARIO,
+    TIER0_PHYSICAL_ALLOCATION_SCENARIO,
+    FINAL_BOTTOM_UP_ROLLUP_SCENARIO,
+    L_ENERGY_PCF_GOVERNANCE_SCENARIO,
+    RAW_CLAIM_HYPOTHESIS_GATE_SCENARIO,
+    RAW_CLAIM_HYPOTHESIS_ACCEPTANCE_SCENARIO,
+    RAW_CLAIM_CONFLICT_SCENARIO,
+    RAW_CLAIM_CONFLICT_RESOLUTION_SCENARIO,
+    SYNTHETIC_PCF_SMOKE_SCENARIO,
+    SYNTHETIC_PCF_ANOMALY_SCENARIO,
+    SYNTHETIC_PCF_RESOLUTION_SCENARIO,
+)
+_DOWNSTREAM_CANDIDATE_IDS = frozenset(
+    scenario.scenario_id
+    for scenario in (
         ALPHA_INVALID_ALLOCATION_SCENARIO,
         ALPHA_PHYSICAL_ALLOCATION_SCENARIO,
         STEEL_FRAME_PROXY_SCENARIO,
@@ -68,14 +96,54 @@ def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
         TIER0_PHYSICAL_ALLOCATION_SCENARIO,
         FINAL_BOTTOM_UP_ROLLUP_SCENARIO,
         L_ENERGY_PCF_GOVERNANCE_SCENARIO,
-        RAW_CLAIM_HYPOTHESIS_GATE_SCENARIO,
-        RAW_CLAIM_HYPOTHESIS_ACCEPTANCE_SCENARIO,
-        RAW_CLAIM_CONFLICT_SCENARIO,
-        RAW_CLAIM_CONFLICT_RESOLUTION_SCENARIO,
-        SYNTHETIC_PCF_SMOKE_SCENARIO,
-        SYNTHETIC_PCF_ANOMALY_SCENARIO,
-        SYNTHETIC_PCF_RESOLUTION_SCENARIO,
+    )
+)
+_SCENARIO_RESIDENCY = {
+    scenario.scenario_id: ScenarioResidency(
+        tier="downstream-candidate",
+        target_pack="comp-scenario-packs",
+        reason=(
+            "large domain workflow fixture retained temporarily until the "
+            "downstream scenario pack owns it"
+        ),
+    )
+    if scenario.scenario_id in _DOWNSTREAM_CANDIDATE_IDS
+    else ScenarioResidency(
+        tier="core-kernel",
+        reason="small authority boundary scenario for comp kernel regression",
+    )
+    for scenario in _REGISTERED_SCENARIOS
+}
+
+
+def registered_scenarios() -> tuple[ScenarioDefinition, ...]:
+    return _REGISTERED_SCENARIOS
+
+
+def core_kernel_scenarios() -> tuple[ScenarioDefinition, ...]:
+    return tuple(
+        scenario
+        for scenario in _REGISTERED_SCENARIOS
+        if _SCENARIO_RESIDENCY[scenario.scenario_id].tier == "core-kernel"
     )
 
 
-__all__ = ["registered_scenarios"]
+def downstream_candidate_scenarios() -> tuple[ScenarioDefinition, ...]:
+    return tuple(
+        scenario
+        for scenario in _REGISTERED_SCENARIOS
+        if _SCENARIO_RESIDENCY[scenario.scenario_id].tier == "downstream-candidate"
+    )
+
+
+def scenario_residency(scenario_id: str) -> ScenarioResidency:
+    return _SCENARIO_RESIDENCY[scenario_id]
+
+
+__all__ = [
+    "ScenarioResidency",
+    "core_kernel_scenarios",
+    "downstream_candidate_scenarios",
+    "registered_scenarios",
+    "scenario_residency",
+]

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -70,6 +70,11 @@ def test_domain_scenario_cli_lists_registered_scenarios(capsys):
     assert "synthetic_pcf.anomaly.v1" in captured.out
     assert "synthetic_pcf.resolution.v1" in captured.out
     assert "Canonical raw text PCF working loop" in captured.out
+    assert "canonical_working_loop.raw_text_pcf.v1\tcore-kernel\t" in captured.out
+    assert (
+        "l_energy.final_bottom_up_pcf_rollup.v1\tdownstream-candidate\t"
+        in captured.out
+    )
 
 
 def test_domain_scenario_cli_runs_human_summary(capsys):

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -75,6 +75,7 @@ def test_domain_scenario_cli_lists_registered_scenarios(capsys):
         "l_energy.final_bottom_up_pcf_rollup.v1\tdownstream-candidate\t"
         in captured.out
     )
+    assert "synthetic_pcf.smoke.v1\tdownstream-candidate\t" in captured.out
 
 
 def test_domain_scenario_cli_runs_human_summary(capsys):

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from tests.domain_scenarios.registry import (
+    core_kernel_scenarios,
+    downstream_candidate_scenarios,
+    registered_scenarios,
+    scenario_residency,
+)
+
+
+def test_domain_scenario_registry_marks_core_and_downstream_candidate_sets():
+    registered_ids = {scenario.scenario_id for scenario in registered_scenarios()}
+    core_ids = {scenario.scenario_id for scenario in core_kernel_scenarios()}
+    downstream_ids = {
+        scenario.scenario_id for scenario in downstream_candidate_scenarios()
+    }
+
+    assert core_ids | downstream_ids == registered_ids
+    assert core_ids.isdisjoint(downstream_ids)
+    assert core_ids == {
+        "canonical_working_loop.raw_text_pcf.v1",
+        "tiny_pcf.location_based_electricity.v1",
+        "synthetic.raw_claim_hypothesis_gate.v1",
+        "synthetic.raw_claim_hypothesis_acceptance.v1",
+        "synthetic.raw_claim_conflict.v1",
+        "synthetic.raw_claim_conflict_resolution.v1",
+        "synthetic_pcf.smoke.v1",
+        "synthetic_pcf.anomaly.v1",
+        "synthetic_pcf.resolution.v1",
+    }
+    assert downstream_ids == {
+        "l_energy.alpha_invalid_allocation_rfi.v1",
+        "l_energy.alpha_physical_allocation_correction.v1",
+        "l_energy.steel_frame_proxy_assignment.v1",
+        "l_energy.carbon_tech_certificate_submission.v1",
+        "l_energy.l_materials_composition_rollup.v1",
+        "l_energy.c_pack_yield_rollup.v1",
+        "l_energy.tier0_physical_allocation.v1",
+        "l_energy.final_bottom_up_pcf_rollup.v1",
+        "l_energy_pcf_governance.v1",
+    }
+
+
+def test_domain_scenario_residency_metadata_explains_diet_boundary():
+    raw_claim_residency = scenario_residency(
+        "synthetic.raw_claim_conflict_resolution.v1"
+    )
+    l_energy_residency = scenario_residency("l_energy.final_bottom_up_pcf_rollup.v1")
+
+    assert raw_claim_residency.tier == "core-kernel"
+    assert raw_claim_residency.target_pack is None
+    assert "authority boundary" in raw_claim_residency.reason
+
+    assert l_energy_residency.tier == "downstream-candidate"
+    assert l_energy_residency.target_pack == "comp-scenario-packs"
+    assert "large domain workflow" in l_energy_residency.reason
+
+
+def test_domain_scenario_docs_explain_residency_tiers():
+    readme = Path("tests/domain_scenarios/README.md").read_text(encoding="utf-8")
+    extension_doc = Path("docs/extensions/scenario-packs.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Scenario Residency" in readme
+    assert "core-kernel" in readme
+    assert "downstream-candidate" in readme
+    assert "l_energy.*" in readme
+    assert "registry exposes residency metadata" in extension_doc

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -24,9 +24,6 @@ def test_domain_scenario_registry_marks_core_and_downstream_candidate_sets():
         "synthetic.raw_claim_hypothesis_acceptance.v1",
         "synthetic.raw_claim_conflict.v1",
         "synthetic.raw_claim_conflict_resolution.v1",
-        "synthetic_pcf.smoke.v1",
-        "synthetic_pcf.anomaly.v1",
-        "synthetic_pcf.resolution.v1",
     }
     assert downstream_ids == {
         "l_energy.alpha_invalid_allocation_rfi.v1",
@@ -38,6 +35,9 @@ def test_domain_scenario_registry_marks_core_and_downstream_candidate_sets():
         "l_energy.tier0_physical_allocation.v1",
         "l_energy.final_bottom_up_pcf_rollup.v1",
         "l_energy_pcf_governance.v1",
+        "synthetic_pcf.smoke.v1",
+        "synthetic_pcf.anomaly.v1",
+        "synthetic_pcf.resolution.v1",
     }
 
 
@@ -46,6 +46,7 @@ def test_domain_scenario_residency_metadata_explains_diet_boundary():
         "synthetic.raw_claim_conflict_resolution.v1"
     )
     l_energy_residency = scenario_residency("l_energy.final_bottom_up_pcf_rollup.v1")
+    synthetic_residency = scenario_residency("synthetic_pcf.smoke.v1")
 
     assert raw_claim_residency.tier == "core-kernel"
     assert raw_claim_residency.target_pack is None
@@ -54,6 +55,10 @@ def test_domain_scenario_residency_metadata_explains_diet_boundary():
     assert l_energy_residency.tier == "downstream-candidate"
     assert l_energy_residency.target_pack == "comp-scenario-packs"
     assert "large domain workflow" in l_energy_residency.reason
+
+    assert synthetic_residency.tier == "downstream-candidate"
+    assert synthetic_residency.target_pack == "comp-scenario-packs"
+    assert "synthetic generator" in synthetic_residency.reason
 
 
 def test_domain_scenario_docs_explain_residency_tiers():
@@ -66,4 +71,7 @@ def test_domain_scenario_docs_explain_residency_tiers():
     assert "core-kernel" in readme
     assert "downstream-candidate" in readme
     assert "l_energy.*" in readme
+    assert "synthetic PCF smoke/anomaly/resolution" in readme
+    assert "copy/reconstruct -> external run -> parallel validation" in extension_doc
+    assert "public_projection_smoke" in extension_doc
     assert "registry exposes residency metadata" in extension_doc


### PR DESCRIPTION
## Summary
- add scenario residency metadata to the domain scenario registry
- classify small authority-boundary scenarios as `core-kernel`
- classify L-Energy workflow scenarios and synthetic PCF smoke/anomaly/resolution as `downstream-candidate`
- show residency tier in `python -m tests.domain_scenarios list`
- document that downstream candidates are not removed until copy/reconstruct -> external run -> parallel validation -> internal shrink/remove
- document `public_projection_smoke` as the first external prepared-bundle run before larger pack migration

## Why

This keeps `comp` from growing into the owner of domain/product scenario packs while avoiding a validation gap. Internal candidates stay in place until `comp-scenario-packs` can run the same trust meaning through public `comp` APIs or CLI.

## Validation
- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_domain_scenario_lab.py -q` -> 27 passed
- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_domain_scenario_lab.py tests/test_scenario_contracts.py tests/test_package_smoke.py -q` -> 63 passed
- `python -m tests.domain_scenarios list` -> synthetic PCF and L-Energy scenarios print as `downstream-candidate`
- `python -m pytest -q` -> 452 passed, 9 skipped
- `git diff --check HEAD~1..HEAD` -> passed
