### PR TITLE
[codex] Split synthetic oracle helpers

### DIFF
--- a/comp/scenarios/synthetic/generator.py
+++ b/comp/scenarios/synthetic/generator.py
@@ -38,8 +38,12 @@ from comp.scenarios.synthetic.models import (
     SyntheticResolutionArtifacts,
     SyntheticRun,
 )
+from comp.scenarios.synthetic.oracle import (
+    calculation_obligation_id,
+    expected_smoke_receipt,
+    reference_search_obligation_id,
+)
 from comp.scenarios.synthetic.sources import (
-    _synthetic_source_dependency_refs,
     build_synthetic_loaded_source,
     build_synthetic_loaded_sources,
     synthetic_source_input_dependency_id,
@@ -130,7 +134,7 @@ def generate_synthetic_pcf_run(config: SyntheticScenarioConfig) -> SyntheticRun:
                     witness_id=source_witness_id,
                 ),
             ),
-            expected_receipt=_expected_smoke_receipt(
+            expected_receipt=expected_smoke_receipt(
                 config,
                 source_witness_id=source_witness_id,
                 derived_value=derived_value,
@@ -224,13 +228,13 @@ def _generate_synthetic_pcf_resolution_run(
             expected_resolved_obligations=(
                 resolved_obligation,
                 ExpectedObligation(
-                    obligation_id=_reference_search_obligation_id(config),
+                    obligation_id=reference_search_obligation_id(config),
                     kind="reference_search_required",
                     field="co2e_kg",
                     reason="unknown_reference",
                 ),
                 ExpectedObligation(
-                    obligation_id=_calculation_obligation_id(config),
+                    obligation_id=calculation_obligation_id(config),
                     kind="calculation_blocked",
                     field="co2e_kg",
                     reason="unknown_reference",
@@ -247,14 +251,14 @@ def _generate_synthetic_pcf_resolution_run(
                     source_ref=resolution.source_ref,
                 ),
             ),
-            expected_receipt=_expected_smoke_receipt(
+            expected_receipt=expected_smoke_receipt(
                 config,
                 source_witness_id=source_witness_id,
                 derived_value=derived_value,
                 resolved_obligation_ids=(
                     resolved_obligation.obligation_id,
-                    _reference_search_obligation_id(config),
-                    _calculation_obligation_id(config),
+                    reference_search_obligation_id(config),
+                    calculation_obligation_id(config),
                 ),
             ),
         ),
@@ -543,90 +547,6 @@ def _multiply(left: int | float, right: int | float) -> int | float:
     if value == value.to_integral_value():
         return float(value)
     return float(value)
-
-
-def _expected_smoke_receipt(
-    config: SyntheticScenarioConfig,
-    *,
-    source_witness_id: str,
-    derived_value: int | float,
-    resolved_obligation_ids: tuple[str, ...] | None = None,
-) -> ExpectedReceipt:
-    commit_package_id = f"commit-package:{config.subject_id}"
-    governance_decision_id = f"governance-decision:{commit_package_id}"
-    manifest_dependency_id = _synthetic_manifest_dependency_id(config)
-    resolved_ids = resolved_obligation_ids or (
-        _reference_search_obligation_id(config),
-        _calculation_obligation_id(config),
-    )
-    source_dependency_refs = _synthetic_source_dependency_refs(config)
-    return ExpectedReceipt(
-        public_row_id=config.public_row_id,
-        projection_id=config.projection_id,
-        authorized_fields=("electricity_kwh", "co2e_kg"),
-        public_row={
-            "electricity_kwh": config.electricity_kwh,
-            "co2e_kg": derived_value,
-        },
-        governance_status="commit",
-        commit_package_id=commit_package_id,
-        governance_decision_id=governance_decision_id,
-        checked_claim_witness_ids=(source_witness_id,),
-        reference_binding_ids=(config.binding_id,),
-        derived_claim_ids=(config.output_claim_id,),
-        calculation_trace_ids=(f"trace:{config.output_claim_id}",),
-        formula_ids=(config.formula_id,),
-        resolved_obligation_ids=resolved_ids,
-        dependency_refs=(
-            ExpectedDependencyRef(
-                dependency_kind="synthetic_manifest",
-                dependency_id=manifest_dependency_id,
-            ),
-            *source_dependency_refs,
-        ),
-        artifact_refs=(
-            ExpectedArtifactRef(commit_package_id, "commit_package"),
-            ExpectedArtifactRef(governance_decision_id, "governance_decision"),
-            ExpectedArtifactRef(
-                f"checked_claim:electricity_kwh:{source_witness_id}",
-                "checked_claim",
-            ),
-            ExpectedArtifactRef(config.output_claim_id, "derived_claim"),
-            ExpectedArtifactRef(source_witness_id, "evidence_witness"),
-            ExpectedArtifactRef(config.binding_id, "reference_binding"),
-            ExpectedArtifactRef(
-                f"trace:{config.output_claim_id}",
-                "calculation_trace",
-            ),
-            ExpectedArtifactRef(config.formula_id, "formula"),
-            ExpectedArtifactRef(manifest_dependency_id, "synthetic_manifest"),
-            *(
-                ExpectedArtifactRef(
-                    ref.dependency_id,
-                    ref.dependency_kind,
-                )
-                for ref in source_dependency_refs
-            ),
-        ),
-    )
-
-
-def _synthetic_manifest_dependency_id(config: SyntheticScenarioConfig) -> str:
-    return f"synthetic_manifest:{config.scenario_id}:seed-{config.seed}"
-
-
-def _reference_search_obligation_id(config: SyntheticScenarioConfig) -> str:
-    return (
-        f"resolve:{config.formula_id}:{config.output_claim_id}:"
-        "reference_search_required"
-    )
-
-
-def _calculation_obligation_id(config: SyntheticScenarioConfig) -> str:
-    return (
-        f"calculation:{config.formula_id}:{config.output_claim_id}:"
-        "unknown_reference"
-    )
 
 
 __all__ = [

--- a/comp/scenarios/synthetic/oracle.py
+++ b/comp/scenarios/synthetic/oracle.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from comp.scenarios.synthetic.config import SyntheticScenarioConfig
+from comp.scenarios.synthetic.models import (
+    ExpectedArtifactRef,
+    ExpectedDependencyRef,
+    ExpectedReceipt,
+)
+from comp.scenarios.synthetic.sources import synthetic_source_dependency_refs
+
+
+def expected_smoke_receipt(
+    config: SyntheticScenarioConfig,
+    *,
+    source_witness_id: str,
+    derived_value: int | float,
+    resolved_obligation_ids: tuple[str, ...] | None = None,
+) -> ExpectedReceipt:
+    commit_package_id = f"commit-package:{config.subject_id}"
+    governance_decision_id = f"governance-decision:{commit_package_id}"
+    manifest_dependency_id = synthetic_manifest_dependency_id(config)
+    resolved_ids = resolved_obligation_ids or (
+        reference_search_obligation_id(config),
+        calculation_obligation_id(config),
+    )
+    source_dependency_refs = synthetic_source_dependency_refs(config)
+    return ExpectedReceipt(
+        public_row_id=config.public_row_id,
+        projection_id=config.projection_id,
+        authorized_fields=("electricity_kwh", "co2e_kg"),
+        public_row={
+            "electricity_kwh": config.electricity_kwh,
+            "co2e_kg": derived_value,
+        },
+        governance_status="commit",
+        commit_package_id=commit_package_id,
+        governance_decision_id=governance_decision_id,
+        checked_claim_witness_ids=(source_witness_id,),
+        reference_binding_ids=(config.binding_id,),
+        derived_claim_ids=(config.output_claim_id,),
+        calculation_trace_ids=(f"trace:{config.output_claim_id}",),
+        formula_ids=(config.formula_id,),
+        resolved_obligation_ids=resolved_ids,
+        dependency_refs=(
+            ExpectedDependencyRef(
+                dependency_kind="synthetic_manifest",
+                dependency_id=manifest_dependency_id,
+            ),
+            *source_dependency_refs,
+        ),
+        artifact_refs=(
+            ExpectedArtifactRef(commit_package_id, "commit_package"),
+            ExpectedArtifactRef(governance_decision_id, "governance_decision"),
+            ExpectedArtifactRef(
+                f"checked_claim:electricity_kwh:{source_witness_id}",
+                "checked_claim",
+            ),
+            ExpectedArtifactRef(config.output_claim_id, "derived_claim"),
+            ExpectedArtifactRef(source_witness_id, "evidence_witness"),
+            ExpectedArtifactRef(config.binding_id, "reference_binding"),
+            ExpectedArtifactRef(
+                f"trace:{config.output_claim_id}",
+                "calculation_trace",
+            ),
+            ExpectedArtifactRef(config.formula_id, "formula"),
+            ExpectedArtifactRef(manifest_dependency_id, "synthetic_manifest"),
+            *(
+                ExpectedArtifactRef(
+                    ref.dependency_id,
+                    ref.dependency_kind,
+                )
+                for ref in source_dependency_refs
+            ),
+        ),
+    )
+
+
+def synthetic_manifest_dependency_id(config: SyntheticScenarioConfig) -> str:
+    return f"synthetic_manifest:{config.scenario_id}:seed-{config.seed}"
+
+
+def reference_search_obligation_id(config: SyntheticScenarioConfig) -> str:
+    return (
+        f"resolve:{config.formula_id}:{config.output_claim_id}:"
+        "reference_search_required"
+    )
+
+
+def calculation_obligation_id(config: SyntheticScenarioConfig) -> str:
+    return (
+        f"calculation:{config.formula_id}:{config.output_claim_id}:"
+        "unknown_reference"
+    )
+
+
+__all__ = [
+    "calculation_obligation_id",
+    "expected_smoke_receipt",
+    "reference_search_obligation_id",
+    "synthetic_manifest_dependency_id",
+]

--- a/comp/scenarios/synthetic/sources.py
+++ b/comp/scenarios/synthetic/sources.py
@@ -115,7 +115,7 @@ def _synthetic_source_content_digest(rows: tuple[dict[str, Any], ...]) -> str:
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
 
 
-def _synthetic_source_dependency_refs(
+def synthetic_source_dependency_refs(
     config: SyntheticScenarioConfig,
 ) -> tuple[ExpectedDependencyRef, ...]:
     return tuple(
@@ -148,5 +148,6 @@ def _synthetic_source_identities(
 __all__ = [
     "build_synthetic_loaded_source",
     "build_synthetic_loaded_sources",
+    "synthetic_source_dependency_refs",
     "synthetic_source_input_dependency_id",
 ]

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -43,6 +43,33 @@ def test_synthetic_data_models_live_outside_generator_module() -> None:
     )
 
 
+def test_synthetic_expected_receipt_oracle_lives_outside_generator_module() -> None:
+    from comp.scenarios.synthetic.oracle import (
+        calculation_obligation_id,
+        expected_smoke_receipt,
+        reference_search_obligation_id,
+    )
+
+    config = SyntheticScenarioConfig.pcf_smoke(seed=7)
+    run = generate_synthetic_pcf_run(config)
+    derived_value = run.oracle.expected_derived_claims[0].value
+
+    assert expected_smoke_receipt.__module__ == "comp.scenarios.synthetic.oracle"
+    assert generate_synthetic_pcf_run.__globals__["expected_smoke_receipt"] is (
+        expected_smoke_receipt
+    )
+    assert run.oracle.expected_receipt == expected_smoke_receipt(
+        config,
+        source_witness_id=f"witness:{config.source_row_id}:electricity_kwh",
+        derived_value=derived_value,
+    )
+    assert run.oracle.expected_receipt is not None
+    assert run.oracle.expected_receipt.resolved_obligation_ids == (
+        reference_search_obligation_id(config),
+        calculation_obligation_id(config),
+    )
+
+
 def test_synthetic_pcf_generator_writes_oracle_not_truth(tmp_path: Path) -> None:
     config = SyntheticScenarioConfig.pcf_smoke(seed=7)
 


### PR DESCRIPTION
## Summary
- move synthetic expected receipt and obligation id helpers into `comp.scenarios.synthetic.oracle`
- update `generator.py` to call the oracle helpers instead of owning receipt expectation construction
- expose source dependency refs from `sources.py` for oracle construction
- add a boundary test proving the expected receipt helper lives outside the generator module

## Why

After splitting the writer, models, and source helpers, `generator.py` still owned expected receipt construction. This slice keeps behavior unchanged while separating synthetic input/run construction from oracle expectation construction.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py -q` -> 16 passed
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q` -> 50 passed
- `python -m pytest -q` -> 458 passed, 9 skipped
- `git diff --cached --check` -> passed before commit
