### PR TITLE
[codex] Move synthetic PCF value helper

### DIFF
--- a/comp/scenarios/synthetic/pcf_fixtures.py
+++ b/comp/scenarios/synthetic/pcf_fixtures.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 from comp.scenarios.synthetic.config import SyntheticScenarioConfig
 from comp.scenarios.synthetic.models import (
     ExpectedCalculatedClaim,
@@ -64,6 +66,16 @@ def electricity_witness_id(source_row_id: str) -> str:
     return f"witness:{source_row_id}:electricity_kwh"
 
 
+def calculate_co2e_value(
+    activity_amount: int | float,
+    factor_value: int | float,
+) -> int | float:
+    value = Decimal(str(activity_amount)) * Decimal(str(factor_value))
+    if value == value.to_integral_value():
+        return float(value)
+    return float(value)
+
+
 def electricity_expected_claim(
     claim_id: str,
     row: RawElectricityRow,
@@ -108,6 +120,7 @@ def co2e_expected_calculated_claim(
 
 
 __all__ = [
+    "calculate_co2e_value",
     "co2e_expected_calculated_claim",
     "electricity_expected_claim",
     "electricity_source_map",

--- a/comp/scenarios/synthetic/run_builders.py
+++ b/comp/scenarios/synthetic/run_builders.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from decimal import Decimal
-
 from comp.scenarios.synthetic.anomaly_specs import (
     anomaly_specs,
     missing_unit_resolution_artifact,
@@ -25,6 +23,7 @@ from comp.scenarios.synthetic.oracle import (
     reference_search_obligation_id,
 )
 from comp.scenarios.synthetic.pcf_fixtures import (
+    calculate_co2e_value,
     co2e_expected_calculated_claim,
     electricity_expected_claim,
     electricity_source_map,
@@ -37,7 +36,7 @@ from comp.scenarios.synthetic.pcf_fixtures import (
 def build_synthetic_pcf_smoke_run(config: SyntheticScenarioConfig) -> SyntheticRun:
     raw_row = raw_electricity_row(config)
     source_witness_id = electricity_witness_id(raw_row.source_row_id)
-    derived_value = _multiply(raw_row.amount, config.factor_value)
+    derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
     expected_claim = electricity_expected_claim(config.input_claim_id, raw_row)
     return SyntheticRun(
         config=config,
@@ -71,7 +70,7 @@ def build_synthetic_pcf_resolution_run(
     missing_unit = missing_unit_spec(config)
     raw_row = missing_unit["row"]
     source_witness_id = electricity_witness_id(raw_row.source_row_id)
-    derived_value = _multiply(raw_row.amount, config.factor_value)
+    derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
     resolution = missing_unit_resolution_artifact(raw_row)
     resolved_obligation = missing_unit["obligation"]
 
@@ -188,14 +187,6 @@ def build_synthetic_pcf_anomaly_run(
             source_to_expected_claim_map=expected_maps,
         ),
     )
-
-
-def _multiply(left: int | float, right: int | float) -> int | float:
-    value = Decimal(str(left)) * Decimal(str(right))
-    if value == value.to_integral_value():
-        return float(value)
-    return float(value)
-
 
 __all__ = [
     "build_synthetic_pcf_anomaly_run",

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -132,6 +132,7 @@ def test_synthetic_run_builders_live_outside_generator_module() -> None:
 
 def test_synthetic_pcf_fixtures_live_outside_run_builders_module() -> None:
     from comp.scenarios.synthetic.pcf_fixtures import (
+        calculate_co2e_value,
         electricity_expected_claim,
         electricity_source_map,
         pcf_master,
@@ -145,8 +146,15 @@ def test_synthetic_pcf_fixtures_live_outside_run_builders_module() -> None:
 
     assert pcf_master.__module__ == "comp.scenarios.synthetic.pcf_fixtures"
     assert build_synthetic_pcf_smoke_run.__globals__["pcf_master"] is pcf_master
+    assert build_synthetic_pcf_smoke_run.__globals__["calculate_co2e_value"] is (
+        calculate_co2e_value
+    )
     assert run.master == pcf_master(config)
     assert run.master.reference_catalog == (pcf_reference_record(config),)
+    assert run.oracle.expected_derived_claims[0].value == calculate_co2e_value(
+        raw_row.amount,
+        config.factor_value,
+    )
     assert run.oracle.expected_claims == (
         electricity_expected_claim(config.input_claim_id, raw_row),
     )


### PR DESCRIPTION
## Summary
- Move the synthetic PCF CO2e value calculation helper into `pcf_fixtures`.
- Remove the local Decimal helper from `run_builders.py` so run builders keep focusing on scenario assembly.
- Extend the PCF fixture boundary test to assert run builders consume the extracted value helper and preserve the expected derived claim value.

## Why
After extracting PCF fixture primitives, the remaining local calculation helper was the last small shared fixture rule inside `run_builders.py`. This keeps calculation/value fixture construction with the rest of the synthetic PCF fixture surface.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py -q` -> 19 passed
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q` -> 53 passed
- `python -m pytest -q` -> 469 passed, 9 skipped
- `git diff --cached --check` -> passed