### PR TITLE
[codex] Add external artifact material source

### DIFF
--- a/comp/runtime/__init__.py
+++ b/comp/runtime/__init__.py
@@ -2,12 +2,16 @@
 
 from comp.runtime.compiler_run_artifacts import (
     CompilerRunArtifactMaterializationError,
+    ExternalArtifactMaterial,
+    ExternalArtifactMaterialSource,
     materialize_compiler_run_artifacts,
 )
 from comp.runtime.trust_runtime import TrustRuntime
 
 __all__ = [
     "CompilerRunArtifactMaterializationError",
+    "ExternalArtifactMaterial",
+    "ExternalArtifactMaterialSource",
     "TrustRuntime",
     "materialize_compiler_run_artifacts",
 ]

--- a/comp/runtime/compiler_run_artifacts.py
+++ b/comp/runtime/compiler_run_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
 from typing import Any
 
 from comp.compiler_tool import (
@@ -15,11 +16,58 @@ class CompilerRunArtifactMaterializationError(RuntimeError):
     """Raised when a compiler run cannot be serialized into artifact material."""
 
 
+@dataclass(frozen=True)
+class ExternalArtifactMaterial:
+    artifact_kind: str
+    artifact_id: str
+    body: Mapping[str, Any]
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.artifact_kind, self.artifact_id)
+
+
+@dataclass(frozen=True)
+class ExternalArtifactMaterialSource:
+    materials: tuple[ExternalArtifactMaterial, ...] = field(default_factory=tuple)
+
+    def __init__(
+        self,
+        materials: Iterable[ExternalArtifactMaterial] = (),
+    ) -> None:
+        material_tuple = tuple(materials)
+        object.__setattr__(self, "materials", material_tuple)
+        object.__setattr__(self, "_bodies", _external_bodies_by_key(material_tuple))
+
+    @classmethod
+    def from_bodies(
+        cls,
+        bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+    ) -> "ExternalArtifactMaterialSource":
+        return cls(
+            ExternalArtifactMaterial(
+                artifact_kind=artifact_kind,
+                artifact_id=artifact_id,
+                body=body,
+            )
+            for (artifact_kind, artifact_id), body in bodies.items()
+        )
+
+    def body_for(self, ref: ArtifactRef) -> Mapping[str, Any]:
+        try:
+            return dict(self._bodies[(ref.artifact_kind, ref.artifact_id)])
+        except KeyError as exc:
+            raise CompilerRunArtifactMaterializationError(
+                "Compiler run artifact materialization missing external artifact body: "
+                f"{ref.artifact_kind}:{ref.artifact_id}."
+            ) from exc
+
+
 def materialize_compiler_run_artifacts(
     report: ValidationReport,
     preparation: CommitPreparation,
     *,
-    external_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]] | None = None,
+    external_material_source: ExternalArtifactMaterialSource | None = None,
     schema_version: str = "compiler-run-v1",
 ) -> tuple[ArtifactMaterial, ...]:
     receipt = preparation.receipt
@@ -28,13 +76,17 @@ def materialize_compiler_run_artifacts(
             "Compiler run artifact materialization requires a receipt."
         )
 
-    external_bodies = external_artifact_bodies or {}
+    material_source = (
+        external_material_source
+        if external_material_source is not None
+        else ExternalArtifactMaterialSource()
+    )
     return tuple(
         ArtifactMaterial(
             artifact_id=ref.artifact_id,
             artifact_kind=ref.artifact_kind,
             schema_version=schema_version,
-            body=_artifact_body_for_ref(report, preparation, external_bodies, ref),
+            body=_artifact_body_for_ref(report, preparation, material_source, ref),
         )
         for ref in receipt_artifact_refs(receipt)
     )
@@ -43,7 +95,7 @@ def materialize_compiler_run_artifacts(
 def _artifact_body_for_ref(
     report: ValidationReport,
     preparation: CommitPreparation,
-    external_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+    external_material_source: ExternalArtifactMaterialSource,
     ref: ArtifactRef,
 ) -> Mapping[str, Any]:
     if ref.artifact_kind == "commit_package":
@@ -96,7 +148,7 @@ def _artifact_body_for_ref(
     if ref.artifact_kind == "evidence_witness":
         witness = _evidence_witness_by_id(report, ref.artifact_id)
         if witness is None:
-            return _external_body(ref, external_artifact_bodies)
+            return external_material_source.body_for(ref)
         fingerprint = evidence_ref_fingerprint(witness)
         return {
             "dependency_kind": fingerprint.dependency_kind,
@@ -171,20 +223,24 @@ def _artifact_body_for_ref(
                 if claim.formula_id == ref.artifact_id
             ),
         }
-    return _external_body(ref, external_artifact_bodies)
+    return external_material_source.body_for(ref)
 
 
-def _external_body(
-    ref: ArtifactRef,
-    external_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
-) -> Mapping[str, Any]:
-    try:
-        return dict(external_artifact_bodies[(ref.artifact_kind, ref.artifact_id)])
-    except KeyError as exc:
-        raise CompilerRunArtifactMaterializationError(
-            "Compiler run artifact materialization missing external artifact body: "
-            f"{ref.artifact_kind}:{ref.artifact_id}."
-        ) from exc
+def _external_bodies_by_key(
+    materials: tuple[ExternalArtifactMaterial, ...],
+) -> dict[tuple[str, str], Mapping[str, Any]]:
+    bodies: dict[tuple[str, str], Mapping[str, Any]] = {}
+    for material in materials:
+        existing = bodies.get(material.key)
+        if existing is None:
+            bodies[material.key] = dict(material.body)
+            continue
+        if existing != dict(material.body):
+            raise CompilerRunArtifactMaterializationError(
+                "Compiler run artifact materialization has conflicting external "
+                f"material: {material.artifact_kind}:{material.artifact_id}."
+            )
+    return bodies
 
 
 def _projection_value_commitment_body(commitment) -> dict[str, str]:
@@ -242,5 +298,7 @@ def _by_id(items, item_id: str, field: str):
 
 __all__ = [
     "CompilerRunArtifactMaterializationError",
+    "ExternalArtifactMaterial",
+    "ExternalArtifactMaterialSource",
     "materialize_compiler_run_artifacts",
 ]

--- a/docs/architecture/contracts/artifact-envelope-builder.md
+++ b/docs/architecture/contracts/artifact-envelope-builder.md
@@ -501,13 +501,19 @@ It exposes:
 
 ```text
 CompilerRunArtifactMaterializationError
+ExternalArtifactMaterial
+ExternalArtifactMaterialSource
 materialize_compiler_run_artifacts(...)
 ```
 
 `materialize_compiler_run_artifacts(...)` consumes `ValidationReport`,
-`CommitPreparation`, and externally supplied dependency artifact bodies. It
-requires an already-issued receipt on the preparation, derives the receipt refs,
-and returns `ArtifactMaterial` for `build_receipt_envelope_set(...)`.
+`CommitPreparation`, and an `ExternalArtifactMaterialSource`. It requires an
+already-issued receipt on the preparation, derives the receipt refs, and returns
+`ArtifactMaterial` for `build_receipt_envelope_set(...)`.
+
+`ExternalArtifactMaterialSource` is a named external material boundary, not an authority source.
+It supplies replay bodies for receipt-cited dependencies that are not owned by
+the compiler run object graph.
 
 The materializer may inspect compiler objects to serialize compiler-run
 material. It must not mint receipts, call `build_public_output(...)`, record
@@ -549,7 +555,7 @@ DomainScenarioResult
 ```
 
 Scenario helpers may prepare external artifact bodies for fixtures, but they
-must not recreate `ArtifactEnvelope` construction or receipt-ref coverage
+must pass them through `ExternalArtifactMaterialSource`. They must not recreate `ArtifactEnvelope` construction or receipt-ref coverage
 policy.
 
 ## Review Checklist

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -122,8 +122,8 @@ DomainScenarioResult
 ```
 
 Scenario helpers may prepare external artifact bodies for fixture-only records,
-but they should not construct `ArtifactEnvelope` objects directly or duplicate
-receipt-ref coverage policy.
+but they should pass them through `ExternalArtifactMaterialSource`, not construct
+`ArtifactEnvelope` objects directly or duplicate receipt-ref coverage policy.
 
 ## External Scenario Packs
 

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -13,7 +13,10 @@ from comp.persistence import (
     build_receipt_envelope_set,
     replay_public_projection,
 )
-from comp.runtime import materialize_compiler_run_artifacts
+from comp.runtime import (
+    ExternalArtifactMaterialSource,
+    materialize_compiler_run_artifacts,
+)
 from tests.domain_scenarios.core import DomainScenarioResult
 
 
@@ -37,7 +40,9 @@ def scenario_replay_bundle(
     materials = materialize_compiler_run_artifacts(
         result.report,
         result.preparation,
-        external_artifact_bodies=_scenario_external_artifact_bodies(result),
+        external_material_source=ExternalArtifactMaterialSource.from_bodies(
+            _scenario_external_artifact_bodies(result)
+        ),
         schema_version="domain-scenario-v1",
     )
     for envelope in build_receipt_envelope_set(receipt, materials):

--- a/tests/support/synthetic/replay.py
+++ b/tests/support/synthetic/replay.py
@@ -16,7 +16,10 @@ from comp.persistence import (
     build_receipt_envelope_set,
     replay_public_projection,
 )
-from comp.runtime import materialize_compiler_run_artifacts
+from comp.runtime import (
+    ExternalArtifactMaterialSource,
+    materialize_compiler_run_artifacts,
+)
 
 
 @dataclass(frozen=True)
@@ -38,7 +41,9 @@ def synthetic_replay_bundle(
     materials = materialize_compiler_run_artifacts(
         report,
         preparation,
-        external_artifact_bodies=dependency_artifact_bodies,
+        external_material_source=ExternalArtifactMaterialSource.from_bodies(
+            dependency_artifact_bodies
+        ),
         schema_version="synthetic-scenario-v1",
     )
     build_receipt_envelope_set(receipt, materials, record_to=artifacts)

--- a/tests/test_compiler_run_artifact_materializer.py
+++ b/tests/test_compiler_run_artifact_materializer.py
@@ -29,6 +29,8 @@ from comp.persistence import (
 )
 from comp.runtime import (
     CompilerRunArtifactMaterializationError,
+    ExternalArtifactMaterial,
+    ExternalArtifactMaterialSource,
     materialize_compiler_run_artifacts,
 )
 
@@ -39,7 +41,9 @@ def test_materialize_compiler_run_artifacts_builds_replayable_materials():
     materials = materialize_compiler_run_artifacts(
         report,
         preparation,
-        external_artifact_bodies=external_bodies,
+        external_material_source=ExternalArtifactMaterialSource.from_bodies(
+            external_bodies
+        ),
     )
     assert all(isinstance(material, ArtifactMaterial) for material in materials)
     assert {
@@ -102,8 +106,26 @@ def test_materialize_compiler_run_artifacts_requires_external_dependency_body():
         materialize_compiler_run_artifacts(
             report,
             preparation,
-            external_artifact_bodies=missing_reference_record,
+            external_material_source=ExternalArtifactMaterialSource.from_bodies(
+                missing_reference_record
+            ),
         )
+
+
+def test_external_artifact_material_source_rejects_conflicting_materials():
+    first = ExternalArtifactMaterial(
+        artifact_kind="reference_record",
+        artifact_id="factor-1",
+        body={"reference_id": "factor-1", "factor_value": 0.1},
+    )
+    second = ExternalArtifactMaterial(
+        artifact_kind="reference_record",
+        artifact_id="factor-1",
+        body={"reference_id": "factor-1", "factor_value": 0.2},
+    )
+
+    with pytest.raises(CompilerRunArtifactMaterializationError, match="conflicting"):
+        ExternalArtifactMaterialSource((first, second))
 
 
 def _accepted_compiler_run():

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -134,7 +134,8 @@ def test_domain_scenario_docs_explain_residency_tiers():
     assert "registry exposes residency metadata" in extension_doc
     assert "Scenario replay uses the production materializer boundary" in readme
     assert "materialize_compiler_run_artifacts(...)" in readme
-    assert "should not construct `ArtifactEnvelope` objects directly" in readme
+    assert "ExternalArtifactMaterialSource" in readme
+    assert "not construct\n`ArtifactEnvelope` objects directly" in readme
 
 
 def test_domain_scenario_replay_uses_production_materializer_boundary():
@@ -144,7 +145,8 @@ def test_domain_scenario_replay_uses_production_materializer_boundary():
 
     assert "materialize_compiler_run_artifacts" in source
     assert "build_receipt_envelope_set" in source
-    assert "external_artifact_bodies=_scenario_external_artifact_bodies(result)" in source
+    assert "ExternalArtifactMaterialSource.from_bodies" in source
+    assert "external_material_source=" in source
 
     for stale_policy in (
         "ArtifactEnvelope.from_body(",
@@ -152,6 +154,7 @@ def test_domain_scenario_replay_uses_production_materializer_boundary():
         "evidence_ref_fingerprint",
         "_artifact_envelope_for_ref",
         "_artifact_body_for_ref",
+        "external_artifact_bodies=",
     ):
         assert stale_policy not in source
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -921,8 +921,11 @@ def test_artifact_envelope_builder_contract_separates_coverage_from_materializat
         "`build_receipt_envelope_set(...)`",
         "`comp.runtime.compiler_run_artifacts`",
         "`materialize_compiler_run_artifacts(...)`",
+        "`ExternalArtifactMaterialSource`",
+        "not an authority source",
         "It must not mint receipts, call `build_public_output(...)`, record",
         "Domain Scenario Lab replay must exercise the same path:",
+        "must pass them through `ExternalArtifactMaterialSource`",
         "must not recreate `ArtifactEnvelope` construction or receipt-ref coverage",
         "`tests/test_artifact_envelope_builder.py`",
         "`tests/test_compiler_run_artifact_materializer.py`",
@@ -997,6 +1000,8 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     )
     from comp.runtime import (
         CompilerRunArtifactMaterializationError,
+        ExternalArtifactMaterial,
+        ExternalArtifactMaterialSource,
         TrustRuntime,
         materialize_compiler_run_artifacts,
     )
@@ -1058,6 +1063,8 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert replay_public_projection is not None
     assert verify_materialized_public_projection is not None
     assert CompilerRunArtifactMaterializationError is not None
+    assert ExternalArtifactMaterial is not None
+    assert ExternalArtifactMaterialSource is not None
     assert TrustRuntime is not None
     assert materialize_compiler_run_artifacts is not None
 


### PR DESCRIPTION
## Summary
- Add `ExternalArtifactMaterial` and `ExternalArtifactMaterialSource` as the explicit external material boundary for compiler-run artifact materialization.
- Change `materialize_compiler_run_artifacts(...)` to consume the named source instead of a raw `external_artifact_bodies` mapping.
- Route synthetic and domain scenario replay helpers through the new source, and update contract/docs smoke coverage for the boundary.

## Validation
- `python -m pytest tests/test_compiler_run_artifact_materializer.py tests/test_domain_scenario_pack_diet.py tests/test_package_smoke.py::test_artifact_envelope_builder_contract_separates_coverage_from_materialization tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer tests/test_synthetic_run_harness.py tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py -q`
- `python -m pytest tests/test_authority_import_boundaries.py tests/test_package_smoke.py -q`
- `python -m pytest -q`