### PR TITLE
[codex] Move synthetic resolution oracle expectations

### DIFF
--- a/comp/scenarios/synthetic/oracle.py
+++ b/comp/scenarios/synthetic/oracle.py
@@ -4,7 +4,10 @@ from comp.scenarios.synthetic.config import SyntheticScenarioConfig
 from comp.scenarios.synthetic.models import (
     ExpectedArtifactRef,
     ExpectedDependencyRef,
+    ExpectedObligation,
     ExpectedReceipt,
+    ExpectedResolutionArtifact,
+    SyntheticResolutionArtifact,
 )
 from comp.scenarios.synthetic.sources import synthetic_source_dependency_refs
 
@@ -79,6 +82,42 @@ def synthetic_manifest_dependency_id(config: SyntheticScenarioConfig) -> str:
     return f"synthetic_manifest:{config.scenario_id}:seed-{config.seed}"
 
 
+def expected_reference_search_obligation(
+    config: SyntheticScenarioConfig,
+) -> ExpectedObligation:
+    return ExpectedObligation(
+        obligation_id=reference_search_obligation_id(config),
+        kind="reference_search_required",
+        field="co2e_kg",
+        reason="unknown_reference",
+    )
+
+
+def expected_calculation_obligation(
+    config: SyntheticScenarioConfig,
+) -> ExpectedObligation:
+    return ExpectedObligation(
+        obligation_id=calculation_obligation_id(config),
+        kind="calculation_blocked",
+        field="co2e_kg",
+        reason="unknown_reference",
+    )
+
+
+def expected_resolution_artifact(
+    resolution: SyntheticResolutionArtifact,
+) -> ExpectedResolutionArtifact:
+    return ExpectedResolutionArtifact(
+        artifact_id=resolution.artifact_id,
+        obligation_id=resolution.obligation_id,
+        source_row_id=resolution.source_row_id,
+        field=resolution.field,
+        resolved_value=resolution.resolved_value,
+        witness_id=resolution.witness_id,
+        source_ref=resolution.source_ref,
+    )
+
+
 def reference_search_obligation_id(config: SyntheticScenarioConfig) -> str:
     return (
         f"resolve:{config.formula_id}:{config.output_claim_id}:"
@@ -95,6 +134,9 @@ def calculation_obligation_id(config: SyntheticScenarioConfig) -> str:
 
 __all__ = [
     "calculation_obligation_id",
+    "expected_calculation_obligation",
+    "expected_reference_search_obligation",
+    "expected_resolution_artifact",
     "expected_smoke_receipt",
     "reference_search_obligation_id",
     "synthetic_manifest_dependency_id",

--- a/comp/scenarios/synthetic/run_builders.py
+++ b/comp/scenarios/synthetic/run_builders.py
@@ -8,8 +8,6 @@ from comp.scenarios.synthetic.anomaly_specs import (
 from comp.scenarios.synthetic.config import SyntheticScenarioConfig
 from comp.scenarios.synthetic.manifest import build_manifest
 from comp.scenarios.synthetic.models import (
-    ExpectedObligation,
-    ExpectedResolutionArtifact,
     OUTPUT_CONTRACT,
     RESOLUTION_OUTPUT_CONTRACT,
     SyntheticOracle,
@@ -18,9 +16,10 @@ from comp.scenarios.synthetic.models import (
     SyntheticRun,
 )
 from comp.scenarios.synthetic.oracle import (
-    calculation_obligation_id,
+    expected_calculation_obligation,
+    expected_reference_search_obligation,
+    expected_resolution_artifact,
     expected_smoke_receipt,
-    reference_search_obligation_id,
 )
 from comp.scenarios.synthetic.pcf_fixtures import (
     calculate_co2e_value,
@@ -73,6 +72,8 @@ def build_synthetic_pcf_resolution_run(
     derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
     resolution = missing_unit_resolution_artifact(raw_row)
     resolved_obligation = missing_unit["obligation"]
+    reference_search_obligation = expected_reference_search_obligation(config)
+    calculation_obligation = expected_calculation_obligation(config)
 
     return SyntheticRun(
         config=config,
@@ -105,29 +106,11 @@ def build_synthetic_pcf_resolution_run(
             ),
             expected_resolved_obligations=(
                 resolved_obligation,
-                ExpectedObligation(
-                    obligation_id=reference_search_obligation_id(config),
-                    kind="reference_search_required",
-                    field="co2e_kg",
-                    reason="unknown_reference",
-                ),
-                ExpectedObligation(
-                    obligation_id=calculation_obligation_id(config),
-                    kind="calculation_blocked",
-                    field="co2e_kg",
-                    reason="unknown_reference",
-                ),
+                reference_search_obligation,
+                calculation_obligation,
             ),
             expected_resolution_artifacts=(
-                ExpectedResolutionArtifact(
-                    artifact_id=resolution.artifact_id,
-                    obligation_id=resolution.obligation_id,
-                    source_row_id=resolution.source_row_id,
-                    field=resolution.field,
-                    resolved_value=resolution.resolved_value,
-                    witness_id=resolution.witness_id,
-                    source_ref=resolution.source_ref,
-                ),
+                expected_resolution_artifact(resolution),
             ),
             expected_receipt=expected_smoke_receipt(
                 config,
@@ -135,8 +118,8 @@ def build_synthetic_pcf_resolution_run(
                 derived_value=derived_value,
                 resolved_obligation_ids=(
                     resolved_obligation.obligation_id,
-                    reference_search_obligation_id(config),
-                    calculation_obligation_id(config),
+                    reference_search_obligation.obligation_id,
+                    calculation_obligation.obligation_id,
                 ),
             ),
         ),

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -71,6 +71,34 @@ def test_synthetic_expected_receipt_oracle_lives_outside_generator_module() -> N
     )
 
 
+def test_synthetic_resolution_oracle_expectations_live_outside_run_builders_module() -> None:
+    from comp.scenarios.synthetic.oracle import (
+        expected_calculation_obligation,
+        expected_reference_search_obligation,
+        expected_resolution_artifact,
+    )
+    from comp.scenarios.synthetic.run_builders import build_synthetic_pcf_resolution_run
+
+    config = SyntheticScenarioConfig.pcf_resolution(seed=17)
+    run = build_synthetic_pcf_resolution_run(config)
+    resolution = run.resolution_artifacts.unit_witnesses[0]
+
+    assert (
+        expected_reference_search_obligation.__module__
+        == "comp.scenarios.synthetic.oracle"
+    )
+    assert build_synthetic_pcf_resolution_run.__globals__[
+        "expected_reference_search_obligation"
+    ] is expected_reference_search_obligation
+    assert run.oracle.expected_resolved_obligations[1:] == (
+        expected_reference_search_obligation(config),
+        expected_calculation_obligation(config),
+    )
+    assert run.oracle.expected_resolution_artifacts == (
+        expected_resolution_artifact(resolution),
+    )
+
+
 def test_synthetic_anomaly_specs_live_outside_generator_module() -> None:
     from comp.scenarios.synthetic.anomaly_specs import (
         anomaly_specs,


### PR DESCRIPTION
## Summary
- Add resolution expectation helpers to `comp.scenarios.synthetic.oracle` for reference-search obligation, calculation-blocked obligation, and resolution artifact expectations.
- Update `run_builders.py` to consume those oracle helpers instead of constructing those expectation dataclasses inline.
- Add a boundary test proving resolution run builders consume the extracted oracle helpers and preserve expected resolved obligations and resolution artifacts.

## Why
`run_builders.py` should assemble scenario shape, while oracle expectation details belong with the synthetic oracle helpers. This continues the generator/testkit cleanup without touching the deeper raw-claim promotion or adapter responsibilities.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py -q` -> 20 passed
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q` -> 54 passed
- `python -m pytest -q` -> 470 passed, 9 skipped
- `git diff --cached --check` -> passed