### PR TITLE
[codex] sync l-energy rollup downstream coverage

### DIFF
--- a/docs/extensions/downstream-registry.json
+++ b/docs/extensions/downstream-registry.json
@@ -42,12 +42,66 @@
           ]
         },
         {
+          "id": "l_energy_c_pack_yield_rollup",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy.c_pack_yield_rollup.v1"
+          ]
+        },
+        {
+          "id": "l_energy_carbon_tech_certificate_submission",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy.carbon_tech_certificate_submission.v1"
+          ]
+        },
+        {
+          "id": "l_energy_final_bottom_up_pcf_rollup",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy.final_bottom_up_pcf_rollup.v1"
+          ]
+        },
+        {
+          "id": "l_energy_l_materials_composition_rollup",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy.l_materials_composition_rollup.v1"
+          ]
+        },
+        {
           "id": "l_energy_pcf_governance",
           "status": "seed",
           "scope": "large-domain-and-product-e2e",
           "cutover_state": "parallel-validation",
           "covers_comp_scenario_ids": [
             "l_energy_pcf_governance.v1"
+          ]
+        },
+        {
+          "id": "l_energy_steel_frame_proxy_assignment",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy.steel_frame_proxy_assignment.v1"
+          ]
+        },
+        {
+          "id": "l_energy_tier0_physical_allocation",
+          "status": "seed",
+          "scope": "large-domain-and-product-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "l_energy.tier0_physical_allocation.v1"
           ]
         }
       ],

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -28,6 +28,24 @@ l_energy_alpha_invalid_allocation_rfi
 
 l_energy_alpha_physical_allocation_correction
   seeded accepted/projection pack in parallel validation for l_energy.alpha_physical_allocation_correction.v1
+
+l_energy_c_pack_yield_rollup
+  seeded accepted/projection pack in parallel validation for l_energy.c_pack_yield_rollup.v1
+
+l_energy_carbon_tech_certificate_submission
+  seeded accepted/projection pack in parallel validation for l_energy.carbon_tech_certificate_submission.v1
+
+l_energy_final_bottom_up_pcf_rollup
+  seeded accepted/projection pack in parallel validation for l_energy.final_bottom_up_pcf_rollup.v1
+
+l_energy_l_materials_composition_rollup
+  seeded accepted/projection pack in parallel validation for l_energy.l_materials_composition_rollup.v1
+
+l_energy_steel_frame_proxy_assignment
+  seeded accepted/projection pack in parallel validation for l_energy.steel_frame_proxy_assignment.v1
+
+l_energy_tier0_physical_allocation
+  seeded accepted/projection pack in parallel validation for l_energy.tier0_physical_allocation.v1
 ```
 
 ## Boundary

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -166,6 +166,9 @@ downstream-candidate
 Current core-kernel scenarios include `canonical_working_loop`, `tiny_pcf`,
 and the raw-claim boundary scenarios. Current downstream-candidate scenarios
 are the `l_energy.*` family, `l_energy_pcf_governance.v1`, and synthetic PCF smoke/anomaly/resolution.
+The blocked/accepted allocation pair and accepted L-Energy rollup-chain
+scenarios have seeded downstream packs in parallel validation; synthetic PCF
+scenarios remain pending external coverage.
 
 Downstream-candidate is not a removal instruction. Keep the internal scenario
 until a downstream pack has copied or reconstructed the same trust meaning, run

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -112,6 +112,24 @@ _SYNTHETIC_PCF_DOWNSTREAM_IDS = frozenset(
 _DOWNSTREAM_CANDIDATE_IDS = (
     _LARGE_DOMAIN_DOWNSTREAM_IDS | _SYNTHETIC_PCF_DOWNSTREAM_IDS
 )
+_ROLLUP_EXTERNAL_PACK_IDS = {
+    STEEL_FRAME_PROXY_SCENARIO.scenario_id: (
+        "l_energy_steel_frame_proxy_assignment"
+    ),
+    CARBON_TECH_CERTIFICATE_SCENARIO.scenario_id: (
+        "l_energy_carbon_tech_certificate_submission"
+    ),
+    L_MATERIALS_COMPOSITION_SCENARIO.scenario_id: (
+        "l_energy_l_materials_composition_rollup"
+    ),
+    C_PACK_YIELD_ROLLUP_SCENARIO.scenario_id: "l_energy_c_pack_yield_rollup",
+    TIER0_PHYSICAL_ALLOCATION_SCENARIO.scenario_id: (
+        "l_energy_tier0_physical_allocation"
+    ),
+    FINAL_BOTTOM_UP_ROLLUP_SCENARIO.scenario_id: (
+        "l_energy_final_bottom_up_pcf_rollup"
+    ),
+}
 
 
 def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
@@ -139,6 +157,19 @@ def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
                 "accepted large domain workflow fixture has a seeded downstream "
                 "canonical bundle but remains internal until parallel validation "
                 "covers the same trust meaning"
+            ),
+        )
+    if scenario_id in _ROLLUP_EXTERNAL_PACK_IDS:
+        return ScenarioResidency(
+            tier="downstream-candidate",
+            target_pack="comp-scenario-packs",
+            external_pack_id=_ROLLUP_EXTERNAL_PACK_IDS[scenario_id],
+            external_contract_id="canonical_projection_smoke",
+            cutover_state="parallel-validation",
+            reason=(
+                "accepted large domain workflow rollup-chain fixture has a seeded "
+                "downstream canonical bundle but remains internal until "
+                "parallel validation covers the same trust meaning"
             ),
         )
     if scenario_id == L_ENERGY_PCF_GOVERNANCE_SCENARIO.scenario_id:

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -8,6 +8,25 @@ from tests.domain_scenarios.registry import (
     scenario_residency,
 )
 
+ROLLUP_EXTERNAL_PACKS = {
+    "l_energy.steel_frame_proxy_assignment.v1": (
+        "l_energy_steel_frame_proxy_assignment"
+    ),
+    "l_energy.carbon_tech_certificate_submission.v1": (
+        "l_energy_carbon_tech_certificate_submission"
+    ),
+    "l_energy.l_materials_composition_rollup.v1": (
+        "l_energy_l_materials_composition_rollup"
+    ),
+    "l_energy.c_pack_yield_rollup.v1": "l_energy_c_pack_yield_rollup",
+    "l_energy.tier0_physical_allocation.v1": (
+        "l_energy_tier0_physical_allocation"
+    ),
+    "l_energy.final_bottom_up_pcf_rollup.v1": (
+        "l_energy_final_bottom_up_pcf_rollup"
+    ),
+}
+
 
 def test_domain_scenario_registry_marks_core_and_downstream_candidate_sets():
     registered_ids = {scenario.scenario_id for scenario in registered_scenarios()}
@@ -70,7 +89,10 @@ def test_downstream_candidate_cutover_metadata_tracks_external_coverage():
     accepted_allocation = scenario_residency(
         "l_energy.alpha_physical_allocation_correction.v1"
     )
-    l_energy_rollup = scenario_residency("l_energy.final_bottom_up_pcf_rollup.v1")
+    rollup_residencies = {
+        scenario_id: scenario_residency(scenario_id)
+        for scenario_id in ROLLUP_EXTERNAL_PACKS
+    }
     synthetic = scenario_residency("synthetic_pcf.smoke.v1")
     raw_claim = scenario_residency(
         "synthetic.raw_claim_conflict_resolution.v1"
@@ -100,9 +122,13 @@ def test_downstream_candidate_cutover_metadata_tracks_external_coverage():
     assert accepted_allocation.external_contract_id == "canonical_projection_smoke"
     assert accepted_allocation.cutover_state == "parallel-validation"
 
-    assert l_energy_rollup.tier == "downstream-candidate"
-    assert l_energy_rollup.external_pack_id is None
-    assert l_energy_rollup.cutover_state == "pending-external-coverage"
+    for scenario_id, external_pack_id in ROLLUP_EXTERNAL_PACKS.items():
+        residency = rollup_residencies[scenario_id]
+        assert residency.tier == "downstream-candidate"
+        assert residency.target_pack == "comp-scenario-packs"
+        assert residency.external_pack_id == external_pack_id
+        assert residency.external_contract_id == "canonical_projection_smoke"
+        assert residency.cutover_state == "parallel-validation"
 
     assert synthetic.tier == "downstream-candidate"
     assert synthetic.external_pack_id is None
@@ -131,6 +157,8 @@ def test_domain_scenario_docs_explain_residency_tiers():
     assert "public_projection_smoke" in extension_doc
     assert "l_energy_alpha_invalid_allocation_rfi" in extension_doc
     assert "l_energy_alpha_physical_allocation_correction" in extension_doc
+    for external_pack_id in ROLLUP_EXTERNAL_PACKS.values():
+        assert external_pack_id in extension_doc
     assert "registry exposes residency metadata" in extension_doc
     assert "Scenario replay uses the production materializer boundary" in readme
     assert "materialize_compiler_run_artifacts(...)" in readme
@@ -199,10 +227,64 @@ def test_downstream_registry_records_active_pack_cutover_state():
             ],
         },
         {
+            "id": "l_energy_c_pack_yield_rollup",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": [
+                "l_energy.c_pack_yield_rollup.v1"
+            ],
+        },
+        {
+            "id": "l_energy_carbon_tech_certificate_submission",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": [
+                "l_energy.carbon_tech_certificate_submission.v1"
+            ],
+        },
+        {
+            "id": "l_energy_final_bottom_up_pcf_rollup",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": [
+                "l_energy.final_bottom_up_pcf_rollup.v1"
+            ],
+        },
+        {
+            "id": "l_energy_l_materials_composition_rollup",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": [
+                "l_energy.l_materials_composition_rollup.v1"
+            ],
+        },
+        {
             "id": "l_energy_pcf_governance",
             "status": "seed",
             "scope": "large-domain-and-product-e2e",
             "cutover_state": "parallel-validation",
             "covers_comp_scenario_ids": ["l_energy_pcf_governance.v1"],
+        },
+        {
+            "id": "l_energy_steel_frame_proxy_assignment",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": [
+                "l_energy.steel_frame_proxy_assignment.v1"
+            ],
+        },
+        {
+            "id": "l_energy_tier0_physical_allocation",
+            "status": "seed",
+            "scope": "large-domain-and-product-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": [
+                "l_energy.tier0_physical_allocation.v1"
+            ],
         },
     ]


### PR DESCRIPTION
## Summary

- Mark six accepted L-Energy rollup-chain scenarios as `parallel-validation` downstream candidates.
- Point each residency entry at the matching `comp-scenario-packs` external pack and `canonical_projection_smoke` contract.
- Sync `docs/extensions/downstream-registry.json`, `docs/extensions/scenario-packs.md`, and Domain Scenario Lab docs with the downstream pack list.
- Keep internal scenario execution unchanged; this records compatibility coverage only.

## Dependency

Depends on downstream draft PR minntcho/comp-scenario-packs#27, which adds the runnable rollup-chain packs. This PR should stay draft until that downstream evidence lands.

## Validation

- RED: `python -m pytest tests/test_domain_scenario_pack_diet.py -q` failed with rollup scenarios still pending external coverage and docs/registry missing the packs.
- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_package_smoke.py -q` -> 43 passed
- `python -m pytest -q` -> 518 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `git diff --check` -> no whitespace errors