### PR TITLE
[codex] sync downstream scenario pack cutover state

### DIFF
--- a/docs/extensions/downstream-registry.json
+++ b/docs/extensions/downstream-registry.json
@@ -6,7 +6,7 @@
     {
       "id": "comp-scenario-packs",
       "repo": "minntcho/comp-scenario-packs",
-      "status": "planned",
+      "status": "active",
       "relationship": "downstream",
       "scope": "large-domain-and-product-e2e",
       "required_for_comp_pr_ci": false,
@@ -15,10 +15,29 @@
       "dependency_direction": "downstream_consumes_comp",
       "expected_comp_dependency_before_v1": "comp @ git+https://github.com/minntcho/comp@<ref>",
       "expected_comp_dependency_after_v1": "comp>=1.0,<2.0",
+      "current_packs": [
+        {
+          "id": "public_projection_smoke",
+          "status": "active",
+          "scope": "canonical-runtime-smoke",
+          "cutover_state": "baseline-public-surface",
+          "covers_comp_scenario_ids": []
+        },
+        {
+          "id": "l_energy_pcf_governance",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy_pcf_governance.v1"
+          ]
+        }
+      ],
       "notes": [
         "comp keeps only minimal kernel e2e scenarios internally.",
         "Large domain, product, platform, importer, UI, and supplier workflow scenarios continue downstream.",
-        "Downstream packs must consume comp through public APIs after v1.0."
+        "Downstream packs must consume comp through public APIs after v1.0.",
+        "Current downstream packs are compatibility signals only; they do not authorize projection."
       ]
     }
   ]

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -8,10 +8,20 @@ Can block PRs: no
 Large domain, product, platform, importer, UI, and supplier workflow scenarios
 belong in downstream scenario-pack repositories.
 
-The first downstream repository is expected to be:
+The first downstream repository is active:
 
 ```text
 https://github.com/minntcho/comp-scenario-packs
+```
+
+Current checked-in packs:
+
+```text
+public_projection_smoke
+  active baseline public-surface smoke
+
+l_energy_pcf_governance
+  seeded large-domain pack in parallel validation for l_energy_pcf_governance.v1
 ```
 
 ## Boundary

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -158,6 +158,19 @@ Downstream-candidate is not a removal instruction. Keep the internal scenario
 until a downstream pack has copied or reconstructed the same trust meaning, run
 it through public `comp` APIs, and passed parallel validation.
 
+Cutover states:
+
+```text
+internal-kernel-regression
+  stays in comp as a small authority-boundary regression scenario
+
+pending-external-coverage
+  downstream target exists, but no runnable external pack covers the same trust meaning yet
+
+parallel-validation
+  downstream pack has a runnable canonical bundle; keep the internal scenario until reports prove equivalence over time
+```
+
 ## Local Runner
 
 The scenario registry can also be inspected without opening the pytest files:

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -62,6 +62,9 @@ class ScenarioResidency:
     tier: str
     reason: str
     target_pack: str | None = None
+    external_pack_id: str | None = None
+    external_contract_id: str | None = None
+    cutover_state: str = "internal-kernel-regression"
 
 
 _REGISTERED_SCENARIOS = (
@@ -112,10 +115,24 @@ _DOWNSTREAM_CANDIDATE_IDS = (
 
 
 def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
+    if scenario_id == L_ENERGY_PCF_GOVERNANCE_SCENARIO.scenario_id:
+        return ScenarioResidency(
+            tier="downstream-candidate",
+            target_pack="comp-scenario-packs",
+            external_pack_id="l_energy_pcf_governance",
+            external_contract_id="canonical_projection_smoke",
+            cutover_state="parallel-validation",
+            reason=(
+                "large domain workflow fixture has a seeded downstream canonical "
+                "bundle but remains internal until parallel validation covers the "
+                "same trust meaning"
+            ),
+        )
     if scenario_id in _LARGE_DOMAIN_DOWNSTREAM_IDS:
         return ScenarioResidency(
             tier="downstream-candidate",
             target_pack="comp-scenario-packs",
+            cutover_state="pending-external-coverage",
             reason=(
                 "large domain workflow fixture retained temporarily until the "
                 "downstream scenario pack owns it"
@@ -125,6 +142,7 @@ def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
         return ScenarioResidency(
             tier="downstream-candidate",
             target_pack="comp-scenario-packs",
+            cutover_state="pending-external-coverage",
             reason=(
                 "synthetic generator fixture retained temporarily until the "
                 "downstream scenario pack owns generated replay checks"
@@ -132,6 +150,7 @@ def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
         )
     return ScenarioResidency(
         tier="core-kernel",
+        cutover_state="internal-kernel-regression",
         reason="small authority boundary scenario for comp kernel regression",
     )
 

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from tests.domain_scenarios.registry import (
@@ -61,6 +62,32 @@ def test_domain_scenario_residency_metadata_explains_diet_boundary():
     assert "synthetic generator" in synthetic_residency.reason
 
 
+def test_downstream_candidate_cutover_metadata_tracks_external_coverage():
+    l_energy = scenario_residency("l_energy_pcf_governance.v1")
+    l_energy_rollup = scenario_residency("l_energy.final_bottom_up_pcf_rollup.v1")
+    synthetic = scenario_residency("synthetic_pcf.smoke.v1")
+    raw_claim = scenario_residency(
+        "synthetic.raw_claim_conflict_resolution.v1"
+    )
+
+    assert l_energy.tier == "downstream-candidate"
+    assert l_energy.target_pack == "comp-scenario-packs"
+    assert l_energy.external_pack_id == "l_energy_pcf_governance"
+    assert l_energy.external_contract_id == "canonical_projection_smoke"
+    assert l_energy.cutover_state == "parallel-validation"
+
+    assert l_energy_rollup.tier == "downstream-candidate"
+    assert l_energy_rollup.external_pack_id is None
+    assert l_energy_rollup.cutover_state == "pending-external-coverage"
+
+    assert synthetic.tier == "downstream-candidate"
+    assert synthetic.external_pack_id is None
+    assert synthetic.cutover_state == "pending-external-coverage"
+
+    assert raw_claim.tier == "core-kernel"
+    assert raw_claim.cutover_state == "internal-kernel-regression"
+
+
 def test_domain_scenario_docs_explain_residency_tiers():
     readme = Path("tests/domain_scenarios/README.md").read_text(encoding="utf-8")
     extension_doc = Path("docs/extensions/scenario-packs.md").read_text(
@@ -72,6 +99,44 @@ def test_domain_scenario_docs_explain_residency_tiers():
     assert "downstream-candidate" in readme
     assert "l_energy.*" in readme
     assert "synthetic PCF smoke/anomaly/resolution" in readme
+    assert "Cutover states" in readme
+    assert "internal-kernel-regression" in readme
+    assert "pending-external-coverage" in readme
+    assert "parallel-validation" in readme
     assert "copy/reconstruct -> external run -> parallel validation" in extension_doc
     assert "public_projection_smoke" in extension_doc
     assert "registry exposes residency metadata" in extension_doc
+
+
+def test_downstream_registry_records_active_pack_cutover_state():
+    registry = json.loads(
+        Path("docs/extensions/downstream-registry.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    packs = {pack["id"]: pack for pack in registry["packs"]}
+    downstream = packs["comp-scenario-packs"]
+
+    assert downstream["status"] == "active"
+    assert downstream["authority_policy"] == (
+        "compatibility_signal_not_authority_source"
+    )
+    assert downstream["dependency_direction"] == "downstream_consumes_comp"
+    assert downstream["required_for_comp_pr_ci"] is False
+    assert downstream["recommended_for_release_candidate"] is True
+    assert downstream["current_packs"] == [
+        {
+            "id": "public_projection_smoke",
+            "status": "active",
+            "scope": "canonical-runtime-smoke",
+            "cutover_state": "baseline-public-surface",
+            "covers_comp_scenario_ids": [],
+        },
+        {
+            "id": "l_energy_pcf_governance",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": ["l_energy_pcf_governance.v1"],
+        },
+    ]


### PR DESCRIPTION
## Summary

- Mark `comp-scenario-packs` as the active downstream scenario-pack repository and record the currently checked-in packs.
- Add cutover metadata to domain scenario residency so `l_energy_pcf_governance.v1` is tracked as `parallel-validation` against the seeded downstream pack.
- Document cutover states and assert the registry/docs stay aligned with downstream compatibility boundaries.

## Boundary

Downstream packs remain compatibility signals only. They do not authorize projection, and `comp` keeps the receipt/replay authority boundary internal.

## Validation

- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_package_smoke.py -q` -> `40 passed`
- `python -m pytest -q` -> `491 passed, 9 skipped`
- `python -m tests.domain_scenarios run-all` -> `Passed: 18/18`
- `git diff --check` -> passed

Related downstream PR: https://github.com/minntcho/comp-scenario-packs/pull/16