### PR TITLE
[codex] document public output gate api

### DIFF
--- a/docs/api/compiler-tool.md
+++ b/docs/api/compiler-tool.md
@@ -72,7 +72,8 @@ from comp import build_public_output
 
 Those names are owned by the judgment/public-output gate, not by
 `comp.compiler_tool`. They appear in the quickstart because the first user path
-is only complete when it reaches receipt-gated projection.
+is only complete when it reaches receipt-gated projection. See
+`api/public-output-gate.md` for the top-level gate API.
 
 Stable compiler-tool names:
 

--- a/docs/api/public-output-gate.md
+++ b/docs/api/public-output-gate.md
@@ -1,0 +1,112 @@
+# Public Output Gate API
+
+This document classifies the top-level `comp` public-output gate surface. It is
+an API reference, not an architecture authority contract.
+
+The core rule is:
+
+```text
+PublicOutputReceipt is the projection authority.
+ValidationReport is not public-output authority.
+PublicOutput is a materialized view, not authority.
+build_public_output(..., receipt=...) is the gate.
+```
+
+The gate exists so public rows cannot be created directly from candidates,
+compiler reports, review packages, review decisions, replay reports, or product
+UI state. A public projection must pass through a clean
+`PublicOutputReceipt`.
+
+## Stable public API
+
+Use these names for public-output examples and package users:
+
+```python
+from comp import PublicOutput, PublicOutputBlocked, PublicOutputSpec
+from comp import PublicOutputReceipt, PublicOutputReceiptCitations
+from comp import PublicOutputValueCommitment, DependencyFingerprint
+from comp import build_public_output
+```
+
+Stable names:
+
+```text
+PublicOutput
+PublicOutputBlocked
+PublicOutputSpec
+PublicOutputReceipt
+PublicOutputReceiptCitations
+PublicOutputValueCommitment
+DependencyFingerprint
+build_public_output
+```
+
+## Authority Roles
+
+`PublicOutputSpec` defines the projection shape. It names the projection and the
+fields the caller wants to materialize. It does not authorize output.
+
+`PublicOutputReceipt` is the projection authority. Its `projection_id`,
+`authorized_fields`, citation snapshot, value commitments, and dependency
+fingerprints are the authority bundle checked by `build_public_output`.
+
+`PublicOutputReceiptCitations` records the receipt barrier snapshot: governance
+status, package completeness, open obligations, hazards, authorized fields,
+value commitments, and dependency fingerprints.
+
+`PublicOutputValueCommitment` records the digest for a projected value. Public
+projection blocks if the source value does not match the committed digest.
+
+`DependencyFingerprint` records the dependency declarations or source artifacts
+that the receipt cites. It supports replay and audit without becoming projection
+authority by itself.
+
+`PublicOutput` is the materialized projection view returned by
+`build_public_output`. It is derived from a receipt-authorized projection; it is
+not an authority root.
+
+## Gate Behavior
+
+`build_public_output(...)` requires a `PublicOutputReceipt`.
+
+It blocks when:
+
+```text
+receipt is missing
+receipt.projection_id does not match PublicOutputSpec.projection_id
+requested output fields are not authorized by the receipt
+receipt citations are missing or not clean
+open obligations or hazards remain in the receipt snapshot
+projected values do not match receipt value commitments
+```
+
+It returns only the fields named by `PublicOutputSpec.output_fields`. Extra
+fields in the source row are not included in the public output.
+
+## Relationship To Compiler Tool
+
+`comp.compiler_tool` can prepare a commit path and build a
+`PublicOutputReceipt` when a report becomes a clean package with a commit
+decision. The compiler tool still does not make public output directly.
+
+The first user path is:
+
+```text
+InterpretationHypothesis / ClaimCandidate / EvidenceRef
+-> CompilerTool
+-> ValidationReport
+-> prepare_commit
+-> PublicOutputReceipt
+-> build_public_output
+-> PublicOutput
+```
+
+The boundary remains:
+
+```text
+ValidationReport != public-output authority
+ReviewPackage != public-output authority
+ReviewDecision != public-output authority
+PublicOutputReceipt == public-output authority
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,7 @@ These documents classify public package surfaces. They are not architecture
 authority contracts unless an active contract explicitly references them.
 
 1. `api/compiler-tool.md`
+2. `api/public-output-gate.md`
 
 ## Examples
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -104,6 +104,16 @@ TOP_LEVEL_QUICKSTART_GATE = {
     "PublicOutputSpec",
     "build_public_output",
 }
+PUBLIC_OUTPUT_GATE_PUBLIC = {
+    "PublicOutput",
+    "PublicOutputBlocked",
+    "PublicOutputSpec",
+    "PublicOutputReceipt",
+    "PublicOutputReceiptCitations",
+    "PublicOutputValueCommitment",
+    "DependencyFingerprint",
+    "build_public_output",
+}
 COMPILER_TOOL_ADVANCED_PUBLIC = {
     "SemanticJudgment",
     "ReferenceOption",
@@ -253,6 +263,24 @@ def test_readme_compiler_tool_quickstart_executes_receipt_gate_path():
     assert namespace["blocked_without_receipt"] is True
     assert namespace["row"] == {"amount": 1200, "unit": "kWh"}
     assert "internal_note" not in namespace["row"]
+
+
+def test_public_output_gate_api_reference_is_documented():
+    api_doc = Path("docs/api/public-output-gate.md").read_text(encoding="utf-8")
+    compiler_tool_doc = Path("docs/api/compiler-tool.md").read_text(
+        encoding="utf-8"
+    )
+    docs_index = Path("docs/index.md").read_text(encoding="utf-8")
+
+    assert "api/public-output-gate.md" in docs_index
+    assert "api/public-output-gate.md" in compiler_tool_doc
+    assert "PublicOutputReceipt is the projection authority" in api_doc
+    assert "ValidationReport is not public-output authority" in api_doc
+    assert "build_public_output(..., receipt=...)" in api_doc
+    assert "materialized view, not authority" in api_doc
+    for name in PUBLIC_OUTPUT_GATE_PUBLIC:
+        assert hasattr(comp, name), name
+        assert name in api_doc, name
 
 
 def test_compiler_tool_advanced_surface_is_documented():


### PR DESCRIPTION
## Summary
- Add `docs/api/public-output-gate.md` for the top-level receipt-gated projection surface.
- Link the new API reference from `docs/index.md` and the compiler-tool quickstart companion gate note.
- Add smoke coverage so the public-output gate symbols stay exported and documented.

## Why
After stabilizing the compiler quickstart inputs, the public-output exit path needs its own API reference instead of living as an appendix inside `compiler-tool.md`. This keeps `CompilerTool` as the candidate/report entry path and `build_public_output(..., receipt=...)` as the receipt-authorized projection gate.

## Validation
- `python -m pytest tests/test_package_smoke.py -q` -> 35 passed
- `python -m pytest tests/test_receipt_gated_projection.py tests/test_commit_receipt_builder.py tests/test_commit_preparation_flow.py -q` -> 24 passed
- `python -m pytest -q` -> 489 passed, 9 skipped
- `git diff --check` -> no whitespace errors; Git reported CRLF conversion warnings for touched files