### PR TITLE
[codex] Add deterministic revision loop

### DIFF
--- a/minchoagnt/__init__.py
+++ b/minchoagnt/__init__.py
@@ -15,6 +15,17 @@ from minchoagnt.review import (
     ReviewPlan,
     ReviewPlanValidationError,
 )
+from minchoagnt.revision_loop import (
+    LoopTrace,
+    ObligationReflection,
+    RevisedHypothesis,
+    RevisionIteration,
+    WitnessFixtureRule,
+    WitnessRequest,
+    deterministic_revision_loop,
+    obligation_reflection,
+    revised_hypothesis_fixture,
+)
 from minchoagnt.skills import SkillStore
 from minchoagnt.workbench import ReviewWorkbench, WorkbenchRun
 from minchoagnt.work_orders import (
@@ -43,14 +54,23 @@ __all__ = [
     "ReviewPlan",
     "ReviewPlanValidationError",
     "ReviewSummary",
+    "LoopTrace",
+    "ObligationReflection",
+    "RevisedHypothesis",
+    "RevisionIteration",
     "ReviewWorkbench",
     "SkillStore",
+    "WitnessFixtureRule",
+    "WitnessRequest",
     "WorkbenchRun",
     "LLMWorkOrder",
     "LLMWorkerSubmission",
     "LLMWorkerResult",
     "AbstentionArtifact",
     "DeterministicLLMWorker",
+    "deterministic_revision_loop",
+    "obligation_reflection",
+    "revised_hypothesis_fixture",
     "semantic_work_orders_from_result",
     "semantic_work_orders_from_tasks",
     "apply_llm_worker_results",

--- a/minchoagnt/revision_loop.py
+++ b/minchoagnt/revision_loop.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from comp.compiler_tool import (
+    ClaimCandidate,
+    EvidenceRef,
+    InterpretationHypothesis,
+    ValidationReport,
+    resolver_tasks_from_report,
+)
+from minchoagnt.comp_adapter import CompCompileResult, CompCompilerAdapter
+
+
+@dataclass(frozen=True)
+class WitnessFixtureRule:
+    field: str
+    witness_id: str
+    source: str
+    span: str | None = None
+    text: str | None = None
+
+    @property
+    def rule_id(self) -> str:
+        return f"witness_fixture:{self.field}:{self.witness_id}"
+
+
+@dataclass(frozen=True)
+class WitnessRequest:
+    requirement_id: str
+    field: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ObligationReflection:
+    status: str
+    witness_requests: tuple[WitnessRequest, ...] = field(default_factory=tuple)
+    unhandled_requirement_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RevisedHypothesis:
+    source_hypothesis_id: str
+    hypothesis: InterpretationHypothesis
+    applied_requirement_ids: tuple[str, ...] = field(default_factory=tuple)
+    applied_rule_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RevisionIteration:
+    revision_index: int
+    source: CompCompileResult
+    reflection: ObligationReflection
+    revision: RevisedHypothesis
+    result: CompCompileResult
+
+
+@dataclass(frozen=True)
+class LoopTrace:
+    initial: CompCompileResult
+    iterations: tuple[RevisionIteration, ...] = field(default_factory=tuple)
+    receipt: None = None
+
+    @property
+    def final(self) -> CompCompileResult:
+        if not self.iterations:
+            return self.initial
+        return self.iterations[-1].result
+
+
+def obligation_reflection(report: ValidationReport) -> ObligationReflection:
+    witness_requests: list[WitnessRequest] = []
+    unhandled_requirement_ids: list[str] = []
+
+    for task in resolver_tasks_from_report(report):
+        if (
+            task.requirement_kind == "find_source_witness"
+            and task.reason == "missing_source_witness"
+        ):
+            witness_requests.append(
+                WitnessRequest(
+                    requirement_id=task.requirement_id,
+                    field=task.field,
+                    reason=task.reason,
+                )
+            )
+            continue
+        unhandled_requirement_ids.append(task.requirement_id)
+
+    return ObligationReflection(
+        status=report.status,
+        witness_requests=tuple(witness_requests),
+        unhandled_requirement_ids=tuple(unhandled_requirement_ids),
+    )
+
+
+def revised_hypothesis_fixture(
+    hypothesis: InterpretationHypothesis,
+    reflection: ObligationReflection,
+    *,
+    fixture_rules: tuple[WitnessFixtureRule, ...] = (),
+) -> RevisedHypothesis:
+    rules_by_field = {rule.field: rule for rule in fixture_rules}
+    applied_requests: list[WitnessRequest] = []
+    applied_rules: list[WitnessFixtureRule] = []
+
+    for request in reflection.witness_requests:
+        rule = rules_by_field.get(request.field)
+        if rule is None:
+            continue
+        applied_requests.append(request)
+        applied_rules.append(rule)
+
+    if not applied_requests:
+        return RevisedHypothesis(
+            source_hypothesis_id=hypothesis.hypothesis_id,
+            hypothesis=hypothesis,
+        )
+
+    witness_ids = {witness.witness_id for witness in hypothesis.witnesses}
+    new_witnesses = list(hypothesis.witnesses)
+    for rule in applied_rules:
+        if rule.witness_id not in witness_ids:
+            new_witnesses.append(
+                EvidenceRef(
+                    witness_id=rule.witness_id,
+                    field=rule.field,
+                    source=rule.source,
+                    span=rule.span,
+                    text=rule.text,
+                )
+            )
+            witness_ids.add(rule.witness_id)
+
+    witness_id_by_field = {rule.field: rule.witness_id for rule in applied_rules}
+    revised_claims = tuple(
+        _revise_claim_witness(claim, witness_id_by_field)
+        for claim in hypothesis.claims
+    )
+
+    return RevisedHypothesis(
+        source_hypothesis_id=hypothesis.hypothesis_id,
+        hypothesis=InterpretationHypothesis(
+            hypothesis_id=f"{hypothesis.hypothesis_id}:revision",
+            subject_id=hypothesis.subject_id,
+            claims=revised_claims,
+            witnesses=tuple(new_witnesses),
+        ),
+        applied_requirement_ids=tuple(
+            request.requirement_id for request in applied_requests
+        ),
+        applied_rule_ids=tuple(rule.rule_id for rule in applied_rules),
+    )
+
+
+def deterministic_revision_loop(
+    adapter: CompCompilerAdapter,
+    hypothesis: InterpretationHypothesis,
+    *,
+    fixture_rules: tuple[WitnessFixtureRule, ...] = (),
+    max_revisions: int = 1,
+) -> LoopTrace:
+    if max_revisions < 0:
+        raise ValueError("max_revisions must be non-negative.")
+
+    initial = adapter.compile(hypothesis)
+    current = initial
+    iterations: list[RevisionIteration] = []
+
+    for revision_index in range(1, max_revisions + 1):
+        if current.report.status == "accepted":
+            break
+
+        reflection = obligation_reflection(current.report)
+        revision = revised_hypothesis_fixture(
+            current.hypothesis,
+            reflection,
+            fixture_rules=fixture_rules,
+        )
+        if not revision.applied_requirement_ids:
+            break
+
+        revised = adapter.compile(revision.hypothesis)
+        iteration = RevisionIteration(
+            revision_index=revision_index,
+            source=current,
+            reflection=reflection,
+            revision=revision,
+            result=revised,
+        )
+        iterations.append(iteration)
+        current = revised
+
+    return LoopTrace(initial=initial, iterations=tuple(iterations), receipt=None)
+
+
+def _revise_claim_witness(
+    claim: ClaimCandidate,
+    witness_id_by_field: dict[str, str],
+) -> ClaimCandidate:
+    witness_id = witness_id_by_field.get(claim.field)
+    if witness_id is None:
+        return claim
+    return replace(claim, witness_id=witness_id)
+
+
+__all__ = [
+    "LoopTrace",
+    "ObligationReflection",
+    "RevisedHypothesis",
+    "RevisionIteration",
+    "WitnessFixtureRule",
+    "WitnessRequest",
+    "deterministic_revision_loop",
+    "obligation_reflection",
+    "revised_hypothesis_fixture",
+]

--- a/tests/test_minchoagnt_revision_loop.py
+++ b/tests/test_minchoagnt_revision_loop.py
@@ -1,0 +1,176 @@
+from comp.compiler_tool import (
+    ClaimCandidate,
+    EvidenceRef,
+    InterpretationHypothesis,
+)
+from minchoagnt import (
+    CompCompilerAdapter,
+    LoopTrace,
+    ObligationReflection,
+    RevisedHypothesis,
+    RevisionIteration,
+    WitnessFixtureRule,
+    WitnessRequest,
+    deterministic_revision_loop,
+    obligation_reflection,
+    revised_hypothesis_fixture,
+)
+
+
+TINY_KNOWN_FIELDS = frozenset({"activity", "amount", "unit", "reporting_year"})
+
+
+def test_obligation_reflection_extracts_missing_source_witness_request():
+    adapter = _adapter()
+    result = adapter.compile(_missing_unit_witness_hypothesis())
+
+    reflection = obligation_reflection(result.report)
+
+    assert reflection == ObligationReflection(
+        status="blocked",
+        witness_requests=(
+            WitnessRequest(
+                requirement_id=(
+                    "validation_requirement:find_source_witness:"
+                    "unit:missing_source_witness"
+                ),
+                field="unit",
+                reason="missing_source_witness",
+            ),
+        ),
+        unhandled_requirement_ids=(),
+    )
+
+
+def test_revised_hypothesis_fixture_adds_grounded_witness_without_mutating_source():
+    hypothesis = _missing_unit_witness_hypothesis()
+    reflection = obligation_reflection(_adapter().compile(hypothesis).report)
+    rule = WitnessFixtureRule(
+        field="unit",
+        witness_id="w-unit",
+        source="invoice.csv",
+        span="unit-column",
+        text="Unit: kWh",
+    )
+
+    revision = revised_hypothesis_fixture(
+        hypothesis,
+        reflection,
+        fixture_rules=(rule,),
+    )
+
+    assert revision == RevisedHypothesis(
+        source_hypothesis_id="hyp-rev-1",
+        hypothesis=InterpretationHypothesis(
+            hypothesis_id="hyp-rev-1:revision",
+            subject_id="claim-1",
+            claims=(
+                ClaimCandidate("unit", "kwh", witness_id="w-unit"),
+            ),
+            witnesses=(
+                EvidenceRef(
+                    "w-unit",
+                    "unit",
+                    source="invoice.csv",
+                    span="unit-column",
+                    text="Unit: kWh",
+                ),
+            ),
+        ),
+        applied_requirement_ids=(
+            "validation_requirement:find_source_witness:unit:missing_source_witness",
+        ),
+        applied_rule_ids=("witness_fixture:unit:w-unit",),
+    )
+    assert hypothesis.claims[0].witness_id is None
+    assert hypothesis.witnesses == ()
+
+
+def test_deterministic_revision_loop_recompiles_revised_hypothesis():
+    trace = deterministic_revision_loop(
+        _adapter(),
+        _missing_unit_witness_hypothesis(),
+        fixture_rules=(
+            WitnessFixtureRule(
+                field="unit",
+                witness_id="w-unit",
+                source="invoice.csv",
+            ),
+        ),
+        max_revisions=1,
+    )
+
+    assert trace.initial.report.status == "blocked"
+    assert len(trace.iterations) == 1
+    revised_claim = trace.iterations[0].revision.hypothesis.claims[0]
+    assert revised_claim.witness_id == "w-unit"
+    assert trace.iterations[0].result.report.status == "accepted"
+    assert trace.final.report.status == "accepted"
+
+
+def test_revision_loop_never_mints_receipts_after_accepted_report():
+    trace = deterministic_revision_loop(
+        _adapter(),
+        _missing_unit_witness_hypothesis(),
+        fixture_rules=(
+            WitnessFixtureRule(
+                field="unit",
+                witness_id="w-unit",
+                source="invoice.csv",
+            ),
+        ),
+        max_revisions=2,
+    )
+
+    assert isinstance(trace, LoopTrace)
+    assert isinstance(trace.iterations[0], RevisionIteration)
+    assert trace.initial.receipt is None
+    assert trace.receipt is None
+    assert trace.final.receipt is None
+    assert all(iteration.result.receipt is None for iteration in trace.iterations)
+
+
+def test_unsupported_unit_reflection_stays_unhandled():
+    hypothesis = InterpretationHypothesis(
+        hypothesis_id="hyp-unsupported-unit",
+        subject_id="claim-1",
+        claims=(ClaimCandidate("unit", "mwh", witness_id="w-unit"),),
+        witnesses=(EvidenceRef("w-unit", "unit", source="invoice.csv"),),
+    )
+    result = _adapter().compile(hypothesis)
+
+    reflection = obligation_reflection(result.report)
+    revision = revised_hypothesis_fixture(
+        hypothesis,
+        reflection,
+        fixture_rules=(
+            WitnessFixtureRule(
+                field="unit",
+                witness_id="w-unit-2",
+                source="invoice.csv",
+            ),
+        ),
+    )
+
+    assert reflection.witness_requests == ()
+    assert reflection.unhandled_requirement_ids == (
+        "validation_requirement:find_source_witness:unit:unsupported_unit",
+    )
+    assert revision.hypothesis == hypothesis
+    assert revision.applied_requirement_ids == ()
+
+
+def _adapter():
+    return CompCompilerAdapter(
+        allowed_units=frozenset({"kwh"}),
+        known_fields=TINY_KNOWN_FIELDS,
+    )
+
+
+def _missing_unit_witness_hypothesis():
+    return InterpretationHypothesis(
+        hypothesis_id="hyp-rev-1",
+        subject_id="claim-1",
+        claims=(ClaimCandidate("unit", "kwh", witness_id=None),),
+        witnesses=(),
+    )


### PR DESCRIPTION
## Summary

- Add `minchoagnt.revision_loop` as an agent-side outer revision loop, separate from report-level resolver artifact application.
- Reflect `ValidationReport` obligations into witness requests and unhandled requirement ids.
- Add a deterministic fixture reviser that creates a new `InterpretationHypothesis` with grounded evidence witnesses.
- Add loop tracing for initial compile plus up to `max_revisions` revision iterations while keeping receipts absent.

## Authority boundary

This PR keeps the dependency direction as `minchoagnt -> comp.compiler_tool`. The new loop does not import or call receipt, projection, replay, persistence, runtime, explanation, or view authority paths. A successful/accepted report still leaves `CompCompileResult.receipt` and `LoopTrace.receipt` as `None`.

## Validation

- `COMP_TEST_MYSQL_HOST=127.0.0.1 COMP_TEST_MYSQL_PORT=3307 COMP_TEST_MYSQL_USER=comp COMP_TEST_MYSQL_PASSWORD=comp COMP_TEST_MYSQL_DATABASE=comp_test python -m pytest -q` -> 526 passed
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `python -m pytest tests/test_minchoagnt_revision_loop.py tests/test_minchoagnt_comp_adapter.py tests/test_authority_import_boundaries.py -q` -> 18 passed
- `git diff --cached --check` -> no whitespace errors