### PR TITLE
[codex] Add revision work items

### DIFF
--- a/minchoagnt/__init__.py
+++ b/minchoagnt/__init__.py
@@ -20,10 +20,12 @@ from minchoagnt.revision_loop import (
     ObligationReflection,
     RevisedHypothesis,
     RevisionIteration,
+    RevisionWorkItem,
     WitnessFixtureRule,
     WitnessRequest,
     deterministic_revision_loop,
     obligation_reflection,
+    revision_work_items_from_reflection,
     revised_hypothesis_fixture,
 )
 from minchoagnt.skills import SkillStore
@@ -58,6 +60,7 @@ __all__ = [
     "ObligationReflection",
     "RevisedHypothesis",
     "RevisionIteration",
+    "RevisionWorkItem",
     "ReviewWorkbench",
     "SkillStore",
     "WitnessFixtureRule",
@@ -70,6 +73,7 @@ __all__ = [
     "DeterministicLLMWorker",
     "deterministic_revision_loop",
     "obligation_reflection",
+    "revision_work_items_from_reflection",
     "revised_hypothesis_fixture",
     "semantic_work_orders_from_result",
     "semantic_work_orders_from_tasks",

--- a/minchoagnt/revision_loop.py
+++ b/minchoagnt/revision_loop.py
@@ -44,6 +44,22 @@ class ObligationReflection:
 
 
 @dataclass(frozen=True)
+class RevisionWorkItem:
+    work_item_id: str
+    requirement_id: str
+    task_kind: str
+    field: str
+    reason: str
+    allowed_actions: tuple[str, ...] = field(default_factory=tuple)
+    forbidden_outputs: tuple[str, ...] = field(default_factory=tuple)
+    expected_artifacts: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def can_authorize_public_projection(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
 class RevisedHypothesis:
     source_hypothesis_id: str
     hypothesis: InterpretationHypothesis
@@ -98,6 +114,31 @@ def obligation_reflection(report: ValidationReport) -> ObligationReflection:
         status=report.status,
         witness_requests=tuple(witness_requests),
         unhandled_requirement_ids=tuple(unhandled_requirement_ids),
+    )
+
+
+def revision_work_items_from_reflection(
+    reflection: ObligationReflection,
+) -> tuple[RevisionWorkItem, ...]:
+    return tuple(
+        RevisionWorkItem(
+            work_item_id=f"revision-work-item:{request.requirement_id}",
+            requirement_id=request.requirement_id,
+            task_kind="attach_source_witness",
+            field=request.field,
+            reason=request.reason,
+            allowed_actions=(
+                "attach_grounded_witness",
+                "abstain_with_reason",
+            ),
+            forbidden_outputs=(
+                "create_reference_binding",
+                "create_commit_receipt",
+                "build_public_output",
+            ),
+            expected_artifacts=("evidence_witness", "abstention"),
+        )
+        for request in reflection.witness_requests
     )
 
 
@@ -236,9 +277,11 @@ __all__ = [
     "RevisedHypothesis",
     "RevisionStopReason",
     "RevisionIteration",
+    "RevisionWorkItem",
     "WitnessFixtureRule",
     "WitnessRequest",
     "deterministic_revision_loop",
     "obligation_reflection",
+    "revision_work_items_from_reflection",
     "revised_hypothesis_fixture",
 ]

--- a/tests/test_minchoagnt_revision_loop.py
+++ b/tests/test_minchoagnt_revision_loop.py
@@ -9,10 +9,12 @@ from minchoagnt import (
     ObligationReflection,
     RevisedHypothesis,
     RevisionIteration,
+    RevisionWorkItem,
     WitnessFixtureRule,
     WitnessRequest,
     deterministic_revision_loop,
     obligation_reflection,
+    revision_work_items_from_reflection,
     revised_hypothesis_fixture,
 )
 
@@ -40,6 +42,41 @@ def test_obligation_reflection_extracts_missing_source_witness_request():
         ),
         unhandled_requirement_ids=(),
     )
+
+
+def test_missing_source_witness_reflection_becomes_revision_work_item():
+    result = _adapter().compile(_missing_unit_witness_hypothesis())
+    reflection = obligation_reflection(result.report)
+
+    work_items = revision_work_items_from_reflection(reflection)
+
+    assert work_items == (
+        RevisionWorkItem(
+            work_item_id=(
+                "revision-work-item:"
+                "validation_requirement:find_source_witness:"
+                "unit:missing_source_witness"
+            ),
+            requirement_id=(
+                "validation_requirement:find_source_witness:"
+                "unit:missing_source_witness"
+            ),
+            task_kind="attach_source_witness",
+            field="unit",
+            reason="missing_source_witness",
+            allowed_actions=(
+                "attach_grounded_witness",
+                "abstain_with_reason",
+            ),
+            forbidden_outputs=(
+                "create_reference_binding",
+                "create_commit_receipt",
+                "build_public_output",
+            ),
+            expected_artifacts=("evidence_witness", "abstention"),
+        ),
+    )
+    assert work_items[0].can_authorize_public_projection is False
 
 
 def test_revised_hypothesis_fixture_adds_grounded_witness_without_mutating_source():
@@ -157,6 +194,7 @@ def test_unsupported_unit_reflection_stays_unhandled():
     assert reflection.unhandled_requirement_ids == (
         "validation_requirement:find_source_witness:unit:unsupported_unit",
     )
+    assert revision_work_items_from_reflection(reflection) == ()
     assert revision.hypothesis == hypothesis
     assert revision.applied_requirement_ids == ()
 


### PR DESCRIPTION
## Summary
- Add `RevisionWorkItem` as an agent-side description of fixture-safe revision work.
- Convert `missing_source_witness` obligation reflections into work items with limited allowed actions and explicit forbidden authority outputs.
- Export the new work-item API through `minchoagnt`.

## Authority boundary
- Work items can propose/abstain only; `can_authorize_public_projection` is always `False`.
- Unsupported-unit obligations remain unhandled and do not become fixture-safe work items.
- No receipt, projection, replay, ledger, or persistence authority is imported into the revision loop.

## Validation
- `python -m pytest tests/test_minchoagnt_revision_loop.py -q`
- `python -m pytest tests/test_minchoagnt_revision_loop.py tests/test_minchoagnt_llm_work_orders.py tests/test_authority_import_boundaries.py -q`
- `COMP_TEST_MYSQL_* ... python -m pytest -q` (`532 passed`)
- `python -m tests.domain_scenarios run-all` (`18/18`)
- `python -m pytest tests/test_package_smoke.py -q`
- `git diff --check`