### PR TITLE
[codex] Add receipt envelope set builder

### DIFF
--- a/comp/persistence/__init__.py
+++ b/comp/persistence/__init__.py
@@ -2,6 +2,12 @@
 
 from comp.persistence.digest import artifact_digest
 from comp.persistence.envelope import ArtifactEnvelope
+from comp.persistence.envelope_builder import (
+    ArtifactMaterial,
+    ArtifactRecorder,
+    ReceiptEnvelopeSetBuildError,
+    build_receipt_envelope_set,
+)
 from comp.persistence.ledger import (
     ArtifactConflict,
     ArtifactIntegrityError,
@@ -30,6 +36,8 @@ from comp.persistence.replay import (
 __all__ = [
     "ArtifactConflict",
     "ArtifactEnvelope",
+    "ArtifactMaterial",
+    "ArtifactRecorder",
     "ArtifactRef",
     "ArtifactIntegrityError",
     "ArtifactStore",
@@ -41,9 +49,11 @@ __all__ = [
     "ProjectionReplayBlocked",
     "ProjectionReplayReport",
     "ReceiptConflict",
+    "ReceiptEnvelopeSetBuildError",
     "ReceiptLedgerKey",
     "apply_trust_spine_schema",
     "artifact_digest",
+    "build_receipt_envelope_set",
     "receipt_artifact_refs",
     "replay_public_projection",
     "verify_artifact_envelope",

--- a/comp/persistence/envelope_builder.py
+++ b/comp/persistence/envelope_builder.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from comp.judgment import PublicOutputReceipt
+from comp.persistence.envelope import ArtifactEnvelope
+from comp.persistence.ledger import PersistenceError
+from comp.persistence.replay import ArtifactRef, receipt_artifact_refs
+
+
+class ReceiptEnvelopeSetBuildError(PersistenceError):
+    """Raised when receipt-cited artifact material cannot produce envelopes."""
+
+
+class ArtifactRecorder(Protocol):
+    def record(self, envelope: ArtifactEnvelope) -> ArtifactEnvelope:
+        ...
+
+
+@dataclass(frozen=True)
+class ArtifactMaterial:
+    artifact_id: str
+    artifact_kind: str
+    schema_version: str
+    body: Mapping[str, Any]
+    source_refs: tuple[str, ...] = field(default_factory=tuple)
+    meta: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def to_envelope(self) -> ArtifactEnvelope:
+        return ArtifactEnvelope.from_body(
+            artifact_id=self.artifact_id,
+            artifact_kind=self.artifact_kind,
+            schema_version=self.schema_version,
+            body=self.body,
+            source_refs=tuple(self.source_refs),
+            meta=tuple(self.meta),
+        )
+
+
+def build_receipt_envelope_set(
+    receipt: PublicOutputReceipt | None,
+    materials: Iterable[ArtifactMaterial],
+    *,
+    record_to: ArtifactRecorder | None = None,
+) -> tuple[ArtifactEnvelope, ...]:
+    if receipt is None:
+        raise ReceiptEnvelopeSetBuildError("Receipt envelope set requires a receipt.")
+    if receipt.citations is None:
+        raise ReceiptEnvelopeSetBuildError(
+            "Receipt envelope set requires receipt citations."
+        )
+
+    available = _envelopes_by_id(materials)
+    required_refs = receipt_artifact_refs(receipt)
+    envelopes: list[ArtifactEnvelope] = []
+    for ref in required_refs:
+        envelope = _required_envelope(ref, available)
+        _verify_value_commitment_source(ref, envelope, receipt)
+        _verify_dependency_fingerprint_source(ref, envelope, receipt)
+        envelopes.append(envelope)
+
+    if record_to is None:
+        return tuple(envelopes)
+    return tuple(record_to.record(envelope) for envelope in envelopes)
+
+
+def _envelopes_by_id(
+    materials: Iterable[ArtifactMaterial],
+) -> dict[str, ArtifactEnvelope]:
+    envelopes: dict[str, ArtifactEnvelope] = {}
+    for material in materials:
+        envelope = material.to_envelope()
+        existing = envelopes.get(envelope.artifact_id)
+        if existing is None:
+            envelopes[envelope.artifact_id] = envelope
+            continue
+        if (
+            existing.artifact_kind != envelope.artifact_kind
+            or existing.schema_version != envelope.schema_version
+            or existing.body_digest != envelope.body_digest
+        ):
+            raise ReceiptEnvelopeSetBuildError(
+                f"Receipt envelope set has conflicting material: "
+                f"{envelope.artifact_id}."
+            )
+    return envelopes
+
+
+def _required_envelope(
+    ref: ArtifactRef,
+    available: Mapping[str, ArtifactEnvelope],
+) -> ArtifactEnvelope:
+    try:
+        envelope = available[ref.artifact_id]
+    except KeyError as exc:
+        raise ReceiptEnvelopeSetBuildError(
+            f"Receipt envelope set missing artifact: {ref.artifact_id}."
+        ) from exc
+    if envelope.artifact_kind != ref.artifact_kind:
+        raise ReceiptEnvelopeSetBuildError(
+            f"Receipt envelope set artifact kind mismatch: {ref.artifact_id}."
+        )
+    return envelope
+
+
+def _verify_value_commitment_source(
+    ref: ArtifactRef,
+    envelope: ArtifactEnvelope,
+    receipt: PublicOutputReceipt,
+) -> None:
+    assert receipt.citations is not None
+    source_refs = {
+        (commitment.source_id, commitment.source_kind)
+        for commitment in receipt.citations.projection_value_commitments
+    }
+    if (ref.artifact_id, ref.artifact_kind) not in source_refs:
+        return
+    if "value" not in envelope.body:
+        raise ReceiptEnvelopeSetBuildError(
+            "Receipt envelope set committed value source lacks value: "
+            f"{ref.artifact_id}."
+        )
+
+
+def _verify_dependency_fingerprint_source(
+    ref: ArtifactRef,
+    envelope: ArtifactEnvelope,
+    receipt: PublicOutputReceipt,
+) -> None:
+    assert receipt.citations is not None
+    fingerprints = {
+        (fingerprint.dependency_id, fingerprint.dependency_kind): fingerprint
+        for fingerprint in receipt.citations.dependency_fingerprints
+    }
+    fingerprint = fingerprints.get((ref.artifact_id, ref.artifact_kind))
+    if fingerprint is None:
+        return
+
+    body = envelope.body
+    if (
+        body.get("dependency_kind") != fingerprint.dependency_kind
+        or body.get("dependency_id") != fingerprint.dependency_id
+        or body.get("fingerprint") != fingerprint.fingerprint
+        or body.get("digest_alg") != fingerprint.digest_alg
+    ):
+        raise ReceiptEnvelopeSetBuildError(
+            "Receipt envelope set dependency fingerprint mismatch: "
+            f"{ref.artifact_id}."
+        )
+
+
+__all__ = [
+    "ArtifactMaterial",
+    "ArtifactRecorder",
+    "ReceiptEnvelopeSetBuildError",
+    "build_receipt_envelope_set",
+]

--- a/docs/architecture/contracts/artifact-envelope-builder.md
+++ b/docs/architecture/contracts/artifact-envelope-builder.md
@@ -460,6 +460,44 @@ verify reference catalog snapshot coverage
 If replay requires data that the builder does not preserve, the builder contract
 is incomplete and should be updated before adding another backend.
 
+## Current Implementation Status
+
+The first production receipt coverage builder lives in:
+
+```text
+comp.persistence.envelope_builder
+```
+
+`comp.persistence.envelope_builder` is a persistence module, not a compiler-run
+adapter.
+
+It exposes:
+
+```text
+ArtifactMaterial
+ReceiptEnvelopeSetBuildError
+build_receipt_envelope_set(...)
+```
+
+`build_receipt_envelope_set(...)` consumes a `PublicOutputReceipt` and
+compiler-agnostic `ArtifactMaterial` items. It derives required refs from
+`receipt_artifact_refs(...)`, verifies cited material coverage, builds
+`ArtifactEnvelope` objects, and can optionally record the envelopes into a store
+through a `record(...)` boundary.
+
+The implementation does not import `comp.compiler_tool`, does not inspect
+compiler reports, and does not produce compiler-run material. The
+compiler-aware materializer remains a later adapter slice.
+
+Coverage lives in:
+
+```text
+tests/test_artifact_envelope_builder.py
+```
+
+`tests/test_artifact_envelope_builder.py` pins the compiler-agnostic coverage
+builder behavior.
+
 ## Testing Expectations
 
 Tests for the first production builder should cover:

--- a/tests/test_artifact_envelope_builder.py
+++ b/tests/test_artifact_envelope_builder.py
@@ -1,0 +1,181 @@
+import pytest
+
+from comp.persistence import (
+    ArtifactMaterial,
+    InMemoryArtifactStore,
+    ReceiptEnvelopeSetBuildError,
+    build_receipt_envelope_set,
+    replay_public_projection,
+)
+from tests.support.persistence_cases import (
+    artifact_body_for_ref,
+    receipt_projection_case,
+)
+
+
+def _material_for_ref(ref, *, committed_values=None):
+    return ArtifactMaterial(
+        artifact_id=ref.artifact_id,
+        artifact_kind=ref.artifact_kind,
+        schema_version="v1",
+        body=artifact_body_for_ref(ref, committed_values=committed_values),
+    )
+
+
+def _materials_for_receipt(receipt, *, committed_values=None):
+    from comp.persistence import receipt_artifact_refs
+
+    return tuple(
+        _material_for_ref(ref, committed_values=committed_values)
+        for ref in receipt_artifact_refs(receipt)
+    )
+
+
+def test_build_receipt_envelope_set_covers_receipt_refs_and_replays():
+    case = receipt_projection_case(amount=100)
+    materials = _materials_for_receipt(
+        case.receipt,
+        committed_values=case.source_values,
+    )
+
+    envelopes = build_receipt_envelope_set(case.receipt, materials)
+    store = InMemoryArtifactStore()
+    for envelope in envelopes:
+        store.record(envelope)
+
+    replay = replay_public_projection(
+        case.source_values,
+        case.projection,
+        receipt=case.receipt,
+        artifacts=store,
+    )
+
+    assert {envelope.artifact_id for envelope in envelopes} == {
+        ref.artifact_id for ref in replay.artifact_refs
+    }
+    assert replay.public_row == case.public_row
+
+
+def test_build_receipt_envelope_set_records_to_store_when_requested():
+    case = receipt_projection_case(amount=100)
+    store = InMemoryArtifactStore()
+
+    envelopes = build_receipt_envelope_set(
+        case.receipt,
+        _materials_for_receipt(case.receipt, committed_values=case.source_values),
+        record_to=store,
+    )
+
+    assert tuple(store.envelopes()) == envelopes
+
+
+def test_build_receipt_envelope_set_requires_receipt_citations():
+    case = receipt_projection_case(amount=100)
+    receipt = type(case.receipt)(
+        draft_id=case.receipt.draft_id,
+        winner_receipt_ids=case.receipt.winner_receipt_ids,
+        barrier_snapshot=case.receipt.barrier_snapshot,
+        public_row_id=case.receipt.public_row_id,
+        projection_id=case.receipt.projection_id,
+        authorized_fields=case.receipt.authorized_fields,
+        citations=None,
+    )
+
+    with pytest.raises(ReceiptEnvelopeSetBuildError, match="citations"):
+        build_receipt_envelope_set(receipt, ())
+
+
+def test_build_receipt_envelope_set_fails_when_cited_material_is_missing():
+    case = receipt_projection_case(amount=100)
+    materials = tuple(
+        material
+        for material in _materials_for_receipt(
+            case.receipt,
+            committed_values=case.source_values,
+        )
+        if material.artifact_id != "decision-1"
+    )
+
+    with pytest.raises(ReceiptEnvelopeSetBuildError, match="missing artifact"):
+        build_receipt_envelope_set(case.receipt, materials)
+
+
+def test_build_receipt_envelope_set_fails_when_required_kind_mismatches():
+    case = receipt_projection_case(amount=100)
+    materials = tuple(
+        ArtifactMaterial(
+            artifact_id=material.artifact_id,
+            artifact_kind="commit_package",
+            schema_version=material.schema_version,
+            body=material.body,
+        )
+        if material.artifact_id == "decision-1"
+        else material
+        for material in _materials_for_receipt(
+            case.receipt,
+            committed_values=case.source_values,
+        )
+    )
+
+    with pytest.raises(ReceiptEnvelopeSetBuildError, match="artifact kind"):
+        build_receipt_envelope_set(case.receipt, materials)
+
+
+def test_build_receipt_envelope_set_fails_on_duplicate_conflicting_material():
+    case = receipt_projection_case(amount=100)
+    materials = list(
+        _materials_for_receipt(case.receipt, committed_values=case.source_values)
+    )
+    materials.append(
+        ArtifactMaterial(
+            artifact_id="decision-1",
+            artifact_kind="governance_decision",
+            schema_version="v1",
+            body={"decision_id": "decision-1", "status": "changed"},
+        )
+    )
+
+    with pytest.raises(ReceiptEnvelopeSetBuildError, match="conflicting material"):
+        build_receipt_envelope_set(case.receipt, materials)
+
+
+def test_build_receipt_envelope_set_requires_committed_value_source_body():
+    case = receipt_projection_case(amount=100)
+    materials = tuple(
+        ArtifactMaterial(
+            artifact_id=material.artifact_id,
+            artifact_kind=material.artifact_kind,
+            schema_version=material.schema_version,
+            body={"claim_id": material.artifact_id, "field": "amount"},
+        )
+        if material.artifact_id == "checked_claim:amount:span-amount"
+        else material
+        for material in _materials_for_receipt(
+            case.receipt,
+            committed_values=case.source_values,
+        )
+    )
+
+    with pytest.raises(ReceiptEnvelopeSetBuildError, match="committed value"):
+        build_receipt_envelope_set(case.receipt, materials)
+
+
+def test_build_receipt_envelope_set_checks_dependency_fingerprint_body():
+    case = receipt_projection_case(amount=100)
+    materials = tuple(
+        ArtifactMaterial(
+            artifact_id=material.artifact_id,
+            artifact_kind=material.artifact_kind,
+            schema_version=material.schema_version,
+            body={**material.body, "fingerprint": "sha256:wrong"},
+        )
+        if material.artifact_id == "fixture-factor"
+        else material
+        for material in _materials_for_receipt(
+            case.receipt,
+            committed_values=case.source_values,
+        )
+    )
+
+    with pytest.raises(ReceiptEnvelopeSetBuildError, match="dependency fingerprint"):
+        build_receipt_envelope_set(case.receipt, materials)

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -916,6 +916,10 @@ def test_artifact_envelope_builder_contract_separates_coverage_from_materializat
         "A compiler-run materializer may read compiler objects and produce artifact material.",
         "The materializer is outside `comp.persistence` and must not mint receipts, discharge requirements, or decide projection authority.",
         "Production code should generalize the materializer contract without making scenario fixtures authoritative.",
+        "## Current Implementation Status",
+        "`comp.persistence.envelope_builder`",
+        "`build_receipt_envelope_set(...)`",
+        "`tests/test_artifact_envelope_builder.py`",
     ):
         assert line in builder_doc
 
@@ -973,11 +977,14 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     from comp.persistence import (
         ArtifactStore,
         ArtifactEnvelope,
+        ArtifactMaterial,
         ArtifactRef,
         InMemoryArtifactStore,
         InMemoryReceiptLedger,
         ProjectionReplayReport,
+        ReceiptEnvelopeSetBuildError,
         artifact_digest,
+        build_receipt_envelope_set,
         replay_public_projection,
         verify_materialized_public_projection,
     )
@@ -1028,11 +1035,14 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert export_receipt_proof_graph is not None
     assert ArtifactStore is not None
     assert ArtifactEnvelope is not None
+    assert ArtifactMaterial is not None
     assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None
     assert InMemoryReceiptLedger is not None
     assert ProjectionReplayReport is not None
+    assert ReceiptEnvelopeSetBuildError is not None
     assert artifact_digest is not None
+    assert build_receipt_envelope_set is not None
     assert replay_public_projection is not None
     assert verify_materialized_public_projection is not None
 


### PR DESCRIPTION
## Summary
- Adds compiler-agnostic `comp.persistence.envelope_builder` with `ArtifactMaterial`, `ReceiptEnvelopeSetBuildError`, and `build_receipt_envelope_set(...)`.
- Keeps the builder under the receipt coverage role only: it derives required refs from `receipt_artifact_refs(...)`, verifies cited material, builds/records `ArtifactEnvelope`s, and does not import `comp.compiler_tool`.
- Updates the active Artifact Envelope Builder contract and package smoke coverage to pin the implementation boundary.

## Context
This is the implementation slice on top of #294, which split the ArtifactEnvelope builder contract into `ReceiptEnvelopeSetBuilder` and `CompilerRunArtifactMaterializer` roles.

## Validation
- `python -m pytest tests/test_artifact_envelope_builder.py tests/test_package_smoke.py::test_artifact_envelope_builder_contract_separates_coverage_from_materialization tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer tests/test_authority_import_boundaries.py -q` => 14 passed
- `python -m pytest -q` => 501 passed, 9 skipped
