### PR TITLE
[codex] Add compiler run artifact materializer

### DIFF
--- a/comp/runtime/__init__.py
+++ b/comp/runtime/__init__.py
@@ -1,5 +1,13 @@
 """Runtime primitives that execute the comp trust path without product ingestion."""
 
+from comp.runtime.compiler_run_artifacts import (
+    CompilerRunArtifactMaterializationError,
+    materialize_compiler_run_artifacts,
+)
 from comp.runtime.trust_runtime import TrustRuntime
 
-__all__ = ["TrustRuntime"]
+__all__ = [
+    "CompilerRunArtifactMaterializationError",
+    "TrustRuntime",
+    "materialize_compiler_run_artifacts",
+]

--- a/comp/runtime/compiler_run_artifacts.py
+++ b/comp/runtime/compiler_run_artifacts.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from comp.compiler_tool import (
+    CommitPreparation,
+    ValidationReport,
+    evidence_ref_fingerprint,
+)
+from comp.persistence import ArtifactMaterial, ArtifactRef, receipt_artifact_refs
+
+
+class CompilerRunArtifactMaterializationError(RuntimeError):
+    """Raised when a compiler run cannot be serialized into artifact material."""
+
+
+def materialize_compiler_run_artifacts(
+    report: ValidationReport,
+    preparation: CommitPreparation,
+    *,
+    external_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]] | None = None,
+    schema_version: str = "compiler-run-v1",
+) -> tuple[ArtifactMaterial, ...]:
+    receipt = preparation.receipt
+    if receipt is None:
+        raise CompilerRunArtifactMaterializationError(
+            "Compiler run artifact materialization requires a receipt."
+        )
+
+    external_bodies = external_artifact_bodies or {}
+    return tuple(
+        ArtifactMaterial(
+            artifact_id=ref.artifact_id,
+            artifact_kind=ref.artifact_kind,
+            schema_version=schema_version,
+            body=_artifact_body_for_ref(report, preparation, external_bodies, ref),
+        )
+        for ref in receipt_artifact_refs(receipt)
+    )
+
+
+def _artifact_body_for_ref(
+    report: ValidationReport,
+    preparation: CommitPreparation,
+    external_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+    ref: ArtifactRef,
+) -> Mapping[str, Any]:
+    if ref.artifact_kind == "commit_package":
+        package = preparation.package
+        return {
+            "package_id": package.package_id,
+            "subject_id": package.subject_id,
+            "report_status": package.report_status,
+            "complete": package.complete,
+            "checked_claim_fields": package.checked_claim_fields,
+            "checked_claim_witness_ids": package.checked_claim_witness_ids,
+            "semantic_judgment_ids": package.semantic_judgment_ids,
+            "reference_binding_ids": package.reference_binding_ids,
+            "derived_claim_fields": package.derived_claim_fields,
+            "derived_claim_ids": package.derived_claim_ids,
+            "calculation_trace_ids": package.calculation_trace_ids,
+            "formula_ids": package.formula_ids,
+            "open_obligation_ids": package.open_obligation_ids,
+            "resolved_obligation_ids": package.resolved_obligation_ids,
+            "hazard_ids": package.hazard_ids,
+            "profile_id": package.profile_id,
+            "projection_value_commitments": tuple(
+                _projection_value_commitment_body(commitment)
+                for commitment in package.projection_value_commitments
+            ),
+            "dependency_fingerprints": tuple(
+                _dependency_fingerprint_body(fingerprint)
+                for fingerprint in package.dependency_fingerprints
+            ),
+        }
+    if ref.artifact_kind == "governance_decision":
+        decision = preparation.decision
+        return {
+            "decision_id": decision.decision_id,
+            "package_id": decision.package_id,
+            "subject_id": decision.subject_id,
+            "status": decision.status,
+            "reasons": decision.reasons,
+            "profile_id": decision.profile_id,
+        }
+    if ref.artifact_kind == "checked_claim":
+        claim = _checked_claim_by_source_id(report, ref.artifact_id)
+        return {
+            "claim_id": ref.artifact_id,
+            "field": claim.field,
+            "value": claim.value,
+            "witness_id": claim.witness_id,
+            "origin": claim.origin,
+        }
+    if ref.artifact_kind == "evidence_witness":
+        witness = _evidence_witness_by_id(report, ref.artifact_id)
+        fingerprint = evidence_ref_fingerprint(witness)
+        return {
+            "dependency_kind": fingerprint.dependency_kind,
+            "dependency_id": fingerprint.dependency_id,
+            "witness_id": witness.witness_id,
+            "field": witness.field,
+            "source": witness.source,
+            "span": witness.span,
+            "text": witness.text,
+            "fingerprint": fingerprint.fingerprint,
+            "digest_alg": fingerprint.digest_alg,
+        }
+    if ref.artifact_kind == "reference_binding":
+        binding = _by_id(report.canonical_references, ref.artifact_id, "binding_id")
+        return {
+            "binding_id": binding.binding_id,
+            "claim_id": binding.claim_id,
+            "reference_id": binding.reference_id,
+            "reference_type": binding.reference_type,
+            "selected_candidate_id": binding.selected_candidate_id,
+            "selector_rule_id": binding.selector_rule_id,
+            "source_witness_ids": binding.source_witness_ids,
+            "rejected_candidates": tuple(
+                {
+                    "candidate_id": candidate.candidate_id,
+                    "reference_id": candidate.reference_id,
+                    "reason": candidate.reason,
+                    "selector_rule_id": candidate.selector_rule_id,
+                }
+                for candidate in binding.rejected_candidates
+            ),
+            "authority": binding.authority,
+        }
+    if ref.artifact_kind == "derived_claim":
+        claim = _by_id(report.calculated_claims, ref.artifact_id, "claim_id")
+        return {
+            "claim_id": claim.claim_id,
+            "field": claim.field,
+            "value": claim.value,
+            "unit": claim.unit,
+            "formula_id": claim.formula_id,
+            "trace_id": claim.trace.trace_id,
+            "origin": claim.origin,
+        }
+    if ref.artifact_kind == "calculation_trace":
+        trace = _trace_by_id(report, ref.artifact_id)
+        return {
+            "trace_id": trace.trace_id,
+            "formula_id": trace.formula_id,
+            "input_claim_ids": trace.input_claim_ids,
+            "reference_binding_ids": trace.reference_binding_ids,
+            "steps": tuple(
+                {
+                    "step_id": step.step_id,
+                    "operation": step.operation,
+                    "input_ids": step.input_ids,
+                    "output_value": step.output_value,
+                    "output_unit": step.output_unit,
+                    "exact_output_value": step.exact_output_value,
+                    "rounding_quantum": step.rounding_quantum,
+                    "rounding_mode": step.rounding_mode,
+                }
+                for step in trace.steps
+            ),
+        }
+    if ref.artifact_kind == "formula":
+        return {
+            "formula_id": ref.artifact_id,
+            "derived_claim_ids": tuple(
+                claim.claim_id
+                for claim in report.calculated_claims
+                if claim.formula_id == ref.artifact_id
+            ),
+        }
+    return _external_body(ref, external_artifact_bodies)
+
+
+def _external_body(
+    ref: ArtifactRef,
+    external_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> Mapping[str, Any]:
+    try:
+        return dict(external_artifact_bodies[(ref.artifact_kind, ref.artifact_id)])
+    except KeyError as exc:
+        raise CompilerRunArtifactMaterializationError(
+            "Compiler run artifact materialization missing external artifact body: "
+            f"{ref.artifact_kind}:{ref.artifact_id}."
+        ) from exc
+
+
+def _projection_value_commitment_body(commitment) -> dict[str, str]:
+    return {
+        "field": commitment.field,
+        "source_kind": commitment.source_kind,
+        "source_id": commitment.source_id,
+        "value_digest": commitment.value_digest,
+        "digest_alg": commitment.digest_alg,
+    }
+
+
+def _dependency_fingerprint_body(fingerprint) -> dict[str, str]:
+    return {
+        "dependency_kind": fingerprint.dependency_kind,
+        "dependency_id": fingerprint.dependency_id,
+        "fingerprint": fingerprint.fingerprint,
+        "digest_alg": fingerprint.digest_alg,
+    }
+
+
+def _checked_claim_by_source_id(report: ValidationReport, source_id: str):
+    for claim in report.checked_claims:
+        if source_id == f"checked_claim:{claim.field}:{claim.witness_id}":
+            return claim
+    raise CompilerRunArtifactMaterializationError(
+        f"Compiler run artifact materialization missing checked claim: {source_id}."
+    )
+
+
+def _evidence_witness_by_id(report: ValidationReport, witness_id: str):
+    for witness in report.evidence_refs:
+        if witness.witness_id == witness_id:
+            return witness
+    raise CompilerRunArtifactMaterializationError(
+        f"Compiler run artifact materialization missing evidence witness: {witness_id}."
+    )
+
+
+def _trace_by_id(report: ValidationReport, trace_id: str):
+    for claim in report.calculated_claims:
+        if claim.trace.trace_id == trace_id:
+            return claim.trace
+    raise CompilerRunArtifactMaterializationError(
+        f"Compiler run artifact materialization missing calculation trace: {trace_id}."
+    )
+
+
+def _by_id(items, item_id: str, field: str):
+    for item in items:
+        if getattr(item, field) == item_id:
+            return item
+    raise CompilerRunArtifactMaterializationError(
+        f"Compiler run artifact materialization missing artifact: {item_id}."
+    )
+
+
+__all__ = [
+    "CompilerRunArtifactMaterializationError",
+    "materialize_compiler_run_artifacts",
+]

--- a/comp/scenario_contracts/__init__.py
+++ b/comp/scenario_contracts/__init__.py
@@ -26,7 +26,14 @@ from comp.scenario_contracts.manifest import (
 )
 from comp.scenario_contracts.report import write_report
 from comp.scenario_contracts.result import InvariantResult, ScenarioResult
-from comp.scenario_contracts.runner import run_scenario
+
+
+def __getattr__(name: str):
+    if name == "run_scenario":
+        from comp.scenario_contracts.runner import run_scenario
+
+        return run_scenario
+    raise AttributeError(name)
 
 __all__ = [
     "InvariantResult",

--- a/docs/architecture/contracts/artifact-envelope-builder.md
+++ b/docs/architecture/contracts/artifact-envelope-builder.md
@@ -486,17 +486,43 @@ compiler-agnostic `ArtifactMaterial` items. It derives required refs from
 through a `record(...)` boundary.
 
 The implementation does not import `comp.compiler_tool`, does not inspect
-compiler reports, and does not produce compiler-run material. The
-compiler-aware materializer remains a later adapter slice.
+compiler reports, and does not produce compiler-run material.
+
+The first production compiler-run materializer lives in:
+
+```text
+comp.runtime.compiler_run_artifacts
+```
+
+`comp.runtime.compiler_run_artifacts` is a runtime adapter, not a persistence
+module and not a receipt gate.
+
+It exposes:
+
+```text
+CompilerRunArtifactMaterializationError
+materialize_compiler_run_artifacts(...)
+```
+
+`materialize_compiler_run_artifacts(...)` consumes `ValidationReport`,
+`CommitPreparation`, and externally supplied dependency artifact bodies. It
+requires an already-issued receipt on the preparation, derives the receipt refs,
+and returns `ArtifactMaterial` for `build_receipt_envelope_set(...)`.
+
+The materializer may inspect compiler objects to serialize compiler-run
+material. It must not mint receipts, call `build_public_output(...)`, record
+envelopes, or decide projection authority.
 
 Coverage lives in:
 
 ```text
 tests/test_artifact_envelope_builder.py
+tests/test_compiler_run_artifact_materializer.py
 ```
 
 `tests/test_artifact_envelope_builder.py` pins the compiler-agnostic coverage
-builder behavior.
+builder behavior. `tests/test_compiler_run_artifact_materializer.py` pins the
+compiler-aware adapter behavior.
 
 ## Testing Expectations
 

--- a/tests/support/synthetic/replay.py
+++ b/tests/support/synthetic/replay.py
@@ -7,18 +7,16 @@ from typing import Any
 from comp.compiler_tool import (
     CommitPreparation,
     ValidationReport,
-    evidence_ref_fingerprint,
 )
 from comp.judgment import PublicOutputSpec
 from comp.persistence import (
-    ArtifactEnvelope,
-    ArtifactRef,
     InMemoryArtifactStore,
     InMemoryReceiptLedger,
     ProjectionReplayReport,
-    receipt_artifact_refs,
+    build_receipt_envelope_set,
     replay_public_projection,
 )
+from comp.runtime import materialize_compiler_run_artifacts
 
 
 @dataclass(frozen=True)
@@ -37,15 +35,13 @@ def synthetic_replay_bundle(
         raise AssertionError("Synthetic replay requires a commit receipt.")
 
     artifacts = InMemoryArtifactStore()
-    for ref in receipt_artifact_refs(receipt):
-        artifacts.record(
-            _artifact_envelope_for_ref(
-                report,
-                preparation,
-                dependency_artifact_bodies,
-                ref,
-            )
-        )
+    materials = materialize_compiler_run_artifacts(
+        report,
+        preparation,
+        external_artifact_bodies=dependency_artifact_bodies,
+        schema_version="synthetic-scenario-v1",
+    )
+    build_receipt_envelope_set(receipt, materials, record_to=artifacts)
 
     receipt_ledger = InMemoryReceiptLedger()
     receipt_ledger.record(receipt)
@@ -77,168 +73,6 @@ def replay_synthetic_projection(
         receipt=ledger_receipt,
         artifacts=bundle.artifacts,
     )
-
-
-def _artifact_envelope_for_ref(
-    report: ValidationReport,
-    preparation: CommitPreparation,
-    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
-    ref: ArtifactRef,
-) -> ArtifactEnvelope:
-    return ArtifactEnvelope.from_body(
-        artifact_id=ref.artifact_id,
-        artifact_kind=ref.artifact_kind,
-        schema_version="synthetic-scenario-v1",
-        body=_artifact_body_for_ref(
-            report,
-            preparation,
-            dependency_artifact_bodies,
-            ref,
-        ),
-    )
-
-
-def _artifact_body_for_ref(
-    report: ValidationReport,
-    preparation: CommitPreparation,
-    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
-    ref: ArtifactRef,
-) -> dict[str, Any]:
-    dependency_body = dependency_artifact_bodies.get(
-        (ref.artifact_kind, ref.artifact_id)
-    )
-    if dependency_body is not None:
-        return dict(dependency_body)
-
-    if ref.artifact_kind == "commit_package":
-        package = preparation.package
-        return {
-            "package_id": package.package_id,
-            "subject_id": package.subject_id,
-            "report_status": package.report_status,
-            "complete": package.complete,
-            "reference_binding_ids": package.reference_binding_ids,
-            "derived_claim_ids": package.derived_claim_ids,
-            "calculation_trace_ids": package.calculation_trace_ids,
-            "formula_ids": package.formula_ids,
-            "open_obligation_ids": package.open_obligation_ids,
-            "hazard_ids": package.hazard_ids,
-        }
-    if ref.artifact_kind == "governance_decision":
-        decision = preparation.decision
-        return {
-            "decision_id": decision.decision_id,
-            "package_id": decision.package_id,
-            "subject_id": decision.subject_id,
-            "status": decision.status,
-            "reasons": decision.reasons,
-            "profile_id": decision.profile_id,
-        }
-    if ref.artifact_kind == "checked_claim":
-        claim = _checked_claim_by_source_id(report, ref.artifact_id)
-        return {
-            "claim_id": ref.artifact_id,
-            "field": claim.field,
-            "value": claim.value,
-            "witness_id": claim.witness_id,
-            "origin": claim.origin,
-        }
-    if ref.artifact_kind == "evidence_witness":
-        witness = _evidence_witness_by_id(report, ref.artifact_id)
-        fingerprint = evidence_ref_fingerprint(witness)
-        return {
-            "dependency_kind": fingerprint.dependency_kind,
-            "dependency_id": fingerprint.dependency_id,
-            "witness_id": witness.witness_id,
-            "field": witness.field,
-            "source": witness.source,
-            "span": witness.span,
-            "text": witness.text,
-            "fingerprint": fingerprint.fingerprint,
-            "digest_alg": fingerprint.digest_alg,
-        }
-    if ref.artifact_kind == "reference_binding":
-        binding = _by_id(report.canonical_references, ref.artifact_id, "binding_id")
-        return {
-            "binding_id": binding.binding_id,
-            "claim_id": binding.claim_id,
-            "reference_id": binding.reference_id,
-            "reference_type": binding.reference_type,
-            "selected_candidate_id": binding.selected_candidate_id,
-            "selector_rule_id": binding.selector_rule_id,
-            "source_witness_ids": binding.source_witness_ids,
-            "rejected_candidates": tuple(
-                {
-                    "candidate_id": candidate.candidate_id,
-                    "reference_id": candidate.reference_id,
-                    "reason": candidate.reason,
-                    "selector_rule_id": candidate.selector_rule_id,
-                }
-                for candidate in binding.rejected_candidates
-            ),
-            "authority": binding.authority,
-        }
-    if ref.artifact_kind == "derived_claim":
-        claim = _by_id(report.calculated_claims, ref.artifact_id, "claim_id")
-        return {
-            "claim_id": claim.claim_id,
-            "field": claim.field,
-            "value": claim.value,
-            "unit": claim.unit,
-            "formula_id": claim.formula_id,
-            "trace_id": claim.trace.trace_id,
-            "origin": claim.origin,
-        }
-    if ref.artifact_kind == "calculation_trace":
-        trace = _trace_by_id(report, ref.artifact_id)
-        return {
-            "trace_id": trace.trace_id,
-            "formula_id": trace.formula_id,
-            "input_claim_ids": trace.input_claim_ids,
-            "reference_binding_ids": trace.reference_binding_ids,
-            "steps": tuple(
-                {
-                    "step_id": step.step_id,
-                    "operation": step.operation,
-                    "input_ids": step.input_ids,
-                    "output_value": step.output_value,
-                    "output_unit": step.output_unit,
-                }
-                for step in trace.steps
-            ),
-        }
-    if ref.artifact_kind == "formula":
-        return {"formula_id": ref.artifact_id}
-
-    raise AssertionError(f"Unsupported synthetic artifact ref: {ref}.")
-
-
-def _checked_claim_by_source_id(report: ValidationReport, source_id: str):
-    for claim in report.checked_claims:
-        if source_id == f"checked_claim:{claim.field}:{claim.witness_id}":
-            return claim
-    raise AssertionError(f"Synthetic checked claim not found: {source_id}.")
-
-
-def _evidence_witness_by_id(report: ValidationReport, witness_id: str):
-    for witness in report.evidence_refs:
-        if witness.witness_id == witness_id:
-            return witness
-    raise AssertionError(f"Synthetic evidence witness not found: {witness_id}.")
-
-
-def _trace_by_id(report: ValidationReport, trace_id: str):
-    for claim in report.calculated_claims:
-        if claim.trace.trace_id == trace_id:
-            return claim.trace
-    raise AssertionError(f"Synthetic calculation trace not found: {trace_id}.")
-
-
-def _by_id(items, item_id: str, field: str):
-    for item in items:
-        if getattr(item, field) == item_id:
-            return item
-    raise AssertionError(f"Synthetic artifact not found: {item_id}.")
 
 
 __all__ = [

--- a/tests/test_compiler_run_artifact_materializer.py
+++ b/tests/test_compiler_run_artifact_materializer.py
@@ -1,0 +1,265 @@
+import pytest
+
+from comp.compiler_tool import (
+    CalculatedClaim,
+    CalculationStep,
+    CalculationTrace,
+    CanonicalReference,
+    CheckedClaim,
+    CompilerProfile,
+    DomainPack,
+    EvidenceRef,
+    ReferenceCatalog,
+    ReferenceCatalogSnapshot,
+    ReferenceRecord,
+    ValidationReport,
+    ValidationRequirement,
+    prepare_commit,
+    profile_lock_envelope_body,
+    reference_catalog_snapshot_fingerprint,
+    reference_record_fingerprint,
+)
+from comp.judgment import PublicOutputSpec
+from comp.persistence import (
+    ArtifactMaterial,
+    InMemoryArtifactStore,
+    build_receipt_envelope_set,
+    receipt_artifact_refs,
+    replay_public_projection,
+)
+from comp.runtime import (
+    CompilerRunArtifactMaterializationError,
+    materialize_compiler_run_artifacts,
+)
+
+
+def test_materialize_compiler_run_artifacts_builds_replayable_materials():
+    report, preparation, external_bodies = _accepted_compiler_run()
+
+    materials = materialize_compiler_run_artifacts(
+        report,
+        preparation,
+        external_artifact_bodies=external_bodies,
+    )
+    assert all(isinstance(material, ArtifactMaterial) for material in materials)
+    assert {
+        (material.artifact_kind, material.artifact_id) for material in materials
+    } == {
+        (ref.artifact_kind, ref.artifact_id)
+        for ref in receipt_artifact_refs(preparation.receipt)
+    }
+
+    envelopes = build_receipt_envelope_set(preparation.receipt, materials)
+    store = InMemoryArtifactStore()
+    for envelope in envelopes:
+        store.record(envelope)
+
+    replay = replay_public_projection(
+        {"amount": 1200, "co2e_emission": 0.48},
+        PublicOutputSpec("public-row", ("amount", "co2e_emission")),
+        receipt=preparation.receipt,
+        artifacts=store,
+    )
+
+    assert replay.public_row == {"amount": 1200, "co2e_emission": 0.48}
+
+
+def test_materialize_compiler_run_artifacts_requires_receipt():
+    report = ValidationReport(
+        status="accepted",
+        validation_requirements=(
+            ValidationRequirement(
+                kind="reference_selection_required",
+                field="co2e_emission",
+                reason="ambiguous",
+                requirement_id="reference-selection:hyp-1:co2e_emission",
+            ),
+        ),
+    )
+    preparation = prepare_commit(
+        report,
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+        projection_id="public-row",
+    )
+
+    with pytest.raises(CompilerRunArtifactMaterializationError, match="receipt"):
+        materialize_compiler_run_artifacts(report, preparation)
+
+
+def test_materialize_compiler_run_artifacts_requires_external_dependency_body():
+    report, preparation, external_bodies = _accepted_compiler_run()
+    missing_reference_record = {
+        key: body
+        for key, body in external_bodies.items()
+        if key != ("reference_record", "factor.kr_grid.2024.location_based")
+    }
+
+    with pytest.raises(
+        CompilerRunArtifactMaterializationError,
+        match="missing external artifact body",
+    ):
+        materialize_compiler_run_artifacts(
+            report,
+            preparation,
+            external_artifact_bodies=missing_reference_record,
+        )
+
+
+def _accepted_compiler_run():
+    profile = CompilerProfile(
+        profile_id="pcf-profile",
+        domain_packs=(DomainPack(domain_id="pcf", version="2026.1"),),
+        projection_policy_id="pcf-public-row.v1",
+    )
+    profile_body = profile_lock_envelope_body(profile)
+    profile_fingerprint = _fingerprint_from_body(profile_body)
+
+    reference_record = ReferenceRecord(
+        reference_id="factor.kr_grid.2024.location_based",
+        reference_type="emission_factor",
+        labels=("KR grid 2024 location based",),
+        attributes=(
+            ("factor_value", 0.0004),
+            ("input_unit", "kWh"),
+            ("output_unit", "tCO2e"),
+        ),
+        source="factor-catalog.csv",
+        witness_ids=("ref-factor-row-17",),
+    )
+    reference_fingerprint = reference_record_fingerprint(reference_record)
+    catalog = ReferenceCatalog(records=(reference_record,))
+    snapshot = ReferenceCatalogSnapshot.from_catalog(
+        catalog,
+        catalog_id="fixture-catalog",
+        catalog_version="2026.1",
+        selected_reference_ids=(reference_record.reference_id,),
+    )
+    snapshot_fingerprint = reference_catalog_snapshot_fingerprint(snapshot)
+
+    binding = CanonicalReference(
+        binding_id="bind-amount-factor",
+        claim_id="checked_claim:amount:span-amount",
+        reference_id=reference_record.reference_id,
+        reference_type="emission_factor",
+        selected_candidate_id="candidate:factor",
+        selector_rule_id="factor-selector.v1",
+        source_witness_ids=("ref-factor-row-17",),
+    )
+    report = ValidationReport(
+        status="accepted",
+        evidence_refs=(
+            EvidenceRef(
+                witness_id="span-amount",
+                field="amount",
+                source="invoice.pdf",
+                span="page=1#xywh=10,10,20,20",
+                text="Amount 1200 kWh",
+            ),
+        ),
+        checked_claims=(
+            CheckedClaim(
+                field="amount",
+                value=1200,
+                witness_id="span-amount",
+                origin="source_text",
+            ),
+        ),
+        canonical_references=(binding,),
+        calculated_claims=(
+            CalculatedClaim(
+                claim_id="hyp-1:co2e_emission",
+                field="co2e_emission",
+                value=0.48,
+                unit="tCO2e",
+                trace=CalculationTrace(
+                    trace_id="trace:hyp-1:co2e_emission",
+                    formula_id="ghg.electricity_factor_multiplication.v1",
+                    input_claim_ids=("checked_claim:amount:span-amount",),
+                    reference_binding_ids=("bind-amount-factor",),
+                    steps=(
+                        CalculationStep(
+                            step_id="multiply-input-by-factor",
+                            operation="multiply",
+                            input_ids=(
+                                "checked_claim:amount:span-amount",
+                                "bind-amount-factor",
+                            ),
+                            output_value=0.48,
+                            output_unit="tCO2e",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    preparation = prepare_commit(
+        report,
+        subject_id="facility-1",
+        public_row_id="public-row-1",
+        projection_id="public-row",
+        profile_id=profile.profile_id,
+        dependency_fingerprints=(
+            profile_fingerprint,
+            reference_fingerprint,
+            snapshot_fingerprint,
+        ),
+    )
+
+    external_bodies = {
+        ("compiler_profile", profile.profile_id): profile_body,
+        (
+            "reference_record",
+            reference_record.reference_id,
+        ): _reference_record_body(reference_record, reference_fingerprint),
+        (
+            "reference_catalog_snapshot",
+            snapshot.snapshot_id,
+        ): _catalog_snapshot_body(snapshot, snapshot_fingerprint),
+    }
+    return report, preparation, external_bodies
+
+
+def _fingerprint_from_body(body):
+    from comp.compiler_tool import DependencyFingerprint
+
+    return DependencyFingerprint(
+        dependency_kind=body["dependency_kind"],
+        dependency_id=body["dependency_id"],
+        fingerprint=body["fingerprint"],
+        digest_alg=body["digest_alg"],
+    )
+
+
+def _dependency_fingerprint_body(fingerprint):
+    return {
+        "dependency_kind": fingerprint.dependency_kind,
+        "dependency_id": fingerprint.dependency_id,
+        "fingerprint": fingerprint.fingerprint,
+        "digest_alg": fingerprint.digest_alg,
+    }
+
+
+def _reference_record_body(record, fingerprint):
+    return {
+        **_dependency_fingerprint_body(fingerprint),
+        "reference_id": record.reference_id,
+        "reference_type": record.reference_type,
+        "labels": record.labels,
+        "attributes": record.attributes,
+        "source": record.source,
+        "witness_ids": record.witness_ids,
+    }
+
+
+def _catalog_snapshot_body(snapshot, fingerprint):
+    return {
+        **_dependency_fingerprint_body(fingerprint),
+        "snapshot_id": snapshot.snapshot_id,
+        "catalog_id": snapshot.catalog_id,
+        "catalog_version": snapshot.catalog_version,
+        "record_fingerprints": tuple(
+            _dependency_fingerprint_body(record_fingerprint)
+            for record_fingerprint in snapshot.record_fingerprints
+        ),
+    }

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -919,13 +919,18 @@ def test_artifact_envelope_builder_contract_separates_coverage_from_materializat
         "## Current Implementation Status",
         "`comp.persistence.envelope_builder`",
         "`build_receipt_envelope_set(...)`",
+        "`comp.runtime.compiler_run_artifacts`",
+        "`materialize_compiler_run_artifacts(...)`",
+        "It must not mint receipts, call `build_public_output(...)`, record",
         "`tests/test_artifact_envelope_builder.py`",
+        "`tests/test_compiler_run_artifact_materializer.py`",
     ):
         assert line in builder_doc
 
     for stale_line in (
         "This document defines the contract for turning a completed compiler run into",
         "The production builder should accept the smallest set that can explain a",
+        "compiler-aware materializer remains a later adapter slice",
     ):
         assert stale_line not in builder_doc
 
@@ -988,6 +993,11 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         replay_public_projection,
         verify_materialized_public_projection,
     )
+    from comp.runtime import (
+        CompilerRunArtifactMaterializationError,
+        TrustRuntime,
+        materialize_compiler_run_artifacts,
+    )
 
     assert pyproject["project"]["description"] == (
         "Receipt-gated proof package compiler for obligation, reference, "
@@ -1045,6 +1055,9 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert build_receipt_envelope_set is not None
     assert replay_public_projection is not None
     assert verify_materialized_public_projection is not None
+    assert CompilerRunArtifactMaterializationError is not None
+    assert TrustRuntime is not None
+    assert materialize_compiler_run_artifacts is not None
 
 
 def test_legacy_pipeline_sources_are_not_active_files():


### PR DESCRIPTION
## Summary
- Adds `comp.runtime.compiler_run_artifacts` as the compiler-aware adapter that turns a completed compiler run into `ArtifactMaterial` for the persistence builder.
- Keeps authority boundaries split: the materializer requires an already-issued receipt, does not mint receipts, does not record envelopes, and leaves replay/envelope construction to `comp.persistence`.
- Replaces the synthetic replay fixture-shaped envelope builder with the production materializer plus `build_receipt_envelope_set(...)`.
- Updates the Artifact Envelope Builder contract and smoke coverage for the new runtime adapter export.

## Notes
- `comp.scenario_contracts.__init__` now lazy-loads `run_scenario` to avoid the existing `comp.runtime` import cycle once runtime exposes more public adapter APIs.

## Validation
- `python -m pytest tests/test_compiler_run_artifact_materializer.py tests/test_artifact_envelope_builder.py tests/test_package_smoke.py::test_artifact_envelope_builder_contract_separates_coverage_from_materialization tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer tests/test_authority_import_boundaries.py tests/test_synthetic_run_harness.py tests/test_synthetic_resolution_scenario.py tests/test_synthetic_raw_claim_conflict_resolution.py tests/test_l_energy_pcf_scenario.py tests/test_scenario_contracts.py tests/test_receipt_proof_graph_cli.py -q` => 60 passed
- `python -m pytest -q` => 508 passed, 13 skipped
