### PR TITLE
[codex] align synthetic oracle requirement vocabulary

### DIFF
--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -90,7 +90,7 @@ def test_synthetic_resolution_oracle_expectations_live_outside_run_builders_modu
     assert build_synthetic_pcf_resolution_run.__globals__[
         "expected_reference_search_obligation"
     ] is expected_reference_search_obligation
-    assert run.oracle.expected_resolved_obligations[1:] == (
+    assert run.oracle.expected_resolved_validation_requirements[1:] == (
         expected_reference_search_obligation(config),
         expected_calculation_obligation(config),
     )


### PR DESCRIPTION
## Summary
- Update the synthetic resolution oracle test that drifted back to `expected_resolved_obligations` after concurrent main changes.
- Keep the synthetic oracle surface aligned with `expected_resolved_validation_requirements`.
- Preserve the friendly rename guard so legacy report field vocabulary fails fast when it re-enters active Python tests.

## Tests
- `python -m pytest -q tests/test_complete_friendly_rename.py::test_legacy_validation_report_field_names_are_not_active_python_surface tests/test_synthetic_scenario_generator.py::test_synthetic_resolution_oracle_expectations_live_outside_run_builders_module`
- `python -m pytest -q`
- legacy report field pattern search returned no active Python matches

draft PR for review sequencing.