### PR TITLE
[codex] audit residual obligation vocabulary

### DIFF
--- a/docs/architecture/contracts/friendly-authority-vocabulary.md
+++ b/docs/architecture/contracts/friendly-authority-vocabulary.md
@@ -198,6 +198,42 @@ migration, not search-and-replace cleanup.
 identifiers for source spans and receipt citations. Rename them only when the
 receipt, replay, and scenario-contract payloads move together.
 
+### Residual obligation vocabulary
+
+The active validation model has moved to `ValidationRequirement.requirement_id`.
+Remaining `obligation` strings are not one kind of debt. They fall into four
+different boundaries:
+
+| Residual surface | Classification | Rename rule |
+| --- | --- | --- |
+| `ReviewPackage.open_obligation_ids` | Receipt schema and governance facts | Keep until a receipt/barrier codec migration can prove old-body replay and new-body output together. |
+| `ReviewPackage.resolved_obligation_ids` | Receipt schema and governance facts | Keep with `open_obligation_ids`; do not split the pair. |
+| `PublicOutputReceiptCitations.open_obligation_ids` | Receipt schema and governance facts | Keep because it is part of the public-output barrier snapshot. |
+| `PublicOutputReceiptCitations.resolved_obligation_ids` | Receipt schema and governance facts | Keep because replay and proof graphs cite this serialized field. |
+| `SyntheticResolutionArtifact.obligation_id` | Synthetic resolution artifact payloads | Keep until the synthetic fixture CSV/body schema moves with loaders, writers, oracle assertions, and replay fixtures. |
+| `ExpectedResolutionArtifact.obligation_id` | Synthetic resolution artifact payloads | Keep with `SyntheticResolutionArtifact.obligation_id`; it mirrors the fixture payload. |
+| `ExpectedReceipt.resolved_obligation_ids` | Synthetic expected receipt payloads | Keep until expected receipt fixtures and receipt citations migrate together. |
+| `synthetic-obligation:*` string ids | Fixture id values | Keep as stable ids unless a fixture migration rewrites expected outputs intentionally. |
+| `obligation-kernel-working-theory.md` prose | Docs prose and historical theory language | Do not batch-edit; update only when that map is revised or demoted. |
+| Test function names and local variables using `obligation` | Test-local wording | Rename opportunistically with the behavior under test, not as a standalone churn PR. |
+
+Do not rename all remaining `obligation` strings in one PR. A safe migration
+must pick exactly one boundary:
+
+```text
+Receipt schema and governance facts
+Synthetic resolution artifact payloads
+Docs prose and historical theory language
+Test-local wording
+```
+
+The review question is:
+
+```text
+Does this PR move one serialized or authority boundary completely, or is it only
+making the vocabulary look cleaner while leaving replay and receipt fields split?
+```
+
 ## 7. Non-Goals
 
 Do not use Korean Python class names.

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -796,6 +796,16 @@ def test_friendly_authority_vocabulary_names_rename_path_without_moving_authorit
     assert "`PublicOutputReceipt.projection_id`" in vocabulary
     assert "`DependencyFingerprint.dependency_kind=\"evidence_witness\"`" in vocabulary
     assert "Do not add a blanket ban on `projection` or `witness`" in vocabulary
+    assert "### Residual obligation vocabulary" in vocabulary
+    assert "`ReviewPackage.open_obligation_ids`" in vocabulary
+    assert "`PublicOutputReceiptCitations.resolved_obligation_ids`" in vocabulary
+    assert "`SyntheticResolutionArtifact.obligation_id`" in vocabulary
+    assert "`ExpectedReceipt.resolved_obligation_ids`" in vocabulary
+    assert "Do not rename all remaining `obligation` strings in one PR." in vocabulary
+    assert "Receipt schema and governance facts" in vocabulary
+    assert "Synthetic resolution artifact payloads" in vocabulary
+    assert "Docs prose and historical theory language" in vocabulary
+    assert "Test-local wording" in vocabulary
     assert "Only a clean public-output receipt can authorize public output." in vocabulary
 
 


### PR DESCRIPTION
## Summary
- classify the remaining `obligation` vocabulary by boundary instead of treating it as one rename backlog
- document which receipt/governance fields, synthetic artifact payloads, fixture ids, docs prose, and test-local wording should stay put for now
- extend the package smoke test so the friendly vocabulary contract keeps that migration guidance visible

## Validation
- `python -m pytest -q` -> 489 passed, 9 skipped
- `python -m pytest -q tests/test_package_smoke.py::test_friendly_authority_vocabulary_names_rename_path_without_moving_authority` -> 1 passed
- `git diff --check`