### PR TITLE
[codex] lock agent core boundary

### DIFF
--- a/docs/architecture/contracts/memory-assisted-compiler-loop.md
+++ b/docs/architecture/contracts/memory-assisted-compiler-loop.md
@@ -2,7 +2,7 @@
 
 Status: active-contract
 Owner: agent-layer
-Last checked against code: 2026-05-20
+Last checked against code: 2026-05-22
 Can block PRs: yes
 
 This document fixes the integration boundary between `comp` and a
@@ -83,8 +83,9 @@ Memory / Skills / Session Trace
 -> Receipt-gated Projection
 ```
 
-`minchoagnt` may improve the next `InterpretationHypothesis`. It must not mint
-`Fact`, `PublicOutputReceipt`, or public projection authority.
+`minchoagnt` may improve the next `InterpretationHypothesis`. It may record
+compiler-report-derived facts through the public adapter path, but it must not
+mint freestanding `Fact`, `PublicOutputReceipt`, or public projection authority.
 
 Allowed:
 
@@ -127,8 +128,8 @@ The orchestration layer may import `comp`:
 
 ```python
 from comp.compiler_tool import CompilerTool, InterpretationHypothesis
-from comp.compiler_tool import compile_report_to_facts
-from comp.judgment import JudgmentState, PublicOutputReceipt, build_public_output
+from comp.compiler_tool import compile_report_to_facts, resolver_tasks_from_report
+from comp.judgment import Fact, JudgmentState, SubjectRef
 ```
 
 This keeps the dependency direction honest:
@@ -137,6 +138,25 @@ This keeps the dependency direction honest:
 agent layer depends on compiler authority
 compiler authority does not depend on agent memory
 ```
+
+### 3.1 Agent Core Boundary Contract
+
+The import boundary is part of the contract, not just a packaging preference.
+
+`comp` must not import `minchoagnt`.
+
+`minchoagnt` may import `comp.compiler_tool` report, resolver-task, and fact-adapter contracts.
+
+`minchoagnt` may import judgment value types needed to hold report-derived facts,
+such as `Fact`, `JudgmentState`, and `SubjectRef`.
+
+`minchoagnt` must not import `PublicOutputReceipt`, receipt builders, replay engines, or projection gates.
+
+`CompCompilerAdapter` records report-derived facts and leaves receipt issuance to `comp` governance and receipt paths.
+
+Agent output is proposal and resolution material, not projection authority.
+
+This is machine-checked by `tests/test_authority_import_boundaries.py`.
 
 ---
 

--- a/minchoagnt/comp_adapter.py
+++ b/minchoagnt/comp_adapter.py
@@ -23,7 +23,7 @@ from comp.compiler_tool import (
     resolver_task_from_obligation,
     resolver_tasks_from_report,
 )
-from comp.judgment import PublicOutputReceipt, Fact, JudgmentState, SubjectRef
+from comp.judgment import Fact, JudgmentState, SubjectRef
 
 
 @dataclass(frozen=True)
@@ -32,7 +32,7 @@ class CompCompileResult:
     subject: SubjectRef
     report: ValidationReport
     judgment: JudgmentState = field(default_factory=JudgmentState)
-    receipt: PublicOutputReceipt | None = None
+    receipt: None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_authority_import_boundaries.py
+++ b/tests/test_authority_import_boundaries.py
@@ -89,6 +89,32 @@ AUTHORITY_BOUNDARY_RULES = (
             "minchoagnt",
         ),
     ),
+    ImportBoundaryRule(
+        label="agent orchestration layer",
+        paths=(Path("minchoagnt"),),
+        forbidden_prefixes=(
+            "comp.explanation",
+            "comp.persistence",
+            "comp.views",
+            "comp.scenario_contracts",
+            "comp.scenarios",
+            "comp.runtime",
+        ),
+        forbidden_imports=(
+            "comp:PublicOutput",
+            "comp:PublicOutputReceipt",
+            "comp:PublicOutputSpec",
+            "comp:build_public_output",
+            "comp.compiler_tool:build_public_output_receipt",
+            "comp.compiler_tool:prepare_commit",
+            "comp.judgment:PublicOutput",
+            "comp.judgment:PublicOutputReceipt",
+            "comp.judgment:PublicOutputSpec",
+            "comp.judgment:build_public_output",
+            "comp.persistence:replay_public_projection",
+            "comp.persistence.replay:replay_public_projection",
+        ),
+    ),
 )
 
 
@@ -115,6 +141,29 @@ def test_trust_kernel_contract_documents_machine_checked_import_boundaries():
     )
     for line in expected_lines:
         assert line in contract
+
+
+def test_agent_layer_does_not_call_projection_receipt_or_replay_authority():
+    forbidden_calls = {
+        "build_public_output",
+        "build_public_output_receipt",
+        "prepare_commit",
+        "replay_public_projection",
+        "export_receipt_proof_graph",
+        "explain_public_field",
+        "InMemoryReceiptLedger",
+        "MySQLReceiptLedger",
+        "PublicOutputReceipt",
+    }
+    violations = []
+    for source_path in _python_files((Path("minchoagnt"),)):
+        for called in _called_names(source_path):
+            if called.rsplit(".", 1)[-1] in forbidden_calls:
+                violations.append(
+                    f"agent orchestration layer: {source_path} calls {called}"
+                )
+
+    assert violations == []
 
 
 def _rule_violations(rule: ImportBoundaryRule) -> list[str]:
@@ -149,6 +198,26 @@ def _imports(path: Path) -> tuple[str, ...]:
             imports.append(node.module)
             imports.extend(f"{node.module}:{alias.name}" for alias in node.names)
     return tuple(imports)
+
+
+def _called_names(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    calls = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            calls.append(_call_name(node.func))
+    return tuple(call for call in calls if call)
+
+
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _call_name(node.value)
+        if base:
+            return f"{base}.{node.attr}"
+        return node.attr
+    return ""
 
 
 def _is_forbidden(imported: str, rule: ImportBoundaryRule) -> bool:

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -481,7 +481,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "agent-layer",
             "yes",
-            "2026-05-20",
+            "2026-05-22",
         ),
         "obligation-kernel-working-theory.md": (
             "implementation-map",
@@ -768,6 +768,23 @@ def test_receipt_graph_renderers_have_non_authority_module_boundary():
     assert "export_receipt_proof_graph" not in receipt_graph.__dict__
     assert "replay_public_projection" not in receipt_graph.__dict__
     assert "build_public_output" not in receipt_graph.__dict__
+
+
+def test_memory_assisted_loop_documents_agent_core_boundary_contract():
+    loop_doc = Path(
+        "docs/architecture/contracts/memory-assisted-compiler-loop.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## 3.1 Agent Core Boundary Contract" in loop_doc
+    for line in (
+        "`comp` must not import `minchoagnt`.",
+        "`minchoagnt` may import `comp.compiler_tool` report, resolver-task, and fact-adapter contracts.",
+        "`minchoagnt` must not import `PublicOutputReceipt`, receipt builders, replay engines, or projection gates.",
+        "`CompCompilerAdapter` records report-derived facts and leaves receipt issuance to `comp` governance and receipt paths.",
+        "Agent output is proposal and resolution material, not projection authority.",
+        "tests/test_authority_import_boundaries.py",
+    ):
+        assert line in loop_doc
 
 
 def test_pyproject_packages_comp_core_scenarios_and_agent_layer():


### PR DESCRIPTION
## Summary

- Add AST import and call-boundary checks for the `minchoagnt` agent layer so it cannot import/call receipt, projection, replay, persistence, explanation, or view authority paths.
- Remove the agent adapter's direct `PublicOutputReceipt` type import and keep `CompCompileResult.receipt` as an explicit absent receipt field.
- Update the memory-assisted compiler loop contract with the machine-checked agent/core boundary and refreshed governance date.

## Why

`minchoagnt` can help resolve obligations and record report-derived facts, but it must not become a receipt minting, replay, projection, or explanation authority surface. This keeps `comp` as the trust kernel and the agent layer as proposal/resolution material.

## Validation

- `python -m pytest tests/test_authority_import_boundaries.py tests/test_package_smoke.py tests/test_minchoagnt_comp_adapter.py tests/test_minchoagnt_llm_work_orders.py -q` -> 47 passed
- `python -m pytest tests/test_complete_friendly_rename.py::test_legacy_authority_names_are_not_active_repo_surface tests/test_authority_import_boundaries.py -q` -> 4 passed
- `python -m pytest -q` -> 482 passed, 9 skipped
- `python -m tests.domain_scenarios list`
- `python -m tests.domain_scenarios run-all` -> 18/18 passed