### PR TITLE
[codex] rename validation report fields

### DIFF
--- a/comp/compiler_tool/calculation_flow.py
+++ b/comp/compiler_tool/calculation_flow.py
@@ -47,7 +47,7 @@ def resolve_reference_grounded_calculation(
         criteria=criteria,
         field=formula.output_field,
     )
-    binding = _binding_for(selected.reference_bindings, criteria.binding_id)
+    binding = _binding_for(selected.canonical_references, criteria.binding_id)
     if binding is None:
         return selected
 
@@ -64,7 +64,7 @@ def resolve_reference_grounded_calculation(
 def _has_reference_search_obligation(report: ValidationReport) -> bool:
     return any(
         obligation.kind == "reference_search_required"
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     )
 
 

--- a/comp/compiler_tool/calculation_report.py
+++ b/comp/compiler_tool/calculation_report.py
@@ -22,7 +22,7 @@ def apply_calculation_result(
         return with_recomputed_status(
             replace(
                 report,
-                derived_claims=(*report.derived_claims, result.derived_claim),
+                calculated_claims=(*report.calculated_claims, result.derived_claim),
                 can_build_public_output=False,
             )
         )
@@ -47,7 +47,7 @@ def apply_calculation_result(
     return with_recomputed_status(
         replace(
             report,
-            obligations=_append_unique(report.obligations, obligation),
+            validation_requirements=_append_unique(report.validation_requirements, obligation),
             can_build_public_output=False,
         )
     )

--- a/comp/compiler_tool/calculation_resolution.py
+++ b/comp/compiler_tool/calculation_resolution.py
@@ -9,20 +9,20 @@ from comp.compiler_tool.models import ValidationReport, ValidationRequirement
 def plan_calculation_resolution(report: ValidationReport) -> ValidationReport:
     follow_ups = tuple(
         follow_up
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
         for follow_up in _follow_up_obligations(obligation)
     )
     if not follow_ups:
         return report
 
-    obligations = report.obligations
+    obligations = report.validation_requirements
     for follow_up in follow_ups:
         if follow_up not in obligations:
             obligations = (*obligations, follow_up)
 
     return replace(
         report,
-        obligations=obligations,
+        validation_requirements=obligations,
         can_build_public_output=False,
     )
 

--- a/comp/compiler_tool/calculation_retry.py
+++ b/comp/compiler_tool/calculation_retry.py
@@ -33,15 +33,15 @@ def retry_blocked_calculation(
     )
     if result.status == "calculated" and result.derived_claim is not None:
         open_obligations, resolved = _split_matching_calculation_obligations(
-            report.obligations,
+            report.validation_requirements,
             formula=formula,
             output_claim_id=output_claim_id,
         )
         base_report = replace(
             report,
-            obligations=open_obligations,
-            resolved_obligations=_append_unique_obligations(
-                report.resolved_obligations,
+            validation_requirements=open_obligations,
+            resolved_validation_requirements=_append_unique_obligations(
+                report.resolved_validation_requirements,
                 resolved,
             ),
             can_build_public_output=False,
@@ -49,8 +49,8 @@ def retry_blocked_calculation(
         return with_recomputed_status(
             replace(
                 base_report,
-                derived_claims=_append_unique_derived_claim(
-                    base_report.derived_claims,
+                calculated_claims=_append_unique_derived_claim(
+                    base_report.calculated_claims,
                     result.derived_claim,
                 ),
                 can_build_public_output=False,

--- a/comp/compiler_tool/commit_package.py
+++ b/comp/compiler_tool/commit_package.py
@@ -50,10 +50,10 @@ def build_commit_package(
 ) -> ReviewPackage:
     report_status = recompute_report_status(report)
     open_obligation_ids = tuple(
-        _obligation_id(obligation) for obligation in report.obligations
+        _obligation_id(obligation) for obligation in report.validation_requirements
     )
     has_open_blocking_obligation = any(
-        obligation.blocking for obligation in report.obligations
+        obligation.blocking for obligation in report.validation_requirements
     )
     hazard_ids = tuple(_hazard_id(hazard) for hazard in report.hazards)
 
@@ -67,20 +67,20 @@ def build_commit_package(
         ),
         semantic_judgment_ids=tuple(semantic_judgment_ids),
         reference_binding_ids=tuple(
-            binding.binding_id for binding in report.reference_bindings
+            binding.binding_id for binding in report.canonical_references
         ),
-        derived_claim_fields=tuple(claim.field for claim in report.derived_claims),
-        derived_claim_ids=tuple(claim.claim_id for claim in report.derived_claims),
+        derived_claim_fields=tuple(claim.field for claim in report.calculated_claims),
+        derived_claim_ids=tuple(claim.claim_id for claim in report.calculated_claims),
         calculation_trace_ids=tuple(
-            claim.trace.trace_id for claim in report.derived_claims
+            claim.trace.trace_id for claim in report.calculated_claims
         ),
-        formula_ids=_unique(claim.formula_id for claim in report.derived_claims),
+        formula_ids=_unique(claim.formula_id for claim in report.calculated_claims),
         projection_value_commitments=_projection_value_commitments(report),
         dependency_fingerprints=tuple(dependency_fingerprints),
         open_obligation_ids=open_obligation_ids,
         resolved_obligation_ids=tuple(
             _obligation_id(obligation)
-            for obligation in report.resolved_obligations
+            for obligation in report.resolved_validation_requirements
         ),
         hazard_ids=hazard_ids,
         profile_id=profile_id,
@@ -124,7 +124,7 @@ def _projection_value_commitments(
             source_id=claim.claim_id,
             value=claim.value,
         )
-        for claim in report.derived_claims
+        for claim in report.calculated_claims
     )
     return checked + derived
 

--- a/comp/compiler_tool/judgment_adapter.py
+++ b/comp/compiler_tool/judgment_adapter.py
@@ -25,7 +25,7 @@ def compile_report_to_facts(report: ValidationReport, subject: SubjectRef) -> se
             )
         )
 
-    for claim in report.derived_claims:
+    for claim in report.calculated_claims:
         facts.add(
             Fact(
                 tag="evidence",
@@ -48,7 +48,7 @@ def compile_report_to_facts(report: ValidationReport, subject: SubjectRef) -> se
             )
         )
 
-    for binding in report.reference_bindings:
+    for binding in report.canonical_references:
         facts.add(
             Fact(
                 tag="prov_edge",
@@ -124,10 +124,10 @@ def compile_report_to_facts(report: ValidationReport, subject: SubjectRef) -> se
             )
         )
 
-    for obligation in report.obligations:
+    for obligation in report.validation_requirements:
         facts.add(_obligation_fact("hazard_open", report.status, subject, obligation))
 
-    for obligation in report.resolved_obligations:
+    for obligation in report.resolved_validation_requirements:
         facts.add(
             _obligation_fact(
                 "hazard_discharge",

--- a/comp/compiler_tool/models.py
+++ b/comp/compiler_tool/models.py
@@ -137,15 +137,15 @@ class Hazard:
 @dataclass(frozen=True)
 class ValidationReport:
     status: CompileStatus
-    evidence_witnesses: tuple[EvidenceRef, ...] = field(default_factory=tuple)
+    evidence_refs: tuple[EvidenceRef, ...] = field(default_factory=tuple)
     checked_claims: tuple[CheckedClaim, ...] = field(default_factory=tuple)
     failed_claims: tuple[FailedClaim, ...] = field(default_factory=tuple)
     unknowns: tuple[UnknownClaim, ...] = field(default_factory=tuple)
     unchecked_areas: tuple[UncheckedArea, ...] = field(default_factory=tuple)
-    obligations: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
-    resolved_obligations: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
+    validation_requirements: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
+    resolved_validation_requirements: tuple[ValidationRequirement, ...] = field(default_factory=tuple)
     hazards: tuple[Hazard, ...] = field(default_factory=tuple)
-    reference_candidates: tuple[ReferenceOption, ...] = field(default_factory=tuple)
-    reference_bindings: tuple[CanonicalReference, ...] = field(default_factory=tuple)
-    derived_claims: tuple[CalculatedClaim, ...] = field(default_factory=tuple)
+    reference_options: tuple[ReferenceOption, ...] = field(default_factory=tuple)
+    canonical_references: tuple[CanonicalReference, ...] = field(default_factory=tuple)
+    calculated_claims: tuple[CalculatedClaim, ...] = field(default_factory=tuple)
     can_build_public_output: bool = False

--- a/comp/compiler_tool/profile_runner.py
+++ b/comp/compiler_tool/profile_runner.py
@@ -65,9 +65,9 @@ def run_profile_rules(
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=hypothesis.witnesses,
+            evidence_refs=hypothesis.witnesses,
             failed_claims=tuple(failed_claims),
-            obligations=tuple(obligations),
+            validation_requirements=tuple(obligations),
             can_build_public_output=False,
         )
     )
@@ -150,9 +150,9 @@ def _merge_compile_reports(
     return with_recomputed_status(
         replace(
             baseline_report,
-            evidence_witnesses=_merge_unique(
-                baseline_report.evidence_witnesses,
-                profile_rule_report.evidence_witnesses,
+            evidence_refs=_merge_unique(
+                baseline_report.evidence_refs,
+                profile_rule_report.evidence_refs,
             ),
             checked_claims=_merge_unique(
                 baseline_report.checked_claims,
@@ -170,29 +170,29 @@ def _merge_compile_reports(
                 baseline_report.unchecked_areas,
                 profile_rule_report.unchecked_areas,
             ),
-            obligations=_merge_unique(
-                baseline_report.obligations,
-                profile_rule_report.obligations,
+            validation_requirements=_merge_unique(
+                baseline_report.validation_requirements,
+                profile_rule_report.validation_requirements,
             ),
-            resolved_obligations=_merge_unique(
-                baseline_report.resolved_obligations,
-                profile_rule_report.resolved_obligations,
+            resolved_validation_requirements=_merge_unique(
+                baseline_report.resolved_validation_requirements,
+                profile_rule_report.resolved_validation_requirements,
             ),
             hazards=_merge_unique(
                 baseline_report.hazards,
                 profile_rule_report.hazards,
             ),
-            reference_candidates=_merge_unique(
-                baseline_report.reference_candidates,
-                profile_rule_report.reference_candidates,
+            reference_options=_merge_unique(
+                baseline_report.reference_options,
+                profile_rule_report.reference_options,
             ),
-            reference_bindings=_merge_unique(
-                baseline_report.reference_bindings,
-                profile_rule_report.reference_bindings,
+            canonical_references=_merge_unique(
+                baseline_report.canonical_references,
+                profile_rule_report.canonical_references,
             ),
-            derived_claims=_merge_unique(
-                baseline_report.derived_claims,
-                profile_rule_report.derived_claims,
+            calculated_claims=_merge_unique(
+                baseline_report.calculated_claims,
+                profile_rule_report.calculated_claims,
             ),
             can_build_public_output=(
                 baseline_report.can_build_public_output

--- a/comp/compiler_tool/reference_resolution.py
+++ b/comp/compiler_tool/reference_resolution.py
@@ -21,11 +21,11 @@ def resolve_reference_search_obligations(
     retrieval_method: str = "keyword",
 ) -> ValidationReport:
     obligations: list[ValidationRequirement] = []
-    candidates = report.reference_candidates
-    resolved_obligations = report.resolved_obligations
+    candidates = report.reference_options
+    resolved_validation_requirements = report.resolved_validation_requirements
     changed = False
 
-    for obligation in report.obligations:
+    for obligation in report.validation_requirements:
         if not _is_reference_search_obligation(obligation):
             obligations.append(obligation)
             continue
@@ -46,8 +46,8 @@ def resolve_reference_search_obligations(
             continue
 
         candidates = _append_unique_candidates(candidates, found)
-        resolved_obligations = _append_unique_obligations(
-            resolved_obligations,
+        resolved_validation_requirements = _append_unique_obligations(
+            resolved_validation_requirements,
             (obligation,),
         )
         changed = True
@@ -58,9 +58,9 @@ def resolve_reference_search_obligations(
     return with_recomputed_status(
         replace(
             report,
-            obligations=tuple(obligations),
-            resolved_obligations=resolved_obligations,
-            reference_candidates=candidates,
+            validation_requirements=tuple(obligations),
+            resolved_validation_requirements=resolved_validation_requirements,
+            reference_options=candidates,
             can_build_public_output=False,
         )
     )

--- a/comp/compiler_tool/reference_selection_report.py
+++ b/comp/compiler_tool/reference_selection_report.py
@@ -20,7 +20,7 @@ def apply_reference_selection(
     field: str,
 ) -> ValidationReport:
     result = select_reference_binding(
-        candidates=report.reference_candidates,
+        candidates=report.reference_options,
         catalog=catalog,
         criteria=criteria,
     )
@@ -29,24 +29,24 @@ def apply_reference_selection(
     if result.status == "bound" and result.binding is not None:
         open_obligations = tuple(
             obligation
-            for obligation in report.obligations
+            for obligation in report.validation_requirements
             if not _matches_selection_obligation(obligation, obligation_id)
         )
         resolved = tuple(
             obligation
-            for obligation in report.obligations
+            for obligation in report.validation_requirements
             if _matches_selection_obligation(obligation, obligation_id)
         )
         return with_recomputed_status(
             replace(
                 report,
-                obligations=open_obligations,
-                resolved_obligations=_append_unique_obligations(
-                    report.resolved_obligations,
+                validation_requirements=open_obligations,
+                resolved_validation_requirements=_append_unique_obligations(
+                    report.resolved_validation_requirements,
                     resolved,
                 ),
-                reference_bindings=_append_unique_bindings(
-                    report.reference_bindings,
+                canonical_references=_append_unique_bindings(
+                    report.canonical_references,
                     (result.binding,),
                 ),
                 can_build_public_output=False,
@@ -64,7 +64,7 @@ def apply_reference_selection(
     return with_recomputed_status(
         replace(
             report,
-            obligations=_append_unique_obligation_by_id(report.obligations, obligation),
+            validation_requirements=_append_unique_obligation_by_id(report.validation_requirements, obligation),
             can_build_public_output=False,
         )
     )

--- a/comp/compiler_tool/report_status.py
+++ b/comp/compiler_tool/report_status.py
@@ -10,21 +10,21 @@ def recompute_report_status(report: ValidationReport) -> CompileStatus:
         return "blocked"
     if any(
         obligation.kind == "calculation_blocked" and obligation.blocking
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     ):
         return "blocked"
     if report.hazards:
         return "review_required"
     if any(
         obligation.kind == "semantic_judgment_required" and obligation.blocking
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     ):
         return "review_required"
     if report.unchecked_areas:
         return "unchecked"
     if report.unknowns:
         return "underconstrained"
-    if any(obligation.blocking for obligation in report.obligations):
+    if any(obligation.blocking for obligation in report.validation_requirements):
         return "review_required"
     return "accepted"
 

--- a/comp/compiler_tool/resolver_tasks.py
+++ b/comp/compiler_tool/resolver_tasks.py
@@ -28,7 +28,7 @@ class ResolverTask:
 def resolver_tasks_from_report(report: ValidationReport) -> tuple[ResolverTask, ...]:
     return tuple(
         resolver_task_from_obligation(obligation)
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     )
 
 
@@ -63,7 +63,7 @@ def _task_type(obligation_kind: str) -> str:
 def _required_artifact(obligation_kind: str) -> str:
     return {
         "semantic_judgment_required": "semantic_judgment",
-        "reference_search_required": "reference_candidates",
+        "reference_search_required": "reference_options",
         "reference_selection_required": "reference_binding",
         "reference_context_required": "context_attachment",
         "find_context": "context_attachment",

--- a/comp/compiler_tool/retrieval_resolution.py
+++ b/comp/compiler_tool/retrieval_resolution.py
@@ -19,11 +19,11 @@ def resolve_reference_retrieval_obligations(
     limit: int = 10,
 ) -> ValidationReport:
     obligations: list[ValidationRequirement] = []
-    candidates = report.reference_candidates
-    resolved_obligations = report.resolved_obligations
+    candidates = report.reference_options
+    resolved_validation_requirements = report.resolved_validation_requirements
     changed = False
 
-    for obligation in report.obligations:
+    for obligation in report.validation_requirements:
         if not _is_reference_search_obligation(obligation):
             obligations.append(obligation)
             continue
@@ -39,8 +39,8 @@ def resolve_reference_retrieval_obligations(
             continue
 
         candidates = _append_unique_candidates(candidates, found)
-        resolved_obligations = _append_unique_obligations(
-            resolved_obligations,
+        resolved_validation_requirements = _append_unique_obligations(
+            resolved_validation_requirements,
             (obligation,),
         )
         changed = True
@@ -51,9 +51,9 @@ def resolve_reference_retrieval_obligations(
     return with_recomputed_status(
         replace(
             report,
-            obligations=tuple(obligations),
-            resolved_obligations=resolved_obligations,
-            reference_candidates=candidates,
+            validation_requirements=tuple(obligations),
+            resolved_validation_requirements=resolved_validation_requirements,
+            reference_options=candidates,
             can_build_public_output=False,
         )
     )

--- a/comp/compiler_tool/semantic.py
+++ b/comp/compiler_tool/semantic.py
@@ -30,7 +30,7 @@ def apply_semantic_judgments(
     newly_resolved: list[ValidationRequirement] = []
     hazards = list(report.hazards)
 
-    for obligation in report.obligations:
+    for obligation in report.validation_requirements:
         if obligation.kind != "semantic_judgment_required":
             open_obligations.append(obligation)
             continue
@@ -71,20 +71,20 @@ def apply_semantic_judgments(
     return with_recomputed_status(
         ValidationReport(
             status=report.status,
-            evidence_witnesses=report.evidence_witnesses,
+            evidence_refs=report.evidence_refs,
             checked_claims=report.checked_claims,
             failed_claims=report.failed_claims,
             unknowns=report.unknowns,
             unchecked_areas=report.unchecked_areas,
-            obligations=tuple(open_obligations),
-            resolved_obligations=(
-                *report.resolved_obligations,
+            validation_requirements=tuple(open_obligations),
+            resolved_validation_requirements=(
+                *report.resolved_validation_requirements,
                 *tuple(newly_resolved),
             ),
             hazards=tuple(hazards),
-            reference_candidates=report.reference_candidates,
-            reference_bindings=report.reference_bindings,
-            derived_claims=report.derived_claims,
+            reference_options=report.reference_options,
+            canonical_references=report.canonical_references,
+            calculated_claims=report.calculated_claims,
             can_build_public_output=report.can_build_public_output,
         )
     )

--- a/comp/compiler_tool/tool.py
+++ b/comp/compiler_tool/tool.py
@@ -108,12 +108,12 @@ class CompilerTool:
         return with_recomputed_status(
             ValidationReport(
                 status="accepted",
-                evidence_witnesses=tuple(hypothesis.witnesses),
+                evidence_refs=tuple(hypothesis.witnesses),
                 checked_claims=tuple(checked),
                 failed_claims=tuple(failed),
                 unknowns=tuple(unknowns),
                 unchecked_areas=tuple(unchecked),
-                obligations=tuple(obligations),
+                validation_requirements=tuple(obligations),
                 hazards=tuple(hazards),
                 can_build_public_output=False,
             )

--- a/comp/scenarios/synthetic/adapters.py
+++ b/comp/scenarios/synthetic/adapters.py
@@ -144,15 +144,15 @@ class SyntheticPcfAdapter:
 
     def resolution_seed_report(self) -> ValidationReport:
         report = self.blocked_report()
-        resolved_obligations = self._resolved_unit_obligations()
-        if not resolved_obligations:
+        resolved_validation_requirements = self._resolved_unit_obligations()
+        if not resolved_validation_requirements:
             return report
         return with_recomputed_status(
             replace(
                 report,
-                resolved_obligations=(
-                    *report.resolved_obligations,
-                    *resolved_obligations,
+                resolved_validation_requirements=(
+                    *report.resolved_validation_requirements,
+                    *resolved_validation_requirements,
                 ),
                 can_build_public_output=False,
             )
@@ -277,10 +277,10 @@ class SyntheticPcfAdapter:
         return with_recomputed_status(
             ValidationReport(
                 status="accepted",
-                evidence_witnesses=tuple(witnesses),
+                evidence_refs=tuple(witnesses),
                 checked_claims=tuple(checked),
                 failed_claims=tuple(failed),
-                obligations=tuple(obligations),
+                validation_requirements=tuple(obligations),
                 hazards=tuple(hazards),
                 can_build_public_output=False,
             )
@@ -288,7 +288,7 @@ class SyntheticPcfAdapter:
 
     def projection_source(self, report: ValidationReport) -> dict[str, object]:
         values = {claim.field: claim.value for claim in report.checked_claims}
-        values.update({claim.field: claim.value for claim in report.derived_claims})
+        values.update({claim.field: claim.value for claim in report.calculated_claims})
         return values
 
     def dependency_fingerprints(self) -> tuple[DependencyFingerprint, ...]:

--- a/comp/scenarios/synthetic/models.py
+++ b/comp/scenarios/synthetic/models.py
@@ -401,13 +401,13 @@ class SyntheticInputBundle:
 @dataclass(frozen=True)
 class SyntheticOracle:
     expected_claims: tuple[ExpectedClaim, ...]
-    expected_derived_claims: tuple[ExpectedCalculatedClaim, ...]
-    expected_obligations: tuple[ExpectedObligation, ...]
+    expected_calculated_claims: tuple[ExpectedCalculatedClaim, ...]
+    expected_validation_requirements: tuple[ExpectedObligation, ...]
     expected_hazards: tuple[ExpectedHazard, ...]
     expected_failed_claims: tuple[ExpectedFailedClaim, ...]
     injected_anomalies: tuple[InjectedAnomaly, ...]
     source_to_expected_claim_map: tuple[ExpectedSourceMap, ...]
-    expected_resolved_obligations: tuple[ExpectedObligation, ...] | None = None
+    expected_resolved_validation_requirements: tuple[ExpectedObligation, ...] | None = None
     expected_resolution_artifacts: tuple[ExpectedResolutionArtifact, ...] | None = None
     expected_receipt: ExpectedReceipt | None = None
 

--- a/comp/scenarios/synthetic/raw_claim_promotion.py
+++ b/comp/scenarios/synthetic/raw_claim_promotion.py
@@ -100,7 +100,7 @@ def promote_raw_claim_hypothesis(
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=(
+            evidence_refs=(
                 *hypothesis.witnesses,
                 *_support_witnesses(profile),
             ),
@@ -136,9 +136,9 @@ def promote_raw_claim_hypothesis(
                     origin="physical_allocation_support",
                 ),
             ),
-            resolved_obligations=_resolved_obligations(profile),
-            reference_bindings=_reference_bindings(profile),
-            derived_claims=_derived_claims(
+            resolved_validation_requirements=_resolved_validation_requirements(profile),
+            canonical_references=_canonical_references(profile),
+            calculated_claims=_calculated_claims(
                 profile,
                 electricity_mwh=electricity_mwh,
                 allocation_share=allocation_share,
@@ -200,7 +200,7 @@ def _support_witnesses(
     )
 
 
-def _resolved_obligations(
+def _resolved_validation_requirements(
     profile: SyntheticRawClaimPromotionProfile,
 ) -> tuple[ValidationRequirement, ...]:
     return (
@@ -238,7 +238,7 @@ def _resolved_obligations(
     )
 
 
-def _reference_bindings(
+def _canonical_references(
     profile: SyntheticRawClaimPromotionProfile,
 ) -> tuple[CanonicalReference, ...]:
     return (
@@ -275,7 +275,7 @@ def _reference_bindings(
     )
 
 
-def _derived_claims(
+def _calculated_claims(
     profile: SyntheticRawClaimPromotionProfile,
     *,
     electricity_mwh: Decimal,

--- a/comp/scenarios/synthetic/run_builders.py
+++ b/comp/scenarios/synthetic/run_builders.py
@@ -45,10 +45,10 @@ def build_synthetic_pcf_smoke_run(config: SyntheticScenarioConfig) -> SyntheticR
         raw_sources=SyntheticRawSources(electricity_rows=(raw_row,)),
         oracle=SyntheticOracle(
             expected_claims=(expected_claim,),
-            expected_derived_claims=(
+            expected_calculated_claims=(
                 co2e_expected_calculated_claim(config, derived_value),
             ),
-            expected_obligations=(),
+            expected_validation_requirements=(),
             expected_hazards=(),
             expected_failed_claims=(),
             injected_anomalies=(),
@@ -93,17 +93,17 @@ def build_synthetic_pcf_resolution_run(
                     unit=resolution.resolved_value,
                 ),
             ),
-            expected_derived_claims=(
+            expected_calculated_claims=(
                 co2e_expected_calculated_claim(config, derived_value),
             ),
-            expected_obligations=(),
+            expected_validation_requirements=(),
             expected_hazards=(),
             expected_failed_claims=(),
             injected_anomalies=(missing_unit["anomaly"],),
             source_to_expected_claim_map=(
                 electricity_source_map(config.input_claim_id, raw_row),
             ),
-            expected_resolved_obligations=(
+            expected_resolved_validation_requirements=(
                 resolved_obligation,
                 ExpectedObligation(
                     obligation_id=reference_search_obligation_id(config),
@@ -173,8 +173,8 @@ def build_synthetic_pcf_anomaly_run(
         raw_sources=SyntheticRawSources(electricity_rows=rows),
         oracle=SyntheticOracle(
             expected_claims=expected_claims,
-            expected_derived_claims=(),
-            expected_obligations=tuple(spec["obligation"] for spec in specs),
+            expected_calculated_claims=(),
+            expected_validation_requirements=tuple(spec["obligation"] for spec in specs),
             expected_hazards=tuple(
                 spec["hazard"] for spec in specs if spec["hazard"] is not None
             ),

--- a/comp/scenarios/synthetic/writer.py
+++ b/comp/scenarios/synthetic/writer.py
@@ -84,14 +84,17 @@ def write_synthetic_run(run: SyntheticRun, run_dir: Path) -> Path:
         (claim.to_row() for claim in run.oracle.expected_claims),
     )
     _write_csv(
-        run_dir / "oracle" / "expected_derived_claims.csv",
+        run_dir / "oracle" / "expected_calculated_claims.csv",
         ["claim_id", "field", "value", "unit", "formula_id"],
-        (claim.to_row() for claim in run.oracle.expected_derived_claims),
+        (claim.to_row() for claim in run.oracle.expected_calculated_claims),
     )
     _write_csv(
-        run_dir / "oracle" / "expected_obligations.csv",
+        run_dir / "oracle" / "expected_validation_requirements.csv",
         ["obligation_id", "kind", "field", "reason"],
-        (obligation.to_row() for obligation in run.oracle.expected_obligations),
+        (
+            requirement.to_row()
+            for requirement in run.oracle.expected_validation_requirements
+        ),
     )
     _write_csv(
         run_dir / "oracle" / "expected_hazards.csv",
@@ -119,13 +122,13 @@ def write_synthetic_run(run: SyntheticRun, run_dir: Path) -> Path:
         ],
         (item.to_row() for item in run.oracle.source_to_expected_claim_map),
     )
-    if run.oracle.expected_resolved_obligations is not None:
+    if run.oracle.expected_resolved_validation_requirements is not None:
         _write_csv(
-            run_dir / "oracle" / "expected_resolved_obligations.csv",
+            run_dir / "oracle" / "expected_resolved_validation_requirements.csv",
             ["obligation_id", "kind", "field", "reason"],
             (
                 obligation.to_row()
-                for obligation in run.oracle.expected_resolved_obligations
+                for obligation in run.oracle.expected_resolved_validation_requirements
             ),
         )
     if run.oracle.expected_resolution_artifacts is not None:

--- a/comp/user_messages.py
+++ b/comp/user_messages.py
@@ -48,7 +48,7 @@ _REASON_MESSAGE_KEYS = {
     "missing_source_witness": "missing_evidence",
     "missing_evidence": "missing_evidence",
     "ambiguous_reference": "ambiguous_reference",
-    "multiple_reference_candidates": "ambiguous_reference",
+    "multiple_reference_options": "ambiguous_reference",
     "unsupported_unit": "unsupported_unit",
     "public_output_receipt_required": "public_output_receipt_required",
     "public_output_requires_receipt": "public_output_receipt_required",

--- a/comp/views/validation_summary.py
+++ b/comp/views/validation_summary.py
@@ -38,17 +38,17 @@ def validation_summary_view(report: ValidationReport) -> dict[str, Any]:
         "can_make_public_output": report.can_build_public_output,
         "public_output": _public_output_view(report),
         "sections": [
-            _count_section("EvidenceRef", len(report.evidence_witnesses)),
-            _count_section("CanonicalReference", len(report.reference_bindings)),
-            _count_section("CalculatedClaim", len(report.derived_claims)),
+            _count_section("EvidenceRef", len(report.evidence_refs)),
+            _count_section("CanonicalReference", len(report.canonical_references)),
+            _count_section("CalculatedClaim", len(report.calculated_claims)),
         ],
         "open_requirements": [
             _requirement_view(requirement)
-            for requirement in report.obligations
+            for requirement in report.validation_requirements
         ],
         "resolved_requirements": [
             _requirement_view(requirement)
-            for requirement in report.resolved_obligations
+            for requirement in report.resolved_validation_requirements
         ],
         "review_items": [_review_item_view(hazard) for hazard in report.hazards],
     }

--- a/docs/architecture/contracts/friendly-authority-vocabulary.md
+++ b/docs/architecture/contracts/friendly-authority-vocabulary.md
@@ -147,38 +147,21 @@ PublicOutput is a receipt-verifiable view, not authority.
 
 ## 6. Residual Field Vocabulary Audit
 
-The canonical class and export names are complete. Some active fields, fixture
-keys, and serialized receipt/replay payload keys still contain older vocabulary.
-They must be handled by category, not by a global text replacement.
+The canonical class, export, and active `ValidationReport` field names are
+complete. Active Python-facing report fields use friendly names only:
 
-### Safe active field rename candidates
+| Active field | Boundary |
+| --- | --- |
+| `ValidationReport.evidence_refs` | Grounding references for validation. |
+| `ValidationReport.reference_options` | Candidate-only retrieved references. |
+| `ValidationReport.canonical_references` | Deterministically selected references that may authorize calculation input. |
+| `ValidationReport.calculated_claims` | Calculated values that still cannot authorize public output. |
+| `ValidationReport.validation_requirements` | Open work required before the report can become clean. |
+| `ValidationReport.resolved_validation_requirements` | Completed validation requirements retained for audit and review context. |
 
-These are active Python-facing names that still expose older terms. They should
-be renamed in a breaking follow-up PR when the call sites can move together:
-
-| Current active field | Preferred field | Why it can move |
-| --- | --- | --- |
-| `ValidationReport.evidence_witnesses` | `ValidationReport.evidence_refs` | The value type is already `EvidenceRef`; this is an active object field, not receipt authority. |
-| `ValidationReport.reference_candidates` | `ValidationReport.reference_options` | The value type is already `ReferenceOption`; this is compiler report state. |
-| `ValidationReport.reference_bindings` | `ValidationReport.canonical_references` | The value type is already `CanonicalReference`; this is calculation input authority, not a free-form selection. |
-| `ValidationReport.derived_claims` | `ValidationReport.calculated_claims` | The value type is already `CalculatedClaim`; this is report state and public-output precondition input. |
-| `ValidationReport.obligations` | `ValidationReport.validation_requirements` | The value type is already `ValidationRequirement`; this field is user-visible enough to deserve the friendly name. |
-| `ValidationReport.resolved_obligations` | `ValidationReport.resolved_validation_requirements` | Keeps the open/resolved pair aligned after `obligations` moves. |
-
-Required shorthand for the next active-field PR:
-
-```text
-`ValidationReport.evidence_witnesses` -> `ValidationReport.evidence_refs`
-`ValidationReport.reference_candidates` -> `ValidationReport.reference_options`
-`ValidationReport.reference_bindings` -> `ValidationReport.canonical_references`
-`ValidationReport.derived_claims` -> `ValidationReport.calculated_claims`
-`ValidationReport.obligations` -> `ValidationReport.validation_requirements`
-`ValidationReport.resolved_obligations` -> `ValidationReport.resolved_validation_requirements`
-```
-
-Do not add aliases for these fields unless a migration PR explicitly proves the
-temporary duplicate surface cannot leak into docs, examples, or downstream
-imports. The default migration shape is still a breaking rename.
+The report-field rename is intentionally breaking. Do not add compatibility
+aliases for the previous field names. `tests/test_complete_friendly_rename.py`
+blocks those names from returning to active Python surfaces.
 
 ### Codec-bound receipt and replay vocabulary
 

--- a/docs/architecture/maps/obligation-kernel-working-theory.md
+++ b/docs/architecture/maps/obligation-kernel-working-theory.md
@@ -995,7 +995,7 @@ Acceptance criteria:
 ValidationRequirement(reference_search_required)
 -> ReferenceQuery
 -> ReferenceResolver.search(...)
--> ValidationReport.reference_candidates
+-> ValidationReport.reference_options
 
 No CanonicalReference is created by retrieval.
 No CalculatedClaim is created by retrieval.

--- a/docs/architecture/north-stars/retrieval-fabric-north-star.md
+++ b/docs/architecture/north-stars/retrieval-fabric-north-star.md
@@ -477,7 +477,7 @@ ValidationRequirement(kind="reference_search_required")
 -> ReferenceQuery
 -> ReferenceResolver.search(...)
 -> ReferenceOption[]
--> ValidationReport.reference_candidates
+-> ValidationReport.reference_options
 ```
 
 The bridge may discharge the search obligation, but it must not create:

--- a/minchoagnt/comp_adapter.py
+++ b/minchoagnt/comp_adapter.py
@@ -215,7 +215,7 @@ class DeterministicCompResolver:
     ) -> tuple[str, ...]:
         return tuple(
             resolver_task_from_obligation(obligation).obligation_id
-            for obligation in report.obligations
+            for obligation in report.validation_requirements
             if query_for_obligation(obligation) is not None
         )
 

--- a/tests/domain_scenarios/canonical_working_loop/fixtures.py
+++ b/tests/domain_scenarios/canonical_working_loop/fixtures.py
@@ -280,7 +280,7 @@ def projection_source(report: ValidationReport) -> dict[str, object]:
     values: dict[str, object] = {
         claim.field: claim.value for claim in report.checked_claims
     }
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -115,7 +115,7 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         field=formula().output_field,
     )
     binding = _binding_for(
-        selected_report.reference_bindings,
+        selected_report.canonical_references,
         "bind-canonical-electricity-factor",
     )
     resolved_report = selected_report
@@ -180,7 +180,7 @@ def _dependency_fingerprints(
         calculation_formula_declaration_fingerprint(formula()),
         *tuple(
             evidence_ref_fingerprint(witness)
-            for witness in report.evidence_witnesses
+            for witness in report.evidence_refs
             if witness.witness_id in _checked_claim_witness_ids(report)
         ),
     ]

--- a/tests/domain_scenarios/core.py
+++ b/tests/domain_scenarios/core.py
@@ -124,22 +124,22 @@ def assert_scenario_contract(
             assert result.projection[key] == expected
 
     assert _contains_in_order(
-        tuple(item.kind for item in result.report.resolved_obligations),
+        tuple(item.kind for item in result.report.resolved_validation_requirements),
         contract.required_resolved_obligation_kinds,
     )
     assert _contains_in_order(
         tuple(
             candidate.reference_id
-            for candidate in result.report.reference_candidates
+            for candidate in result.report.reference_options
         ),
         contract.required_reference_candidate_ids,
     )
     assert _contains_in_order(
-        tuple(binding.binding_id for binding in result.report.reference_bindings),
+        tuple(binding.binding_id for binding in result.report.canonical_references),
         contract.required_reference_binding_ids,
     )
     assert _contains_in_order(
-        tuple(claim.claim_id for claim in result.report.derived_claims),
+        tuple(claim.claim_id for claim in result.report.calculated_claims),
         contract.required_derived_claim_ids,
     )
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/alpha_invalid_allocation_rfi.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/alpha_invalid_allocation_rfi.py
@@ -86,7 +86,7 @@ def alpha_invalid_allocation_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=(
+            evidence_refs=(
                 EvidenceRef(
                     witness_id="source:alpha-metal-initial-submission",
                     field="raw_material_name",
@@ -112,7 +112,7 @@ def alpha_invalid_allocation_report() -> ValidationReport:
                     witness_id="source:alpha-metal-initial-submission",
                 ),
             ),
-            obligations=(
+            validation_requirements=(
                 ValidationRequirement(
                     kind="find_context",
                     field="rolling_residence_time",

--- a/tests/domain_scenarios/l_energy_pcf_governance/alpha_physical_allocation_correction.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/alpha_physical_allocation_correction.py
@@ -120,16 +120,16 @@ def alpha_physical_allocation_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="source:alpha-metal-original-invalid-allocation",
@@ -192,7 +192,7 @@ def _checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=ELECTRICITY_BINDING_ID,
@@ -213,7 +213,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     values = _calculated_values()
     return (
         _derived_claim(
@@ -371,7 +371,7 @@ def _calculated_values() -> dict[str, object]:
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/c_pack_yield_rollup.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/c_pack_yield_rollup.py
@@ -136,17 +136,17 @@ def c_pack_yield_rollup_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            resolved_obligations=_resolved_obligations(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            resolved_validation_requirements=_resolved_validation_requirements(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="source:c-pack-yield-fixture",
@@ -166,7 +166,7 @@ def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
             witness_id="source:c-pack-child-claims",
             field="lower_tier_child_claims",
             source="tests/e2e/expected/001-l-energy-pcf-governance.receipt.json",
-            span="derived_claims.c_pack.children",
+            span="calculated_claims.c_pack.children",
             text="Alpha Metal 5,306; Steel Frame proxy 4,750",
         ),
     )
@@ -231,7 +231,7 @@ def _checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
+def _resolved_validation_requirements() -> tuple[ValidationRequirement, ...]:
     return (
         ValidationRequirement(
             kind="child_claims_available",
@@ -248,7 +248,7 @@ def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=ELECTRICITY_BINDING_ID,
@@ -261,7 +261,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     values = _calculated_values()
     return (
         _derived_claim(
@@ -412,7 +412,7 @@ def _calculated_values() -> dict[str, object]:
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/carbon_tech_certificate_submission.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/carbon_tech_certificate_submission.py
@@ -122,17 +122,17 @@ def carbon_tech_certificate_submission_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            resolved_obligations=_resolved_obligations(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            resolved_validation_requirements=_resolved_validation_requirements(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="source:carbon-tech-certificate-metadata",
@@ -199,7 +199,7 @@ def _checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
+def _resolved_validation_requirements() -> tuple[ValidationRequirement, ...]:
     return (
         ValidationRequirement(
             kind="certificate_boundary_supported",
@@ -210,7 +210,7 @@ def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=CERTIFICATE_FACTOR_BINDING_ID,
@@ -223,7 +223,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     raw_emission = Decimal(PRODUCTION_TON) * CERTIFICATE_FACTOR_TCO2E_PER_TON
     final_emission = _round_half_up(raw_emission)
     return (
@@ -261,7 +261,7 @@ def _derived_claims() -> tuple[CalculatedClaim, ...]:
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/final_bottom_up_rollup.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/final_bottom_up_rollup.py
@@ -140,17 +140,17 @@ def final_bottom_up_rollup_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            resolved_obligations=_resolved_obligations(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            resolved_validation_requirements=_resolved_validation_requirements(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="source:final-rollup-production",
@@ -163,7 +163,7 @@ def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
             witness_id="source:final-rollup-child-receipts",
             field="child_receipts",
             source="tests/e2e/expected/001-l-energy-pcf-governance.receipt.json",
-            span="derived_claims.final_rollup.children",
+            span="calculated_claims.final_rollup.children",
             text=(
                 "L-Energy own 1,695; C-Pack 10,534; Carbon Tech 13,390; "
                 "L-Materials 174,375"
@@ -238,7 +238,7 @@ def _checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
+def _resolved_validation_requirements() -> tuple[ValidationRequirement, ...]:
     return (
         ValidationRequirement(
             kind="child_claims_accepted_or_proxy_authorized",
@@ -255,7 +255,7 @@ def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         _child_receipt_binding(
             binding_id=TIER0_CHILD_BINDING_ID,
@@ -287,7 +287,7 @@ def _child_receipt_binding(*, binding_id: str, reference_id: str) -> CanonicalRe
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     values = _calculated_values()
     return (
         _derived_claim(
@@ -433,7 +433,7 @@ def _calculated_values() -> dict[str, object]:
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/fixtures.py
@@ -62,7 +62,7 @@ def checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def reference_bindings() -> tuple[CanonicalReference, ...]:
+def canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=ELECTRICITY_BINDING_ID,
@@ -107,15 +107,15 @@ def reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def downstream_reference_bindings() -> tuple[CanonicalReference, ...]:
+def downstream_canonical_references() -> tuple[CanonicalReference, ...]:
     return tuple(
         binding
-        for binding in reference_bindings()
+        for binding in canonical_references()
         if binding.binding_id != ELECTRICITY_BINDING_ID
     )
 
 
-def derived_claims() -> tuple[CalculatedClaim, ...]:
+def calculated_claims() -> tuple[CalculatedClaim, ...]:
     return (
         _derived_claim(
             claim_id=OUTPUT_CLAIM_ID,
@@ -189,9 +189,9 @@ def derived_claims() -> tuple[CalculatedClaim, ...]:
     )
 
 
-def downstream_derived_claims() -> tuple[CalculatedClaim, ...]:
+def downstream_calculated_claims() -> tuple[CalculatedClaim, ...]:
     return tuple(
-        claim for claim in derived_claims() if claim.claim_id != OUTPUT_CLAIM_ID
+        claim for claim in calculated_claims() if claim.claim_id != OUTPUT_CLAIM_ID
     )
 
 
@@ -497,13 +497,13 @@ def attach_downstream_fixture_artifacts(report: ValidationReport) -> ValidationR
     return with_recomputed_status(
         replace(
             report,
-            reference_bindings=_append_missing_reference_bindings(
-                report.reference_bindings,
-                downstream_reference_bindings(),
+            canonical_references=_append_missing_canonical_references(
+                report.canonical_references,
+                downstream_canonical_references(),
             ),
-            derived_claims=_append_missing_derived_claims(
-                report.derived_claims,
-                downstream_derived_claims(),
+            calculated_claims=_append_missing_calculated_claims(
+                report.calculated_claims,
+                downstream_calculated_claims(),
             ),
             can_build_public_output=False,
         )
@@ -514,8 +514,8 @@ def compile_report() -> ValidationReport:
     return ValidationReport(
         status="accepted",
         checked_claims=checked_claims(),
-        reference_bindings=reference_bindings(),
-        derived_claims=derived_claims(),
+        canonical_references=canonical_references(),
+        calculated_claims=calculated_claims(),
     )
 
 
@@ -542,7 +542,7 @@ def _derived_claim(
     )
 
 
-def _append_missing_reference_bindings(
+def _append_missing_canonical_references(
     existing: tuple[CanonicalReference, ...],
     additions: tuple[CanonicalReference, ...],
 ) -> tuple[CanonicalReference, ...]:
@@ -553,7 +553,7 @@ def _append_missing_reference_bindings(
     )
 
 
-def _append_missing_derived_claims(
+def _append_missing_calculated_claims(
     existing: tuple[CalculatedClaim, ...],
     additions: tuple[CalculatedClaim, ...],
 ) -> tuple[CalculatedClaim, ...]:
@@ -578,15 +578,15 @@ __all__ = [
     "checked_claims",
     "compile_report",
     "criteria",
-    "derived_claims",
-    "downstream_derived_claims",
-    "downstream_reference_bindings",
+    "calculated_claims",
+    "downstream_calculated_claims",
+    "downstream_canonical_references",
     "formula",
     "input_claim",
     "profile",
     "reference_pack",
     "reference_resolver",
-    "reference_bindings",
+    "canonical_references",
     "retrieval_query_context",
     "retrieval_query_policy",
 ]

--- a/tests/domain_scenarios/l_energy_pcf_governance/l_materials_composition_rollup.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/l_materials_composition_rollup.py
@@ -122,11 +122,11 @@ def l_materials_composition_rollup_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            resolved_obligations=_resolved_obligations(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            resolved_validation_requirements=_resolved_validation_requirements(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
@@ -137,7 +137,7 @@ def invalid_l_materials_composition_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(mn_share=INVALID_MN_SHARE),
             failed_claims=(
                 FailedClaim(
@@ -160,7 +160,7 @@ def invalid_l_materials_composition_report() -> ValidationReport:
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="source:l-materials-composition",
@@ -180,7 +180,7 @@ def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
             witness_id="source:l-materials-ncm-factor",
             field="mapped_ncm_factor_tco2e_per_ton",
             source="tests/e2e/expected/001-l-energy-pcf-governance.receipt.json",
-            span="derived_claims.l_materials.factor",
+            span="calculated_claims.l_materials.factor",
             text="15.5 tCO2e/ton",
         ),
     )
@@ -236,7 +236,7 @@ def _checked_claims(
     )
 
 
-def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
+def _resolved_validation_requirements() -> tuple[ValidationRequirement, ...]:
     return (
         ValidationRequirement(
             kind="composition_total_validated",
@@ -247,7 +247,7 @@ def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=COMPOSITION_FACTOR_BINDING_ID,
@@ -260,7 +260,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     composition_total = NI_SHARE + CO_SHARE + MN_SHARE
     emission = Decimal(PRODUCTION_TON) * MAPPED_NCM_FACTOR_TCO2E_PER_TON
     composition_step = CalculationStep(
@@ -308,7 +308,7 @@ def _derived_claims() -> tuple[CalculatedClaim, ...]:
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -195,7 +195,7 @@ def run_l_energy_pcf_governance_scenario(
 
 def _projection_source(report) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 
@@ -223,7 +223,7 @@ def _compile_retrieval_backed_report(
         criteria=criteria(),
         field=formula().output_field,
     )
-    binding = _binding_for(selected_report.reference_bindings, ELECTRICITY_BINDING_ID)
+    binding = _binding_for(selected_report.canonical_references, ELECTRICITY_BINDING_ID)
     resolved_report = selected_report
     if binding is not None:
         resolved_report = retry_blocked_calculation(
@@ -245,7 +245,7 @@ def _dependency_fingerprints(
     return _dependency_fingerprints_for_reference_ids(
         scenario_profile,
         pack,
-        tuple(candidate.reference_id for candidate in report.reference_candidates),
+        tuple(candidate.reference_id for candidate in report.reference_options),
     )
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/steel_frame_proxy_assignment.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/steel_frame_proxy_assignment.py
@@ -126,17 +126,17 @@ def steel_frame_proxy_assignment_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            resolved_obligations=_resolved_obligations(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            resolved_validation_requirements=_resolved_validation_requirements(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="source:c-pack-lower-tier-requirement",
@@ -197,7 +197,7 @@ def _checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
+def _resolved_validation_requirements() -> tuple[ValidationRequirement, ...]:
     return (
         ValidationRequirement(
             kind="find_source_witness",
@@ -214,7 +214,7 @@ def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=PROXY_BINDING_ID,
@@ -227,7 +227,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     missing_mass = REQUIRED_LOWER_TIER_INPUT_TON - VERIFIED_ALPHA_INPUT_TON
     proxy_emission = int(Decimal(missing_mass) * PROXY_FACTOR_TCO2E_PER_TON)
     missing_mass_step = CalculationStep(
@@ -276,7 +276,7 @@ def _derived_claims() -> tuple[CalculatedClaim, ...]:
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/tier0_physical_allocation.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/tier0_physical_allocation.py
@@ -129,16 +129,16 @@ def tier0_physical_allocation_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="source:l-energy-site-energy",
@@ -201,7 +201,7 @@ def _checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=ELECTRICITY_BINDING_ID,
@@ -222,7 +222,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     values = _calculated_values()
     return (
         _derived_claim(
@@ -381,7 +381,7 @@ def _calculated_values() -> dict[str, object]:
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -149,7 +149,7 @@ def _artifact_body_for_ref(
         }
     if ref.artifact_kind == "reference_binding":
         binding = _by_id(
-            result.report.reference_bindings,
+            result.report.canonical_references,
             ref.artifact_id,
             "binding_id",
         )
@@ -173,7 +173,7 @@ def _artifact_body_for_ref(
             "authority": binding.authority,
         }
     if ref.artifact_kind == "derived_claim":
-        claim = _by_id(result.report.derived_claims, ref.artifact_id, "claim_id")
+        claim = _by_id(result.report.calculated_claims, ref.artifact_id, "claim_id")
         return {
             "claim_id": claim.claim_id,
             "field": claim.field,
@@ -221,14 +221,14 @@ def _checked_claim_by_source_id(result: DomainScenarioResult, source_id: str):
 
 
 def _evidence_witness_by_id(result: DomainScenarioResult, witness_id: str):
-    for witness in result.report.evidence_witnesses:
+    for witness in result.report.evidence_refs:
         if witness.witness_id == witness_id:
             return witness
     return None
 
 
 def _trace_by_id(result: DomainScenarioResult, trace_id: str):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.trace.trace_id == trace_id:
             return claim.trace
     raise AssertionError(f"Scenario calculation trace not found: {trace_id}.")

--- a/tests/domain_scenarios/synthetic_raw_claim_conflict/scenario.py
+++ b/tests/domain_scenarios/synthetic_raw_claim_conflict/scenario.py
@@ -95,7 +95,7 @@ def raw_conflict_hypothesis() -> InterpretationHypothesis:
                 origin="parser_candidate",
             ),
         ),
-        witnesses=_evidence_witnesses()[:2],
+        witnesses=_evidence_refs()[:2],
     )
 
 
@@ -109,7 +109,7 @@ def run_raw_claim_conflict_scenario() -> DomainScenarioResult:
         profile_id=PROFILE_ID,
         dependency_fingerprints=tuple(
             evidence_ref_fingerprint(witness)
-            for witness in report.evidence_witnesses
+            for witness in report.evidence_refs
         ),
     )
     return build_domain_scenario_result(
@@ -126,20 +126,20 @@ def raw_claim_conflict_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
             failed_claims=_failed_claims(),
-            resolved_obligations=_resolved_obligations(),
-            obligations=_open_obligations(),
+            resolved_validation_requirements=_resolved_validation_requirements(),
+            validation_requirements=_open_obligations(),
             hazards=_hazards(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=False,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="w-email-electricity-march",
@@ -223,7 +223,7 @@ def _failed_claims() -> tuple[FailedClaim, ...]:
     )
 
 
-def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
+def _resolved_validation_requirements() -> tuple[ValidationRequirement, ...]:
     return (
         ValidationRequirement(
             kind="site_alias_resolved",
@@ -267,7 +267,7 @@ def _hazards() -> tuple[Hazard, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=ALIAS_BINDING_ID,
@@ -296,7 +296,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     email_mwh = EMAIL_GWH * GWH_TO_MWH_FACTOR
     ems_mwh = EMS_GWH * GWH_TO_MWH_FACTOR
     return (

--- a/tests/domain_scenarios/synthetic_raw_claim_conflict_resolution/scenario.py
+++ b/tests/domain_scenarios/synthetic_raw_claim_conflict_resolution/scenario.py
@@ -91,7 +91,7 @@ def run_raw_claim_conflict_resolution_scenario() -> DomainScenarioResult:
         profile_id=PROFILE_ID,
         dependency_fingerprints=tuple(
             evidence_ref_fingerprint(witness)
-            for witness in report.evidence_witnesses
+            for witness in report.evidence_refs
         ),
     )
     projection = None
@@ -115,17 +115,17 @@ def raw_claim_conflict_resolution_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=_evidence_witnesses(),
+            evidence_refs=_evidence_refs(),
             checked_claims=_checked_claims(),
-            resolved_obligations=_resolved_obligations(),
-            reference_bindings=_reference_bindings(),
-            derived_claims=_derived_claims(),
+            resolved_validation_requirements=_resolved_validation_requirements(),
+            canonical_references=_canonical_references(),
+            calculated_claims=_calculated_claims(),
             can_build_public_output=True,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id="w-email-electricity-march",
@@ -210,7 +210,7 @@ def _checked_claims() -> tuple[CheckedClaim, ...]:
     )
 
 
-def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
+def _resolved_validation_requirements() -> tuple[ValidationRequirement, ...]:
     return (
         ValidationRequirement(
             kind="site_alias_resolved",
@@ -239,7 +239,7 @@ def _resolved_obligations() -> tuple[ValidationRequirement, ...]:
     )
 
 
-def _reference_bindings() -> tuple[CanonicalReference, ...]:
+def _canonical_references() -> tuple[CanonicalReference, ...]:
     return (
         CanonicalReference(
             binding_id=ALIAS_BINDING_ID,
@@ -279,7 +279,7 @@ def _reference_bindings() -> tuple[CanonicalReference, ...]:
     )
 
 
-def _derived_claims() -> tuple[CalculatedClaim, ...]:
+def _calculated_claims() -> tuple[CalculatedClaim, ...]:
     email_mwh = EMAIL_GWH * GWH_TO_MWH_FACTOR
     ems_mwh = EMS_GWH * GWH_TO_MWH_FACTOR
     return (
@@ -359,7 +359,7 @@ def _source_electricity_claim(
 
 def _projection_source(report: ValidationReport) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/synthetic_raw_claim_hypothesis_acceptance/scenario.py
+++ b/tests/domain_scenarios/synthetic_raw_claim_hypothesis_acceptance/scenario.py
@@ -89,7 +89,7 @@ def run_raw_claim_hypothesis_acceptance_scenario() -> DomainScenarioResult:
         profile_id=PROFILE_ID,
         dependency_fingerprints=tuple(
             evidence_ref_fingerprint(witness)
-            for witness in report.evidence_witnesses
+            for witness in report.evidence_refs
         ),
     )
     projection = None
@@ -172,7 +172,7 @@ def _acceptance_profile() -> SyntheticRawClaimPromotionProfile:
 
 def _projection_source(report) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/synthetic_raw_claim_hypothesis_gate/scenario.py
+++ b/tests/domain_scenarios/synthetic_raw_claim_hypothesis_gate/scenario.py
@@ -92,7 +92,7 @@ def raw_claim_hypothesis() -> InterpretationHypothesis:
                 origin="llm_extractor_candidate",
             ),
         ),
-        witnesses=_evidence_witnesses(),
+        witnesses=_evidence_refs(),
     )
 
 
@@ -105,7 +105,7 @@ def run_raw_claim_hypothesis_gate_scenario() -> DomainScenarioResult:
         projection_id=PROJECTION_ID,
         profile_id=PROFILE_ID,
         dependency_fingerprints=(
-            evidence_ref_fingerprint(report.evidence_witnesses[0]),
+            evidence_ref_fingerprint(report.evidence_refs[0]),
         ),
     )
     return build_domain_scenario_result(
@@ -123,16 +123,16 @@ def raw_claim_hypothesis_gate_report() -> ValidationReport:
     return with_recomputed_status(
         ValidationReport(
             status="accepted",
-            evidence_witnesses=hypothesis.witnesses,
+            evidence_refs=hypothesis.witnesses,
             failed_claims=_failed_claims(),
-            obligations=_open_obligations(),
+            validation_requirements=_open_obligations(),
             hazards=_hazards(),
             can_build_public_output=False,
         )
     )
 
 
-def _evidence_witnesses() -> tuple[EvidenceRef, ...]:
+def _evidence_refs() -> tuple[EvidenceRef, ...]:
     return (
         EvidenceRef(
             witness_id=WITNESS_ID,

--- a/tests/domain_scenarios/tiny_pcf/scenario.py
+++ b/tests/domain_scenarios/tiny_pcf/scenario.py
@@ -97,7 +97,7 @@ def run_tiny_pcf_scenario() -> DomainScenarioResult:
 
 def _projection_source(report) -> dict[str, object]:
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values
 
 

--- a/tests/domain_scenarios/views.py
+++ b/tests/domain_scenarios/views.py
@@ -30,13 +30,13 @@ def report_view(report) -> dict[str, Any]:
         "friendly_summary": validation_summary_view(report),
         "open_obligations": [
             _obligation_view(obligation)
-            for obligation in report.obligations
+            for obligation in report.validation_requirements
         ],
-        "resolved_obligations": [
+        "resolved_validation_requirements": [
             _obligation_view(obligation)
-            for obligation in report.resolved_obligations
+            for obligation in report.resolved_validation_requirements
         ],
-        "reference_candidates": [
+        "reference_options": [
             {
                 "candidate_id": candidate.candidate_id,
                 "reference_id": candidate.reference_id,
@@ -45,9 +45,9 @@ def report_view(report) -> dict[str, Any]:
                 "retrieval_score": candidate.retrieval_score,
                 "authority": candidate.authority,
             }
-            for candidate in report.reference_candidates
+            for candidate in report.reference_options
         ],
-        "reference_bindings": [
+        "canonical_references": [
             {
                 "binding_id": binding.binding_id,
                 "reference_id": binding.reference_id,
@@ -60,9 +60,9 @@ def report_view(report) -> dict[str, Any]:
                     for rejected in binding.rejected_candidates
                 ],
             }
-            for binding in report.reference_bindings
+            for binding in report.canonical_references
         ],
-        "derived_claims": [
+        "calculated_claims": [
             {
                 "claim_id": claim.claim_id,
                 "field": claim.field,
@@ -72,7 +72,7 @@ def report_view(report) -> dict[str, Any]:
                 "formula_id": claim.formula_id,
                 "reference_binding_ids": claim.trace.reference_binding_ids,
             }
-            for claim in report.derived_claims
+            for claim in report.calculated_claims
         ],
     }
 

--- a/tests/support/synthetic/oracle_assertions.py
+++ b/tests/support/synthetic/oracle_assertions.py
@@ -35,7 +35,7 @@ def load_synthetic_oracle(oracle_dir: Path) -> SyntheticOracle:
             )
             for row in _read_csv(oracle_dir / "expected_claims.csv")
         ),
-        expected_derived_claims=tuple(
+        expected_calculated_claims=tuple(
             ExpectedCalculatedClaim(
                 claim_id=row["claim_id"],
                 field=row["field"],
@@ -43,16 +43,18 @@ def load_synthetic_oracle(oracle_dir: Path) -> SyntheticOracle:
                 unit=row["unit"],
                 formula_id=row["formula_id"],
             )
-            for row in _read_csv(oracle_dir / "expected_derived_claims.csv")
+            for row in _read_csv(oracle_dir / "expected_calculated_claims.csv")
         ),
-        expected_obligations=tuple(
+        expected_validation_requirements=tuple(
             ExpectedObligation(
                 obligation_id=row["obligation_id"],
                 kind=row["kind"],
                 field=row["field"],
                 reason=row["reason"],
             )
-            for row in _read_csv(oracle_dir / "expected_obligations.csv")
+            for row in _read_csv(
+                oracle_dir / "expected_validation_requirements.csv"
+            )
         ),
         expected_hazards=tuple(
             ExpectedHazard(
@@ -96,8 +98,8 @@ def load_synthetic_oracle(oracle_dir: Path) -> SyntheticOracle:
         expected_receipt=_read_expected_receipt(
             oracle_dir / "expected_receipt.json"
         ),
-        expected_resolved_obligations=_read_expected_obligations_if_exists(
-            oracle_dir / "expected_resolved_obligations.csv"
+        expected_resolved_validation_requirements=_read_expected_validation_requirements_if_exists(
+            oracle_dir / "expected_resolved_validation_requirements.csv"
         ),
         expected_resolution_artifacts=_read_expected_resolution_artifacts_if_exists(
             oracle_dir / "expected_resolution_artifacts.csv"
@@ -114,22 +116,22 @@ def assert_synthetic_oracle_matches_report(
     ), "expected checked claims did not match report.checked_claims"
     assert _derived_claim_rows(report) == _expected_derived_claim_rows(
         oracle
-    ), "expected derived claims did not match report.derived_claims"
+    ), "expected derived claims did not match report.calculated_claims"
     assert _failed_claim_rows(report) == _expected_failed_claim_rows(
         oracle
     ), "expected failed claims did not match report.failed_claims"
     assert _obligation_rows(report) == _expected_obligation_rows(
         oracle
-    ), "expected obligations did not match report.obligations"
+    ), "expected validation requirements did not match report.validation_requirements"
     assert _hazard_rows(report) == _expected_hazard_rows(
         oracle
     ), "expected hazards did not match report.hazards"
-    if oracle.expected_resolved_obligations is not None:
+    if oracle.expected_resolved_validation_requirements is not None:
         assert _resolved_obligation_rows(
             report
         ) == _expected_resolved_obligation_rows(
             oracle
-        ), "expected resolved obligations did not match report.resolved_obligations"
+        ), "expected resolved obligations did not match report.resolved_validation_requirements"
     _assert_source_map_matches_witnesses(oracle, report)
 
 
@@ -205,14 +207,14 @@ def _expected_derived_claim_rows(
 ) -> tuple[tuple[Any, ...], ...]:
     return tuple(
         (claim.claim_id, claim.field, claim.value, claim.unit, claim.formula_id)
-        for claim in oracle.expected_derived_claims
+        for claim in oracle.expected_calculated_claims
     )
 
 
 def _derived_claim_rows(report: ValidationReport) -> tuple[tuple[Any, ...], ...]:
     return tuple(
         (claim.claim_id, claim.field, claim.value, claim.unit, claim.formula_id)
-        for claim in report.derived_claims
+        for claim in report.calculated_claims
     )
 
 
@@ -242,14 +244,14 @@ def _expected_obligation_rows(
             obligation.field,
             obligation.reason,
         )
-        for obligation in oracle.expected_obligations
+        for obligation in oracle.expected_validation_requirements
     )
 
 
 def _expected_resolved_obligation_rows(
     oracle: SyntheticOracle,
 ) -> tuple[tuple[Any, ...], ...]:
-    if oracle.expected_resolved_obligations is None:
+    if oracle.expected_resolved_validation_requirements is None:
         return ()
     return tuple(
         (
@@ -258,7 +260,7 @@ def _expected_resolved_obligation_rows(
             obligation.field,
             obligation.reason,
         )
-        for obligation in oracle.expected_resolved_obligations
+        for obligation in oracle.expected_resolved_validation_requirements
     )
 
 
@@ -276,7 +278,7 @@ def _obligation_rows(report: ValidationReport) -> tuple[tuple[Any, ...], ...]:
             obligation.field,
             obligation.reason,
         )
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     )
 
 
@@ -294,7 +296,7 @@ def _resolved_obligation_rows(report: ValidationReport) -> tuple[tuple[Any, ...]
             obligation.field,
             obligation.reason,
         )
-        for obligation in report.resolved_obligations
+        for obligation in report.resolved_validation_requirements
     )
 
 
@@ -323,7 +325,7 @@ def _assert_source_map_matches_witnesses(
 ) -> None:
     actual = {
         (witness.field, witness.witness_id, witness.source, witness.span)
-        for witness in report.evidence_witnesses
+        for witness in report.evidence_refs
     }
     expected = {
         (
@@ -336,7 +338,7 @@ def _assert_source_map_matches_witnesses(
     }
     missing = expected - actual
     assert not missing, (
-        "source_to_expected_claim_map did not match report.evidence_witnesses: "
+        "source_to_expected_claim_map did not match report.evidence_refs: "
         f"{sorted(missing)}"
     )
 
@@ -358,7 +360,7 @@ def _read_expected_receipt(path: Path) -> ExpectedReceipt | None:
     )
 
 
-def _read_expected_obligations_if_exists(
+def _read_expected_validation_requirements_if_exists(
     path: Path,
 ) -> tuple[ExpectedObligation, ...] | None:
     if not path.exists():

--- a/tests/support/synthetic/replay.py
+++ b/tests/support/synthetic/replay.py
@@ -158,7 +158,7 @@ def _artifact_body_for_ref(
             "digest_alg": fingerprint.digest_alg,
         }
     if ref.artifact_kind == "reference_binding":
-        binding = _by_id(report.reference_bindings, ref.artifact_id, "binding_id")
+        binding = _by_id(report.canonical_references, ref.artifact_id, "binding_id")
         return {
             "binding_id": binding.binding_id,
             "claim_id": binding.claim_id,
@@ -179,7 +179,7 @@ def _artifact_body_for_ref(
             "authority": binding.authority,
         }
     if ref.artifact_kind == "derived_claim":
-        claim = _by_id(report.derived_claims, ref.artifact_id, "claim_id")
+        claim = _by_id(report.calculated_claims, ref.artifact_id, "claim_id")
         return {
             "claim_id": claim.claim_id,
             "field": claim.field,
@@ -221,14 +221,14 @@ def _checked_claim_by_source_id(report: ValidationReport, source_id: str):
 
 
 def _evidence_witness_by_id(report: ValidationReport, witness_id: str):
-    for witness in report.evidence_witnesses:
+    for witness in report.evidence_refs:
         if witness.witness_id == witness_id:
             return witness
     raise AssertionError(f"Synthetic evidence witness not found: {witness_id}.")
 
 
 def _trace_by_id(report: ValidationReport, trace_id: str):
-    for claim in report.derived_claims:
+    for claim in report.calculated_claims:
         if claim.trace.trace_id == trace_id:
             return claim.trace
     raise AssertionError(f"Synthetic calculation trace not found: {trace_id}.")

--- a/tests/test_alpha_invalid_allocation_rfi_scenario.py
+++ b/tests/test_alpha_invalid_allocation_rfi_scenario.py
@@ -30,7 +30,7 @@ def test_alpha_revenue_share_requires_rolling_residence_time_context():
 
     assert tuple(
         (obligation.kind, obligation.field, obligation.reason)
-        for obligation in result.report.obligations
+        for obligation in result.report.validation_requirements
     ) == (
         (
             "find_context",
@@ -63,8 +63,8 @@ def test_alpha_normalization_suggestion_is_not_authoritative():
 def test_alpha_invalid_allocation_cannot_create_receipt_or_projection():
     result = run_alpha_invalid_allocation_rfi_scenario()
 
-    assert result.report.reference_bindings == ()
-    assert result.report.derived_claims == ()
+    assert result.report.canonical_references == ()
+    assert result.report.calculated_claims == ()
     assert result.preparation.receipt is None
     assert result.projection is None
     with pytest.raises(PublicOutputBlocked, match="public-output receipt"):

--- a/tests/test_alpha_physical_allocation_correction_scenario.py
+++ b/tests/test_alpha_physical_allocation_correction_scenario.py
@@ -37,7 +37,7 @@ def test_alpha_physical_allocation_binds_electricity_and_lng_factors():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (ELECTRICITY_BINDING_ID, "platform.factor.electricity_mwh", "emission_factor"),
         (LNG_BINDING_ID, "platform.factor.lng_nm3", "emission_factor"),
@@ -54,10 +54,10 @@ def test_alpha_physical_allocation_commits_without_erasing_invalid_context():
 
     assert result.report.status == "accepted"
     assert result.report.failed_claims == ()
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert "source:alpha-metal-original-invalid-allocation" in tuple(
-        witness.witness_id for witness in result.report.evidence_witnesses
+        witness.witness_id for witness in result.report.evidence_refs
     )
     assert "revenue_share" not in tuple(
         claim.value for claim in result.report.checked_claims
@@ -99,7 +99,7 @@ def test_alpha_physical_allocation_scenario_is_registered_with_contract():
 
 
 def _trace_for(result, claim_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             return claim.trace
     raise AssertionError(f"missing derived claim: {claim_id}")

--- a/tests/test_c_pack_yield_rollup_scenario.py
+++ b/tests/test_c_pack_yield_rollup_scenario.py
@@ -31,7 +31,7 @@ def test_c_pack_yield_rollup_calculates_required_input_and_final_emission():
     }
     assert tuple(
         (claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     ) == (
         ("required_lower_tier_input_ton", 6300, "ton"),
         ("c_pack_own_emission_tco2e", 478, "tCO2e"),
@@ -70,7 +70,7 @@ def test_c_pack_rollup_binds_assembly_electricity_factor():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (ELECTRICITY_BINDING_ID, "platform.factor.electricity_mwh", "emission_factor"),
     )
@@ -84,7 +84,7 @@ def test_c_pack_rollup_creates_receipt_and_projection():
     result = run_c_pack_yield_rollup_scenario()
 
     assert result.report.status == "accepted"
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert result.preparation.package.complete is True
     assert result.preparation.decision.status == "commit"
@@ -115,7 +115,7 @@ def test_c_pack_yield_rollup_scenario_is_registered_with_contract():
 
 
 def _trace_for(result, claim_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             return claim.trace
     raise AssertionError(f"missing derived claim: {claim_id}")

--- a/tests/test_calculation_obligation_requirements.py
+++ b/tests/test_calculation_obligation_requirements.py
@@ -94,7 +94,7 @@ def test_blocked_calculation_report_obligation_carries_requirement_payload():
         formula=_formula(),
     )
 
-    assert report.obligations[0].calculation_requirement == result.requirement
+    assert report.validation_requirements[0].calculation_requirement == result.requirement
 
 
 def test_calculation_requirement_metadata_is_visible_to_judgment_facts():

--- a/tests/test_calculation_report_integration.py
+++ b/tests/test_calculation_report_integration.py
@@ -70,7 +70,7 @@ def test_successful_calculation_adds_derived_claim_to_report():
         catalog=_catalog(),
         formula=_formula(),
     )
-    report = ValidationReport(status="accepted", reference_bindings=(binding,))
+    report = ValidationReport(status="accepted", canonical_references=(binding,))
 
     updated = apply_calculation_result(
         report,
@@ -80,9 +80,9 @@ def test_successful_calculation_adds_derived_claim_to_report():
     )
 
     assert updated.status == "accepted"
-    assert updated.reference_bindings == (binding,)
-    assert updated.derived_claims == (calculation.derived_claim,)
-    assert updated.obligations == ()
+    assert updated.canonical_references == (binding,)
+    assert updated.calculated_claims == (calculation.derived_claim,)
+    assert updated.validation_requirements == ()
     assert updated.can_build_public_output is False
 
 
@@ -95,7 +95,7 @@ def test_blocked_calculation_opens_blocking_obligation_on_report():
         catalog=_catalog(),
         formula=_formula(),
     )
-    report = ValidationReport(status="accepted", reference_bindings=(binding,))
+    report = ValidationReport(status="accepted", canonical_references=(binding,))
 
     updated = apply_calculation_result(
         report,
@@ -105,9 +105,9 @@ def test_blocked_calculation_opens_blocking_obligation_on_report():
     )
 
     assert updated.status == "blocked"
-    assert updated.reference_bindings == (binding,)
-    assert updated.derived_claims == ()
-    assert updated.obligations == (
+    assert updated.canonical_references == (binding,)
+    assert updated.calculated_claims == ()
+    assert updated.validation_requirements == (
         ValidationRequirement(
             kind="calculation_blocked",
             field="co2e_emission",
@@ -193,4 +193,4 @@ def test_semantic_application_preserves_open_calculation_obligation_status():
     updated = apply_semantic_judgments(report, ())
 
     assert updated.status == "blocked"
-    assert updated.obligations == report.obligations
+    assert updated.validation_requirements == report.validation_requirements

--- a/tests/test_calculation_resolution_planner.py
+++ b/tests/test_calculation_resolution_planner.py
@@ -78,8 +78,8 @@ def test_unknown_reference_opens_reference_search_obligation():
     planned = plan_calculation_resolution(report)
 
     assert planned.status == "blocked"
-    assert planned.obligations[0].kind == "calculation_blocked"
-    follow_up = planned.obligations[1]
+    assert planned.validation_requirements[0].kind == "calculation_blocked"
+    follow_up = planned.validation_requirements[1]
     assert follow_up == ValidationRequirement(
         kind="reference_search_required",
         field="co2e_emission",
@@ -90,7 +90,7 @@ def test_unknown_reference_opens_reference_search_obligation():
         ),
         claim_id="hyp-1:co2e_emission",
         blocking=True,
-        calculation_requirement=report.obligations[0].calculation_requirement,
+        calculation_requirement=report.validation_requirements[0].calculation_requirement,
     )
 
 
@@ -99,7 +99,7 @@ def test_missing_factor_value_opens_reference_context_obligation():
 
     planned = plan_calculation_resolution(report)
 
-    follow_up = planned.obligations[1]
+    follow_up = planned.validation_requirements[1]
     assert follow_up.kind == "reference_context_required"
     assert follow_up.reason == "missing_factor_value"
     assert follow_up.calculation_requirement is not None
@@ -111,10 +111,10 @@ def test_unit_mismatch_opens_find_context_obligation():
 
     planned = plan_calculation_resolution(report)
 
-    follow_up = planned.obligations[1]
+    follow_up = planned.validation_requirements[1]
     assert follow_up.kind == "find_context"
     assert follow_up.reason == "unit_mismatch"
-    assert follow_up.calculation_requirement is report.obligations[0].calculation_requirement
+    assert follow_up.calculation_requirement is report.validation_requirements[0].calculation_requirement
     assert follow_up.calculation_requirement.expected_unit == "kWh"
     assert follow_up.calculation_requirement.actual_unit == "MWh"
 
@@ -125,13 +125,13 @@ def test_calculation_resolution_planning_is_idempotent():
     once = plan_calculation_resolution(report)
     twice = plan_calculation_resolution(once)
 
-    assert once.obligations == twice.obligations
+    assert once.validation_requirements == twice.validation_requirements
 
 
 def test_report_without_calculation_requirement_is_unchanged():
     report = ValidationReport(
         status="blocked",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="calculation_blocked",
                 field="co2e_emission",

--- a/tests/test_calculation_retry_report.py
+++ b/tests/test_calculation_retry_report.py
@@ -78,7 +78,7 @@ def _blocked_unknown_reference_report():
 
 def test_retry_blocked_calculation_resolves_old_obligation_and_adds_derived_claim():
     report = _blocked_unknown_reference_report()
-    old_obligation = report.obligations[0]
+    old_obligation = report.validation_requirements[0]
 
     updated = retry_blocked_calculation(
         report,
@@ -90,10 +90,10 @@ def test_retry_blocked_calculation_resolves_old_obligation_and_adds_derived_clai
     )
 
     assert updated.status == "accepted"
-    assert updated.obligations == ()
-    assert updated.resolved_obligations == (old_obligation,)
-    assert len(updated.derived_claims) == 1
-    derived = updated.derived_claims[0]
+    assert updated.validation_requirements == ()
+    assert updated.resolved_validation_requirements == (old_obligation,)
+    assert len(updated.calculated_claims) == 1
+    derived = updated.calculated_claims[0]
     assert derived.claim_id == "hyp-1:co2e_emission"
     assert derived.value == 0.48
     assert derived.unit == "tCO2e"
@@ -121,9 +121,9 @@ def test_retry_blocked_calculation_is_idempotent_after_success():
         output_claim_id="hyp-1:co2e_emission",
     )
 
-    assert twice.derived_claims == once.derived_claims
-    assert twice.resolved_obligations == once.resolved_obligations
-    assert twice.obligations == once.obligations
+    assert twice.calculated_claims == once.calculated_claims
+    assert twice.resolved_validation_requirements == once.resolved_validation_requirements
+    assert twice.validation_requirements == once.validation_requirements
 
 
 def test_retry_blocked_calculation_keeps_obligation_open_when_still_blocked():
@@ -138,6 +138,6 @@ def test_retry_blocked_calculation_keeps_obligation_open_when_still_blocked():
         output_claim_id="hyp-1:co2e_emission",
     )
 
-    assert updated.derived_claims == ()
-    assert updated.resolved_obligations == ()
-    assert updated.obligations == report.obligations
+    assert updated.calculated_claims == ()
+    assert updated.resolved_validation_requirements == ()
+    assert updated.validation_requirements == report.validation_requirements

--- a/tests/test_canonical_working_loop_scenario.py
+++ b/tests/test_canonical_working_loop_scenario.py
@@ -45,14 +45,14 @@ def test_canonical_working_loop_extracts_and_compiles_raw_text():
         "reporting_year",
         "geography",
     ]
-    assert [witness.witness_id for witness in report.evidence_witnesses] == [
+    assert [witness.witness_id for witness in report.evidence_refs] == [
         "w-activity",
         "w-electricity-kwh",
         "w-unit",
         "w-reporting-year",
         "w-geography",
     ]
-    assert report.obligations == ()
+    assert report.validation_requirements == ()
     assert report.can_build_public_output is False
 
 
@@ -60,11 +60,11 @@ def test_canonical_working_loop_opens_calculation_obligation_after_compile():
     report = open_calculation_obligation(compile_raw_evidence(RAW_EVIDENCE))
 
     assert report.status == "blocked"
-    assert [obligation.kind for obligation in report.obligations] == [
+    assert [obligation.kind for obligation in report.validation_requirements] == [
         "calculation_blocked",
     ]
-    assert report.obligations[0].reason == "unknown_reference"
-    assert report.derived_claims == ()
+    assert report.validation_requirements[0].reason == "unknown_reference"
+    assert report.calculated_claims == ()
 
 
 def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
@@ -88,12 +88,12 @@ def test_canonical_working_loop_runs_raw_text_to_receipt_projection():
     )
     assert_scenario_contract(result, SCENARIO.contract)
     assert [
-        candidate.retrieval_method for candidate in result.report.reference_candidates
+        candidate.retrieval_method for candidate in result.report.reference_options
     ] == [
         "embedding_stub:factor",
         "embedding_stub:factor",
     ]
-    assert result.report.reference_bindings[0].selected_candidate_id == (
+    assert result.report.canonical_references[0].selected_candidate_id == (
         "embedding_stub:factor:idx-canonical-kr-grid-2024"
     )
     assert result.projection == {

--- a/tests/test_carbon_tech_certificate_submission_scenario.py
+++ b/tests/test_carbon_tech_certificate_submission_scenario.py
@@ -27,7 +27,7 @@ def test_carbon_certificate_calculates_emission_from_certificate_factor():
     }
     assert tuple(
         (claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     ) == (("carbon_tech_final_emission_tco2e", 13390, "tCO2e"),)
 
 
@@ -36,7 +36,7 @@ def test_carbon_certificate_binds_certificate_factor_and_metadata():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (
             CERTIFICATE_FACTOR_BINDING_ID,
@@ -64,11 +64,11 @@ def test_carbon_certificate_boundary_is_resolved_without_activity_inputs():
     result = run_carbon_tech_certificate_submission_scenario()
 
     assert result.report.status == "accepted"
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert tuple(
         (obligation.kind, obligation.field, obligation.reason)
-        for obligation in result.report.resolved_obligations
+        for obligation in result.report.resolved_validation_requirements
     ) == (
         (
             "certificate_boundary_supported",
@@ -87,7 +87,7 @@ def test_carbon_certificate_boundary_is_resolved_without_activity_inputs():
         claim.field for claim in result.report.checked_claims
     )
     assert tuple(
-        binding.reference_type for binding in result.report.reference_bindings
+        binding.reference_type for binding in result.report.canonical_references
     ) == ("certificate_factor",)
 
 
@@ -123,7 +123,7 @@ def test_carbon_certificate_scenario_is_registered_with_contract():
 
 
 def _trace_for(result, claim_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             return claim.trace
     raise AssertionError(f"missing derived claim: {claim_id}")

--- a/tests/test_commit_package.py
+++ b/tests/test_commit_package.py
@@ -24,7 +24,7 @@ def test_commit_package_collects_report_artifacts_without_receipt_authority():
                 origin="source_text",
             ),
         ),
-        resolved_obligations=(
+        resolved_validation_requirements=(
             ValidationRequirement(
                 kind="calculation_blocked",
                 field="co2e_emission",
@@ -32,7 +32,7 @@ def test_commit_package_collects_report_artifacts_without_receipt_authority():
                 obligation_id="calculation:hyp-1:co2e_emission",
             ),
         ),
-        reference_bindings=(
+        canonical_references=(
             CanonicalReference(
                 binding_id="bind-amount-factor",
                 claim_id="hyp-1:amount",
@@ -40,7 +40,7 @@ def test_commit_package_collects_report_artifacts_without_receipt_authority():
                 reference_type="emission_factor",
             ),
         ),
-        derived_claims=(
+        calculated_claims=(
             CalculatedClaim(
                 claim_id="hyp-1:co2e_emission",
                 field="co2e_emission",
@@ -102,7 +102,7 @@ def test_friendly_review_names_are_canonical():
 def test_commit_package_is_incomplete_with_open_blocking_obligation():
     report = ValidationReport(
         status="accepted",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="reference_selection_required",
                 field="co2e_emission",
@@ -124,7 +124,7 @@ def test_commit_package_is_incomplete_with_open_blocking_obligation():
 def test_commit_package_cites_nonblocking_obligations_without_blocking_completion():
     report = ValidationReport(
         status="review_required",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="nonblocking_hint",
                 field="co2e_emission",

--- a/tests/test_commit_preparation_facts.py
+++ b/tests/test_commit_preparation_facts.py
@@ -58,7 +58,7 @@ def test_commit_preparation_to_facts_keeps_hold_visible_without_receipt_fact():
     preparation = prepare_commit(
         ValidationReport(
             status="accepted",
-            obligations=(
+            validation_requirements=(
                 ValidationRequirement(
                     kind="reference_selection_required",
                     field="co2e_emission",

--- a/tests/test_commit_preparation_flow.py
+++ b/tests/test_commit_preparation_flow.py
@@ -24,7 +24,7 @@ def test_prepare_commit_builds_package_decision_and_receipt_for_accepted_report(
                 origin="source_text",
             ),
         ),
-        reference_bindings=(
+        canonical_references=(
             CanonicalReference(
                 binding_id="bind-amount-factor",
                 claim_id="hyp-1:amount",
@@ -32,7 +32,7 @@ def test_prepare_commit_builds_package_decision_and_receipt_for_accepted_report(
                 reference_type="emission_factor",
             ),
         ),
-        derived_claims=(
+        calculated_claims=(
             CalculatedClaim(
                 claim_id="hyp-1:co2e_emission",
                 field="co2e_emission",
@@ -82,7 +82,7 @@ def test_prepare_commit_builds_package_decision_and_receipt_for_accepted_report(
 def test_prepare_commit_returns_hold_without_receipt_for_open_obligations():
     report = ValidationReport(
         status="accepted",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="reference_selection_required",
                 field="co2e_emission",

--- a/tests/test_commit_receipt_builder.py
+++ b/tests/test_commit_receipt_builder.py
@@ -183,7 +183,7 @@ def test_commit_receipt_builder_commits_checked_and_derived_projection_values():
                 origin="source_text",
             ),
         ),
-        derived_claims=(
+        calculated_claims=(
             CalculatedClaim(
                 claim_id="hyp-1:co2e_emission",
                 field="co2e_emission",

--- a/tests/test_compile_report_to_judgment_facts.py
+++ b/tests/test_compile_report_to_judgment_facts.py
@@ -40,7 +40,7 @@ def test_compile_report_to_facts_maps_each_report_category():
                 reason="missing_rule_coverage",
             ),
         ),
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="find_source_witness",
                 field="unit",
@@ -130,14 +130,14 @@ def test_compile_report_to_facts_maps_each_report_category():
     )
 
 
-def test_resolved_obligations_discharge_matching_hazard_ids():
+def test_resolved_validation_requirements_discharge_matching_hazard_ids():
     subject = SubjectRef("claim", "hyp-1")
     obligation = ValidationRequirement(
         kind="find_source_witness",
         field="unit",
         reason="unsupported_unit",
     )
-    report = ValidationReport(status="accepted", resolved_obligations=(obligation,))
+    report = ValidationReport(status="accepted", resolved_validation_requirements=(obligation,))
 
     facts = compile_report_to_facts(report, subject)
 
@@ -178,7 +178,7 @@ def test_obligation_facts_preserve_explicit_obligation_ids():
     subject = SubjectRef("claim", "hyp-1")
     report = ValidationReport(
         status="review_required",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="semantic_judgment_required",
                 field="scope2_method",
@@ -186,7 +186,7 @@ def test_obligation_facts_preserve_explicit_obligation_ids():
                 obligation_id="obl-custom-open",
             ),
         ),
-        resolved_obligations=(
+        resolved_validation_requirements=(
             ValidationRequirement(
                 kind="find_source_witness",
                 field="unit",

--- a/tests/test_compiler_tool_contract.py
+++ b/tests/test_compiler_tool_contract.py
@@ -74,10 +74,19 @@ def test_friendly_intake_validation_names_are_canonical():
         field="amount",
         reason="missing_source_witness",
     )
+    report = ValidationReport(
+        status="review_required",
+        evidence_refs=(witness,),
+        validation_requirements=(requirement,),
+        resolved_validation_requirements=(),
+    )
 
     assert type(claim).__name__ == "ClaimCandidate"
     assert type(witness).__name__ == "EvidenceRef"
     assert type(requirement).__name__ == "ValidationRequirement"
+    assert report.evidence_refs == (witness,)
+    assert report.validation_requirements == (requirement,)
+    assert report.resolved_validation_requirements == ()
     assert evidence_ref_fingerprint(witness).dependency_kind == "evidence_witness"
 
 
@@ -111,15 +120,18 @@ def test_friendly_reference_calculation_report_names_are_canonical():
     )
     report = ValidationReport(
         status="accepted",
-        reference_candidates=(option,),
-        reference_bindings=(reference,),
-        derived_claims=(calculated,),
+        reference_options=(option,),
+        canonical_references=(reference,),
+        calculated_claims=(calculated,),
     )
 
     assert type(option).__name__ == "ReferenceOption"
     assert type(reference).__name__ == "CanonicalReference"
     assert type(calculated).__name__ == "CalculatedClaim"
     assert type(report).__name__ == "ValidationReport"
+    assert report.reference_options == (option,)
+    assert report.canonical_references == (reference,)
+    assert report.calculated_claims == (calculated,)
     assert option.can_authorize_calculation is False
     assert reference.can_authorize_calculation is True
     assert calculated.can_authorize_public_projection is False
@@ -166,7 +178,7 @@ def test_unsupported_unit_blocks_and_requests_source_witness():
     assert report.failed_claims[0].reason == "unsupported_unit"
     assert any(
         obligation.kind == "find_source_witness" and obligation.field == "unit"
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     )
     assert report.can_build_public_output is False
 
@@ -199,7 +211,7 @@ def test_witness_id_must_resolve_to_grounded_matching_witness():
         assert report.failed_claims[0].reason == expected_reason
         assert any(
             obligation.kind == "find_source_witness" and obligation.field == "amount"
-            for obligation in report.obligations
+            for obligation in report.validation_requirements
         )
 
 
@@ -256,7 +268,7 @@ def test_missing_unit_is_review_required_hazard_not_public_projection():
     )
     assert any(
         obligation.kind == "find_source_witness" and obligation.field == "unit"
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     )
     assert report.can_build_public_output is False
 

--- a/tests/test_complete_friendly_rename.py
+++ b/tests/test_complete_friendly_rename.py
@@ -52,3 +52,43 @@ def test_legacy_authority_names_are_not_active_repo_surface():
                 offenders.append(f"{path_text}: {legacy_name}")
 
     assert offenders == []
+
+
+def test_legacy_validation_report_field_names_are_not_active_python_surface():
+    legacy_field_patterns = tuple(
+        "".join(parts)
+        for parts in (
+            ("evidence", "_witnesses"),
+            ("reference", "_candidates"),
+            ("reference", "_bindings"),
+            ("derived", "_claims"),
+            ("resolved", "_obligations"),
+            (".", "obligations"),
+            ("obligations", "="),
+        )
+    )
+    scanned_roots = ("comp/", "minchoagnt/", "tests/")
+    ignored = (
+        "tests/test_complete_friendly_rename.py",
+        "tests/test_package_smoke.py",
+    )
+
+    paths = subprocess.check_output(
+        ["git", "ls-files"],
+        text=True,
+    ).splitlines()
+    offenders = []
+    for path_text in paths:
+        if path_text.startswith(ignored):
+            continue
+        if not path_text.startswith(scanned_roots):
+            continue
+        path = Path(path_text)
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        for legacy_field in legacy_field_patterns:
+            if legacy_field in text:
+                offenders.append(f"{path_text}: {legacy_field}")
+
+    assert offenders == []

--- a/tests/test_derived_claim_trace.py
+++ b/tests/test_derived_claim_trace.py
@@ -49,9 +49,9 @@ def test_derived_claim_is_calculated_claim_not_public_authority():
     assert claim.formula_id == "ghg.electricity_factor_multiplication.v1"
     assert claim.can_authorize_public_projection is False
 
-    report = ValidationReport(status="accepted", derived_claims=(claim,))
+    report = ValidationReport(status="accepted", calculated_claims=(claim,))
 
-    assert report.derived_claims == (claim,)
+    assert report.calculated_claims == (claim,)
     assert report.can_build_public_output is False
 
 
@@ -64,7 +64,7 @@ def test_calculation_trace_requires_formula_id():
         )
 
 
-def test_semantic_judgment_application_preserves_derived_claims():
+def test_semantic_judgment_application_preserves_calculated_claims():
     claim = _derived_claim()
     obligation = ValidationRequirement(
         kind="semantic_judgment_required",
@@ -81,8 +81,8 @@ def test_semantic_judgment_application_preserves_derived_claims():
     )
     report = ValidationReport(
         status="review_required",
-        obligations=(obligation,),
-        derived_claims=(claim,),
+        validation_requirements=(obligation,),
+        calculated_claims=(claim,),
     )
 
     updated = apply_semantic_judgments(
@@ -101,13 +101,13 @@ def test_semantic_judgment_application_preserves_derived_claims():
         available_span_ids=("span-17",),
     )
 
-    assert updated.derived_claims == (claim,)
+    assert updated.calculated_claims == (claim,)
 
 
 def test_compile_report_to_facts_maps_derived_claim_with_trace_metadata():
     subject = SubjectRef("claim", "hyp-1")
     claim = _derived_claim()
-    report = ValidationReport(status="accepted", derived_claims=(claim,))
+    report = ValidationReport(status="accepted", calculated_claims=(claim,))
 
     facts = compile_report_to_facts(report, subject)
 

--- a/tests/test_domain_scenario_lab.py
+++ b/tests/test_domain_scenario_lab.py
@@ -123,7 +123,7 @@ def test_domain_scenario_cli_summarizes_blocked_requirements_as_actions():
     result = BlockedResult(
         report=ValidationReport(
             status="blocked",
-            obligations=(
+            validation_requirements=(
                 ValidationRequirement(
                     kind="find_source_witness",
                     field="co2e_kg",
@@ -362,7 +362,7 @@ def test_synthetic_pcf_smoke_scenario_runs_generated_raw_to_receipt_flow():
         "electricity_kwh": 1200,
         "co2e_kg": 504.0,
     }
-    assert result.report.evidence_witnesses[0].source == (
+    assert result.report.evidence_refs[0].source == (
         "raw_sources/erp_electricity.csv"
     )
     assert tuple(
@@ -479,14 +479,14 @@ def test_tiny_pcf_scenario_rejects_tampered_projection_value():
 def test_tiny_pcf_scenario_preserves_traceable_domain_artifacts():
     result = run_tiny_pcf_scenario()
 
-    assert tuple(item.kind for item in result.report.resolved_obligations) == (
+    assert tuple(item.kind for item in result.report.resolved_validation_requirements) == (
         EXPECTED_RESOLVED_OBLIGATION_KINDS
     )
     assert tuple(
-        candidate.reference_id for candidate in result.report.reference_candidates
+        candidate.reference_id for candidate in result.report.reference_options
     ) == EXPECTED_REFERENCE_CANDIDATE_IDS
 
-    binding = result.report.reference_bindings[0]
+    binding = result.report.canonical_references[0]
     assert binding.reference_id == "pcf.factor.kr_grid_2024.location_based"
     assert binding.selected_candidate_id == (
         "keyword:pcf.factor.kr_grid_2024.location_based"
@@ -495,7 +495,7 @@ def test_tiny_pcf_scenario_preserves_traceable_domain_artifacts():
         (item.reference_id, item.reason) for item in binding.rejected_candidates
     ) == EXPECTED_REJECTED_CANDIDATES
 
-    derived = result.report.derived_claims[0]
+    derived = result.report.calculated_claims[0]
     assert derived.claim_id == "tiny-pcf:co2e_kg"
     assert derived.value == 504.0
     assert derived.trace.reference_binding_ids == ("bind-electricity-factor",)
@@ -565,15 +565,15 @@ def test_scenario_result_view_exposes_friendly_validation_summary():
     assert friendly["sections"] == [
         {
             "label_ko": "근거자료 위치",
-            "count": len(result.report.evidence_witnesses),
+            "count": len(result.report.evidence_refs),
         },
         {
             "label_ko": "확정 기준",
-            "count": len(result.report.reference_bindings),
+            "count": len(result.report.canonical_references),
         },
         {
             "label_ko": "계산값",
-            "count": len(result.report.derived_claims),
+            "count": len(result.report.calculated_claims),
         },
     ]
 
@@ -675,7 +675,7 @@ def test_tiny_pcf_scenario_exports_json_ready_viewer_payload():
 
     assert exported["scenario_id"] == "tiny_pcf.location_based_electricity.v1"
     assert exported["report"]["status"] == "accepted"
-    assert exported["report"]["reference_bindings"] == [
+    assert exported["report"]["canonical_references"] == [
         {
             "binding_id": "bind-electricity-factor",
             "reference_id": "pcf.factor.kr_grid_2024.location_based",

--- a/tests/test_final_bottom_up_rollup_scenario.py
+++ b/tests/test_final_bottom_up_rollup_scenario.py
@@ -36,7 +36,7 @@ def test_final_bottom_up_rollup_calculates_total_and_intensities():
     )
     assert tuple(
         (claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     ) == (
         ("l_energy_total_emission_tco2e", 199994, "tCO2e"),
         ("kg_co2e_per_pack", 1999.94, "kgCO2e/pack"),
@@ -49,7 +49,7 @@ def test_final_bottom_up_rollup_binds_all_child_receipts():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (
             TIER0_CHILD_BINDING_ID,
@@ -84,12 +84,12 @@ def test_final_bottom_up_rollup_binds_all_child_receipts():
 def test_final_bottom_up_rollup_requires_authorized_child_paths():
     result = run_final_bottom_up_rollup_scenario()
 
-    assert tuple(item.kind for item in result.report.resolved_obligations) == (
+    assert tuple(item.kind for item in result.report.resolved_validation_requirements) == (
         "child_claims_accepted_or_proxy_authorized",
         "rollup_snapshot_created",
     )
     assert result.report.status == "accepted"
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert {
         (claim.field, claim.value)
@@ -138,7 +138,7 @@ def test_final_bottom_up_rollup_scenario_is_registered_with_contract():
 
 
 def _trace_step_value(result, claim_id, step_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             for step in claim.trace.steps:
                 if step.step_id == step_id:

--- a/tests/test_l_energy_pcf_scenario.py
+++ b/tests/test_l_energy_pcf_scenario.py
@@ -78,11 +78,11 @@ def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retriev
     assert "profile_active_retrieval_policy" in result.resolver_steps
     assert "reference_retrieval:embedding_stub:factor" in result.resolver_steps
     assert tuple(
-        obligation.kind for obligation in result.report.resolved_obligations
+        obligation.kind for obligation in result.report.resolved_validation_requirements
     ) == ("reference_search_required", "calculation_blocked")
 
     candidate_ids = tuple(
-        candidate.candidate_id for candidate in result.report.reference_candidates
+        candidate.candidate_id for candidate in result.report.reference_options
     )
     assert candidate_ids == (
         "embedding_stub:factor:idx-l-energy-supplier-electricity-mwh-2025",
@@ -93,16 +93,16 @@ def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retriev
         "embedding_stub:factor:idx-l-energy-us-electricity-mwh-2025",
     )
     assert tuple(
-        candidate.reference_id for candidate in result.report.reference_candidates
+        candidate.reference_id for candidate in result.report.reference_options
     ) == EXPECTED_REFERENCE_CANDIDATE_IDS
     assert all(
         candidate.authority == "candidate_only"
-        for candidate in result.report.reference_candidates
+        for candidate in result.report.reference_options
     )
 
     electricity_binding = next(
         binding
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
         if binding.binding_id == "bind:pcf:electricity_factor"
     )
     assert (
@@ -116,7 +116,7 @@ def test_l_energy_pcf_governance_scenario_resolves_energy_factor_through_retriev
 
     own_emission_claim = next(
         claim
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
         if claim.claim_id == "l-energy:own_emission_tco2e"
     )
     assert own_emission_claim.origin == "calculated"
@@ -174,7 +174,7 @@ def test_l_energy_scenario_accepts_swappable_reference_pack():
 
     assert result.projection == EXPECTED_PROJECTION
     assert tuple(
-        candidate.reference_id for candidate in result.report.reference_candidates
+        candidate.reference_id for candidate in result.report.reference_options
     ) == ("platform.factor.electricity_mwh",)
 
 
@@ -184,7 +184,7 @@ def test_l_energy_pcf_governance_scenario_preserves_actor_receipt_trace():
     assert_scenario_contract(result, L_ENERGY_SCENARIO.contract)
     assert result.preparation.package.open_obligation_ids == ()
     assert result.preparation.package.hazard_ids == ()
-    assert tuple(claim.claim_id for claim in result.report.derived_claims) == (
+    assert tuple(claim.claim_id for claim in result.report.calculated_claims) == (
         EXPECTED_DERIVED_CLAIM_IDS
     )
     assert_receipt_trace(
@@ -201,7 +201,7 @@ def test_l_energy_pcf_governance_scenario_exports_targeted_viewer_payload():
     assert exported["scenario_id"] == "l_energy_pcf_governance.v1"
     assert exported["commit"]["governance_status"] == "commit"
     assert exported["projection"] == EXPECTED_PROJECTION
-    assert len(exported["report"]["derived_claims"]) == len(
+    assert len(exported["report"]["calculated_claims"]) == len(
         EXPECTED_DERIVED_CLAIM_IDS
     )
 

--- a/tests/test_l_materials_composition_rollup_scenario.py
+++ b/tests/test_l_materials_composition_rollup_scenario.py
@@ -29,7 +29,7 @@ def test_l_materials_composition_rollup_calculates_ncm_emission():
     }
     assert tuple(
         (claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     ) == (
         ("composition_total", 1.0, None),
         ("l_materials_final_emission_tco2e", 174375, "tCO2e"),
@@ -41,7 +41,7 @@ def test_l_materials_composition_binds_ncm_factor_and_shares():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (
             COMPOSITION_FACTOR_BINDING_ID,
@@ -71,11 +71,11 @@ def test_l_materials_composition_total_is_resolved_context():
     result = run_l_materials_composition_rollup_scenario()
 
     assert result.report.status == "accepted"
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert tuple(
         (obligation.kind, obligation.field, obligation.reason)
-        for obligation in result.report.resolved_obligations
+        for obligation in result.report.resolved_validation_requirements
     ) == (
         (
             "composition_total_validated",
@@ -106,8 +106,8 @@ def test_l_materials_invalid_composition_blocks_mapping_and_projection():
         (hazard.kind, hazard.field, hazard.severity)
         for hazard in report.hazards
     ) == (("composition_mapping_error", "ncm_composition", "block"),)
-    assert report.reference_bindings == ()
-    assert report.derived_claims == ()
+    assert report.canonical_references == ()
+    assert report.calculated_claims == ()
     assert preparation.receipt is None
     with pytest.raises(PublicOutputBlocked, match="public-output receipt"):
         build_public_output(
@@ -129,7 +129,7 @@ def test_l_materials_composition_scenario_is_registered_with_contract():
 
 
 def _trace_for(result, claim_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             return claim.trace
     raise AssertionError(f"missing derived claim: {claim_id}")

--- a/tests/test_minchoagnt_comp_adapter.py
+++ b/tests/test_minchoagnt_comp_adapter.py
@@ -141,7 +141,7 @@ def test_deterministic_comp_resolver_applies_semantic_judgment_without_receipt()
     compile_result = CompCompileResult(
         hypothesis=InterpretationHypothesis("hyp-sem", "facility-1"),
         subject=SubjectRef("claim", "hyp-sem"),
-        report=ValidationReport(status="review_required", obligations=(obligation,)),
+        report=ValidationReport(status="review_required", validation_requirements=(obligation,)),
     )
     resolver = DeterministicCompResolver(
         semantic_judgments=(
@@ -163,8 +163,8 @@ def test_deterministic_comp_resolver_applies_semantic_judgment_without_receipt()
     assert [task.obligation_id for task in resolution.tasks] == ["obl-scope2"]
     assert resolution.semantic_judgment_ids == ("judgment-scope2",)
     assert resolution.result.report.status == "accepted"
-    assert resolution.result.report.obligations == ()
-    assert resolution.result.report.resolved_obligations == (obligation,)
+    assert resolution.result.report.validation_requirements == ()
+    assert resolution.result.report.resolved_validation_requirements == (obligation,)
     assert resolution.result.receipt is None
 
 
@@ -192,7 +192,7 @@ def test_deterministic_comp_resolver_runs_reference_search_from_task_query():
     compile_result = CompCompileResult(
         hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
         subject=SubjectRef("claim", "hyp-ref"),
-        report=ValidationReport(status="blocked", obligations=(obligation,)),
+        report=ValidationReport(status="blocked", validation_requirements=(obligation,)),
     )
     catalog = ReferenceCatalog(
         records=(
@@ -214,11 +214,11 @@ def test_deterministic_comp_resolver_runs_reference_search_from_task_query():
     assert resolution.reference_query_obligation_ids == (obligation_id,)
     reference_ids = [
         candidate.reference_id
-        for candidate in resolution.result.report.reference_candidates
+        for candidate in resolution.result.report.reference_options
     ]
     assert reference_ids == ["factor.kr_grid.2024.location_based"]
-    assert resolution.result.report.obligations == ()
-    assert resolution.result.report.resolved_obligations == (obligation,)
+    assert resolution.result.report.validation_requirements == ()
+    assert resolution.result.report.resolved_validation_requirements == (obligation,)
     assert resolution.result.receipt is None
 
 
@@ -246,7 +246,7 @@ def test_deterministic_comp_resolver_runs_reference_retrieval_from_task_query():
     compile_result = CompCompileResult(
         hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
         subject=SubjectRef("claim", "hyp-ref"),
-        report=ValidationReport(status="blocked", obligations=(obligation,)),
+        report=ValidationReport(status="blocked", validation_requirements=(obligation,)),
     )
     resolver = DeterministicCompResolver(
         reference_resolver=EmbeddingResolverStub(
@@ -272,16 +272,16 @@ def test_deterministic_comp_resolver_runs_reference_retrieval_from_task_query():
     assert resolution.reference_query_obligation_ids == (obligation_id,)
     assert [
         candidate.retrieval_method
-        for candidate in resolution.result.report.reference_candidates
+        for candidate in resolution.result.report.reference_options
     ] == ["embedding_stub:factor"]
     assert [
         candidate.reference_id
-        for candidate in resolution.result.report.reference_candidates
+        for candidate in resolution.result.report.reference_options
     ] == ["factor.kr_grid.2024.location_based"]
-    assert resolution.result.report.obligations == ()
-    assert resolution.result.report.resolved_obligations == (obligation,)
-    assert resolution.result.report.reference_bindings == ()
-    assert resolution.result.report.derived_claims == ()
+    assert resolution.result.report.validation_requirements == ()
+    assert resolution.result.report.resolved_validation_requirements == (obligation,)
+    assert resolution.result.report.canonical_references == ()
+    assert resolution.result.report.calculated_claims == ()
     assert resolution.result.receipt is None
 
 
@@ -309,7 +309,7 @@ def test_deterministic_comp_resolver_runs_reference_retrieval_from_query_policy(
     compile_result = CompCompileResult(
         hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
         subject=SubjectRef("claim", "hyp-ref"),
-        report=ValidationReport(status="blocked", obligations=(obligation,)),
+        report=ValidationReport(status="blocked", validation_requirements=(obligation,)),
     )
     resolver = DeterministicCompResolver(
         reference_resolver=EmbeddingResolverStub(
@@ -347,11 +347,11 @@ def test_deterministic_comp_resolver_runs_reference_retrieval_from_query_policy(
     assert resolution.reference_query_obligation_ids == (obligation_id,)
     assert [
         candidate.reference_id
-        for candidate in resolution.result.report.reference_candidates
+        for candidate in resolution.result.report.reference_options
     ] == ["factor.kr_grid.2024.location_based"]
-    assert resolution.result.report.resolved_obligations == (obligation,)
-    assert resolution.result.report.reference_bindings == ()
-    assert resolution.result.report.derived_claims == ()
+    assert resolution.result.report.resolved_validation_requirements == (obligation,)
+    assert resolution.result.report.canonical_references == ()
+    assert resolution.result.report.calculated_claims == ()
     assert resolution.result.receipt is None
 
 
@@ -375,7 +375,7 @@ def test_deterministic_comp_resolver_leaves_reference_policy_task_open_without_c
     compile_result = CompCompileResult(
         hypothesis=InterpretationHypothesis("hyp-ref", "facility-1"),
         subject=SubjectRef("claim", "hyp-ref"),
-        report=ValidationReport(status="blocked", obligations=(obligation,)),
+        report=ValidationReport(status="blocked", validation_requirements=(obligation,)),
     )
     resolver = DeterministicCompResolver(
         reference_resolver=EmbeddingResolverStub(entries=()),

--- a/tests/test_minchoagnt_llm_work_orders.py
+++ b/tests/test_minchoagnt_llm_work_orders.py
@@ -42,7 +42,7 @@ def _compile_result() -> CompCompileResult:
         subject=SubjectRef("claim", "hyp-sem"),
         report=ValidationReport(
             status="review_required",
-            obligations=(_semantic_obligation(),),
+            validation_requirements=(_semantic_obligation(),),
         ),
     )
 
@@ -117,8 +117,8 @@ def test_deterministic_llm_worker_submits_semantic_judgment_artifact_only():
     )
 
     assert resolved.report.status == "accepted"
-    assert resolved.report.obligations == ()
-    assert resolved.report.resolved_obligations == (_semantic_obligation(),)
+    assert resolved.report.validation_requirements == ()
+    assert resolved.report.resolved_validation_requirements == (_semantic_obligation(),)
     assert resolved.receipt is None
 
 
@@ -145,8 +145,8 @@ def test_llm_worker_abstention_leaves_semantic_obligation_open():
     )
 
     assert unresolved.report.status == "review_required"
-    assert unresolved.report.obligations == (_semantic_obligation(),)
-    assert unresolved.report.resolved_obligations == ()
+    assert unresolved.report.validation_requirements == (_semantic_obligation(),)
+    assert unresolved.report.resolved_validation_requirements == ()
     assert unresolved.receipt is None
 
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -677,11 +677,16 @@ def test_friendly_authority_vocabulary_names_rename_path_without_moving_authorit
     assert "The first helper lives in `comp.user_messages`" in vocabulary
     assert "user_message_for_reason(\"unsupported_unit\")" in vocabulary
     assert "## 6. Residual Field Vocabulary Audit" in vocabulary
-    assert "Safe active field rename candidates" in vocabulary
-    assert "`ValidationReport.evidence_witnesses` -> `ValidationReport.evidence_refs`" in vocabulary
-    assert "`ValidationReport.reference_candidates` -> `ValidationReport.reference_options`" in vocabulary
-    assert "`ValidationReport.reference_bindings` -> `ValidationReport.canonical_references`" in vocabulary
-    assert "`ValidationReport.derived_claims` -> `ValidationReport.calculated_claims`" in vocabulary
+    assert "active `ValidationReport` field names are" in vocabulary
+    assert "complete. Active Python-facing report fields" in vocabulary
+    assert "`ValidationReport.evidence_refs` | Grounding references" in vocabulary
+    assert "`ValidationReport.reference_options` | Candidate-only" in vocabulary
+    assert "`ValidationReport.canonical_references` | Deterministically" in vocabulary
+    assert "`ValidationReport.calculated_claims` | Calculated values" in vocabulary
+    assert "`ValidationReport.validation_requirements` | Open work" in vocabulary
+    assert "`ValidationReport.resolved_validation_requirements` | Completed" in vocabulary
+    assert "Do not add compatibility" in vocabulary
+    assert "aliases for the previous field names" in vocabulary
     assert "Codec-bound receipt and replay vocabulary" in vocabulary
     assert "`PublicOutputReceipt.projection_id`" in vocabulary
     assert "`DependencyFingerprint.dependency_kind=\"evidence_witness\"`" in vocabulary

--- a/tests/test_receipt_proof_graph.py
+++ b/tests/test_receipt_proof_graph.py
@@ -224,8 +224,8 @@ def test_canonical_scenario_replay_exports_claim_reference_calculation_edges():
         artifacts=bundle.artifacts,
     )
 
-    derived = result.report.derived_claims[0]
-    binding = result.report.reference_bindings[0]
+    derived = result.report.calculated_claims[0]
+    binding = result.report.canonical_references[0]
     trace_id = derived.trace.trace_id
     derived_node_id = artifact_node_id("derived_claim", derived.claim_id)
     trace_node_id = artifact_node_id("calculation_trace", trace_id)

--- a/tests/test_reference_binding_facts.py
+++ b/tests/test_reference_binding_facts.py
@@ -25,7 +25,7 @@ def test_compile_report_to_facts_maps_reference_binding_as_provenance_edge():
         source_witness_ids=("span-amount", "ref-factor-row-17"),
         rejected_candidates=(rejected,),
     )
-    report = ValidationReport(status="accepted", reference_bindings=(binding,))
+    report = ValidationReport(status="accepted", canonical_references=(binding,))
 
     facts = compile_report_to_facts(report, subject)
 

--- a/tests/test_reference_binding_model.py
+++ b/tests/test_reference_binding_model.py
@@ -28,11 +28,11 @@ def test_reference_candidate_is_candidate_only_authority():
 
     report = ValidationReport(
         status="review_required",
-        reference_candidates=(candidate,),
+        reference_options=(candidate,),
     )
 
-    assert report.reference_candidates == (candidate,)
-    assert report.reference_bindings == ()
+    assert report.reference_options == (candidate,)
+    assert report.canonical_references == ()
 
 
 def test_reference_candidate_cannot_claim_binding_authority():
@@ -68,10 +68,10 @@ def test_reference_binding_records_selector_and_rejected_candidates():
     assert binding.can_authorize_calculation is True
     assert binding.rejected_candidates == (rejected,)
 
-    report = ValidationReport(status="accepted", reference_bindings=(binding,))
+    report = ValidationReport(status="accepted", canonical_references=(binding,))
 
-    assert report.reference_bindings == (binding,)
-    assert report.reference_candidates == ()
+    assert report.canonical_references == (binding,)
+    assert report.reference_options == ()
 
 
 def test_reference_binding_cannot_be_downgraded_to_candidate_authority():
@@ -115,9 +115,9 @@ def test_semantic_judgment_application_preserves_reference_artifacts():
     )
     report = ValidationReport(
         status="review_required",
-        obligations=(obligation,),
-        reference_candidates=(candidate,),
-        reference_bindings=(binding,),
+        validation_requirements=(obligation,),
+        reference_options=(candidate,),
+        canonical_references=(binding,),
     )
 
     updated = apply_semantic_judgments(
@@ -136,5 +136,5 @@ def test_semantic_judgment_application_preserves_reference_artifacts():
         available_span_ids=("span-17",),
     )
 
-    assert updated.reference_candidates == (candidate,)
-    assert updated.reference_bindings == (binding,)
+    assert updated.reference_options == (candidate,)
+    assert updated.canonical_references == (binding,)

--- a/tests/test_reference_grounded_calculation_flow.py
+++ b/tests/test_reference_grounded_calculation_flow.py
@@ -125,19 +125,19 @@ def test_reference_grounded_calculation_flow_searches_binds_and_retries():
     )
 
     assert resolved.status == "accepted"
-    assert resolved.obligations == ()
-    assert [item.kind for item in resolved.resolved_obligations] == [
+    assert resolved.validation_requirements == ()
+    assert [item.kind for item in resolved.resolved_validation_requirements] == [
         "reference_search_required",
         "calculation_blocked",
     ]
-    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+    assert [candidate.reference_id for candidate in resolved.reference_options] == [
         "factor.kr_grid.2024.location_based"
     ]
-    assert [binding.reference_id for binding in resolved.reference_bindings] == [
+    assert [binding.reference_id for binding in resolved.canonical_references] == [
         "factor.kr_grid.2024.location_based"
     ]
-    assert len(resolved.derived_claims) == 1
-    assert resolved.derived_claims[0].value == 0.48
+    assert len(resolved.calculated_claims) == 1
+    assert resolved.calculated_claims[0].value == 0.48
     assert resolved.can_build_public_output is False
 
 
@@ -153,10 +153,10 @@ def test_reference_grounded_calculation_flow_stops_when_search_has_no_candidates
     )
 
     assert resolved.status == "blocked"
-    assert resolved.reference_candidates == ()
-    assert resolved.reference_bindings == ()
-    assert resolved.derived_claims == ()
-    assert [item.kind for item in resolved.obligations] == [
+    assert resolved.reference_options == ()
+    assert resolved.canonical_references == ()
+    assert resolved.calculated_claims == ()
+    assert [item.kind for item in resolved.validation_requirements] == [
         "calculation_blocked",
         "reference_search_required",
     ]
@@ -174,10 +174,10 @@ def test_reference_grounded_calculation_flow_exposes_ambiguous_selection():
     )
 
     assert resolved.status == "blocked"
-    assert resolved.reference_bindings == ()
-    assert resolved.derived_claims == ()
-    assert [item.kind for item in resolved.obligations] == [
+    assert resolved.canonical_references == ()
+    assert resolved.calculated_claims == ()
+    assert [item.kind for item in resolved.validation_requirements] == [
         "calculation_blocked",
         "reference_selection_required",
     ]
-    assert resolved.obligations[1].reason == "ambiguous"
+    assert resolved.validation_requirements[1].reason == "ambiguous"

--- a/tests/test_reference_search_resolution.py
+++ b/tests/test_reference_search_resolution.py
@@ -91,23 +91,23 @@ def test_reference_search_resolution_adds_candidates_and_resolves_followup():
 
     assert resolved.status == "blocked"
     assert resolved.can_build_public_output is False
-    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+    assert [candidate.reference_id for candidate in resolved.reference_options] == [
         "factor.kr_grid.2024.location_based"
     ]
-    assert resolved.reference_candidates[0].authority == "candidate_only"
-    assert resolved.reference_candidates[0].source == "tiny-fixture"
-    assert resolved.reference_candidates[0].witness_ids == ("ref-factor-row-17",)
-    assert [obligation.kind for obligation in resolved.obligations] == [
+    assert resolved.reference_options[0].authority == "candidate_only"
+    assert resolved.reference_options[0].source == "tiny-fixture"
+    assert resolved.reference_options[0].witness_ids == ("ref-factor-row-17",)
+    assert [obligation.kind for obligation in resolved.validation_requirements] == [
         "calculation_blocked"
     ]
-    assert [obligation.kind for obligation in resolved.resolved_obligations] == [
+    assert [obligation.kind for obligation in resolved.resolved_validation_requirements] == [
         "reference_search_required"
     ]
 
 
 def test_reference_search_resolution_recomputes_status_after_resolving_only_blocker():
-    obligation = _planned_unknown_reference_report().obligations[1]
-    report = ValidationReport(status="blocked", obligations=(obligation,))
+    obligation = _planned_unknown_reference_report().validation_requirements[1]
+    report = ValidationReport(status="blocked", validation_requirements=(obligation,))
 
     resolved = resolve_reference_search_obligations(
         report,
@@ -116,7 +116,7 @@ def test_reference_search_resolution_recomputes_status_after_resolving_only_bloc
         reference_type="emission_factor",
     )
 
-    assert resolved.obligations == ()
+    assert resolved.validation_requirements == ()
     assert resolved.status == "accepted"
 
 
@@ -162,6 +162,6 @@ def test_reference_search_resolution_is_idempotent():
         reference_type="emission_factor",
     )
 
-    assert twice.reference_candidates == once.reference_candidates
-    assert twice.resolved_obligations == once.resolved_obligations
-    assert twice.obligations == once.obligations
+    assert twice.reference_options == once.reference_options
+    assert twice.resolved_validation_requirements == once.resolved_validation_requirements
+    assert twice.validation_requirements == once.validation_requirements

--- a/tests/test_reference_selection_report.py
+++ b/tests/test_reference_selection_report.py
@@ -81,8 +81,8 @@ def test_reference_selection_adds_binding_and_resolves_matching_obligation():
     obligation = _selection_obligation()
     report = ValidationReport(
         status="blocked",
-        obligations=(obligation,),
-        reference_candidates=(
+        validation_requirements=(obligation,),
+        reference_options=(
             _candidate(
                 "cand-market",
                 "factor.kr_residual_mix.2024.market_based",
@@ -105,10 +105,10 @@ def test_reference_selection_adds_binding_and_resolves_matching_obligation():
 
     assert updated.status == "accepted"
     assert updated.can_build_public_output is False
-    assert updated.obligations == ()
-    assert updated.resolved_obligations == (obligation,)
-    assert len(updated.reference_bindings) == 1
-    binding = updated.reference_bindings[0]
+    assert updated.validation_requirements == ()
+    assert updated.resolved_validation_requirements == (obligation,)
+    assert len(updated.canonical_references) == 1
+    binding = updated.canonical_references[0]
     assert binding.reference_id == "factor.kr_grid.2024.location_based"
     assert binding.selected_candidate_id == "cand-location"
     assert binding.selector_rule_id == "ghg.factor_selector.v1"
@@ -121,7 +121,7 @@ def test_reference_selection_adds_binding_and_resolves_matching_obligation():
 def test_reference_selection_opens_obligation_when_candidates_are_ambiguous():
     report = ValidationReport(
         status="accepted",
-        reference_candidates=(
+        reference_options=(
             _candidate("cand-a", "factor.kr_grid.2024.location_based", 0.99),
             _candidate("cand-b", "factor.kr_grid.2024.location_based", 0.76),
         ),
@@ -135,14 +135,14 @@ def test_reference_selection_opens_obligation_when_candidates_are_ambiguous():
     )
 
     assert updated.status == "review_required"
-    assert updated.reference_bindings == ()
-    assert updated.obligations == (_selection_obligation(reason="ambiguous"),)
+    assert updated.canonical_references == ()
+    assert updated.validation_requirements == (_selection_obligation(reason="ambiguous"),)
 
 
 def test_reference_selection_opens_obligation_when_no_candidate_matches():
     report = ValidationReport(
         status="accepted",
-        reference_candidates=(
+        reference_options=(
             _candidate(
                 "cand-market",
                 "factor.kr_residual_mix.2024.market_based",
@@ -159,14 +159,14 @@ def test_reference_selection_opens_obligation_when_no_candidate_matches():
     )
 
     assert updated.status == "review_required"
-    assert updated.reference_bindings == ()
-    assert updated.obligations == (_selection_obligation(reason="no_match"),)
+    assert updated.canonical_references == ()
+    assert updated.validation_requirements == (_selection_obligation(reason="no_match"),)
 
 
 def test_reference_selection_report_application_is_idempotent():
     report = ValidationReport(
         status="accepted",
-        reference_candidates=(
+        reference_options=(
             _candidate("cand-a", "factor.kr_grid.2024.location_based", 0.99),
             _candidate("cand-b", "factor.kr_grid.2024.location_based", 0.76),
         ),
@@ -185,5 +185,5 @@ def test_reference_selection_report_application_is_idempotent():
         field="co2e_emission",
     )
 
-    assert twice.obligations == once.obligations
-    assert twice.reference_bindings == once.reference_bindings
+    assert twice.validation_requirements == once.validation_requirements
+    assert twice.canonical_references == once.canonical_references

--- a/tests/test_report_status_policy.py
+++ b/tests/test_report_status_policy.py
@@ -32,7 +32,7 @@ from comp.compiler_tool import (
         (
             ValidationReport(
                 status="accepted",
-                obligations=(
+                validation_requirements=(
                     ValidationRequirement(
                         kind="calculation_blocked",
                         field="co2e_emission",
@@ -52,7 +52,7 @@ from comp.compiler_tool import (
         (
             ValidationReport(
                 status="accepted",
-                obligations=(
+                validation_requirements=(
                     ValidationRequirement(
                         kind="semantic_judgment_required",
                         field="scope2_method",
@@ -81,7 +81,7 @@ from comp.compiler_tool import (
         (
             ValidationReport(
                 status="accepted",
-                obligations=(
+                validation_requirements=(
                     ValidationRequirement(
                         kind="reference_selection_required",
                         field="co2e_emission",
@@ -94,7 +94,7 @@ from comp.compiler_tool import (
         (
             ValidationReport(
                 status="review_required",
-                obligations=(
+                validation_requirements=(
                     ValidationRequirement(
                         kind="nonblocking_hint",
                         field="co2e_emission",

--- a/tests/test_resolver_retrieval.py
+++ b/tests/test_resolver_retrieval.py
@@ -57,7 +57,7 @@ def _resolver() -> EmbeddingResolverStub:
 
 def test_reference_query_from_resolver_task_preserves_task_identity():
     task = resolver_tasks_from_report(
-        ValidationReport(status="blocked", obligations=(_reference_search_obligation(),))
+        ValidationReport(status="blocked", validation_requirements=(_reference_search_obligation(),))
     )[0]
 
     query = reference_query_from_resolver_task(
@@ -87,7 +87,7 @@ def test_reference_query_from_resolver_task_rejects_non_reference_search_task():
     task = resolver_tasks_from_report(
         ValidationReport(
             status="review_required",
-            obligations=(
+            validation_requirements=(
                 ValidationRequirement(
                     kind="find_source_witness",
                     field="unit",
@@ -108,7 +108,7 @@ def test_reference_query_from_resolver_task_rejects_non_reference_search_task():
 def test_reference_query_builder_from_tasks_feeds_retrieval_bridge():
     report = ValidationReport(
         status="blocked",
-        obligations=(_reference_search_obligation(),),
+        validation_requirements=(_reference_search_obligation(),),
     )
     tasks = resolver_tasks_from_report(report)
 
@@ -127,20 +127,20 @@ def test_reference_query_builder_from_tasks_feeds_retrieval_bridge():
         ),
     )
 
-    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+    assert [candidate.reference_id for candidate in resolved.reference_options] == [
         "factor.kr_grid.2024.location_based"
     ]
-    assert resolved.reference_candidates[0].authority == "candidate_only"
-    assert resolved.obligations == ()
-    assert resolved.resolved_obligations == (_reference_search_obligation(),)
-    assert resolved.reference_bindings == ()
-    assert resolved.derived_claims == ()
+    assert resolved.reference_options[0].authority == "candidate_only"
+    assert resolved.validation_requirements == ()
+    assert resolved.resolved_validation_requirements == (_reference_search_obligation(),)
+    assert resolved.canonical_references == ()
+    assert resolved.calculated_claims == ()
 
 
 def test_reference_retrieval_resolution_recomputes_status_after_resolving_only_blocker():
     report = ValidationReport(
         status="blocked",
-        obligations=(_reference_search_obligation(),),
+        validation_requirements=(_reference_search_obligation(),),
     )
 
     resolved = resolve_reference_retrieval_obligations(
@@ -158,14 +158,14 @@ def test_reference_retrieval_resolution_recomputes_status_after_resolving_only_b
         ),
     )
 
-    assert resolved.obligations == ()
+    assert resolved.validation_requirements == ()
     assert resolved.status == "accepted"
 
 
 def test_reference_query_builder_from_tasks_leaves_missing_query_open():
     report = ValidationReport(
         status="blocked",
-        obligations=(_reference_search_obligation(),),
+        validation_requirements=(_reference_search_obligation(),),
     )
 
     resolved = resolve_reference_retrieval_obligations(
@@ -184,7 +184,7 @@ def test_reference_query_builder_from_tasks_leaves_missing_query_open():
 
 def test_retrieval_query_policy_renders_reference_query_from_task_payload_and_context():
     task = resolver_tasks_from_report(
-        ValidationReport(status="blocked", obligations=(_reference_search_obligation(),))
+        ValidationReport(status="blocked", validation_requirements=(_reference_search_obligation(),))
     )[0]
     policy = RetrievalQueryPolicy(
         policy_id="pcf-retrieval-policy-v1",
@@ -224,7 +224,7 @@ def test_retrieval_query_policy_renders_reference_query_from_task_payload_and_co
 def test_retrieval_query_policy_leaves_obligation_open_without_matching_rule():
     report = ValidationReport(
         status="blocked",
-        obligations=(_reference_search_obligation(),),
+        validation_requirements=(_reference_search_obligation(),),
     )
     policy = RetrievalQueryPolicy(
         policy_id="pcf-retrieval-policy-v1",
@@ -255,7 +255,7 @@ def test_retrieval_query_policy_leaves_obligation_open_without_matching_rule():
 def test_retrieval_query_policy_leaves_obligation_open_without_required_context():
     report = ValidationReport(
         status="blocked",
-        obligations=(_reference_search_obligation(),),
+        validation_requirements=(_reference_search_obligation(),),
     )
     policy = RetrievalQueryPolicy(
         policy_id="pcf-retrieval-policy-v1",
@@ -286,7 +286,7 @@ def test_retrieval_query_policy_leaves_obligation_open_without_required_context(
 def test_profile_pinned_retrieval_policy_feeds_query_builder():
     report = ValidationReport(
         status="blocked",
-        obligations=(_reference_search_obligation(),),
+        validation_requirements=(_reference_search_obligation(),),
     )
     profile = CompilerProfile(
         profile_id="fixture-profile",
@@ -330,7 +330,7 @@ def test_profile_pinned_retrieval_policy_feeds_query_builder():
         ),
     )
 
-    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+    assert [candidate.reference_id for candidate in resolved.reference_options] == [
         "factor.kr_grid.2024.location_based"
     ]
 
@@ -338,7 +338,7 @@ def test_profile_pinned_retrieval_policy_feeds_query_builder():
 def test_profile_retrieval_query_builder_rejects_inactive_policy_id():
     report = ValidationReport(
         status="blocked",
-        obligations=(_reference_search_obligation(),),
+        validation_requirements=(_reference_search_obligation(),),
     )
     profile = CompilerProfile(
         profile_id="fixture-profile",

--- a/tests/test_resolver_tasks.py
+++ b/tests/test_resolver_tasks.py
@@ -11,7 +11,7 @@ from comp.compiler_tool import (
 def test_semantic_obligation_becomes_resolver_task_with_rubric_payload():
     report = ValidationReport(
         status="review_required",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="semantic_judgment_required",
                 field="scope2_method",
@@ -67,7 +67,7 @@ def test_calculation_reference_search_obligation_preserves_requirement_payload()
     )
     report = ValidationReport(
         status="blocked",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="reference_search_required",
                 field="co2e_emission",
@@ -83,7 +83,7 @@ def test_calculation_reference_search_obligation_preserves_requirement_payload()
     task = resolver_tasks_from_report(report)[0]
 
     assert task.task_type == "reference_search"
-    assert task.required_artifact == "reference_candidates"
+    assert task.required_artifact == "reference_options"
     assert task.obligation_id == (
         "resolve:ghg.electricity_factor_multiplication.v1:"
         "hyp-1:co2e_emission:reference_search_required"
@@ -101,7 +101,7 @@ def test_calculation_reference_search_obligation_preserves_requirement_payload()
 def test_resolver_tasks_use_fallback_obligation_ids_and_ignore_resolved_items():
     report = ValidationReport(
         status="review_required",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="find_source_witness",
                 field="unit",
@@ -109,7 +109,7 @@ def test_resolver_tasks_use_fallback_obligation_ids_and_ignore_resolved_items():
                 blocking=True,
             ),
         ),
-        resolved_obligations=(
+        resolved_validation_requirements=(
             ValidationRequirement(
                 kind="find_source_witness",
                 field="amount",

--- a/tests/test_retrieval_lens_interface.py
+++ b/tests/test_retrieval_lens_interface.py
@@ -37,7 +37,7 @@ def _entries():
     )
 
 
-def test_embedding_resolver_stub_returns_candidate_only_reference_candidates():
+def test_embedding_resolver_stub_returns_candidate_only_reference_options():
     resolver = EmbeddingResolverStub(entries=_entries())
 
     candidates = resolver.search(

--- a/tests/test_retrieval_resolution.py
+++ b/tests/test_retrieval_resolution.py
@@ -138,22 +138,22 @@ def test_retrieval_resolution_adds_candidate_only_candidates_and_resolves_search
 
     assert resolved.status == "blocked"
     assert resolved.can_build_public_output is False
-    assert [candidate.reference_id for candidate in resolved.reference_candidates] == [
+    assert [candidate.reference_id for candidate in resolved.reference_options] == [
         "factor.kr_grid.2024.location_based"
     ]
-    assert resolved.reference_candidates[0].retrieval_method == "embedding_stub:factor"
-    assert resolved.reference_candidates[0].authority == "candidate_only"
-    assert resolved.reference_candidates[0].can_authorize_calculation is False
-    assert resolved.reference_candidates[0].source == "factor-catalog"
-    assert resolved.reference_candidates[0].witness_ids == ("factor-row-2024",)
-    assert [obligation.kind for obligation in resolved.obligations] == [
+    assert resolved.reference_options[0].retrieval_method == "embedding_stub:factor"
+    assert resolved.reference_options[0].authority == "candidate_only"
+    assert resolved.reference_options[0].can_authorize_calculation is False
+    assert resolved.reference_options[0].source == "factor-catalog"
+    assert resolved.reference_options[0].witness_ids == ("factor-row-2024",)
+    assert [obligation.kind for obligation in resolved.validation_requirements] == [
         "calculation_blocked"
     ]
-    assert [obligation.kind for obligation in resolved.resolved_obligations] == [
+    assert [obligation.kind for obligation in resolved.resolved_validation_requirements] == [
         "reference_search_required"
     ]
-    assert resolved.reference_bindings == ()
-    assert resolved.derived_claims == ()
+    assert resolved.canonical_references == ()
+    assert resolved.calculated_claims == ()
 
 
 def test_retrieval_resolution_leaves_followup_open_without_query():
@@ -202,16 +202,16 @@ def test_retrieval_resolution_candidates_can_continue_through_selection_and_retr
         selected,
         _catalog(),
         input_claim=_input(),
-        reference_binding=selected.reference_bindings[0],
+        reference_binding=selected.canonical_references[0],
         formula=_formula(),
         output_claim_id="hyp-1:co2e_emission",
     )
 
-    assert [binding.reference_id for binding in selected.reference_bindings] == [
+    assert [binding.reference_id for binding in selected.canonical_references] == [
         "factor.kr_grid.2024.location_based"
     ]
-    assert selected.derived_claims == ()
+    assert selected.calculated_claims == ()
     assert retried.status == "accepted"
-    assert retried.obligations == ()
-    assert retried.derived_claims[0].value == 0.48
+    assert retried.validation_requirements == ()
+    assert retried.calculated_claims[0].value == 0.48
     assert retried.can_build_public_output is False

--- a/tests/test_semantic_judgment_obligations.py
+++ b/tests/test_semantic_judgment_obligations.py
@@ -50,7 +50,7 @@ def test_semantic_judgment_model_set_is_exported():
 
 def test_matching_semantic_judgment_discharges_obligation():
     obligation = _semantic_obligation()
-    report = ValidationReport(status="review_required", obligations=(obligation,))
+    report = ValidationReport(status="review_required", validation_requirements=(obligation,))
 
     resolved = apply_semantic_judgments(
         report,
@@ -59,14 +59,14 @@ def test_matching_semantic_judgment_discharges_obligation():
     )
 
     assert resolved.status == "accepted"
-    assert resolved.obligations == ()
-    assert resolved.resolved_obligations == (obligation,)
+    assert resolved.validation_requirements == ()
+    assert resolved.resolved_validation_requirements == (obligation,)
     assert resolved.hazards == ()
 
 
 def test_wrong_rubric_does_not_discharge_obligation():
     obligation = _semantic_obligation()
-    report = ValidationReport(status="review_required", obligations=(obligation,))
+    report = ValidationReport(status="review_required", validation_requirements=(obligation,))
 
     resolved = apply_semantic_judgments(
         report,
@@ -75,13 +75,13 @@ def test_wrong_rubric_does_not_discharge_obligation():
     )
 
     assert resolved.status == "review_required"
-    assert resolved.obligations == (obligation,)
-    assert resolved.resolved_obligations == ()
+    assert resolved.validation_requirements == (obligation,)
+    assert resolved.resolved_validation_requirements == ()
 
 
 def test_unaccepted_or_non_required_verdict_does_not_discharge_obligation():
     obligation = _semantic_obligation()
-    report = ValidationReport(status="review_required", obligations=(obligation,))
+    report = ValidationReport(status="review_required", validation_requirements=(obligation,))
 
     refuted = apply_semantic_judgments(
         report,
@@ -95,16 +95,16 @@ def test_unaccepted_or_non_required_verdict_does_not_discharge_obligation():
     )
 
     assert refuted.status == "review_required"
-    assert refuted.obligations == (obligation,)
-    assert refuted.resolved_obligations == ()
+    assert refuted.validation_requirements == (obligation,)
+    assert refuted.resolved_validation_requirements == ()
     assert unsupported.status == "review_required"
-    assert unsupported.obligations == (obligation,)
-    assert unsupported.resolved_obligations == ()
+    assert unsupported.validation_requirements == (obligation,)
+    assert unsupported.resolved_validation_requirements == ()
 
 
 def test_unallowed_judge_or_missing_cited_span_does_not_discharge_obligation():
     obligation = _semantic_obligation()
-    report = ValidationReport(status="review_required", obligations=(obligation,))
+    report = ValidationReport(status="review_required", validation_requirements=(obligation,))
 
     unallowed_judge = apply_semantic_judgments(
         report,
@@ -117,15 +117,15 @@ def test_unallowed_judge_or_missing_cited_span_does_not_discharge_obligation():
         available_span_ids=("span-17",),
     )
 
-    assert unallowed_judge.obligations == (obligation,)
-    assert unallowed_judge.resolved_obligations == ()
-    assert missing_span.obligations == (obligation,)
-    assert missing_span.resolved_obligations == ()
+    assert unallowed_judge.validation_requirements == (obligation,)
+    assert unallowed_judge.resolved_validation_requirements == ()
+    assert missing_span.validation_requirements == (obligation,)
+    assert missing_span.resolved_validation_requirements == ()
 
 
 def test_conflicting_semantic_judgments_keep_obligation_open_and_add_hazard():
     obligation = _semantic_obligation()
-    report = ValidationReport(status="review_required", obligations=(obligation,))
+    report = ValidationReport(status="review_required", validation_requirements=(obligation,))
 
     resolved = apply_semantic_judgments(
         report,
@@ -137,8 +137,8 @@ def test_conflicting_semantic_judgments_keep_obligation_open_and_add_hazard():
     )
 
     assert resolved.status == "review_required"
-    assert resolved.obligations == (obligation,)
-    assert resolved.resolved_obligations == ()
+    assert resolved.validation_requirements == (obligation,)
+    assert resolved.resolved_validation_requirements == ()
     assert len(resolved.hazards) == 1
     assert resolved.hazards[0].kind == "conflicting_semantic_judgment"
     assert resolved.hazards[0].field == "scope2_method"
@@ -158,11 +158,11 @@ def test_nonsemantic_obligations_do_not_reclassify_unchecked_report():
                 reason="missing_rule_coverage",
             ),
         ),
-        obligations=(obligation,),
+        validation_requirements=(obligation,),
     )
 
     resolved = apply_semantic_judgments(report, ())
 
     assert resolved.status == "unchecked"
-    assert resolved.obligations == (obligation,)
-    assert resolved.resolved_obligations == ()
+    assert resolved.validation_requirements == (obligation,)
+    assert resolved.resolved_validation_requirements == ()

--- a/tests/test_steel_frame_proxy_assignment_scenario.py
+++ b/tests/test_steel_frame_proxy_assignment_scenario.py
@@ -27,7 +27,7 @@ def test_steel_frame_proxy_calculates_missing_mass_and_emission():
     }
     assert tuple(
         (claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     ) == (
         ("missing_mass_ton", 1900, "ton"),
         ("steel_frame_final_emission_tco2e", 4750, "tCO2e"),
@@ -39,7 +39,7 @@ def test_steel_frame_proxy_binds_proxy_factor_and_low_quality_metadata():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (PROXY_BINDING_ID, "platform.factor.steel_proxy_per_ton", "proxy_factor"),
     )
@@ -56,11 +56,11 @@ def test_steel_frame_missing_supplier_context_is_explicit_but_not_blocking():
     result = run_steel_frame_proxy_assignment_scenario()
 
     assert result.report.status == "accepted"
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert tuple(
         (obligation.kind, obligation.field, obligation.reason)
-        for obligation in result.report.resolved_obligations
+        for obligation in result.report.resolved_validation_requirements
     ) == (
         (
             "find_source_witness",
@@ -111,7 +111,7 @@ def test_steel_frame_proxy_scenario_is_registered_with_contract():
 
 
 def _trace_for(result, claim_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             return claim.trace
     raise AssertionError(f"missing derived claim: {claim_id}")

--- a/tests/test_synthetic_oracle_assertions.py
+++ b/tests/test_synthetic_oracle_assertions.py
@@ -50,13 +50,13 @@ def test_oracle_assertions_can_load_written_oracle_files(tmp_path) -> None:
     assert_synthetic_oracle_matches_report(oracle, adapter.anomaly_report())
 
 
-def test_oracle_assertions_fail_when_expected_obligation_is_missing() -> None:
+def test_oracle_assertions_fail_when_expected_validation_requirement_is_missing() -> None:
     run = generate_synthetic_pcf_run(SyntheticScenarioConfig.pcf_anomaly(seed=11))
     adapter = SyntheticPcfAdapter(run.input_bundle)
     report = adapter.anomaly_report()
-    report_without_site_alias = replace(report, obligations=report.obligations[:-1])
+    report_without_site_alias = replace(report, validation_requirements=report.validation_requirements[:-1])
 
-    with pytest.raises(AssertionError, match="expected obligations"):
+    with pytest.raises(AssertionError, match="expected validation requirements"):
         assert_synthetic_oracle_matches_report(
             run.oracle,
             report_without_site_alias,

--- a/tests/test_synthetic_raw_claim_conflict.py
+++ b/tests/test_synthetic_raw_claim_conflict.py
@@ -38,7 +38,7 @@ def test_raw_claim_conflict_keeps_source_candidates_separate():
     )
     assert {
         (claim.claim_id, claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     } == {
         (EMAIL_ELECTRICITY_CLAIM_ID, "email_electricity_mwh", 6400, "MWh"),
         (EMS_ELECTRICITY_CLAIM_ID, "ems_electricity_mwh", 6100, "MWh"),
@@ -49,7 +49,7 @@ def test_raw_claim_conflict_keeps_source_candidates_separate():
     }
     assert "electricity_mwh" not in {
         claim.field
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     }
 
 
@@ -58,7 +58,7 @@ def test_raw_claim_conflict_binds_context_but_blocks_winner_selection():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (
             ALIAS_BINDING_ID,
@@ -98,7 +98,7 @@ def test_raw_claim_conflict_opens_obligation_and_blocks_receipt():
 def test_raw_claim_conflict_preserves_all_witness_fingerprints():
     result = run_raw_claim_conflict_scenario()
 
-    assert tuple(witness.witness_id for witness in result.report.evidence_witnesses) == (
+    assert tuple(witness.witness_id for witness in result.report.evidence_refs) == (
         "w-email-electricity-march",
         "w-ems-electricity-march",
         "w-site-alias-policy",
@@ -107,7 +107,7 @@ def test_raw_claim_conflict_preserves_all_witness_fingerprints():
     )
     assert result.preparation.package.dependency_fingerprints == tuple(
         evidence_ref_fingerprint(witness)
-        for witness in result.report.evidence_witnesses
+        for witness in result.report.evidence_refs
     )
 
 

--- a/tests/test_synthetic_raw_claim_conflict_resolution.py
+++ b/tests/test_synthetic_raw_claim_conflict_resolution.py
@@ -17,7 +17,7 @@ def test_raw_claim_conflict_resolution_preserves_conflicting_sources():
 
     assert {
         (claim.claim_id, claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     } >= {
         (EMAIL_ELECTRICITY_CLAIM_ID, "email_electricity_mwh", 6400, "MWh"),
         (EMS_ELECTRICITY_CLAIM_ID, "ems_electricity_mwh", 6100, "MWh"),
@@ -41,19 +41,19 @@ def test_raw_claim_conflict_resolution_cites_resolution_binding_for_winner():
 
     canonical = next(
         claim
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
         if claim.claim_id == CANONICAL_ELECTRICITY_CLAIM_ID
     )
 
     assert RESOLUTION_BINDING_ID in canonical.trace.reference_binding_ids
     assert tuple(
         binding.binding_id
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
         if binding.reference_type == "source_conflict_resolution"
     ) == (RESOLUTION_BINDING_ID,)
     assert tuple(
         obligation.kind
-        for obligation in result.report.resolved_obligations
+        for obligation in result.report.resolved_validation_requirements
         if obligation.field == "electricity_mwh"
     ) == (
         "unit_conversion_policy_applied",
@@ -77,7 +77,7 @@ def test_raw_claim_conflict_resolution_commits_and_projects_selected_value():
 def test_raw_claim_conflict_resolution_fingerprints_resolution_witness():
     result = run_raw_claim_conflict_resolution_scenario()
 
-    assert tuple(witness.witness_id for witness in result.report.evidence_witnesses) == (
+    assert tuple(witness.witness_id for witness in result.report.evidence_refs) == (
         "w-email-electricity-march",
         "w-ems-electricity-march",
         "w-site-alias-policy",
@@ -87,7 +87,7 @@ def test_raw_claim_conflict_resolution_fingerprints_resolution_witness():
     )
     assert result.preparation.package.dependency_fingerprints == tuple(
         evidence_ref_fingerprint(witness)
-        for witness in result.report.evidence_witnesses
+        for witness in result.report.evidence_refs
     )
 
 

--- a/tests/test_synthetic_raw_claim_hypothesis_acceptance.py
+++ b/tests/test_synthetic_raw_claim_hypothesis_acceptance.py
@@ -43,7 +43,7 @@ def test_raw_claim_acceptance_promotes_only_canonical_checked_claims():
         ("total_line_mass_ton", 100000, "physical_allocation_support"),
     }
     assert result.report.failed_claims == ()
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
 
 
@@ -52,7 +52,7 @@ def test_raw_claim_acceptance_binds_alias_unit_and_allocation_support():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (
             ALIAS_BINDING_ID,
@@ -70,7 +70,7 @@ def test_raw_claim_acceptance_binds_alias_unit_and_allocation_support():
             "physical_allocation_support",
         ),
     )
-    assert tuple(item.kind for item in result.report.resolved_obligations) == (
+    assert tuple(item.kind for item in result.report.resolved_validation_requirements) == (
         "site_alias_resolved",
         "unit_conversion_policy_applied",
         "period_validated",
@@ -89,7 +89,7 @@ def test_raw_claim_acceptance_calculates_canonical_values():
 
     assert tuple(
         (claim.claim_id, claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     ) == (
         (ELECTRICITY_MWH_CLAIM_ID, "electricity_mwh", 6400, "MWh"),
         (ALLOCATION_SHARE_CLAIM_ID, "allocation_share", 0.5, None),
@@ -126,7 +126,7 @@ def test_raw_claim_acceptance_creates_receipt_and_projection():
     assert result.projection == EXPECTED_PROJECTION
     assert result.preparation.receipt.citations.dependency_fingerprints == tuple(
         evidence_ref_fingerprint(witness)
-        for witness in result.report.evidence_witnesses
+        for witness in result.report.evidence_refs
     )
 
     with pytest.raises(PublicOutputBlocked, match="value commitment mismatch"):
@@ -153,7 +153,7 @@ def test_raw_claim_acceptance_scenario_is_registered_with_contract():
 
 
 def _trace_step_value(result, claim_id, step_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             for step in claim.trace.steps:
                 if step.step_id == step_id:

--- a/tests/test_synthetic_raw_claim_hypothesis_gate.py
+++ b/tests/test_synthetic_raw_claim_hypothesis_gate.py
@@ -28,16 +28,16 @@ def test_raw_claim_hypotheses_are_candidates_not_authority():
         ("allocation_share", 0.5, "llm_extractor_candidate"),
     )
     assert result.report.checked_claims == ()
-    assert result.report.reference_bindings == ()
-    assert result.report.derived_claims == ()
+    assert result.report.canonical_references == ()
+    assert result.report.calculated_claims == ()
 
 
-def test_raw_evidence_witnesses_are_preserved_and_fingerprinted():
+def test_raw_evidence_refs_are_preserved_and_fingerprinted():
     result = run_raw_claim_hypothesis_gate_scenario()
 
     assert tuple(
         (witness.witness_id, witness.source, witness.span, witness.text)
-        for witness in result.report.evidence_witnesses
+        for witness in result.report.evidence_refs
     ) == (
         (
             "w-email-electricity-march",
@@ -48,7 +48,7 @@ def test_raw_evidence_witnesses_are_preserved_and_fingerprinted():
     )
     assert result.preparation.package.dependency_fingerprints == tuple(
         evidence_ref_fingerprint(witness)
-        for witness in result.report.evidence_witnesses
+        for witness in result.report.evidence_refs
     )
 
 

--- a/tests/test_synthetic_raw_claim_promotion.py
+++ b/tests/test_synthetic_raw_claim_promotion.py
@@ -61,7 +61,7 @@ def test_promotes_supported_raw_candidates_without_projection_authority():
     }
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in report.reference_bindings
+        for binding in report.canonical_references
     ) == (
         (
             ALIAS_BINDING_ID,
@@ -79,13 +79,13 @@ def test_promotes_supported_raw_candidates_without_projection_authority():
             "physical_allocation_support",
         ),
     )
-    assert tuple(item.kind for item in report.resolved_obligations) == (
+    assert tuple(item.kind for item in report.resolved_validation_requirements) == (
         "site_alias_resolved",
         "unit_conversion_policy_applied",
         "period_validated",
         "physical_allocation_support_validated",
     )
-    assert tuple(claim.claim_id for claim in report.derived_claims) == (
+    assert tuple(claim.claim_id for claim in report.calculated_claims) == (
         ELECTRICITY_MWH_CLAIM_ID,
         ALLOCATION_SHARE_CLAIM_ID,
         ALLOCATED_ELECTRICITY_CLAIM_ID,
@@ -111,7 +111,7 @@ def test_promoted_report_can_commit_only_through_prepare_commit():
         profile_id=PROFILE_ID,
         dependency_fingerprints=tuple(
             evidence_ref_fingerprint(witness)
-            for witness in report.evidence_witnesses
+            for witness in report.evidence_refs
         ),
     )
 
@@ -200,5 +200,5 @@ def _acceptance_profile() -> SyntheticRawClaimPromotionProfile:
 
 def _projection_source(report):
     values = {claim.field: claim.value for claim in report.checked_claims}
-    values.update({claim.field: claim.value for claim in report.derived_claims})
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
     return values

--- a/tests/test_synthetic_resolution_scenario.py
+++ b/tests/test_synthetic_resolution_scenario.py
@@ -13,7 +13,7 @@ def test_synthetic_pcf_resolution_scenario_commits_after_artifact_resolution():
 
     assert result.scenario_id == "synthetic_pcf.resolution.v1"
     assert result.report.status == "accepted"
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert result.preparation.decision.status == "commit"
     assert result.preparation.receipt is not None

--- a/tests/test_synthetic_run_harness.py
+++ b/tests/test_synthetic_run_harness.py
@@ -15,7 +15,7 @@ def test_synthetic_run_harness_materializes_smoke_receipt_flow(tmp_path) -> None
 
     assert harness.run_dir.name == "synthetic_pcf.smoke.v1-seed-7"
     assert (harness.run_dir / "raw_sources" / "erp_electricity.csv").is_file()
-    assert (harness.run_dir / "oracle" / "expected_derived_claims.csv").is_file()
+    assert (harness.run_dir / "oracle" / "expected_calculated_claims.csv").is_file()
     assert (harness.run_dir / "oracle" / "expected_receipt.json").is_file()
     assert harness.oracle_checked is True
     assert harness.receipt_oracle_checked is True
@@ -105,15 +105,15 @@ def test_synthetic_run_harness_materializes_resolution_commit_flow(tmp_path) -> 
         harness.run_dir / "resolution_artifacts" / "unit_witnesses.csv"
     ).is_file()
     assert (
-        harness.run_dir / "oracle" / "expected_resolved_obligations.csv"
+        harness.run_dir / "oracle" / "expected_resolved_validation_requirements.csv"
     ).is_file()
     assert harness.oracle_checked is True
     assert harness.receipt_oracle_checked is True
     assert harness.report.status == "accepted"
-    assert harness.report.obligations == ()
+    assert harness.report.validation_requirements == ()
     assert harness.report.hazards == ()
     assert tuple(
-        obligation.obligation_id for obligation in harness.report.resolved_obligations
+        obligation.obligation_id for obligation in harness.report.resolved_validation_requirements
     ) == (
         "synthetic-obligation:missing_unit",
         "resolve:pcf.electricity_factor_multiplication.v1:"

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -53,7 +53,7 @@ def test_synthetic_expected_receipt_oracle_lives_outside_generator_module() -> N
 
     config = SyntheticScenarioConfig.pcf_smoke(seed=7)
     run = generate_synthetic_pcf_run(config)
-    derived_value = run.oracle.expected_derived_claims[0].value
+    derived_value = run.oracle.expected_calculated_claims[0].value
 
     assert expected_smoke_receipt.__module__ == "comp.scenarios.synthetic.oracle"
     assert build_synthetic_pcf_smoke_run.__globals__["expected_smoke_receipt"] is (
@@ -151,7 +151,7 @@ def test_synthetic_pcf_fixtures_live_outside_run_builders_module() -> None:
     )
     assert run.master == pcf_master(config)
     assert run.master.reference_catalog == (pcf_reference_record(config),)
-    assert run.oracle.expected_derived_claims[0].value == calculate_co2e_value(
+    assert run.oracle.expected_calculated_claims[0].value == calculate_co2e_value(
         raw_row.amount,
         config.factor_value,
     )
@@ -209,11 +209,11 @@ def test_synthetic_pcf_generator_writes_oracle_not_truth(tmp_path: Path) -> None
     assert (run_dir / "master" / "reference_catalog.csv").is_file()
     assert (run_dir / "raw_sources" / "erp_electricity.csv").is_file()
     assert (run_dir / "oracle" / "expected_claims.csv").is_file()
-    assert (run_dir / "oracle" / "expected_derived_claims.csv").is_file()
+    assert (run_dir / "oracle" / "expected_calculated_claims.csv").is_file()
     assert (run_dir / "oracle" / "source_to_expected_claim_map.csv").is_file()
     assert not (run_dir / "truth").exists()
 
-    with (run_dir / "oracle" / "expected_derived_claims.csv").open(
+    with (run_dir / "oracle" / "expected_calculated_claims.csv").open(
         encoding="utf-8",
         newline="",
     ) as handle:
@@ -252,14 +252,16 @@ def test_synthetic_pcf_anomaly_generator_writes_pressure_oracle(
     assert (run_dir / "raw_sources" / "erp_electricity.csv").is_file()
     assert (run_dir / "oracle" / "injected_anomalies.csv").is_file()
     assert (run_dir / "oracle" / "expected_failed_claims.csv").is_file()
-    assert (run_dir / "oracle" / "expected_obligations.csv").is_file()
+    assert (run_dir / "oracle" / "expected_validation_requirements.csv").is_file()
     assert (run_dir / "oracle" / "expected_hazards.csv").is_file()
     assert not (run_dir / "truth").exists()
 
     raw_rows = _read_csv(run_dir / "raw_sources" / "erp_electricity.csv")
     injected = _read_csv(run_dir / "oracle" / "injected_anomalies.csv")
     failed = _read_csv(run_dir / "oracle" / "expected_failed_claims.csv")
-    obligations = _read_csv(run_dir / "oracle" / "expected_obligations.csv")
+    obligations = _read_csv(
+        run_dir / "oracle" / "expected_validation_requirements.csv"
+    )
     hazards = _read_csv(run_dir / "oracle" / "expected_hazards.csv")
 
     assert [row["source_row_id"] for row in raw_rows] == [
@@ -320,7 +322,7 @@ def test_synthetic_pcf_resolution_generator_writes_recovery_contract(
     }
     assert (run_dir / "resolution_artifacts" / "unit_witnesses.csv").is_file()
     assert (run_dir / "oracle" / "expected_resolution_artifacts.csv").is_file()
-    assert (run_dir / "oracle" / "expected_resolved_obligations.csv").is_file()
+    assert (run_dir / "oracle" / "expected_resolved_validation_requirements.csv").is_file()
     assert (run_dir / "oracle" / "expected_receipt.json").is_file()
     assert not (run_dir / "truth").exists()
 
@@ -329,7 +331,7 @@ def test_synthetic_pcf_resolution_generator_writes_recovery_contract(
         run_dir / "resolution_artifacts" / "unit_witnesses.csv"
     )
     expected_resolved = _read_csv(
-        run_dir / "oracle" / "expected_resolved_obligations.csv"
+        run_dir / "oracle" / "expected_resolved_validation_requirements.csv"
     )
 
     assert raw_rows[0]["source_row_id"] == "ERP-SYN-PCF-MISSING-UNIT"
@@ -383,7 +385,7 @@ def test_synthetic_pcf_anomaly_adapter_reports_raw_source_pressure() -> None:
 
     assert_synthetic_oracle_matches_report(run.oracle, report)
     assert report.status == "blocked"
-    assert {witness.source for witness in report.evidence_witnesses} == {
+    assert {witness.source for witness in report.evidence_refs} == {
         "raw_sources/erp_electricity.csv",
     }
 
@@ -430,7 +432,7 @@ def test_synthetic_input_loader_roundtrips_disk_sources_without_oracle(
         for source in input_bundle.loaded_sources
     )
     assert report.status == "accepted"
-    assert {witness.source for witness in report.evidence_witnesses} == {
+    assert {witness.source for witness in report.evidence_refs} == {
         "raw_sources/erp_electricity.csv",
     }
 

--- a/tests/test_tier0_physical_allocation_scenario.py
+++ b/tests/test_tier0_physical_allocation_scenario.py
@@ -32,7 +32,7 @@ def test_tier0_physical_allocation_calculates_line_mass_share_and_own_emission()
     }
     assert tuple(
         (claim.field, claim.value, claim.unit)
-        for claim in result.report.derived_claims
+        for claim in result.report.calculated_claims
     ) == (
         ("target_allocation_share", 0.5, None),
         ("allocated_electricity_mwh", 3200, "MWh"),
@@ -48,7 +48,7 @@ def test_tier0_physical_allocation_binds_electricity_and_lng_factors():
 
     assert tuple(
         (binding.binding_id, binding.reference_id, binding.reference_type)
-        for binding in result.report.reference_bindings
+        for binding in result.report.canonical_references
     ) == (
         (ELECTRICITY_BINDING_ID, "platform.factor.electricity_mwh", "emission_factor"),
         (LNG_BINDING_ID, "platform.factor.lng_nm3", "emission_factor"),
@@ -64,7 +64,7 @@ def test_tier0_physical_allocation_checks_site_inputs_and_dqr():
     result = run_tier0_physical_allocation_scenario()
 
     assert result.report.status == "accepted"
-    assert result.report.obligations == ()
+    assert result.report.validation_requirements == ()
     assert result.report.hazards == ()
     assert {
         (claim.field, claim.value)
@@ -114,7 +114,7 @@ def test_tier0_physical_allocation_scenario_is_registered_with_contract():
 
 
 def _trace_for(result, claim_id):
-    for claim in result.report.derived_claims:
+    for claim in result.report.calculated_claims:
         if claim.claim_id == claim_id:
             return claim.trace
     raise AssertionError(f"missing derived claim: {claim_id}")

--- a/tests/test_tiny_domain_fixture.py
+++ b/tests/test_tiny_domain_fixture.py
@@ -182,8 +182,8 @@ def test_tiny_domain_profile_opens_scope2_semantic_obligation():
     report = compile_with_profile(_hypothesis(), _profile())
 
     assert report.status == "review_required"
-    assert len(report.obligations) == 1
-    obligation = report.obligations[0]
+    assert len(report.validation_requirements) == 1
+    obligation = report.validation_requirements[0]
     assert obligation.kind == "semantic_judgment_required"
     assert obligation.field == "scope2_method"
     assert obligation.semantic_requirement is not None
@@ -199,7 +199,7 @@ def test_profile_rule_runner_surface_matches_compat_compile_with_profile():
     report = run_profile_rules(_hypothesis(), _profile())
     compat_report = compile_with_profile(_hypothesis(), _profile())
 
-    assert report.obligations == compat_report.obligations
+    assert report.validation_requirements == compat_report.validation_requirements
     assert report.status == "review_required"
 
 
@@ -220,7 +220,7 @@ def test_compile_with_profile_merges_profile_baseline_and_rule_obligations():
     assert any(
         obligation.kind == "semantic_judgment_required"
         and obligation.field == "scope2_method"
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     )
 
 
@@ -233,13 +233,13 @@ def test_profile_runner_blocks_claim_without_source_witness():
     assert any(
         obligation.kind == "find_source_witness"
         and obligation.field == "scope2_method"
-        for obligation in report.obligations
+        for obligation in report.validation_requirements
     )
 
 
 def test_tiny_domain_semantic_judgment_discharges_obligation():
     report = compile_with_profile(_hypothesis(), _profile())
-    obligation = report.obligations[0]
+    obligation = report.validation_requirements[0]
 
     resolved = apply_semantic_judgments(
         report,
@@ -248,8 +248,8 @@ def test_tiny_domain_semantic_judgment_discharges_obligation():
     )
 
     assert resolved.status == "accepted"
-    assert resolved.obligations == ()
-    assert resolved.resolved_obligations == (obligation,)
+    assert resolved.validation_requirements == ()
+    assert resolved.resolved_validation_requirements == (obligation,)
 
 
 def test_inactive_tiny_domain_rule_does_not_open_obligation():
@@ -259,4 +259,4 @@ def test_inactive_tiny_domain_rule_does_not_open_obligation():
 
     assert active_rule_families(profile) == ()
     assert report.status == "accepted"
-    assert report.obligations == ()
+    assert report.validation_requirements == ()

--- a/tests/test_validation_summary_view.py
+++ b/tests/test_validation_summary_view.py
@@ -8,7 +8,7 @@ def test_validation_summary_view_uses_korean_labels_and_messages():
 
     report = ValidationReport(
         status="blocked",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="find_source_witness",
                 field="co2e_kg",
@@ -16,7 +16,7 @@ def test_validation_summary_view_uses_korean_labels_and_messages():
                 obligation_id="obl-1",
             ),
         ),
-        resolved_obligations=(
+        resolved_validation_requirements=(
             ValidationRequirement(
                 kind="unit_check",
                 field="electricity_mwh",
@@ -79,7 +79,7 @@ def test_validation_summary_view_falls_back_without_leaking_kernel_terms():
 
     report = ValidationReport(
         status="review_required",
-        obligations=(
+        validation_requirements=(
             ValidationRequirement(
                 kind="reference_search_required",
                 field="co2e_kg",


### PR DESCRIPTION
## Summary
- Rename active `ValidationReport` fields to friendly canonical names without compatibility aliases.
- Update compiler, scenario, synthetic oracle, minchoagnt, docs, and tests to use the new report field vocabulary.
- Extend the friendly rename guard so old report field names cannot re-enter active Python surfaces.

## Tests
- `python -m pytest -q`
- legacy report field pattern search returned no active Python matches

draft PR for review sequencing.