### PR TITLE
[codex] Split synthetic anomaly specs

### DIFF
--- a/comp/scenarios/synthetic/anomaly_specs.py
+++ b/comp/scenarios/synthetic/anomaly_specs.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import Any
+
+from comp.scenarios.synthetic.anomalies import (
+    MISSING_UNIT,
+    NEGATIVE_AMOUNT,
+    PERIOD_MISMATCH,
+    SITE_ALIAS,
+    WRONG_UNIT,
+)
+from comp.scenarios.synthetic.config import SyntheticScenarioConfig
+from comp.scenarios.synthetic.models import (
+    ExpectedFailedClaim,
+    ExpectedHazard,
+    ExpectedObligation,
+    InjectedAnomaly,
+    RawElectricityRow,
+    SyntheticResolutionArtifact,
+)
+
+
+def anomaly_specs(config: SyntheticScenarioConfig) -> tuple[dict[str, Any], ...]:
+    specs_by_type = {
+        MISSING_UNIT: missing_unit_spec(config),
+        WRONG_UNIT: _wrong_unit_spec(config),
+        PERIOD_MISMATCH: _period_mismatch_spec(config),
+        NEGATIVE_AMOUNT: _negative_amount_spec(config),
+        SITE_ALIAS: _site_alias_spec(config),
+    }
+    return tuple(specs_by_type[anomaly] for anomaly in config.anomalies)
+
+
+def missing_unit_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+    row_id = "ERP-SYN-PCF-MISSING-UNIT"
+    return {
+        "row": _anomaly_row(config, row_id=row_id, unit=""),
+        "anomaly": InjectedAnomaly(
+            anomaly_id="synthetic-anomaly:missing_unit",
+            anomaly_type=MISSING_UNIT,
+            source_row_id=row_id,
+            field="unit",
+            description="electricity activity row omits its unit",
+        ),
+        "obligation": ExpectedObligation(
+            obligation_id="synthetic-obligation:missing_unit",
+            kind="find_source_witness",
+            field="unit",
+            reason="missing_unit",
+        ),
+        "hazard": ExpectedHazard(
+            hazard_id="hazard:missing_unit:unit:review",
+            kind="missing_unit",
+            field="unit",
+            severity="review",
+        ),
+        "failed_claim": None,
+    }
+
+
+def missing_unit_resolution_artifact(
+    row: RawElectricityRow,
+) -> SyntheticResolutionArtifact:
+    return SyntheticResolutionArtifact(
+        artifact_id="synthetic-resolution:missing_unit:kwh",
+        obligation_id="synthetic-obligation:missing_unit",
+        source_row_id=row.source_row_id,
+        field="unit",
+        resolved_value="kWh",
+        witness_id=f"resolution-witness:{row.source_row_id}:unit",
+        source_ref="unit_witnesses.csv",
+        rationale="operator supplied the omitted electricity unit",
+    )
+
+
+def _wrong_unit_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+    row_id = "ERP-SYN-PCF-WRONG-UNIT"
+    return {
+        "row": _anomaly_row(config, row_id=row_id, unit="MWh"),
+        "anomaly": InjectedAnomaly(
+            anomaly_id="synthetic-anomaly:wrong_unit",
+            anomaly_type=WRONG_UNIT,
+            source_row_id=row_id,
+            field="unit",
+            description="electricity activity row uses an unsupported unit",
+        ),
+        "obligation": ExpectedObligation(
+            obligation_id="synthetic-obligation:wrong_unit",
+            kind="find_source_witness",
+            field="unit",
+            reason="unsupported_unit",
+        ),
+        "hazard": None,
+        "failed_claim": ExpectedFailedClaim(
+            failed_claim_id="synthetic-failed-claim:wrong_unit",
+            field="unit",
+            value="MWh",
+            reason="unsupported_unit",
+            source_row_id=row_id,
+        ),
+    }
+
+
+def _period_mismatch_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+    row_id = "ERP-SYN-PCF-PERIOD-MISMATCH"
+    return {
+        "row": _anomaly_row(config, row_id=row_id, period="2023"),
+        "anomaly": InjectedAnomaly(
+            anomaly_id="synthetic-anomaly:period_mismatch",
+            anomaly_type=PERIOD_MISMATCH,
+            source_row_id=row_id,
+            field="period",
+            description="electricity activity row falls outside the reporting period",
+        ),
+        "obligation": ExpectedObligation(
+            obligation_id="synthetic-obligation:period_mismatch",
+            kind="find_context",
+            field="period",
+            reason="period_mismatch",
+        ),
+        "hazard": ExpectedHazard(
+            hazard_id="hazard:period_mismatch:period:review",
+            kind="period_mismatch",
+            field="period",
+            severity="review",
+        ),
+        "failed_claim": None,
+    }
+
+
+def _negative_amount_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+    row_id = "ERP-SYN-PCF-NEGATIVE-AMOUNT"
+    return {
+        "row": _anomaly_row(config, row_id=row_id, amount=-25),
+        "anomaly": InjectedAnomaly(
+            anomaly_id="synthetic-anomaly:negative_amount",
+            anomaly_type=NEGATIVE_AMOUNT,
+            source_row_id=row_id,
+            field="electricity_kwh",
+            description="electricity activity amount is negative",
+        ),
+        "obligation": ExpectedObligation(
+            obligation_id="synthetic-obligation:negative_amount",
+            kind="investigate_activity_amount",
+            field="electricity_kwh",
+            reason="negative_amount",
+        ),
+        "hazard": ExpectedHazard(
+            hazard_id="hazard:invalid_activity_amount:electricity_kwh:block",
+            kind="invalid_activity_amount",
+            field="electricity_kwh",
+            severity="block",
+        ),
+        "failed_claim": ExpectedFailedClaim(
+            failed_claim_id="synthetic-failed-claim:negative_amount",
+            field="electricity_kwh",
+            value=-25,
+            reason="negative_amount",
+            source_row_id=row_id,
+        ),
+    }
+
+
+def _site_alias_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+    row_id = "ERP-SYN-PCF-SITE-ALIAS"
+    return {
+        "row": _anomaly_row(
+            config,
+            row_id=row_id,
+            site_id="SITE-ALIAS-001",
+            site_name="Synthetic Cell Plant One",
+        ),
+        "anomaly": InjectedAnomaly(
+            anomaly_id="synthetic-anomaly:site_alias",
+            anomaly_type=SITE_ALIAS,
+            source_row_id=row_id,
+            field="site_id",
+            description="electricity activity row uses an unrecognized site alias",
+        ),
+        "obligation": ExpectedObligation(
+            obligation_id="synthetic-obligation:site_alias",
+            kind="resolve_site_identity",
+            field="site_id",
+            reason="site_alias",
+        ),
+        "hazard": ExpectedHazard(
+            hazard_id="hazard:site_alias:site_id:review",
+            kind="site_alias",
+            field="site_id",
+            severity="review",
+        ),
+        "failed_claim": None,
+    }
+
+
+def _anomaly_row(
+    config: SyntheticScenarioConfig,
+    *,
+    row_id: str,
+    amount: int | float | None = None,
+    unit: str | None = None,
+    period: str | None = None,
+    site_id: str | None = None,
+    site_name: str | None = None,
+) -> RawElectricityRow:
+    return RawElectricityRow(
+        source_row_id=row_id,
+        source_ref=config.source_ref,
+        period=period or config.reporting_period,
+        site_id=site_id or config.site_id,
+        site_name=site_name or config.site_name,
+        product_id=config.product_id,
+        activity_type="electricity",
+        amount=config.electricity_kwh if amount is None else amount,
+        unit=config.electricity_unit if unit is None else unit,
+    )
+
+
+__all__ = [
+    "anomaly_specs",
+    "missing_unit_resolution_artifact",
+    "missing_unit_spec",
+]

--- a/comp/scenarios/synthetic/generator.py
+++ b/comp/scenarios/synthetic/generator.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Any
 
-from comp.scenarios.synthetic.anomalies import (
-    MISSING_UNIT,
-    NEGATIVE_AMOUNT,
-    PERIOD_MISMATCH,
-    SITE_ALIAS,
-    WRONG_UNIT,
+from comp.scenarios.synthetic.anomaly_specs import (
+    anomaly_specs,
+    missing_unit_resolution_artifact,
+    missing_unit_spec,
 )
 from comp.scenarios.synthetic.config import SyntheticScenarioConfig
 from comp.scenarios.synthetic.manifest import build_manifest
@@ -48,6 +45,7 @@ from comp.scenarios.synthetic.sources import (
     build_synthetic_loaded_sources,
     synthetic_source_input_dependency_id,
 )
+
 
 def generate_synthetic_pcf_run(config: SyntheticScenarioConfig) -> SyntheticRun:
     if config.scenario_id == "synthetic_pcf.resolution.v1":
@@ -158,11 +156,11 @@ def _generate_synthetic_pcf_resolution_run(
         source="synthetic_reference_catalog",
         witness_id=f"reference-witness:{config.factor_reference_id}",
     )
-    missing_unit = _missing_unit_spec(config)
+    missing_unit = missing_unit_spec(config)
     raw_row = missing_unit["row"]
     source_witness_id = f"witness:{raw_row.source_row_id}:electricity_kwh"
     derived_value = _multiply(raw_row.amount, config.factor_value)
-    resolution = _missing_unit_resolution_artifact(raw_row)
+    resolution = missing_unit_resolution_artifact(raw_row)
     resolved_obligation = missing_unit["obligation"]
 
     return SyntheticRun(
@@ -281,8 +279,8 @@ def _generate_synthetic_pcf_anomaly_run(
         source="synthetic_reference_catalog",
         witness_id=f"reference-witness:{config.factor_reference_id}",
     )
-    anomaly_specs = _anomaly_specs(config)
-    rows = tuple(spec["row"] for spec in anomaly_specs)
+    specs = anomaly_specs(config)
+    rows = tuple(spec["row"] for spec in specs)
     expected_claims = tuple(
         ExpectedClaim(
             claim_id=f"synthetic-pcf-anomaly:{row.source_row_id}:electricity_kwh",
@@ -330,214 +328,18 @@ def _generate_synthetic_pcf_anomaly_run(
         oracle=SyntheticOracle(
             expected_claims=expected_claims,
             expected_derived_claims=(),
-            expected_obligations=tuple(spec["obligation"] for spec in anomaly_specs),
+            expected_obligations=tuple(spec["obligation"] for spec in specs),
             expected_hazards=tuple(
-                spec["hazard"] for spec in anomaly_specs if spec["hazard"] is not None
+                spec["hazard"] for spec in specs if spec["hazard"] is not None
             ),
             expected_failed_claims=tuple(
                 spec["failed_claim"]
-                for spec in anomaly_specs
+                for spec in specs
                 if spec["failed_claim"] is not None
             ),
-            injected_anomalies=tuple(spec["anomaly"] for spec in anomaly_specs),
+            injected_anomalies=tuple(spec["anomaly"] for spec in specs),
             source_to_expected_claim_map=expected_maps,
         ),
-    )
-
-
-def _anomaly_specs(config: SyntheticScenarioConfig) -> tuple[dict[str, Any], ...]:
-    specs_by_type = {
-        MISSING_UNIT: _missing_unit_spec(config),
-        WRONG_UNIT: _wrong_unit_spec(config),
-        PERIOD_MISMATCH: _period_mismatch_spec(config),
-        NEGATIVE_AMOUNT: _negative_amount_spec(config),
-        SITE_ALIAS: _site_alias_spec(config),
-    }
-    return tuple(specs_by_type[anomaly] for anomaly in config.anomalies)
-
-
-def _missing_unit_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
-    row_id = "ERP-SYN-PCF-MISSING-UNIT"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, unit=""),
-        "anomaly": InjectedAnomaly(
-            anomaly_id="synthetic-anomaly:missing_unit",
-            anomaly_type=MISSING_UNIT,
-            source_row_id=row_id,
-            field="unit",
-            description="electricity activity row omits its unit",
-        ),
-        "obligation": ExpectedObligation(
-            obligation_id="synthetic-obligation:missing_unit",
-            kind="find_source_witness",
-            field="unit",
-            reason="missing_unit",
-        ),
-        "hazard": ExpectedHazard(
-            hazard_id="hazard:missing_unit:unit:review",
-            kind="missing_unit",
-            field="unit",
-            severity="review",
-        ),
-        "failed_claim": None,
-    }
-
-
-def _missing_unit_resolution_artifact(
-    row: RawElectricityRow,
-) -> SyntheticResolutionArtifact:
-    return SyntheticResolutionArtifact(
-        artifact_id="synthetic-resolution:missing_unit:kwh",
-        obligation_id="synthetic-obligation:missing_unit",
-        source_row_id=row.source_row_id,
-        field="unit",
-        resolved_value="kWh",
-        witness_id=f"resolution-witness:{row.source_row_id}:unit",
-        source_ref="unit_witnesses.csv",
-        rationale="operator supplied the omitted electricity unit",
-    )
-
-
-def _wrong_unit_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
-    row_id = "ERP-SYN-PCF-WRONG-UNIT"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, unit="MWh"),
-        "anomaly": InjectedAnomaly(
-            anomaly_id="synthetic-anomaly:wrong_unit",
-            anomaly_type=WRONG_UNIT,
-            source_row_id=row_id,
-            field="unit",
-            description="electricity activity row uses an unsupported unit",
-        ),
-        "obligation": ExpectedObligation(
-            obligation_id="synthetic-obligation:wrong_unit",
-            kind="find_source_witness",
-            field="unit",
-            reason="unsupported_unit",
-        ),
-        "hazard": None,
-        "failed_claim": ExpectedFailedClaim(
-            failed_claim_id="synthetic-failed-claim:wrong_unit",
-            field="unit",
-            value="MWh",
-            reason="unsupported_unit",
-            source_row_id=row_id,
-        ),
-    }
-
-
-def _period_mismatch_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
-    row_id = "ERP-SYN-PCF-PERIOD-MISMATCH"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, period="2023"),
-        "anomaly": InjectedAnomaly(
-            anomaly_id="synthetic-anomaly:period_mismatch",
-            anomaly_type=PERIOD_MISMATCH,
-            source_row_id=row_id,
-            field="period",
-            description="electricity activity row falls outside the reporting period",
-        ),
-        "obligation": ExpectedObligation(
-            obligation_id="synthetic-obligation:period_mismatch",
-            kind="find_context",
-            field="period",
-            reason="period_mismatch",
-        ),
-        "hazard": ExpectedHazard(
-            hazard_id="hazard:period_mismatch:period:review",
-            kind="period_mismatch",
-            field="period",
-            severity="review",
-        ),
-        "failed_claim": None,
-    }
-
-
-def _negative_amount_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
-    row_id = "ERP-SYN-PCF-NEGATIVE-AMOUNT"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, amount=-25),
-        "anomaly": InjectedAnomaly(
-            anomaly_id="synthetic-anomaly:negative_amount",
-            anomaly_type=NEGATIVE_AMOUNT,
-            source_row_id=row_id,
-            field="electricity_kwh",
-            description="electricity activity amount is negative",
-        ),
-        "obligation": ExpectedObligation(
-            obligation_id="synthetic-obligation:negative_amount",
-            kind="investigate_activity_amount",
-            field="electricity_kwh",
-            reason="negative_amount",
-        ),
-        "hazard": ExpectedHazard(
-            hazard_id="hazard:invalid_activity_amount:electricity_kwh:block",
-            kind="invalid_activity_amount",
-            field="electricity_kwh",
-            severity="block",
-        ),
-        "failed_claim": ExpectedFailedClaim(
-            failed_claim_id="synthetic-failed-claim:negative_amount",
-            field="electricity_kwh",
-            value=-25,
-            reason="negative_amount",
-            source_row_id=row_id,
-        ),
-    }
-
-
-def _site_alias_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
-    row_id = "ERP-SYN-PCF-SITE-ALIAS"
-    return {
-        "row": _anomaly_row(
-            config,
-            row_id=row_id,
-            site_id="SITE-ALIAS-001",
-            site_name="Synthetic Cell Plant One",
-        ),
-        "anomaly": InjectedAnomaly(
-            anomaly_id="synthetic-anomaly:site_alias",
-            anomaly_type=SITE_ALIAS,
-            source_row_id=row_id,
-            field="site_id",
-            description="electricity activity row uses an unrecognized site alias",
-        ),
-        "obligation": ExpectedObligation(
-            obligation_id="synthetic-obligation:site_alias",
-            kind="resolve_site_identity",
-            field="site_id",
-            reason="site_alias",
-        ),
-        "hazard": ExpectedHazard(
-            hazard_id="hazard:site_alias:site_id:review",
-            kind="site_alias",
-            field="site_id",
-            severity="review",
-        ),
-        "failed_claim": None,
-    }
-
-
-def _anomaly_row(
-    config: SyntheticScenarioConfig,
-    *,
-    row_id: str,
-    amount: int | float | None = None,
-    unit: str | None = None,
-    period: str | None = None,
-    site_id: str | None = None,
-    site_name: str | None = None,
-) -> RawElectricityRow:
-    return RawElectricityRow(
-        source_row_id=row_id,
-        source_ref=config.source_ref,
-        period=period or config.reporting_period,
-        site_id=site_id or config.site_id,
-        site_name=site_name or config.site_name,
-        product_id=config.product_id,
-        activity_type="electricity",
-        amount=config.electricity_kwh if amount is None else amount,
-        unit=config.electricity_unit if unit is None else unit,
     )
 
 

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -70,6 +70,29 @@ def test_synthetic_expected_receipt_oracle_lives_outside_generator_module() -> N
     )
 
 
+def test_synthetic_anomaly_specs_live_outside_generator_module() -> None:
+    from comp.scenarios.synthetic.anomaly_specs import (
+        anomaly_specs,
+        missing_unit_resolution_artifact,
+    )
+
+    config = SyntheticScenarioConfig.pcf_anomaly(seed=11)
+    run = generate_synthetic_pcf_run(config)
+    specs = anomaly_specs(config)
+
+    assert anomaly_specs.__module__ == "comp.scenarios.synthetic.anomaly_specs"
+    assert generate_synthetic_pcf_run.__globals__["anomaly_specs"] is anomaly_specs
+    assert tuple(spec["row"] for spec in specs) == run.raw_sources.electricity_rows
+    assert tuple(spec["anomaly"] for spec in specs) == run.oracle.injected_anomalies
+
+    resolution_run = generate_synthetic_pcf_run(
+        SyntheticScenarioConfig.pcf_resolution(seed=17)
+    )
+    assert resolution_run.resolution_artifacts.unit_witnesses == (
+        missing_unit_resolution_artifact(resolution_run.raw_sources.electricity_rows[0]),
+    )
+
+
 def test_synthetic_pcf_generator_writes_oracle_not_truth(tmp_path: Path) -> None:
     config = SyntheticScenarioConfig.pcf_smoke(seed=7)
 


### PR DESCRIPTION
## Summary
- Move synthetic anomaly row/spec builders into `comp.scenarios.synthetic.anomaly_specs`.
- Keep `generator.py` as the orchestration layer that consumes `anomaly_specs`, `missing_unit_spec`, and `missing_unit_resolution_artifact`.
- Add a boundary test that verifies the generator depends on the extracted anomaly spec module while preserving generated rows, injected anomalies, and resolution artifacts.

## Why
The synthetic generator has been shrinking into orchestration plus small domain helpers. This PR extracts the anomaly fixture/spec construction so future edits to anomaly semantics do not keep expanding `generator.py`.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py -q` -> 17 passed
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q` -> 51 passed
- `python -m pytest -q` -> 460 passed, 9 skipped
- `git diff --cached --check` -> passed