### PR TITLE
[codex] Clarify revision loop trace stops

### DIFF
--- a/minchoagnt/revision_loop.py
+++ b/minchoagnt/revision_loop.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+from typing import Literal
 
 from comp.compiler_tool import (
     ClaimCandidate,
@@ -12,11 +13,14 @@ from comp.compiler_tool import (
 from minchoagnt.comp_adapter import CompCompileResult, CompCompilerAdapter
 
 
+RevisionStopReason = Literal["accepted", "max_revisions", "no_revision"]
+
+
 @dataclass(frozen=True)
 class WitnessFixtureRule:
     field: str
     witness_id: str
-    source: str
+    source: str | None
     span: str | None = None
     text: str | None = None
 
@@ -44,6 +48,7 @@ class RevisedHypothesis:
     source_hypothesis_id: str
     hypothesis: InterpretationHypothesis
     applied_requirement_ids: tuple[str, ...] = field(default_factory=tuple)
+    unapplied_requirement_ids: tuple[str, ...] = field(default_factory=tuple)
     applied_rule_ids: tuple[str, ...] = field(default_factory=tuple)
 
 
@@ -60,6 +65,7 @@ class RevisionIteration:
 class LoopTrace:
     initial: CompCompileResult
     iterations: tuple[RevisionIteration, ...] = field(default_factory=tuple)
+    stop_reason: RevisionStopReason = "accepted"
     receipt: None = None
 
     @property
@@ -104,10 +110,12 @@ def revised_hypothesis_fixture(
     rules_by_field = {rule.field: rule for rule in fixture_rules}
     applied_requests: list[WitnessRequest] = []
     applied_rules: list[WitnessFixtureRule] = []
+    unapplied_requirement_ids: list[str] = list(reflection.unhandled_requirement_ids)
 
     for request in reflection.witness_requests:
         rule = rules_by_field.get(request.field)
         if rule is None:
+            unapplied_requirement_ids.append(request.requirement_id)
             continue
         applied_requests.append(request)
         applied_rules.append(rule)
@@ -116,6 +124,7 @@ def revised_hypothesis_fixture(
         return RevisedHypothesis(
             source_hypothesis_id=hypothesis.hypothesis_id,
             hypothesis=hypothesis,
+            unapplied_requirement_ids=tuple(unapplied_requirement_ids),
         )
 
     witness_ids = {witness.witness_id for witness in hypothesis.witnesses}
@@ -150,6 +159,7 @@ def revised_hypothesis_fixture(
         applied_requirement_ids=tuple(
             request.requirement_id for request in applied_requests
         ),
+        unapplied_requirement_ids=tuple(unapplied_requirement_ids),
         applied_rule_ids=tuple(rule.rule_id for rule in applied_rules),
     )
 
@@ -167,9 +177,11 @@ def deterministic_revision_loop(
     initial = adapter.compile(hypothesis)
     current = initial
     iterations: list[RevisionIteration] = []
+    stop_reason: RevisionStopReason = "accepted"
 
     for revision_index in range(1, max_revisions + 1):
         if current.report.status == "accepted":
+            stop_reason = "accepted"
             break
 
         reflection = obligation_reflection(current.report)
@@ -179,6 +191,7 @@ def deterministic_revision_loop(
             fixture_rules=fixture_rules,
         )
         if not revision.applied_requirement_ids:
+            stop_reason = "no_revision"
             break
 
         revised = adapter.compile(revision.hypothesis)
@@ -191,8 +204,20 @@ def deterministic_revision_loop(
         )
         iterations.append(iteration)
         current = revised
+        if current.report.status == "accepted":
+            stop_reason = "accepted"
+            break
+        stop_reason = "max_revisions"
 
-    return LoopTrace(initial=initial, iterations=tuple(iterations), receipt=None)
+    if max_revisions == 0 and current.report.status != "accepted":
+        stop_reason = "max_revisions"
+
+    return LoopTrace(
+        initial=initial,
+        iterations=tuple(iterations),
+        stop_reason=stop_reason,
+        receipt=None,
+    )
 
 
 def _revise_claim_witness(
@@ -209,6 +234,7 @@ __all__ = [
     "LoopTrace",
     "ObligationReflection",
     "RevisedHypothesis",
+    "RevisionStopReason",
     "RevisionIteration",
     "WitnessFixtureRule",
     "WitnessRequest",

--- a/tests/test_minchoagnt_revision_loop.py
+++ b/tests/test_minchoagnt_revision_loop.py
@@ -106,6 +106,7 @@ def test_deterministic_revision_loop_recompiles_revised_hypothesis():
     assert revised_claim.witness_id == "w-unit"
     assert trace.iterations[0].result.report.status == "accepted"
     assert trace.final.report.status == "accepted"
+    assert trace.stop_reason == "accepted"
 
 
 def test_revision_loop_never_mints_receipts_after_accepted_report():
@@ -158,6 +159,75 @@ def test_unsupported_unit_reflection_stays_unhandled():
     )
     assert revision.hypothesis == hypothesis
     assert revision.applied_requirement_ids == ()
+
+
+def test_unapplied_witness_request_is_visible_in_revision_trace():
+    result = _adapter().compile(_missing_unit_witness_hypothesis())
+    reflection = obligation_reflection(result.report)
+
+    revision = revised_hypothesis_fixture(
+        result.hypothesis,
+        reflection,
+        fixture_rules=(),
+    )
+
+    assert revision.hypothesis == result.hypothesis
+    assert revision.applied_requirement_ids == ()
+    assert revision.unapplied_requirement_ids == (
+        "validation_requirement:find_source_witness:unit:missing_source_witness",
+    )
+
+
+def test_revision_loop_records_no_revision_stop_reason():
+    trace = deterministic_revision_loop(
+        _adapter(),
+        _missing_unit_witness_hypothesis(),
+        fixture_rules=(),
+        max_revisions=2,
+    )
+
+    assert trace.iterations == ()
+    assert trace.stop_reason == "no_revision"
+    assert trace.final.report.status == "blocked"
+
+
+def test_revision_loop_records_max_revisions_stop_reason():
+    trace = deterministic_revision_loop(
+        _adapter(),
+        _missing_unit_witness_hypothesis(),
+        fixture_rules=(
+            WitnessFixtureRule(
+                field="unit",
+                witness_id="w-unit",
+                source=None,
+            ),
+        ),
+        max_revisions=1,
+    )
+
+    assert len(trace.iterations) == 1
+    assert trace.iterations[0].result.report.status == "blocked"
+    assert trace.stop_reason == "max_revisions"
+
+
+def test_revision_loop_records_initial_accepted_stop_reason():
+    accepted = InterpretationHypothesis(
+        hypothesis_id="hyp-accepted",
+        subject_id="claim-1",
+        claims=(ClaimCandidate("unit", "kwh", witness_id="w-unit"),),
+        witnesses=(EvidenceRef("w-unit", "unit", source="invoice.csv"),),
+    )
+
+    trace = deterministic_revision_loop(
+        _adapter(),
+        accepted,
+        fixture_rules=(),
+        max_revisions=2,
+    )
+
+    assert trace.initial.report.status == "accepted"
+    assert trace.iterations == ()
+    assert trace.stop_reason == "accepted"
 
 
 def _adapter():


### PR DESCRIPTION
## Summary

- Add explicit `LoopTrace.stop_reason` values for accepted, no revision, and max revisions.
- Track `RevisedHypothesis.unapplied_requirement_ids` so missing fixture coverage is visible instead of silent.
- Keep `max_revisions` defined as revision attempts after the initial compile.
- Add focused tests for accepted, no-revision, max-revision, and unapplied witness request traces.

## Authority boundary

This is trace-contract hardening only. The revision loop still depends only on `comp.compiler_tool` plus `CompCompilerAdapter`, and it still never imports or calls receipt, projection, replay, persistence, runtime, explanation, or view authority paths.

## Validation

- `COMP_TEST_MYSQL_HOST=127.0.0.1 COMP_TEST_MYSQL_PORT=3307 COMP_TEST_MYSQL_USER=comp COMP_TEST_MYSQL_PASSWORD=comp COMP_TEST_MYSQL_DATABASE=comp_test python -m pytest -q` -> 531 passed
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `python -m pytest tests/test_minchoagnt_revision_loop.py tests/test_minchoagnt_comp_adapter.py tests/test_minchoagnt_llm_work_orders.py tests/test_authority_import_boundaries.py -q` -> 26 passed
- `git diff --check` -> no whitespace errors