### PR TITLE
[codex] Harden MySQL operating contract

### DIFF
--- a/comp/persistence/mysql.py
+++ b/comp/persistence/mysql.py
@@ -101,8 +101,7 @@ class MySQLArtifactStore:
 
     def record(self, envelope: ArtifactEnvelope) -> ArtifactEnvelope:
         verify_artifact_envelope(envelope)
-        existing = self._get_optional(envelope.artifact_id)
-        if existing is None:
+        try:
             with self.connection.cursor() as cursor:
                 cursor.execute(
                     """
@@ -124,16 +123,13 @@ class MySQLArtifactStore:
                 )
             self.connection.commit()
             return envelope
-        if (
-            existing.artifact_kind != envelope.artifact_kind
-            or existing.schema_version != envelope.schema_version
-            or existing.body_digest != envelope.body_digest
-        ):
-            raise ArtifactConflict(
-                f"Artifact already recorded with different content: "
-                f"{envelope.artifact_id}."
-            )
-        return existing
+        except Exception as exc:
+            _rollback(self.connection)
+            if _is_duplicate_key_error(exc):
+                existing = self._get_optional(envelope.artifact_id)
+                if existing is not None:
+                    return _resolve_artifact_duplicate(existing, envelope)
+            raise
 
     def get(self, artifact_id: str) -> ArtifactEnvelope:
         existing = self._get_optional(artifact_id)
@@ -176,8 +172,7 @@ class MySQLReceiptLedger:
 
     def record(self, receipt: PublicOutputReceipt) -> PublicOutputReceipt:
         key = ReceiptLedgerKey.from_receipt(receipt)
-        existing = self._get_optional(key)
-        if existing is None:
+        try:
             rid = receipt_id(receipt)
             body = commit_receipt_to_body(receipt)
             with self.connection.cursor() as cursor:
@@ -201,12 +196,13 @@ class MySQLReceiptLedger:
                 _insert_receipt_indexes(cursor, rid, receipt)
             self.connection.commit()
             return receipt
-        if existing != receipt:
-            raise ReceiptConflict(
-                f"Public-output receipt ledger root already recorded with "
-                f"different content: {key.public_row_id}."
-            )
-        return existing
+        except Exception as exc:
+            _rollback(self.connection)
+            if _is_duplicate_key_error(exc):
+                existing = self._get_optional(key)
+                if existing is not None:
+                    return _resolve_receipt_duplicate(existing, receipt, key)
+            raise
 
     def get(
         self,
@@ -253,6 +249,49 @@ def receipt_id(receipt: PublicOutputReceipt) -> str:
     canonical = _json_dump(encode_persistence_json(body))
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return f"receipt:sha256:{digest}"
+
+
+def _resolve_artifact_duplicate(
+    existing: ArtifactEnvelope,
+    envelope: ArtifactEnvelope,
+) -> ArtifactEnvelope:
+    if (
+        existing.artifact_kind != envelope.artifact_kind
+        or existing.schema_version != envelope.schema_version
+        or existing.body_digest != envelope.body_digest
+    ):
+        raise ArtifactConflict(
+            f"Artifact already recorded with different content: "
+            f"{envelope.artifact_id}."
+        )
+    return existing
+
+
+def _resolve_receipt_duplicate(
+    existing: PublicOutputReceipt,
+    receipt: PublicOutputReceipt,
+    key: ReceiptLedgerKey,
+) -> PublicOutputReceipt:
+    if existing != receipt:
+        raise ReceiptConflict(
+            f"Public-output receipt ledger root already recorded with "
+            f"different content: {key.public_row_id}."
+        )
+    return existing
+
+
+def _is_duplicate_key_error(exc: Exception) -> bool:
+    args = getattr(exc, "args", ())
+    if args:
+        code = args[0]
+        return code == 1062 or str(code) == "1062"
+    return False
+
+
+def _rollback(connection: Any) -> None:
+    rollback = getattr(connection, "rollback", None)
+    if rollback is not None:
+        rollback()
 
 
 def _insert_receipt_indexes(

--- a/tests/test_mysql_operating_contract.py
+++ b/tests/test_mysql_operating_contract.py
@@ -1,7 +1,19 @@
+from dataclasses import replace
+
+import pytest
+
+from comp.persistence import ArtifactConflict, ReceiptConflict
+from comp.persistence.codec import (
+    commit_receipt_to_body,
+    encode_persistence_json,
+)
 from comp.persistence.mysql import (
     TRUST_SPINE_SCHEMA_STATEMENTS,
+    MySQLArtifactStore,
+    MySQLReceiptLedger,
     apply_trust_spine_schema,
 )
+from tests.support.persistence_cases import claim_envelope, receipt_projection_case
 
 
 class RecordingConnection:
@@ -59,3 +71,155 @@ def test_trust_spine_indexes_are_receipt_derived_not_independent_authority():
     assert schema.count(
         "foreign key (receipt_id) references ledger_commit_receipts(receipt_id)"
     ) == 3
+
+
+def test_artifact_duplicate_key_rechecks_existing_envelope():
+    envelope = claim_envelope(value=1200)
+    connection = SequencedConnection(
+        select_rows=[_artifact_row(envelope)],
+        failures=[InsertFailure("artifact_envelopes", DuplicateKeyError())],
+    )
+
+    recorded = MySQLArtifactStore(connection).record(envelope)
+
+    assert recorded == envelope
+    assert connection.rollbacks == 1
+    assert connection.commits == 0
+
+
+def test_artifact_duplicate_key_conflict_raises_domain_error():
+    existing = claim_envelope(value=1200)
+    incoming = claim_envelope(value=1201)
+    connection = SequencedConnection(
+        select_rows=[_artifact_row(existing)],
+        failures=[InsertFailure("artifact_envelopes", DuplicateKeyError())],
+    )
+
+    with pytest.raises(ArtifactConflict, match="artifact:claim:1"):
+        MySQLArtifactStore(connection).record(incoming)
+
+    assert connection.rollbacks == 1
+    assert connection.commits == 0
+
+
+def test_receipt_duplicate_key_conflict_raises_domain_error():
+    receipt = receipt_projection_case(amount=100).receipt
+    changed = replace(receipt, authorized_fields=("site",))
+    connection = SequencedConnection(
+        select_rows=[_receipt_row(receipt)],
+        failures=[InsertFailure("ledger_commit_receipts", DuplicateKeyError())],
+    )
+
+    with pytest.raises(ReceiptConflict, match="public-row-1"):
+        MySQLReceiptLedger(connection).record(changed)
+
+    assert connection.rollbacks == 1
+    assert connection.commits == 0
+
+
+def test_receipt_index_insert_failure_rolls_back_root_transaction():
+    receipt = receipt_projection_case(amount=100).receipt
+    connection = SequencedConnection(
+        select_rows=[None],
+        failures=[
+            InsertFailure(
+                "ledger_receipt_value_commitments",
+                IndexInsertError("index insert failed"),
+            )
+        ],
+    )
+
+    with pytest.raises(IndexInsertError):
+        MySQLReceiptLedger(connection).record(receipt)
+
+    assert connection.rollbacks == 1
+    assert connection.commits == 0
+
+
+class DuplicateKeyError(Exception):
+    def __init__(self):
+        super().__init__(1062, "Duplicate entry")
+
+
+class IndexInsertError(Exception):
+    pass
+
+
+class InsertFailure:
+    def __init__(self, table: str, error: Exception):
+        self.table = table
+        self.error = error
+
+
+class SequencedConnection:
+    def __init__(self, *, select_rows, failures):
+        self.select_rows = list(select_rows)
+        self.failures = list(failures)
+        self.executed = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self):
+        return SequencedCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+class SequencedCursor:
+    def __init__(self, connection):
+        self.connection = connection
+        self._row = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def execute(self, statement, params=None):
+        self.connection.executed.append((statement, params))
+        normalized = " ".join(statement.lower().split())
+        if normalized.startswith("select "):
+            self._row = self.connection.select_rows.pop(0)
+            return
+        for index, failure in enumerate(self.connection.failures):
+            if f"insert into {failure.table}" in normalized:
+                self.connection.failures.pop(index)
+                raise failure.error
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return ()
+
+
+def _artifact_row(envelope):
+    return (
+        envelope.artifact_id,
+        envelope.artifact_kind,
+        envelope.schema_version,
+        envelope.body_digest,
+        _json_dump(encode_persistence_json(envelope.body)),
+        _json_dump(encode_persistence_json(envelope.source_refs)),
+        _json_dump(encode_persistence_json(envelope.meta)),
+    )
+
+
+def _receipt_row(receipt):
+    return (_json_dump(encode_persistence_json(commit_receipt_to_body(receipt))),)
+
+
+def _json_dump(value):
+    import json
+
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )

--- a/tests/test_mysql_persistence_spine.py
+++ b/tests/test_mysql_persistence_spine.py
@@ -1,4 +1,7 @@
+import json
 import os
+import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from decimal import Decimal
 from typing import get_type_hints
@@ -14,6 +17,7 @@ from comp.persistence import (
     replay_public_projection,
     verify_artifact_envelope,
 )
+from comp.persistence.codec import commit_receipt_to_body, encode_persistence_json
 from tests.support.persistence_cases import (
     artifact_store_for_receipt,
     claim_envelope,
@@ -171,6 +175,64 @@ def test_mysql_artifact_store_rejects_conflicting_content():
         connection.close()
 
 
+def test_mysql_artifact_store_returns_existing_after_duplicate_insert_race():
+    from comp.persistence.mysql import MySQLArtifactStore, apply_trust_spine_schema
+
+    writer = _connect_mysql()
+    contender = _connect_mysql()
+    inspector = _connect_mysql()
+    envelope = claim_envelope(value=1200)
+    try:
+        apply_trust_spine_schema(writer)
+        _reset_spine(writer)
+        _insert_artifact_envelope(writer, envelope)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(MySQLArtifactStore(contender).record, envelope)
+            _allow_lock_wait(future)
+            writer.commit()
+
+            assert future.result(timeout=5) == envelope
+
+        assert _table_count(inspector, "artifact_envelopes") == 1
+    finally:
+        writer.rollback()
+        contender.rollback()
+        writer.close()
+        contender.close()
+        inspector.close()
+
+
+def test_mysql_artifact_store_conflict_after_duplicate_insert_race():
+    from comp.persistence.mysql import MySQLArtifactStore, apply_trust_spine_schema
+
+    writer = _connect_mysql()
+    contender = _connect_mysql()
+    inspector = _connect_mysql()
+    existing = claim_envelope(value=1200)
+    incoming = claim_envelope(value=1201)
+    try:
+        apply_trust_spine_schema(writer)
+        _reset_spine(writer)
+        _insert_artifact_envelope(writer, existing)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(MySQLArtifactStore(contender).record, incoming)
+            _allow_lock_wait(future)
+            writer.commit()
+
+            with pytest.raises(ArtifactConflict, match="artifact:claim:1"):
+                future.result(timeout=5)
+
+        assert _table_count(inspector, "artifact_envelopes") == 1
+    finally:
+        writer.rollback()
+        contender.rollback()
+        writer.close()
+        contender.close()
+        inspector.close()
+
+
 def test_mysql_artifact_store_rejects_invalid_digest():
     from comp.persistence.mysql import MySQLArtifactStore, apply_trust_spine_schema
 
@@ -228,6 +290,36 @@ def test_mysql_receipt_ledger_rejects_conflicting_receipt_root():
         connection.close()
 
 
+def test_mysql_receipt_ledger_conflict_after_duplicate_insert_race():
+    from comp.persistence.mysql import MySQLReceiptLedger, apply_trust_spine_schema
+
+    writer = _connect_mysql()
+    contender = _connect_mysql()
+    inspector = _connect_mysql()
+    receipt = receipt_projection_case(amount=100).receipt
+    changed = replace(receipt, authorized_fields=("site",))
+    try:
+        apply_trust_spine_schema(writer)
+        _reset_spine(writer)
+        _insert_receipt_root(writer, receipt)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(MySQLReceiptLedger(contender).record, changed)
+            _allow_lock_wait(future)
+            writer.commit()
+
+            with pytest.raises(ReceiptConflict, match="public-row-1"):
+                future.result(timeout=5)
+
+        assert _table_count(inspector, "ledger_commit_receipts") == 1
+    finally:
+        writer.rollback()
+        contender.rollback()
+        writer.close()
+        contender.close()
+        inspector.close()
+
+
 def test_mysql_receipt_ledger_populates_receipt_indexes():
     from comp.persistence.mysql import MySQLReceiptLedger, apply_trust_spine_schema
 
@@ -253,6 +345,29 @@ def test_mysql_receipt_ledger_populates_receipt_indexes():
     assert value_commitments == len(receipt.citations.projection_value_commitments)
     assert dependencies == len(receipt.citations.dependency_fingerprints)
     assert refs == len(set(receipt_artifact_refs(receipt)))
+
+
+def test_mysql_receipt_ledger_rolls_back_root_when_index_insert_fails():
+    from comp.persistence.mysql import MySQLReceiptLedger, apply_trust_spine_schema
+
+    connection = _connect_mysql()
+    try:
+        apply_trust_spine_schema(connection)
+        _reset_spine(connection)
+        receipt = _receipt_with_duplicate_value_commitments()
+
+        with pytest.raises(Exception):
+            MySQLReceiptLedger(connection).record(receipt)
+
+        assert _spine_counts(connection) == {
+            "ledger_commit_receipts": 0,
+            "ledger_receipt_value_commitments": 0,
+            "ledger_receipt_dependency_fingerprints": 0,
+            "ledger_receipt_artifact_refs": 0,
+        }
+    finally:
+        connection.rollback()
+        connection.close()
 
 
 def test_mysql_artifact_store_supports_replay_public_projection():
@@ -354,3 +469,92 @@ def _payload_has_key(value, key: str) -> bool:
     if isinstance(value, (tuple, list)):
         return any(_payload_has_key(item, key) for item in value)
     return False
+
+
+def _allow_lock_wait(future):
+    time.sleep(0.2)
+    assert not future.done()
+
+
+def _insert_artifact_envelope(connection, envelope):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            insert into artifact_envelopes (
+              artifact_id, artifact_kind, schema_version, body_digest,
+              body, source_refs, meta
+            )
+            values (%s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                envelope.artifact_id,
+                envelope.artifact_kind,
+                envelope.schema_version,
+                envelope.body_digest,
+                _json_dump(encode_persistence_json(envelope.body)),
+                _json_dump(encode_persistence_json(envelope.source_refs)),
+                _json_dump(encode_persistence_json(envelope.meta)),
+            ),
+        )
+
+
+def _insert_receipt_root(connection, receipt):
+    from comp.persistence.mysql import receipt_id
+
+    rid = receipt_id(receipt)
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            insert into ledger_commit_receipts (
+              receipt_id, public_row_id, projection_id, draft_id,
+              receipt_digest, receipt_body
+            )
+            values (%s, %s, %s, %s, %s, %s)
+            """,
+            (
+                rid,
+                receipt.public_row_id,
+                receipt.projection_id,
+                receipt.draft_id,
+                rid.removeprefix("receipt:"),
+                _json_dump(encode_persistence_json(commit_receipt_to_body(receipt))),
+            ),
+        )
+
+
+def _receipt_with_duplicate_value_commitments():
+    receipt = receipt_projection_case(amount=100).receipt
+    assert receipt.citations is not None
+    first = receipt.citations.projection_value_commitments[0]
+    citations = replace(
+        receipt.citations,
+        projection_value_commitments=(first, first),
+    )
+    return replace(receipt, citations=citations)
+
+
+def _spine_counts(connection):
+    return {
+        table: _table_count(connection, table)
+        for table in (
+            "ledger_commit_receipts",
+            "ledger_receipt_value_commitments",
+            "ledger_receipt_dependency_fingerprints",
+            "ledger_receipt_artifact_refs",
+        )
+    }
+
+
+def _table_count(connection, table):
+    with connection.cursor() as cursor:
+        cursor.execute(f"select count(*) from {table}")
+        return cursor.fetchone()[0]
+
+
+def _json_dump(value):
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )


### PR DESCRIPTION
## Summary

- Change `MySQLArtifactStore.record()` and `MySQLReceiptLedger.record()` to use insert-first persistence with duplicate-key recovery.
- Convert duplicate artifact/receipt races into idempotent returns or domain conflicts instead of leaking raw database errors.
- Roll back failed artifact and receipt writes, including receipt root + derived index transactions.
- Add operating-contract unit tests and MySQL integration tests for duplicate insert races and index rollback.

## Why

The MySQL trust spine already had the right authority shape, but the read-before-insert flow left a TOCTOU gap. In a product database, concurrent writes could surface raw duplicate-key errors or leave dirty transaction state instead of preserving the artifact/receipt authority contract.

## Validation

- `COMP_TEST_MYSQL_HOST=127.0.0.1 COMP_TEST_MYSQL_PORT=3307 COMP_TEST_MYSQL_USER=comp COMP_TEST_MYSQL_PASSWORD=comp COMP_TEST_MYSQL_DATABASE=comp_test python -m pytest -q` -> 510 passed
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `git diff --check` -> no whitespace errors

MySQL validation used a local `mysql:8.4` container published as `127.0.0.1:3307`.