### PR TITLE
[codex] Type synthetic anomaly specs

### DIFF
--- a/comp/scenarios/synthetic/anomaly_specs.py
+++ b/comp/scenarios/synthetic/anomaly_specs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
 
 from comp.scenarios.synthetic.anomalies import (
     MISSING_UNIT,
@@ -20,7 +20,16 @@ from comp.scenarios.synthetic.models import (
 )
 
 
-def anomaly_specs(config: SyntheticScenarioConfig) -> tuple[dict[str, Any], ...]:
+@dataclass(frozen=True)
+class AnomalySpec:
+    row: RawElectricityRow
+    anomaly: InjectedAnomaly
+    validation_requirement: ExpectedValidationRequirement
+    hazard: ExpectedHazard | None
+    failed_claim: ExpectedFailedClaim | None
+
+
+def anomaly_specs(config: SyntheticScenarioConfig) -> tuple[AnomalySpec, ...]:
     specs_by_type = {
         MISSING_UNIT: missing_unit_spec(config),
         WRONG_UNIT: _wrong_unit_spec(config),
@@ -31,31 +40,31 @@ def anomaly_specs(config: SyntheticScenarioConfig) -> tuple[dict[str, Any], ...]
     return tuple(specs_by_type[anomaly] for anomaly in config.anomalies)
 
 
-def missing_unit_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+def missing_unit_spec(config: SyntheticScenarioConfig) -> AnomalySpec:
     row_id = "ERP-SYN-PCF-MISSING-UNIT"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, unit=""),
-        "anomaly": InjectedAnomaly(
+    return AnomalySpec(
+        row=_anomaly_row(config, row_id=row_id, unit=""),
+        anomaly=InjectedAnomaly(
             anomaly_id="synthetic-anomaly:missing_unit",
             anomaly_type=MISSING_UNIT,
             source_row_id=row_id,
             field="unit",
             description="electricity activity row omits its unit",
         ),
-        "validation_requirement": ExpectedValidationRequirement(
+        validation_requirement=ExpectedValidationRequirement(
             requirement_id="synthetic-obligation:missing_unit",
             kind="find_source_witness",
             field="unit",
             reason="missing_unit",
         ),
-        "hazard": ExpectedHazard(
+        hazard=ExpectedHazard(
             hazard_id="hazard:missing_unit:unit:review",
             kind="missing_unit",
             field="unit",
             severity="review",
         ),
-        "failed_claim": None,
-    }
+        failed_claim=None,
+    )
 
 
 def missing_unit_resolution_artifact(
@@ -73,124 +82,124 @@ def missing_unit_resolution_artifact(
     )
 
 
-def _wrong_unit_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+def _wrong_unit_spec(config: SyntheticScenarioConfig) -> AnomalySpec:
     row_id = "ERP-SYN-PCF-WRONG-UNIT"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, unit="MWh"),
-        "anomaly": InjectedAnomaly(
+    return AnomalySpec(
+        row=_anomaly_row(config, row_id=row_id, unit="MWh"),
+        anomaly=InjectedAnomaly(
             anomaly_id="synthetic-anomaly:wrong_unit",
             anomaly_type=WRONG_UNIT,
             source_row_id=row_id,
             field="unit",
             description="electricity activity row uses an unsupported unit",
         ),
-        "validation_requirement": ExpectedValidationRequirement(
+        validation_requirement=ExpectedValidationRequirement(
             requirement_id="synthetic-obligation:wrong_unit",
             kind="find_source_witness",
             field="unit",
             reason="unsupported_unit",
         ),
-        "hazard": None,
-        "failed_claim": ExpectedFailedClaim(
+        hazard=None,
+        failed_claim=ExpectedFailedClaim(
             failed_claim_id="synthetic-failed-claim:wrong_unit",
             field="unit",
             value="MWh",
             reason="unsupported_unit",
             source_row_id=row_id,
         ),
-    }
+    )
 
 
-def _period_mismatch_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+def _period_mismatch_spec(config: SyntheticScenarioConfig) -> AnomalySpec:
     row_id = "ERP-SYN-PCF-PERIOD-MISMATCH"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, period="2023"),
-        "anomaly": InjectedAnomaly(
+    return AnomalySpec(
+        row=_anomaly_row(config, row_id=row_id, period="2023"),
+        anomaly=InjectedAnomaly(
             anomaly_id="synthetic-anomaly:period_mismatch",
             anomaly_type=PERIOD_MISMATCH,
             source_row_id=row_id,
             field="period",
             description="electricity activity row falls outside the reporting period",
         ),
-        "validation_requirement": ExpectedValidationRequirement(
+        validation_requirement=ExpectedValidationRequirement(
             requirement_id="synthetic-obligation:period_mismatch",
             kind="find_context",
             field="period",
             reason="period_mismatch",
         ),
-        "hazard": ExpectedHazard(
+        hazard=ExpectedHazard(
             hazard_id="hazard:period_mismatch:period:review",
             kind="period_mismatch",
             field="period",
             severity="review",
         ),
-        "failed_claim": None,
-    }
+        failed_claim=None,
+    )
 
 
-def _negative_amount_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+def _negative_amount_spec(config: SyntheticScenarioConfig) -> AnomalySpec:
     row_id = "ERP-SYN-PCF-NEGATIVE-AMOUNT"
-    return {
-        "row": _anomaly_row(config, row_id=row_id, amount=-25),
-        "anomaly": InjectedAnomaly(
+    return AnomalySpec(
+        row=_anomaly_row(config, row_id=row_id, amount=-25),
+        anomaly=InjectedAnomaly(
             anomaly_id="synthetic-anomaly:negative_amount",
             anomaly_type=NEGATIVE_AMOUNT,
             source_row_id=row_id,
             field="electricity_kwh",
             description="electricity activity amount is negative",
         ),
-        "validation_requirement": ExpectedValidationRequirement(
+        validation_requirement=ExpectedValidationRequirement(
             requirement_id="synthetic-obligation:negative_amount",
             kind="investigate_activity_amount",
             field="electricity_kwh",
             reason="negative_amount",
         ),
-        "hazard": ExpectedHazard(
+        hazard=ExpectedHazard(
             hazard_id="hazard:invalid_activity_amount:electricity_kwh:block",
             kind="invalid_activity_amount",
             field="electricity_kwh",
             severity="block",
         ),
-        "failed_claim": ExpectedFailedClaim(
+        failed_claim=ExpectedFailedClaim(
             failed_claim_id="synthetic-failed-claim:negative_amount",
             field="electricity_kwh",
             value=-25,
             reason="negative_amount",
             source_row_id=row_id,
         ),
-    }
+    )
 
 
-def _site_alias_spec(config: SyntheticScenarioConfig) -> dict[str, Any]:
+def _site_alias_spec(config: SyntheticScenarioConfig) -> AnomalySpec:
     row_id = "ERP-SYN-PCF-SITE-ALIAS"
-    return {
-        "row": _anomaly_row(
+    return AnomalySpec(
+        row=_anomaly_row(
             config,
             row_id=row_id,
             site_id="SITE-ALIAS-001",
             site_name="Synthetic Cell Plant One",
         ),
-        "anomaly": InjectedAnomaly(
+        anomaly=InjectedAnomaly(
             anomaly_id="synthetic-anomaly:site_alias",
             anomaly_type=SITE_ALIAS,
             source_row_id=row_id,
             field="site_id",
             description="electricity activity row uses an unrecognized site alias",
         ),
-        "validation_requirement": ExpectedValidationRequirement(
+        validation_requirement=ExpectedValidationRequirement(
             requirement_id="synthetic-obligation:site_alias",
             kind="resolve_site_identity",
             field="site_id",
             reason="site_alias",
         ),
-        "hazard": ExpectedHazard(
+        hazard=ExpectedHazard(
             hazard_id="hazard:site_alias:site_id:review",
             kind="site_alias",
             field="site_id",
             severity="review",
         ),
-        "failed_claim": None,
-    }
+        failed_claim=None,
+    )
 
 
 def _anomaly_row(
@@ -217,6 +226,7 @@ def _anomaly_row(
 
 
 __all__ = [
+    "AnomalySpec",
     "anomaly_specs",
     "missing_unit_resolution_artifact",
     "missing_unit_spec",

--- a/comp/scenarios/synthetic/oracle.py
+++ b/comp/scenarios/synthetic/oracle.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
-
+from comp.scenarios.synthetic.anomaly_specs import AnomalySpec
 from comp.scenarios.synthetic.config import SyntheticScenarioConfig
 from comp.scenarios.synthetic.models import (
     ExpectedArtifactRef,
@@ -122,13 +121,13 @@ def expected_smoke_oracle(
 
 def expected_resolution_oracle(
     config: SyntheticScenarioConfig,
-    missing_unit: dict[str, Any],
+    missing_unit: AnomalySpec,
     resolution: SyntheticResolutionArtifact,
 ) -> SyntheticOracle:
-    raw_row = missing_unit["row"]
+    raw_row = missing_unit.row
     source_witness_id = electricity_witness_id(raw_row.source_row_id)
     derived_value = calculate_co2e_value(raw_row.amount, config.factor_value)
-    resolved_requirement = missing_unit["validation_requirement"]
+    resolved_requirement = missing_unit.validation_requirement
     reference_search_requirement = expected_reference_search_requirement(config)
     calculation_requirement = expected_calculation_requirement(config)
 
@@ -146,7 +145,7 @@ def expected_resolution_oracle(
         expected_validation_requirements=(),
         expected_hazards=(),
         expected_failed_claims=(),
-        injected_anomalies=(missing_unit["anomaly"],),
+        injected_anomalies=(missing_unit.anomaly,),
         source_to_expected_claim_map=(
             electricity_source_map(config.input_claim_id, raw_row),
         ),
@@ -171,8 +170,8 @@ def expected_resolution_oracle(
     )
 
 
-def expected_anomaly_oracle(specs: tuple[dict[str, Any], ...]) -> SyntheticOracle:
-    rows = tuple(spec["row"] for spec in specs)
+def expected_anomaly_oracle(specs: tuple[AnomalySpec, ...]) -> SyntheticOracle:
+    rows = tuple(spec.row for spec in specs)
     expected_claims = tuple(
         electricity_expected_claim(
             f"synthetic-pcf-anomaly:{row.source_row_id}:electricity_kwh",
@@ -193,15 +192,15 @@ def expected_anomaly_oracle(specs: tuple[dict[str, Any], ...]) -> SyntheticOracl
         expected_claims=expected_claims,
         expected_calculated_claims=(),
         expected_validation_requirements=tuple(
-            spec["validation_requirement"] for spec in specs
+            spec.validation_requirement for spec in specs
         ),
         expected_hazards=tuple(
-            spec["hazard"] for spec in specs if spec["hazard"] is not None
+            spec.hazard for spec in specs if spec.hazard is not None
         ),
         expected_failed_claims=tuple(
-            spec["failed_claim"] for spec in specs if spec["failed_claim"] is not None
+            spec.failed_claim for spec in specs if spec.failed_claim is not None
         ),
-        injected_anomalies=tuple(spec["anomaly"] for spec in specs),
+        injected_anomalies=tuple(spec.anomaly for spec in specs),
         source_to_expected_claim_map=expected_maps,
     )
 

--- a/comp/scenarios/synthetic/run_builders.py
+++ b/comp/scenarios/synthetic/run_builders.py
@@ -40,7 +40,7 @@ def build_synthetic_pcf_resolution_run(
     config: SyntheticScenarioConfig,
 ) -> SyntheticRun:
     missing_unit = missing_unit_spec(config)
-    raw_row = missing_unit["row"]
+    raw_row = missing_unit.row
     resolution = missing_unit_resolution_artifact(raw_row)
 
     return SyntheticRun(
@@ -63,7 +63,7 @@ def build_synthetic_pcf_anomaly_run(
     config: SyntheticScenarioConfig,
 ) -> SyntheticRun:
     specs = anomaly_specs(config)
-    rows = tuple(spec["row"] for spec in specs)
+    rows = tuple(spec.row for spec in specs)
 
     return SyntheticRun(
         config=config,

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -126,7 +126,7 @@ def test_synthetic_resolution_oracle_lives_outside_run_builders_module() -> None
 
     config = SyntheticScenarioConfig.pcf_resolution(seed=17)
     missing_unit = missing_unit_spec(config)
-    raw_row = missing_unit["row"]
+    raw_row = missing_unit.row
     resolution = missing_unit_resolution_artifact(raw_row)
     run = build_synthetic_pcf_resolution_run(config)
 
@@ -181,6 +181,29 @@ def test_synthetic_anomaly_oracle_lives_outside_run_builders_module() -> None:
     assert run.oracle == expected_anomaly_oracle(specs)
 
 
+def test_synthetic_anomaly_specs_are_typed_records() -> None:
+    from comp.scenarios.synthetic.anomaly_specs import (
+        AnomalySpec,
+        anomaly_specs,
+        missing_unit_spec,
+    )
+
+    config = SyntheticScenarioConfig.pcf_anomaly(seed=11)
+    missing_unit = missing_unit_spec(config)
+    specs = anomaly_specs(config)
+
+    assert isinstance(missing_unit, AnomalySpec)
+    assert all(isinstance(spec, AnomalySpec) for spec in specs)
+    assert missing_unit.row.source_row_id == "ERP-SYN-PCF-MISSING-UNIT"
+    assert missing_unit.anomaly.anomaly_type == "missing_unit"
+    assert (
+        missing_unit.validation_requirement.requirement_id
+        == "synthetic-obligation:missing_unit"
+    )
+    assert missing_unit.hazard is not None
+    assert missing_unit.failed_claim is None
+
+
 def test_synthetic_anomaly_specs_live_outside_generator_module() -> None:
     from comp.scenarios.synthetic.anomaly_specs import (
         anomaly_specs,
@@ -197,8 +220,8 @@ def test_synthetic_anomaly_specs_live_outside_generator_module() -> None:
 
     assert anomaly_specs.__module__ == "comp.scenarios.synthetic.anomaly_specs"
     assert build_synthetic_pcf_anomaly_run.__globals__["anomaly_specs"] is anomaly_specs
-    assert tuple(spec["row"] for spec in specs) == run.raw_sources.electricity_rows
-    assert tuple(spec["anomaly"] for spec in specs) == run.oracle.injected_anomalies
+    assert tuple(spec.row for spec in specs) == run.raw_sources.electricity_rows
+    assert tuple(spec.anomaly for spec in specs) == run.oracle.injected_anomalies
 
     resolution_run = generate_synthetic_pcf_run(
         SyntheticScenarioConfig.pcf_resolution(seed=17)


### PR DESCRIPTION
## Summary
- Add a frozen `AnomalySpec` record for synthetic anomaly scenario assembly.
- Replace string-key dict access in run builders and oracle helpers with typed attributes.
- Add a boundary test proving anomaly specs are typed records while preserving existing scenario outputs.

## Validation
- `python -m pytest tests/test_synthetic_scenario_generator.py::test_synthetic_anomaly_specs_are_typed_records -q`
- `python -m pytest tests/test_synthetic_scenario_generator.py -q`
- `python -m pytest tests/test_synthetic_scenario_generator.py tests/test_synthetic_oracle_assertions.py tests/test_synthetic_run_harness.py tests/test_synthetic_raw_claim_promotion.py tests/test_domain_scenario_lab.py -q`
- `python -m pytest -q`
- `git diff --cached --check`