### PR TITLE
[codex] Move synthetic smoke oracle expectations

### DIFF
--- a/comp/scenarios/synthetic/oracle.py
+++ b/comp/scenarios/synthetic/oracle.py
@@ -9,12 +9,16 @@ from comp.scenarios.synthetic.models import (
     ExpectedObligation,
     ExpectedReceipt,
     ExpectedResolutionArtifact,
+    RawElectricityRow,
     SyntheticOracle,
     SyntheticResolutionArtifact,
 )
 from comp.scenarios.synthetic.pcf_fixtures import (
+    calculate_co2e_value,
+    co2e_expected_calculated_claim,
     electricity_expected_claim,
     electricity_source_map,
+    electricity_witness_id,
 )
 from comp.scenarios.synthetic.sources import synthetic_source_dependency_refs
 
@@ -87,6 +91,33 @@ def expected_smoke_receipt(
 
 def synthetic_manifest_dependency_id(config: SyntheticScenarioConfig) -> str:
     return f"synthetic_manifest:{config.scenario_id}:seed-{config.seed}"
+
+
+def expected_smoke_oracle(
+    config: SyntheticScenarioConfig,
+    raw_row: RawElectricityRow,
+) -> SyntheticOracle:
+    source_witness_id = electricity_witness_id(raw_row.source_row_id)
+    derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
+    expected_claim = electricity_expected_claim(config.input_claim_id, raw_row)
+    return SyntheticOracle(
+        expected_claims=(expected_claim,),
+        expected_calculated_claims=(
+            co2e_expected_calculated_claim(config, derived_value),
+        ),
+        expected_validation_requirements=(),
+        expected_hazards=(),
+        expected_failed_claims=(),
+        injected_anomalies=(),
+        source_to_expected_claim_map=(
+            electricity_source_map(config.input_claim_id, raw_row),
+        ),
+        expected_receipt=expected_smoke_receipt(
+            config,
+            source_witness_id=source_witness_id,
+            derived_value=derived_value,
+        ),
+    )
 
 
 def expected_anomaly_oracle(specs: tuple[dict[str, Any], ...]) -> SyntheticOracle:
@@ -178,6 +209,7 @@ __all__ = [
     "expected_calculation_obligation",
     "expected_reference_search_obligation",
     "expected_resolution_artifact",
+    "expected_smoke_oracle",
     "expected_smoke_receipt",
     "reference_search_obligation_id",
     "synthetic_manifest_dependency_id",

--- a/comp/scenarios/synthetic/run_builders.py
+++ b/comp/scenarios/synthetic/run_builders.py
@@ -20,6 +20,7 @@ from comp.scenarios.synthetic.oracle import (
     expected_calculation_obligation,
     expected_reference_search_obligation,
     expected_resolution_artifact,
+    expected_smoke_oracle,
     expected_smoke_receipt,
 )
 from comp.scenarios.synthetic.pcf_fixtures import (
@@ -35,32 +36,12 @@ from comp.scenarios.synthetic.pcf_fixtures import (
 
 def build_synthetic_pcf_smoke_run(config: SyntheticScenarioConfig) -> SyntheticRun:
     raw_row = raw_electricity_row(config)
-    source_witness_id = electricity_witness_id(raw_row.source_row_id)
-    derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
-    expected_claim = electricity_expected_claim(config.input_claim_id, raw_row)
     return SyntheticRun(
         config=config,
         manifest=build_manifest(config, output_contract=OUTPUT_CONTRACT),
         master=pcf_master(config),
         raw_sources=SyntheticRawSources(electricity_rows=(raw_row,)),
-        oracle=SyntheticOracle(
-            expected_claims=(expected_claim,),
-            expected_calculated_claims=(
-                co2e_expected_calculated_claim(config, derived_value),
-            ),
-            expected_validation_requirements=(),
-            expected_hazards=(),
-            expected_failed_claims=(),
-            injected_anomalies=(),
-            source_to_expected_claim_map=(
-                electricity_source_map(config.input_claim_id, raw_row),
-            ),
-            expected_receipt=expected_smoke_receipt(
-                config,
-                source_witness_id=source_witness_id,
-                derived_value=derived_value,
-            ),
-        ),
+        oracle=expected_smoke_oracle(config, raw_row),
     )
 
 

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -71,6 +71,21 @@ def test_synthetic_expected_receipt_oracle_lives_outside_generator_module() -> N
     )
 
 
+def test_synthetic_smoke_oracle_lives_outside_run_builders_module() -> None:
+    from comp.scenarios.synthetic.oracle import expected_smoke_oracle
+    from comp.scenarios.synthetic.run_builders import build_synthetic_pcf_smoke_run
+
+    config = SyntheticScenarioConfig.pcf_smoke(seed=7)
+    run = build_synthetic_pcf_smoke_run(config)
+    raw_row = run.raw_sources.electricity_rows[0]
+
+    assert expected_smoke_oracle.__module__ == "comp.scenarios.synthetic.oracle"
+    assert build_synthetic_pcf_smoke_run.__globals__["expected_smoke_oracle"] is (
+        expected_smoke_oracle
+    )
+    assert run.oracle == expected_smoke_oracle(config, raw_row)
+
+
 def test_synthetic_resolution_oracle_expectations_live_outside_run_builders_module() -> None:
     from comp.scenarios.synthetic.oracle import (
         expected_calculation_obligation,


### PR DESCRIPTION
## Summary
- Add `expected_smoke_oracle` to keep smoke scenario oracle construction in `comp.scenarios.synthetic.oracle`.
- Slim `build_synthetic_pcf_smoke_run` so the run builder assembles the run while the oracle module owns expected values.
- Add a boundary test that proves the smoke oracle helper lives outside `run_builders.py` and preserves the generated oracle shape.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py::test_synthetic_smoke_oracle_lives_outside_run_builders_module -q`
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest -q`
- `git diff --cached --check`