### PR TITLE
[codex] stabilize compiler quickstart inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,86 @@ ReviewDecision != public authority
 PublicOutputReceipt == projection gate
 ```
 
+## 5-minute quickstart: receipt 없이는 공개되지 않는다
+
+<!-- compiler-tool-quickstart:start -->
+```python
+from comp import PublicOutputBlocked, PublicOutputSpec, build_public_output
+from comp.compiler_tool import (
+    ClaimCandidate,
+    CompilerTool,
+    EvidenceRef,
+    InterpretationHypothesis,
+    prepare_commit,
+)
+
+hypothesis = InterpretationHypothesis(
+    hypothesis_id="hyp-1",
+    subject_id="facility-1",
+    claims=(
+        ClaimCandidate(field="amount", value=1200, witness_id="span-amount"),
+        ClaimCandidate(field="unit", value="kWh", witness_id="span-unit"),
+    ),
+    witnesses=(
+        EvidenceRef(
+            witness_id="span-amount",
+            field="amount",
+            source="invoice.pdf",
+            span="p1: electricity amount",
+        ),
+        EvidenceRef(
+            witness_id="span-unit",
+            field="unit",
+            source="invoice.pdf",
+            span="p1: electricity unit",
+        ),
+    ),
+)
+
+report = CompilerTool(
+    known_fields=frozenset({"amount", "unit"}),
+    allowed_units=frozenset({"kWh"}),
+).compile_interpretation(hypothesis)
+
+assert report.status == "accepted"
+assert report.can_build_public_output is False
+
+projection = PublicOutputSpec("public-row", ("amount", "unit"))
+source_row = {
+    "amount": 1200,
+    "unit": "kWh",
+    "internal_note": "operator note, not public",
+}
+
+blocked_without_receipt = False
+try:
+    build_public_output(source_row, projection)
+except PublicOutputBlocked:
+    blocked_without_receipt = True
+
+assert blocked_without_receipt is True
+
+preparation = prepare_commit(
+    report,
+    subject_id="facility-1",
+    public_row_id="public-row-1",
+    projection_id="public-row",
+)
+
+assert preparation.receipt is not None
+
+row = build_public_output(source_row, projection, receipt=preparation.receipt)
+
+assert row == {"amount": 1200, "unit": "kWh"}
+assert "internal_note" not in row
+```
+<!-- compiler-tool-quickstart:end -->
+
+`CompilerTool`은 후보 claim과 evidence 위치를 `ValidationReport`로 바꾼다.
+`ValidationReport`가 accepted여도 공개 권한은 없다. `prepare_commit(...)`이
+clean package와 commit decision을 확인해 `PublicOutputReceipt`를 만들 때만
+`build_public_output(...)`이 통과한다.
+
 embedding과 LLM도 같은 원칙을 따른다.
 
 ```text

--- a/docs/api/compiler-tool.md
+++ b/docs/api/compiler-tool.md
@@ -20,15 +20,66 @@ These names are the preferred import surface for package users and README
 quickstarts.
 
 ```python
+from comp.compiler_tool import InterpretationHypothesis, ClaimCandidate, EvidenceRef
 from comp.compiler_tool import CompilerTool, ValidationReport
 from comp.compiler_tool import resolver_tasks_from_report
 from comp.compiler_tool import prepare_commit, build_public_output_receipt
 from comp.compiler_tool import compile_report_to_facts
 ```
 
-Stable names:
+### Quickstart input models
+
+These models are stable as quickstart input models. They are stable for
+constructing candidate and provenance input to `CompilerTool`. They do not carry
+public-output authority.
 
 ```text
+InterpretationHypothesis
+ClaimCandidate
+EvidenceRef
+```
+
+### Compiler entrypoint
+
+```text
+CompilerTool
+ValidationReport
+```
+
+### Review / resolver handoff
+
+```text
+resolver_tasks_from_report
+```
+
+### Commit preparation
+
+```text
+prepare_commit
+build_public_output_receipt
+compile_report_to_facts
+```
+
+### Quickstart companion gate from top-level `comp`
+
+README quickstarts may pair `comp.compiler_tool` with the top-level public-output
+gate:
+
+```python
+from comp import PublicOutputBlocked, PublicOutputReceipt, PublicOutputSpec
+from comp import build_public_output
+```
+
+Those names are owned by the judgment/public-output gate, not by
+`comp.compiler_tool`. They appear in the quickstart because the first user path
+is only complete when it reaches receipt-gated projection.
+
+Stable compiler-tool names:
+
+```text
+InterpretationHypothesis
+ClaimCandidate
+EvidenceRef
 CompilerTool
 ValidationReport
 resolver_tasks_from_report

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -82,12 +82,27 @@ DOC_OWNERS = {
     "trust-kernel",
 }
 COMPILER_TOOL_STABLE_PUBLIC = {
+    "InterpretationHypothesis",
+    "ClaimCandidate",
+    "EvidenceRef",
     "CompilerTool",
     "ValidationReport",
     "resolver_tasks_from_report",
     "prepare_commit",
     "build_public_output_receipt",
     "compile_report_to_facts",
+}
+COMPILER_TOOL_QUICKSTART_PATH = {
+    "InterpretationHypothesis",
+    "ClaimCandidate",
+    "EvidenceRef",
+    "CompilerTool",
+    "prepare_commit",
+}
+TOP_LEVEL_QUICKSTART_GATE = {
+    "PublicOutputBlocked",
+    "PublicOutputSpec",
+    "build_public_output",
 }
 COMPILER_TOOL_ADVANCED_PUBLIC = {
     "SemanticJudgment",
@@ -162,11 +177,16 @@ def _docs_relative_path(path):
 
 def _readme_compiler_tool_quickstart():
     readme = Path("README.md").read_text(encoding="utf-8")
-    for block in readme.split("```python")[1:]:
+    start = "<!-- compiler-tool-quickstart:start -->"
+    end = "<!-- compiler-tool-quickstart:end -->"
+    if start not in readme or end not in readme:
+        raise AssertionError("README does not mark the compiler_tool quickstart.")
+    quickstart_section = readme.split(start, 1)[1].split(end, 1)[0]
+    for block in quickstart_section.split("```python")[1:]:
         code = block.split("```", 1)[0]
         if "from comp.compiler_tool import" in code:
             return code
-    raise AssertionError("README does not include a compiler_tool quickstart block.")
+    raise AssertionError("README quickstart marker does not include a python block.")
 
 
 def test_top_level_package_exposes_active_judgment_surface():
@@ -194,14 +214,32 @@ def test_top_level_package_no_longer_exports_legacy_runner_surface():
     assert not hasattr(comp, "PipelineRunResult")
 
 
-def test_compiler_tool_stable_public_surface_is_exported_and_in_readme():
+def test_compiler_tool_stable_public_surface_is_exported_and_documented():
     import comp.compiler_tool as compiler_tool
 
-    quickstart = _readme_compiler_tool_quickstart()
+    api_doc = Path("docs/api/compiler-tool.md").read_text(encoding="utf-8")
 
     for name in COMPILER_TOOL_STABLE_PUBLIC:
         assert hasattr(compiler_tool, name), name
+        assert name in api_doc, name
+
+
+def test_readme_compiler_tool_quickstart_uses_required_public_path():
+    quickstart = _readme_compiler_tool_quickstart()
+
+    for name in COMPILER_TOOL_QUICKSTART_PATH:
         assert name in quickstart, name
+    for name in TOP_LEVEL_QUICKSTART_GATE:
+        assert name in quickstart, name
+
+
+def test_readme_compiler_tool_quickstart_executes_receipt_gate_path():
+    namespace = {}
+    exec(_readme_compiler_tool_quickstart(), namespace)
+
+    assert namespace["blocked_without_receipt"] is True
+    assert namespace["row"] == {"amount": 1200, "unit": "kWh"}
+    assert "internal_note" not in namespace["row"]
 
 
 def test_compiler_tool_advanced_surface_is_documented():


### PR DESCRIPTION
## Summary
- Add an executable README quickstart for the compiler tool path, marked for smoke-test extraction.
- Stabilize `InterpretationHypothesis`, `ClaimCandidate`, and `EvidenceRef` as quickstart input models with a limited non-authority contract.
- Update package smoke coverage so the README quickstart executes the receipt gate path and verifies projection filtering.

## Why
The first user path for `CompilerTool` needs a closed, public contract: candidate input enters the compiler, accepted reports still cannot publish, and only a `PublicOutputReceipt` opens `build_public_output` for the projected fields.

## Validation
- `python -m pytest -q` -> 481 passed, 9 skipped
- `git diff --check` -> no whitespace errors; Git reported CRLF conversion warnings for touched files