### PR TITLE
[codex] Move synthetic resolution oracle assembly

### DIFF
--- a/comp/scenarios/synthetic/oracle.py
+++ b/comp/scenarios/synthetic/oracle.py
@@ -120,6 +120,57 @@ def expected_smoke_oracle(
     )
 
 
+def expected_resolution_oracle(
+    config: SyntheticScenarioConfig,
+    missing_unit: dict[str, Any],
+    resolution: SyntheticResolutionArtifact,
+) -> SyntheticOracle:
+    raw_row = missing_unit["row"]
+    source_witness_id = electricity_witness_id(raw_row.source_row_id)
+    derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
+    resolved_requirement = missing_unit["validation_requirement"]
+    reference_search_requirement = expected_reference_search_requirement(config)
+    calculation_requirement = expected_calculation_requirement(config)
+
+    return SyntheticOracle(
+        expected_claims=(
+            electricity_expected_claim(
+                config.input_claim_id,
+                raw_row,
+                unit=resolution.resolved_value,
+            ),
+        ),
+        expected_calculated_claims=(
+            co2e_expected_calculated_claim(config, derived_value),
+        ),
+        expected_validation_requirements=(),
+        expected_hazards=(),
+        expected_failed_claims=(),
+        injected_anomalies=(missing_unit["anomaly"],),
+        source_to_expected_claim_map=(
+            electricity_source_map(config.input_claim_id, raw_row),
+        ),
+        expected_resolved_validation_requirements=(
+            resolved_requirement,
+            reference_search_requirement,
+            calculation_requirement,
+        ),
+        expected_resolution_artifacts=(
+            expected_resolution_artifact(resolution),
+        ),
+        expected_receipt=expected_smoke_receipt(
+            config,
+            source_witness_id=source_witness_id,
+            derived_value=derived_value,
+            resolved_obligation_ids=(
+                resolved_requirement.requirement_id,
+                reference_search_requirement.requirement_id,
+                calculation_requirement.requirement_id,
+            ),
+        ),
+    )
+
+
 def expected_anomaly_oracle(specs: tuple[dict[str, Any], ...]) -> SyntheticOracle:
     rows = tuple(spec["row"] for spec in specs)
     expected_claims = tuple(
@@ -210,6 +261,7 @@ __all__ = [
     "expected_anomaly_oracle",
     "expected_calculation_requirement",
     "expected_reference_search_requirement",
+    "expected_resolution_oracle",
     "expected_resolution_artifact",
     "expected_smoke_oracle",
     "expected_smoke_receipt",

--- a/comp/scenarios/synthetic/run_builders.py
+++ b/comp/scenarios/synthetic/run_builders.py
@@ -10,25 +10,16 @@ from comp.scenarios.synthetic.manifest import build_manifest
 from comp.scenarios.synthetic.models import (
     OUTPUT_CONTRACT,
     RESOLUTION_OUTPUT_CONTRACT,
-    SyntheticOracle,
     SyntheticRawSources,
     SyntheticResolutionArtifacts,
     SyntheticRun,
 )
 from comp.scenarios.synthetic.oracle import (
     expected_anomaly_oracle,
-    expected_calculation_requirement,
-    expected_reference_search_requirement,
-    expected_resolution_artifact,
+    expected_resolution_oracle,
     expected_smoke_oracle,
-    expected_smoke_receipt,
 )
 from comp.scenarios.synthetic.pcf_fixtures import (
-    calculate_co2e_value,
-    co2e_expected_calculated_claim,
-    electricity_expected_claim,
-    electricity_source_map,
-    electricity_witness_id,
     pcf_master,
     raw_electricity_row,
 )
@@ -50,12 +41,7 @@ def build_synthetic_pcf_resolution_run(
 ) -> SyntheticRun:
     missing_unit = missing_unit_spec(config)
     raw_row = missing_unit["row"]
-    source_witness_id = electricity_witness_id(raw_row.source_row_id)
-    derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
     resolution = missing_unit_resolution_artifact(raw_row)
-    resolved_requirement = missing_unit["validation_requirement"]
-    reference_search_requirement = expected_reference_search_requirement(config)
-    calculation_requirement = expected_calculation_requirement(config)
 
     return SyntheticRun(
         config=config,
@@ -68,43 +54,7 @@ def build_synthetic_pcf_resolution_run(
         resolution_artifacts=SyntheticResolutionArtifacts(
             unit_witnesses=(resolution,),
         ),
-        oracle=SyntheticOracle(
-            expected_claims=(
-                electricity_expected_claim(
-                    config.input_claim_id,
-                    raw_row,
-                    unit=resolution.resolved_value,
-                ),
-            ),
-            expected_calculated_claims=(
-                co2e_expected_calculated_claim(config, derived_value),
-            ),
-            expected_validation_requirements=(),
-            expected_hazards=(),
-            expected_failed_claims=(),
-            injected_anomalies=(missing_unit["anomaly"],),
-            source_to_expected_claim_map=(
-                electricity_source_map(config.input_claim_id, raw_row),
-            ),
-            expected_resolved_validation_requirements=(
-                resolved_requirement,
-                reference_search_requirement,
-                calculation_requirement,
-            ),
-            expected_resolution_artifacts=(
-                expected_resolution_artifact(resolution),
-            ),
-            expected_receipt=expected_smoke_receipt(
-                config,
-                source_witness_id=source_witness_id,
-                derived_value=derived_value,
-                resolved_obligation_ids=(
-                    resolved_requirement.requirement_id,
-                    reference_search_requirement.requirement_id,
-                    calculation_requirement.requirement_id,
-                ),
-            ),
-        ),
+        oracle=expected_resolution_oracle(config, missing_unit, resolution),
         output_contract=RESOLUTION_OUTPUT_CONTRACT,
     )
 

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -46,17 +46,17 @@ def test_synthetic_data_models_live_outside_generator_module() -> None:
 def test_synthetic_expected_receipt_oracle_lives_outside_generator_module() -> None:
     from comp.scenarios.synthetic.oracle import (
         calculation_requirement_id,
+        expected_smoke_oracle,
         expected_smoke_receipt,
         reference_search_requirement_id,
     )
-    from comp.scenarios.synthetic.run_builders import build_synthetic_pcf_smoke_run
 
     config = SyntheticScenarioConfig.pcf_smoke(seed=7)
     run = generate_synthetic_pcf_run(config)
     derived_value = run.oracle.expected_calculated_claims[0].value
 
     assert expected_smoke_receipt.__module__ == "comp.scenarios.synthetic.oracle"
-    assert build_synthetic_pcf_smoke_run.__globals__["expected_smoke_receipt"] is (
+    assert expected_smoke_oracle.__globals__["expected_smoke_receipt"] is (
         expected_smoke_receipt
     )
     assert run.oracle.expected_receipt == expected_smoke_receipt(
@@ -116,23 +116,44 @@ def test_synthetic_smoke_oracle_lives_outside_run_builders_module() -> None:
     assert run.oracle == expected_smoke_oracle(config, raw_row)
 
 
+def test_synthetic_resolution_oracle_lives_outside_run_builders_module() -> None:
+    from comp.scenarios.synthetic.anomaly_specs import (
+        missing_unit_resolution_artifact,
+        missing_unit_spec,
+    )
+    from comp.scenarios.synthetic.oracle import expected_resolution_oracle
+    from comp.scenarios.synthetic.run_builders import build_synthetic_pcf_resolution_run
+
+    config = SyntheticScenarioConfig.pcf_resolution(seed=17)
+    missing_unit = missing_unit_spec(config)
+    raw_row = missing_unit["row"]
+    resolution = missing_unit_resolution_artifact(raw_row)
+    run = build_synthetic_pcf_resolution_run(config)
+
+    assert expected_resolution_oracle.__module__ == "comp.scenarios.synthetic.oracle"
+    assert build_synthetic_pcf_resolution_run.__globals__[
+        "expected_resolution_oracle"
+    ] is expected_resolution_oracle
+    assert run.oracle == expected_resolution_oracle(config, missing_unit, resolution)
+
+
 def test_synthetic_resolution_oracle_expectations_live_outside_run_builders_module() -> None:
     from comp.scenarios.synthetic.oracle import (
         expected_calculation_requirement,
         expected_reference_search_requirement,
+        expected_resolution_oracle,
         expected_resolution_artifact,
     )
-    from comp.scenarios.synthetic.run_builders import build_synthetic_pcf_resolution_run
 
     config = SyntheticScenarioConfig.pcf_resolution(seed=17)
-    run = build_synthetic_pcf_resolution_run(config)
+    run = generate_synthetic_pcf_run(config)
     resolution = run.resolution_artifacts.unit_witnesses[0]
 
     assert (
         expected_reference_search_requirement.__module__
         == "comp.scenarios.synthetic.oracle"
     )
-    assert build_synthetic_pcf_resolution_run.__globals__[
+    assert expected_resolution_oracle.__globals__[
         "expected_reference_search_requirement"
     ] is expected_reference_search_requirement
     assert run.oracle.expected_resolved_validation_requirements[1:] == (
@@ -227,6 +248,7 @@ def test_synthetic_pcf_fixtures_live_outside_run_builders_module() -> None:
         pcf_master,
         pcf_reference_record,
     )
+    from comp.scenarios.synthetic.oracle import expected_smoke_oracle
     from comp.scenarios.synthetic.run_builders import build_synthetic_pcf_smoke_run
 
     config = SyntheticScenarioConfig.pcf_smoke(seed=7)
@@ -235,7 +257,7 @@ def test_synthetic_pcf_fixtures_live_outside_run_builders_module() -> None:
 
     assert pcf_master.__module__ == "comp.scenarios.synthetic.pcf_fixtures"
     assert build_synthetic_pcf_smoke_run.__globals__["pcf_master"] is pcf_master
-    assert build_synthetic_pcf_smoke_run.__globals__["calculate_co2e_value"] is (
+    assert expected_smoke_oracle.__globals__["calculate_co2e_value"] is (
         calculate_co2e_value
     )
     assert run.master == pcf_master(config)


### PR DESCRIPTION
## Summary
- Add `expected_resolution_oracle` so resolution scenario oracle assembly lives in `comp.scenarios.synthetic.oracle`.
- Slim `build_synthetic_pcf_resolution_run` to assemble sources/artifacts and delegate expected values to the oracle helper.
- Update boundary tests so run builders depend on scenario-level oracle helpers while oracle helpers own the receipt, fixture, and validation requirement expectations.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py::test_synthetic_resolution_oracle_lives_outside_run_builders_module -q`
- `python -m pytest tests/test_synthetic_scenario_generator.py -q`
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest -q`
- `git diff --cached --check`