### PR TITLE
[codex] Consolidate compiler/domain boundary

### DIFF
--- a/docs/api/compiler-tool.md
+++ b/docs/api/compiler-tool.md
@@ -68,6 +68,43 @@ ReviewDecision != public authority
 PublicOutputReceipt == projection gate
 ```
 
+## Behavior declaration surfaces
+
+These names let domain packs, profiles, fixtures, and reference resources
+declare behavior. They are not authority overrides.
+
+```text
+DomainPack
+CompilerProfile
+RuleFamily
+SemanticRubric
+JudgePolicy
+ReferenceCatalog
+ReferenceCatalogSnapshot
+ReferenceRecord
+CalculationFormula
+RetrievalQueryPolicy
+RetrievalQueryRule
+```
+
+DomainPack is a declaration library.
+CompilerProfile is the active behavior lock.
+Neither is authority.
+
+Behavior declaration surfaces may describe allowed fields, allowed units, active
+rules, rubrics, references, formulas, and retrieval policies. The compiler still
+owns protocol validation, authority promotion, and receipt-gated projection.
+
+They must not:
+
+```text
+mint PublicOutputReceipt
+bypass ReferenceOption -> CanonicalReference selection
+treat rule output as public authority
+authorize projection without receipt
+disable core invariants
+```
+
 ## Experimental / internal-ish API
 
 These names are currently exported for implementation convenience, tests, or

--- a/docs/architecture/contracts/compiler-domain-boundary.md
+++ b/docs/architecture/contracts/compiler-domain-boundary.md
@@ -1,0 +1,142 @@
+# Compiler / Domain Boundary
+
+Status: active-contract
+Owner: trust-kernel
+Last checked against code: 2026-05-22
+Can block PRs: yes
+
+This contract consolidates the compiler/domain boundary already described by
+`trust-kernel-extension-rings.md`, `trust-kernel-hardening.md`, and
+`extension-port-contracts.md`.
+
+The governing rule is:
+
+```text
+Core code must own protocol, not domain meaning.
+Domain behavior may be declared and fingerprinted, but it does not become
+authority.
+```
+
+## Core Compiler Owns
+
+The core compiler owns lifecycle and authority transitions:
+
+```text
+claim lifecycle
+requirement lifecycle
+witness grounding protocol
+semantic judgment protocol validation
+ReferenceOption -> CanonicalReference promotion
+calculation trace minimum contract
+review package construction
+receipt build conditions
+public projection gate
+```
+
+The core may reject incomplete, ungrounded, conflicting, or unsupported
+submitted artifacts. It must not infer ESG, LCA, DPP, PCF, supplier-workflow, or
+product-passport meaning from those artifacts.
+
+## Domain Declaration Surfaces Own
+
+Domain declaration surfaces describe behavior that the compiler may validate,
+activate, fingerprint, and cite:
+
+```text
+domain fields
+allowed units
+domain rule families
+semantic rubrics
+judge policies
+reference catalogs
+calculation formulas
+retrieval query policies
+projection field sets
+```
+
+These surfaces are declarations, not authority overrides. A declaration can make
+the compiler stricter, open more requirements, or supply domain-specific
+material for deterministic gates. It must not bypass those gates.
+
+## DomainPack And CompilerProfile
+
+DomainPack is a declaration library.
+CompilerProfile is the active behavior lock.
+Neither is authority.
+
+`DomainPack` may declare domain behavior such as fields, allowed units, rule
+families, semantic rubrics, judge policies, and retrieval query policies.
+Installed domain packs are inactive until a profile activates their declarations.
+
+`CompilerProfile` may activate and fingerprint behavior. It locks the active
+rule ids, rubric ids, retrieval policy ids, judge policy, projection policy, core
+invariant version, and domain-pack declaration fingerprints used for a compiler
+run.
+
+The compiler still owns protocol validation, authority promotion, and
+receipt-gated projection.
+
+## Structural Field Policy
+
+Core may know structural claim fields only when they are part of the compiler
+baseline protocol.
+
+`unit` is currently treated as a structural claim field because unit presence and
+allowed-unit membership are cross-domain compiler safety checks. The allowed
+unit set remains profile-declared behavior. The domain meaning of a unit remains
+domain-owned.
+
+Allowed in core:
+
+```text
+detect that a submitted claim has a unit field
+detect that a required structural unit field is missing
+check that a submitted unit value is in profile-declared allowed_units
+```
+
+Forbidden in core:
+
+```text
+infer that kWh means Scope 2
+infer that kgCO2e means PCF
+decide factor compatibility from unit meaning alone
+map a unit to ESG, LCA, DPP, supplier, or product-passport semantics
+```
+
+## Import Boundary
+
+Core authority modules must not import concrete domain, product, scenario, runtime, or agent packages.
+This is machine-checked by
+`tests/test_authority_import_boundaries.py`.
+
+The allowed direction is:
+
+```text
+domain/profile declarations -> compiler contracts
+outer adapters and agents -> compiler contracts
+compiler authority path -/-> concrete domain, product, scenario, runtime, or
+agent packages
+```
+
+## Forbidden
+
+These actions violate the boundary:
+
+```text
+hardcoding ESG, LCA, DPP, PCF, supplier, or product-passport business meaning in
+core compiler modules
+letting a DomainPack mint PublicOutputReceipt
+letting a CompilerProfile disable core invariants
+letting a rule evaluator bypass compiler validation
+letting ReferenceCatalog become projection authority
+letting CalculationFormula output become public output without receipt
+letting public projection run without PublicOutputReceipt
+```
+
+Review question:
+
+```text
+Does this change keep domain meaning declarative while leaving lifecycle,
+authority promotion, and receipt-gated projection inside deterministic compiler
+gates?
+```

--- a/docs/architecture/contracts/trust-kernel-extension-rings.md
+++ b/docs/architecture/contracts/trust-kernel-extension-rings.md
@@ -133,6 +133,9 @@ until the profile activates their rules, rubrics, judge policy, retrieval
 policies, or projection policy. Receipts should preserve the profile behavior
 identity through deterministic dependency fingerprints.
 
+The consolidated review contract for this ring lives in
+`compiler-domain-boundary.md`.
+
 ### Compiler Gate / Trust Kernel
 
 The compiler gate is intentionally small. It validates submitted artifacts and
@@ -275,6 +278,8 @@ belongs there, and which layer should own it.
 
 Authority modules cannot import presentation, display, or explanation modules.
 This is checked by `tests/test_authority_import_boundaries.py`.
+The compiler/domain import boundary is consolidated in
+`compiler-domain-boundary.md`.
 
 ```text
 comp.judgment must not import comp.compiler_tool
@@ -283,12 +288,24 @@ comp.judgment must not import comp.explanation
 comp.judgment must not import comp.views
 comp.judgment must not import comp.schema_labels
 comp.judgment must not import comp.user_messages
+comp.judgment must not import comp.scenario_contracts
+comp.judgment must not import comp.scenarios
+comp.judgment must not import comp.domains
+comp.judgment must not import comp.products
+comp.judgment must not import comp.adapters
+comp.judgment must not import comp.runtime
 
 comp.compiler_tool must not import comp.persistence
 comp.compiler_tool must not import comp.explanation
 comp.compiler_tool must not import comp.views
 comp.compiler_tool must not import comp.schema_labels
 comp.compiler_tool must not import comp.user_messages
+comp.compiler_tool must not import comp.scenario_contracts
+comp.compiler_tool must not import comp.scenarios
+comp.compiler_tool must not import comp.domains
+comp.compiler_tool must not import comp.products
+comp.compiler_tool must not import comp.adapters
+comp.compiler_tool must not import comp.runtime
 
 comp.persistence must not import comp.compiler_tool
 comp.persistence must not import comp.explanation

--- a/docs/architecture/contracts/trust-kernel-hardening.md
+++ b/docs/architecture/contracts/trust-kernel-hardening.md
@@ -15,6 +15,9 @@ is the first phase: keep the trust kernel small, keep outer rings
 non-authoritative, and preserve the authority promotion path through deterministic
 gates.
 
+The reviewable compiler/domain boundary is consolidated in
+`compiler-domain-boundary.md`.
+
 ## Thesis
 
 `comp` does not create truth. It compiles the conditions under which a value can
@@ -58,6 +61,8 @@ clean `PublicOutputReceipt`.
 ## Core / Domain Boundary
 
 Core code must own protocol, not ESG meaning.
+For the reviewable compiler/domain contract, see
+`compiler-domain-boundary.md`.
 
 Raw claim promotion is a domain-layer operation. A promotion helper may turn
 supported extractor candidates into `CheckedClaim`, `CanonicalReference`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,13 +35,14 @@ without explicitly updating the contract.
 
 1. `architecture/document-governance.md`
 2. `architecture/contracts/trust-kernel-extension-rings.md`
-3. `architecture/contracts/extension-port-contracts.md`
-4. `architecture/contracts/artifact-envelope-builder.md`
-5. `architecture/contracts/persistence-ledger-boundary.md`
-6. `architecture/contracts/receipt-proof-graph.md`
-7. `architecture/contracts/trust-kernel-hardening.md`
-8. `architecture/contracts/memory-assisted-compiler-loop.md`
-9. `architecture/contracts/friendly-authority-vocabulary.md`
+3. `architecture/contracts/compiler-domain-boundary.md`
+4. `architecture/contracts/extension-port-contracts.md`
+5. `architecture/contracts/artifact-envelope-builder.md`
+6. `architecture/contracts/persistence-ledger-boundary.md`
+7. `architecture/contracts/receipt-proof-graph.md`
+8. `architecture/contracts/trust-kernel-hardening.md`
+9. `architecture/contracts/memory-assisted-compiler-loop.md`
+10. `architecture/contracts/friendly-authority-vocabulary.md`
 
 ### Implementation Maps
 

--- a/tests/test_authority_import_boundaries.py
+++ b/tests/test_authority_import_boundaries.py
@@ -23,7 +23,11 @@ AUTHORITY_BOUNDARY_RULES = (
             "comp.views",
             "comp.schema_labels",
             "comp.user_messages",
+            "comp.scenario_contracts",
             "comp.scenarios",
+            "comp.domains",
+            "comp.products",
+            "comp.adapters",
             "comp.runtime",
             "minchoagnt",
         ),
@@ -37,7 +41,11 @@ AUTHORITY_BOUNDARY_RULES = (
             "comp.views",
             "comp.schema_labels",
             "comp.user_messages",
+            "comp.scenario_contracts",
             "comp.scenarios",
+            "comp.domains",
+            "comp.products",
+            "comp.adapters",
             "comp.runtime",
             "minchoagnt",
         ),
@@ -137,6 +145,23 @@ def test_trust_kernel_contract_documents_machine_checked_import_boundaries():
         "comp.compiler_tool must not import comp.persistence",
         "comp.persistence must not import comp.explanation",
         "comp.views.receipt_graph must remain render-only",
+        "tests/test_authority_import_boundaries.py",
+    )
+    for line in expected_lines:
+        assert line in contract
+
+
+def test_compiler_domain_boundary_documents_machine_checked_import_boundaries():
+    contract = Path(
+        "docs/architecture/contracts/compiler-domain-boundary.md"
+    ).read_text(encoding="utf-8")
+
+    expected_lines = (
+        "Core code must own protocol, not domain meaning.",
+        "DomainPack is a declaration library.",
+        "CompilerProfile is the active behavior lock.",
+        "Neither is authority.",
+        "Core authority modules must not import concrete domain, product, scenario, runtime, or agent packages.",
         "tests/test_authority_import_boundaries.py",
     )
     for line in expected_lines:

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -100,6 +100,19 @@ COMPILER_TOOL_ADVANCED_PUBLIC = {
     "ReferenceCatalog",
     "ReferenceResolver",
 }
+COMPILER_TOOL_BEHAVIOR_DECLARATION_PUBLIC = {
+    "DomainPack",
+    "CompilerProfile",
+    "RuleFamily",
+    "SemanticRubric",
+    "JudgePolicy",
+    "ReferenceCatalog",
+    "ReferenceCatalogSnapshot",
+    "ReferenceRecord",
+    "CalculationFormula",
+    "RetrievalQueryPolicy",
+    "RetrievalQueryRule",
+}
 COMPILER_TOOL_EXPERIMENTAL_NOT_QUICKSTART = {
     "active_retrieval_query_policies",
     "profile_declaration_fingerprint",
@@ -220,6 +233,21 @@ def test_compiler_tool_advanced_surface_is_documented():
     assert "__all__ is not the stability contract" in api_doc
 
 
+def test_compiler_tool_behavior_declaration_surface_is_documented():
+    import comp.compiler_tool as compiler_tool
+
+    api_doc = Path("docs/api/compiler-tool.md").read_text(encoding="utf-8")
+
+    assert "## Behavior declaration surfaces" in api_doc
+    assert "They are not authority overrides." in api_doc
+    assert "DomainPack is a declaration library." in api_doc
+    assert "CompilerProfile is the active behavior lock." in api_doc
+    assert "Neither is authority." in api_doc
+    for name in COMPILER_TOOL_BEHAVIOR_DECLARATION_PUBLIC:
+        assert hasattr(compiler_tool, name), name
+        assert name in api_doc, name
+
+
 def test_compiler_tool_experimental_surface_is_not_in_readme_quickstart():
     quickstart = _readme_compiler_tool_quickstart()
     api_doc = Path("docs/api/compiler-tool.md").read_text(encoding="utf-8")
@@ -323,6 +351,10 @@ def test_document_governance_classifies_architecture_doc_authority():
     assert "document-governance.md" in docs_index
 
     required_headers = {
+        "docs/architecture/contracts/compiler-domain-boundary.md": (
+            "Status: active-contract",
+            "Can block PRs: yes",
+        ),
         "docs/architecture/contracts/trust-kernel-extension-rings.md": (
             "Status: active-contract",
             "Can block PRs: yes",
@@ -436,6 +468,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "2026-05-20",
         ),
         "document-governance.md": (
+            "active-contract",
+            "trust-kernel",
+            "yes",
+            "2026-05-22",
+        ),
+        "compiler-domain-boundary.md": (
             "active-contract",
             "trust-kernel",
             "yes",
@@ -607,6 +645,7 @@ def test_docs_index_groups_architecture_docs_by_governance_authority():
         "### Historical Notes"
     )
     assert "archive/architecture/active-surface-cutover.md" in docs_index
+    assert "architecture/contracts/compiler-domain-boundary.md" in docs_index
     assert "architecture/contracts/friendly-authority-vocabulary.md" in docs_index
     assert "archive/architecture/legacy-archive-cutover-plan.md" in docs_index
     assert "archive/architecture/llm-orchestrated-compiler-tool-loop.md" in docs_index


### PR DESCRIPTION
## Summary

- Add an active compiler/domain boundary contract that consolidates the existing trust-kernel, hardening, and extension-port rules.
- Classify `comp.compiler_tool` behavior declaration surfaces so DomainPack/Profile/reference/formula/query policy exports are not mistaken for authority overrides.
- Extend machine-checked governance/import-boundary coverage for the new contract and concrete domain/product ring imports.

## Why

The repo already had the compiler/domain rule spread across several contracts and tests. This PR makes it reviewable as one governed active contract: DomainPack is a declaration library, CompilerProfile is the active behavior lock, and neither is authority.

## Validation

- `python -m pytest tests/test_package_smoke.py tests/test_authority_import_boundaries.py -q` -> 36 passed
- `python -m pytest -q` -> 486 passed, 9 skipped
- `git diff --check` -> exit 0