### PR TITLE
[codex] sync blocked l-energy downstream coverage

### DIFF
--- a/docs/extensions/downstream-registry.json
+++ b/docs/extensions/downstream-registry.json
@@ -24,6 +24,15 @@
           "covers_comp_scenario_ids": []
         },
         {
+          "id": "l_energy_alpha_invalid_allocation_rfi",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy.alpha_invalid_allocation_rfi.v1"
+          ]
+        },
+        {
           "id": "l_energy_pcf_governance",
           "status": "seed",
           "scope": "large-domain-and-product-e2e",

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -22,6 +22,9 @@ public_projection_smoke
 
 l_energy_pcf_governance
   seeded large-domain pack in parallel validation for l_energy_pcf_governance.v1
+
+l_energy_alpha_invalid_allocation_rfi
+  seeded blocked/no-projection pack in parallel validation for l_energy.alpha_invalid_allocation_rfi.v1
 ```
 
 ## Boundary

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -115,6 +115,19 @@ _DOWNSTREAM_CANDIDATE_IDS = (
 
 
 def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
+    if scenario_id == ALPHA_INVALID_ALLOCATION_SCENARIO.scenario_id:
+        return ScenarioResidency(
+            tier="downstream-candidate",
+            target_pack="comp-scenario-packs",
+            external_pack_id="l_energy_alpha_invalid_allocation_rfi",
+            external_contract_id="canonical_blocked_projection_smoke",
+            cutover_state="parallel-validation",
+            reason=(
+                "blocked large domain workflow fixture has a seeded downstream "
+                "canonical bundle but remains internal until parallel validation "
+                "covers the same trust meaning"
+            ),
+        )
     if scenario_id == L_ENERGY_PCF_GOVERNANCE_SCENARIO.scenario_id:
         return ScenarioResidency(
             tier="downstream-candidate",

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -64,6 +64,9 @@ def test_domain_scenario_residency_metadata_explains_diet_boundary():
 
 def test_downstream_candidate_cutover_metadata_tracks_external_coverage():
     l_energy = scenario_residency("l_energy_pcf_governance.v1")
+    blocked_allocation = scenario_residency(
+        "l_energy.alpha_invalid_allocation_rfi.v1"
+    )
     l_energy_rollup = scenario_residency("l_energy.final_bottom_up_pcf_rollup.v1")
     synthetic = scenario_residency("synthetic_pcf.smoke.v1")
     raw_claim = scenario_residency(
@@ -75,6 +78,16 @@ def test_downstream_candidate_cutover_metadata_tracks_external_coverage():
     assert l_energy.external_pack_id == "l_energy_pcf_governance"
     assert l_energy.external_contract_id == "canonical_projection_smoke"
     assert l_energy.cutover_state == "parallel-validation"
+
+    assert blocked_allocation.tier == "downstream-candidate"
+    assert blocked_allocation.target_pack == "comp-scenario-packs"
+    assert blocked_allocation.external_pack_id == (
+        "l_energy_alpha_invalid_allocation_rfi"
+    )
+    assert blocked_allocation.external_contract_id == (
+        "canonical_blocked_projection_smoke"
+    )
+    assert blocked_allocation.cutover_state == "parallel-validation"
 
     assert l_energy_rollup.tier == "downstream-candidate"
     assert l_energy_rollup.external_pack_id is None
@@ -105,6 +118,7 @@ def test_domain_scenario_docs_explain_residency_tiers():
     assert "parallel-validation" in readme
     assert "copy/reconstruct -> external run -> parallel validation" in extension_doc
     assert "public_projection_smoke" in extension_doc
+    assert "l_energy_alpha_invalid_allocation_rfi" in extension_doc
     assert "registry exposes residency metadata" in extension_doc
 
 
@@ -131,6 +145,15 @@ def test_downstream_registry_records_active_pack_cutover_state():
             "scope": "canonical-runtime-smoke",
             "cutover_state": "baseline-public-surface",
             "covers_comp_scenario_ids": [],
+        },
+        {
+            "id": "l_energy_alpha_invalid_allocation_rfi",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": [
+                "l_energy.alpha_invalid_allocation_rfi.v1"
+            ],
         },
         {
             "id": "l_energy_pcf_governance",


### PR DESCRIPTION
## Summary

- record `l_energy_alpha_invalid_allocation_rfi` in the downstream scenario-pack registry
- mark `l_energy.alpha_invalid_allocation_rfi.v1` as `parallel-validation` with the downstream blocked/no-projection pack
- keep the internal `comp` scenario in place; this PR only syncs coverage state

## Boundary

Downstream coverage remains a compatibility signal. `comp` continues to own receipt replay, projection gates, and internal authority-kernel regressions.

## Dependency

This should stay draft until the downstream pack PR lands: https://github.com/minntcho/comp-scenario-packs/pull/20

## Test Plan

- `python -m pytest tests/test_domain_scenario_pack_diet.py::test_downstream_candidate_cutover_metadata_tracks_external_coverage tests/test_domain_scenario_pack_diet.py::test_downstream_registry_records_active_pack_cutover_state tests/test_domain_scenario_pack_diet.py::test_domain_scenario_docs_explain_residency_tiers -q` red before implementation
- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_package_smoke.py -q` -> `42 passed`
- `python -m pytest -q` -> `493 passed, 9 skipped`
- `python -m tests.domain_scenarios run-all` -> `Passed: 18/18`
- `git diff --check` -> passed