### PR TITLE
[codex] Move synthetic anomaly oracle expectations

### DIFF
--- a/comp/scenarios/synthetic/oracle.py
+++ b/comp/scenarios/synthetic/oracle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from comp.scenarios.synthetic.config import SyntheticScenarioConfig
 from comp.scenarios.synthetic.models import (
     ExpectedArtifactRef,
@@ -7,7 +9,12 @@ from comp.scenarios.synthetic.models import (
     ExpectedObligation,
     ExpectedReceipt,
     ExpectedResolutionArtifact,
+    SyntheticOracle,
     SyntheticResolutionArtifact,
+)
+from comp.scenarios.synthetic.pcf_fixtures import (
+    electricity_expected_claim,
+    electricity_source_map,
 )
 from comp.scenarios.synthetic.sources import synthetic_source_dependency_refs
 
@@ -82,6 +89,39 @@ def synthetic_manifest_dependency_id(config: SyntheticScenarioConfig) -> str:
     return f"synthetic_manifest:{config.scenario_id}:seed-{config.seed}"
 
 
+def expected_anomaly_oracle(specs: tuple[dict[str, Any], ...]) -> SyntheticOracle:
+    rows = tuple(spec["row"] for spec in specs)
+    expected_claims = tuple(
+        electricity_expected_claim(
+            f"synthetic-pcf-anomaly:{row.source_row_id}:electricity_kwh",
+            row,
+        )
+        for row in rows
+        if float(row.amount) >= 0
+    )
+    expected_maps = tuple(
+        electricity_source_map(
+            f"synthetic-pcf-anomaly:{row.source_row_id}:electricity_kwh",
+            row,
+        )
+        for row in rows
+        if float(row.amount) >= 0
+    )
+    return SyntheticOracle(
+        expected_claims=expected_claims,
+        expected_calculated_claims=(),
+        expected_validation_requirements=tuple(spec["obligation"] for spec in specs),
+        expected_hazards=tuple(
+            spec["hazard"] for spec in specs if spec["hazard"] is not None
+        ),
+        expected_failed_claims=tuple(
+            spec["failed_claim"] for spec in specs if spec["failed_claim"] is not None
+        ),
+        injected_anomalies=tuple(spec["anomaly"] for spec in specs),
+        source_to_expected_claim_map=expected_maps,
+    )
+
+
 def expected_reference_search_obligation(
     config: SyntheticScenarioConfig,
 ) -> ExpectedObligation:
@@ -134,6 +174,7 @@ def calculation_obligation_id(config: SyntheticScenarioConfig) -> str:
 
 __all__ = [
     "calculation_obligation_id",
+    "expected_anomaly_oracle",
     "expected_calculation_obligation",
     "expected_reference_search_obligation",
     "expected_resolution_artifact",

--- a/comp/scenarios/synthetic/run_builders.py
+++ b/comp/scenarios/synthetic/run_builders.py
@@ -16,6 +16,7 @@ from comp.scenarios.synthetic.models import (
     SyntheticRun,
 )
 from comp.scenarios.synthetic.oracle import (
+    expected_anomaly_oracle,
     expected_calculation_obligation,
     expected_reference_search_obligation,
     expected_resolution_artifact,
@@ -132,43 +133,13 @@ def build_synthetic_pcf_anomaly_run(
 ) -> SyntheticRun:
     specs = anomaly_specs(config)
     rows = tuple(spec["row"] for spec in specs)
-    expected_claims = tuple(
-        electricity_expected_claim(
-            f"synthetic-pcf-anomaly:{row.source_row_id}:electricity_kwh",
-            row,
-        )
-        for row in rows
-        if float(row.amount) >= 0
-    )
-    expected_maps = tuple(
-        electricity_source_map(
-            f"synthetic-pcf-anomaly:{row.source_row_id}:electricity_kwh",
-            row,
-        )
-        for row in rows
-        if float(row.amount) >= 0
-    )
 
     return SyntheticRun(
         config=config,
         manifest=build_manifest(config, output_contract=OUTPUT_CONTRACT),
         master=pcf_master(config),
         raw_sources=SyntheticRawSources(electricity_rows=rows),
-        oracle=SyntheticOracle(
-            expected_claims=expected_claims,
-            expected_calculated_claims=(),
-            expected_validation_requirements=tuple(spec["obligation"] for spec in specs),
-            expected_hazards=tuple(
-                spec["hazard"] for spec in specs if spec["hazard"] is not None
-            ),
-            expected_failed_claims=tuple(
-                spec["failed_claim"]
-                for spec in specs
-                if spec["failed_claim"] is not None
-            ),
-            injected_anomalies=tuple(spec["anomaly"] for spec in specs),
-            source_to_expected_claim_map=expected_maps,
-        ),
+        oracle=expected_anomaly_oracle(specs),
     )
 
 __all__ = [

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -90,13 +90,29 @@ def test_synthetic_resolution_oracle_expectations_live_outside_run_builders_modu
     assert build_synthetic_pcf_resolution_run.__globals__[
         "expected_reference_search_obligation"
     ] is expected_reference_search_obligation
-    assert run.oracle.expected_resolved_obligations[1:] == (
+    assert run.oracle.expected_resolved_validation_requirements[1:] == (
         expected_reference_search_obligation(config),
         expected_calculation_obligation(config),
     )
     assert run.oracle.expected_resolution_artifacts == (
         expected_resolution_artifact(resolution),
     )
+
+
+def test_synthetic_anomaly_oracle_lives_outside_run_builders_module() -> None:
+    from comp.scenarios.synthetic.anomaly_specs import anomaly_specs
+    from comp.scenarios.synthetic.oracle import expected_anomaly_oracle
+    from comp.scenarios.synthetic.run_builders import build_synthetic_pcf_anomaly_run
+
+    config = SyntheticScenarioConfig.pcf_anomaly(seed=11)
+    specs = anomaly_specs(config)
+    run = build_synthetic_pcf_anomaly_run(config)
+
+    assert expected_anomaly_oracle.__module__ == "comp.scenarios.synthetic.oracle"
+    assert build_synthetic_pcf_anomaly_run.__globals__["expected_anomaly_oracle"] is (
+        expected_anomaly_oracle
+    )
+    assert run.oracle == expected_anomaly_oracle(specs)
 
 
 def test_synthetic_anomaly_specs_live_outside_generator_module() -> None:


### PR DESCRIPTION
## Summary
- Add `expected_anomaly_oracle` to `comp.scenarios.synthetic.oracle` for anomaly expected claims, validation requirements, hazards, failed claims, injected anomalies, and source maps.
- Update `run_builders.py` so the anomaly run builder delegates oracle construction to the oracle helper and keeps only scenario assembly.
- Add a boundary test for the anomaly oracle helper and update the resolution boundary assertion to use the current `expected_resolved_validation_requirements` field name.

## Why
After moving resolution expectation helpers out of `run_builders.py`, the anomaly builder still carried inline oracle expectation projection. This keeps expectation logic in the synthetic oracle module without touching the deeper adapter or raw-claim promotion responsibilities.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py -q` -> 21 passed
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q` -> 55 passed
- `python -m pytest -q` -> 472 passed, 9 skipped
- `git diff --cached --check` -> passed