### PR TITLE
[codex] Use external material sources in scenarios

### DIFF
--- a/comp/scenarios/synthetic/adapters.py
+++ b/comp/scenarios/synthetic/adapters.py
@@ -31,6 +31,7 @@ from comp.scenarios.synthetic.sources import (
     synthetic_source_input_dependency_id,
 )
 from comp.scenarios.synthetic.references import reference_catalog_from_input_bundle
+from comp.runtime import ExternalArtifactMaterial, ExternalArtifactMaterialSource
 
 
 class SyntheticPcfAdapter:
@@ -297,30 +298,37 @@ class SyntheticPcfAdapter:
             *self.synthetic_source_fingerprints(),
         )
 
-    def dependency_artifact_bodies(self):
+    def external_material_source(self) -> ExternalArtifactMaterialSource:
         manifest_fingerprint = self.synthetic_manifest_fingerprint()
-        bodies = {
-            (
-                manifest_fingerprint.dependency_kind,
-                manifest_fingerprint.dependency_id,
-            ): {
-                "dependency_kind": manifest_fingerprint.dependency_kind,
-                "dependency_id": manifest_fingerprint.dependency_id,
-                "fingerprint": manifest_fingerprint.fingerprint,
-                "digest_alg": manifest_fingerprint.digest_alg,
-                "manifest": self.input_bundle.manifest,
-            }
-        }
+        materials = [
+            ExternalArtifactMaterial(
+                artifact_kind=manifest_fingerprint.dependency_kind,
+                artifact_id=manifest_fingerprint.dependency_id,
+                body={
+                    "dependency_kind": manifest_fingerprint.dependency_kind,
+                    "dependency_id": manifest_fingerprint.dependency_id,
+                    "fingerprint": manifest_fingerprint.fingerprint,
+                    "digest_alg": manifest_fingerprint.digest_alg,
+                    "manifest": self.input_bundle.manifest,
+                },
+            )
+        ]
         for source in self.input_bundle.loaded_sources:
             fingerprint = self.synthetic_source_fingerprint(source)
-            bodies[(fingerprint.dependency_kind, fingerprint.dependency_id)] = {
-                "dependency_kind": fingerprint.dependency_kind,
-                "dependency_id": fingerprint.dependency_id,
-                "fingerprint": fingerprint.fingerprint,
-                "digest_alg": fingerprint.digest_alg,
-                "source": source.to_payload(),
-            }
-        return bodies
+            materials.append(
+                ExternalArtifactMaterial(
+                    artifact_kind=fingerprint.dependency_kind,
+                    artifact_id=fingerprint.dependency_id,
+                    body={
+                        "dependency_kind": fingerprint.dependency_kind,
+                        "dependency_id": fingerprint.dependency_id,
+                        "fingerprint": fingerprint.fingerprint,
+                        "digest_alg": fingerprint.digest_alg,
+                        "source": source.to_payload(),
+                    },
+                )
+            )
+        return ExternalArtifactMaterialSource(materials)
 
     def synthetic_manifest_fingerprint(self) -> DependencyFingerprint:
         return DependencyFingerprint.from_payload(

--- a/docs/architecture/contracts/artifact-envelope-builder.md
+++ b/docs/architecture/contracts/artifact-envelope-builder.md
@@ -554,8 +554,8 @@ DomainScenarioResult
 -> replay_public_projection(...)
 ```
 
-Scenario helpers may prepare external artifact bodies for fixtures, but they
-must pass them through `ExternalArtifactMaterialSource`. They must not recreate `ArtifactEnvelope` construction or receipt-ref coverage
+Scenario helpers may prepare fixture-owned external material, but they
+must expose it as `ExternalArtifactMaterialSource`. They must not recreate `ArtifactEnvelope` construction or receipt-ref coverage
 policy.
 
 ## Review Checklist

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -121,8 +121,8 @@ DomainScenarioResult
 -> replay_public_projection(...)
 ```
 
-Scenario helpers may prepare external artifact bodies for fixture-only records,
-but they should pass them through `ExternalArtifactMaterialSource`, not construct
+Scenario helpers may prepare fixture-owned external material for fixture-only records,
+but they should expose it as `ExternalArtifactMaterialSource`, not construct
 `ArtifactEnvelope` objects directly or duplicate receipt-ref coverage policy.
 
 ## External Scenario Packs

--- a/tests/domain_scenarios/canonical_working_loop/scenario.py
+++ b/tests/domain_scenarios/canonical_working_loop/scenario.py
@@ -19,6 +19,7 @@ from comp.compiler_tool import (
     resolver_tasks_from_report,
     retry_blocked_calculation,
 )
+from comp.runtime import ExternalArtifactMaterial, ExternalArtifactMaterialSource
 from tests.domain_scenarios.canonical_working_loop.expected import (
     EXPECTED_PROJECTION,
     EXPECTED_REFERENCE_CANDIDATE_IDS,
@@ -158,11 +159,15 @@ def run_canonical_working_loop_scenario() -> DomainScenarioResult:
         projection=projection,
         subject=SubjectRef("claim", SUBJECT_ID),
         resolver_steps=RESOLVER_STEPS,
-        dependency_artifact_bodies={
-            ("compiler_profile", scenario_profile.profile_id): (
-                profile_lock_envelope_body(scenario_profile)
+        external_material_source=ExternalArtifactMaterialSource(
+            (
+                ExternalArtifactMaterial(
+                    artifact_kind="compiler_profile",
+                    artifact_id=scenario_profile.profile_id,
+                    body=profile_lock_envelope_body(scenario_profile),
+                ),
             ),
-        },
+        ),
     )
 
 

--- a/tests/domain_scenarios/core.py
+++ b/tests/domain_scenarios/core.py
@@ -12,6 +12,7 @@ from comp.compiler_tool import (
     compile_report_to_facts,
 )
 from comp.judgment import DependencyFingerprint, Fact, SubjectRef
+from comp.runtime import ExternalArtifactMaterialSource
 
 
 @dataclass(frozen=True)
@@ -63,8 +64,8 @@ class DomainScenarioResult:
     report_facts: frozenset[Fact]
     commit_facts: frozenset[Fact]
     resolver_steps: tuple[str, ...]
-    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]] = field(
-        default_factory=dict
+    external_material_source: ExternalArtifactMaterialSource = field(
+        default_factory=ExternalArtifactMaterialSource
     )
 
     def to_dict(self) -> dict[str, Any]:
@@ -84,8 +85,7 @@ def build_domain_scenario_result(
     projection: dict[str, Any] | None,
     subject: SubjectRef,
     resolver_steps: tuple[str, ...],
-    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]]
-    | None = None,
+    external_material_source: ExternalArtifactMaterialSource | None = None,
 ) -> DomainScenarioResult:
     return DomainScenarioResult(
         scenario_id=scenario_id,
@@ -95,7 +95,11 @@ def build_domain_scenario_result(
         report_facts=frozenset(compile_report_to_facts(report, subject)),
         commit_facts=frozenset(commit_preparation_to_facts(preparation, subject)),
         resolver_steps=resolver_steps,
-        dependency_artifact_bodies=dependency_artifact_bodies or {},
+        external_material_source=(
+            external_material_source
+            if external_material_source is not None
+            else ExternalArtifactMaterialSource()
+        ),
     )
 
 

--- a/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+++ b/tests/domain_scenarios/l_energy_pcf_governance/scenario.py
@@ -19,6 +19,7 @@ from comp.compiler_tool import (
     resolver_tasks_from_report,
     retry_blocked_calculation,
 )
+from comp.runtime import ExternalArtifactMaterial, ExternalArtifactMaterialSource
 from tests.domain_scenarios.core import (
     DomainScenarioResult,
     ScenarioContract,
@@ -185,11 +186,15 @@ def run_l_energy_pcf_governance_scenario(
         projection=projection,
         subject=SubjectRef("claim", SUBJECT_ID),
         resolver_steps=RESOLVER_STEPS,
-        dependency_artifact_bodies={
-            ("compiler_profile", scenario_profile.profile_id): (
-                profile_lock_envelope_body(scenario_profile)
+        external_material_source=ExternalArtifactMaterialSource(
+            (
+                ExternalArtifactMaterial(
+                    artifact_kind="compiler_profile",
+                    artifact_id=scenario_profile.profile_id,
+                    body=profile_lock_envelope_body(scenario_profile),
+                ),
             ),
-        },
+        ),
     )
 
 

--- a/tests/domain_scenarios/persistence.py
+++ b/tests/domain_scenarios/persistence.py
@@ -14,6 +14,7 @@ from comp.persistence import (
     replay_public_projection,
 )
 from comp.runtime import (
+    ExternalArtifactMaterial,
     ExternalArtifactMaterialSource,
     materialize_compiler_run_artifacts,
 )
@@ -40,9 +41,7 @@ def scenario_replay_bundle(
     materials = materialize_compiler_run_artifacts(
         result.report,
         result.preparation,
-        external_material_source=ExternalArtifactMaterialSource.from_bodies(
-            _scenario_external_artifact_bodies(result)
-        ),
+        external_material_source=_scenario_external_material_source(result),
         schema_version="domain-scenario-v1",
     )
     for envelope in build_receipt_envelope_set(receipt, materials):
@@ -88,40 +87,70 @@ def replay_scenario_projection(
     )
 
 
-def _scenario_external_artifact_bodies(
+def _scenario_external_material_source(
     result: DomainScenarioResult,
-) -> dict[tuple[str, str], dict[str, Any]]:
-    bodies = {
-        key: dict(body) for key, body in result.dependency_artifact_bodies.items()
+) -> ExternalArtifactMaterialSource:
+    materials = {
+        material.key: material for material in result.external_material_source.materials
     }
     receipt = result.preparation.receipt
     if receipt is None or receipt.citations is None:
-        return bodies
+        return ExternalArtifactMaterialSource(materials.values())
 
     for judgment_id in receipt.citations.semantic_judgment_ids:
-        bodies.setdefault(
-            ("semantic_judgment", judgment_id),
+        _setdefault_material(
+            materials,
+            "semantic_judgment",
+            judgment_id,
             {"judgment_id": judgment_id},
         )
 
     for witness_id in receipt.citations.checked_claim_witness_ids:
-        bodies.setdefault(
-            ("evidence_witness", witness_id),
+        _setdefault_material(
+            materials,
+            "evidence_witness",
+            witness_id,
             {"witness_id": witness_id, "source": "domain_scenario"},
         )
 
     for fingerprint in receipt.citations.dependency_fingerprints:
         key = (fingerprint.dependency_kind, fingerprint.dependency_id)
-        if key in bodies:
+        if key in materials:
             continue
         if fingerprint.dependency_kind == "reference_catalog_snapshot":
-            bodies[key] = _reference_catalog_snapshot_body(
-                fingerprint,
-                receipt.citations.dependency_fingerprints,
+            _setdefault_material(
+                materials,
+                fingerprint.dependency_kind,
+                fingerprint.dependency_id,
+                _reference_catalog_snapshot_body(
+                    fingerprint,
+                    receipt.citations.dependency_fingerprints,
+                ),
             )
             continue
-        bodies[key] = _dependency_fingerprint_body(fingerprint)
-    return bodies
+        _setdefault_material(
+            materials,
+            fingerprint.dependency_kind,
+            fingerprint.dependency_id,
+            _dependency_fingerprint_body(fingerprint),
+        )
+    return ExternalArtifactMaterialSource(materials.values())
+
+
+def _setdefault_material(
+    materials: dict[tuple[str, str], ExternalArtifactMaterial],
+    artifact_kind: str,
+    artifact_id: str,
+    body: dict[str, Any],
+) -> None:
+    materials.setdefault(
+        (artifact_kind, artifact_id),
+        ExternalArtifactMaterial(
+            artifact_kind=artifact_kind,
+            artifact_id=artifact_id,
+            body=body,
+        ),
+    )
 
 
 def _reference_catalog_snapshot_body(

--- a/tests/domain_scenarios/synthetic_pcf_anomaly/scenario.py
+++ b/tests/domain_scenarios/synthetic_pcf_anomaly/scenario.py
@@ -68,7 +68,7 @@ def run_synthetic_pcf_anomaly_scenario() -> DomainScenarioResult:
         projection=None,
         subject=SubjectRef("claim", adapter.subject_id),
         resolver_steps=RESOLVER_STEPS,
-        dependency_artifact_bodies=adapter.dependency_artifact_bodies(),
+        external_material_source=adapter.external_material_source(),
     )
 
 

--- a/tests/domain_scenarios/synthetic_pcf_resolution/scenario.py
+++ b/tests/domain_scenarios/synthetic_pcf_resolution/scenario.py
@@ -103,7 +103,7 @@ def run_synthetic_pcf_resolution_scenario() -> DomainScenarioResult:
         projection=projection,
         subject=SubjectRef("claim", adapter.subject_id),
         resolver_steps=RESOLVER_STEPS,
-        dependency_artifact_bodies=adapter.dependency_artifact_bodies(),
+        external_material_source=adapter.external_material_source(),
     )
 
 

--- a/tests/domain_scenarios/synthetic_pcf_smoke/scenario.py
+++ b/tests/domain_scenarios/synthetic_pcf_smoke/scenario.py
@@ -99,7 +99,7 @@ def run_synthetic_pcf_smoke_scenario() -> DomainScenarioResult:
         projection=projection,
         subject=SubjectRef("claim", adapter.subject_id),
         resolver_steps=RESOLVER_STEPS,
-        dependency_artifact_bodies=adapter.dependency_artifact_bodies(),
+        external_material_source=adapter.external_material_source(),
     )
 
 

--- a/tests/support/synthetic/replay.py
+++ b/tests/support/synthetic/replay.py
@@ -31,7 +31,7 @@ class SyntheticReplayBundle:
 def synthetic_replay_bundle(
     report: ValidationReport,
     preparation: CommitPreparation,
-    dependency_artifact_bodies: Mapping[tuple[str, str], Mapping[str, Any]],
+    external_material_source: ExternalArtifactMaterialSource,
 ) -> SyntheticReplayBundle:
     receipt = preparation.receipt
     if receipt is None:
@@ -41,9 +41,7 @@ def synthetic_replay_bundle(
     materials = materialize_compiler_run_artifacts(
         report,
         preparation,
-        external_material_source=ExternalArtifactMaterialSource.from_bodies(
-            dependency_artifact_bodies
-        ),
+        external_material_source=external_material_source,
         schema_version="synthetic-scenario-v1",
     )
     build_receipt_envelope_set(receipt, materials, record_to=artifacts)

--- a/tests/support/synthetic/run_harness.py
+++ b/tests/support/synthetic/run_harness.py
@@ -148,7 +148,7 @@ def _replay_if_authorized(
     bundle = synthetic_replay_bundle(
         report,
         preparation,
-        adapter.dependency_artifact_bodies(),
+        adapter.external_material_source(),
     )
     return replay_synthetic_projection(
         projection,

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -163,6 +163,7 @@ def test_domain_scenario_docs_explain_residency_tiers():
     assert "Scenario replay uses the production materializer boundary" in readme
     assert "materialize_compiler_run_artifacts(...)" in readme
     assert "ExternalArtifactMaterialSource" in readme
+    assert "fixture-owned external material" in readme
     assert "not construct\n`ArtifactEnvelope` objects directly" in readme
 
 
@@ -173,7 +174,7 @@ def test_domain_scenario_replay_uses_production_materializer_boundary():
 
     assert "materialize_compiler_run_artifacts" in source
     assert "build_receipt_envelope_set" in source
-    assert "ExternalArtifactMaterialSource.from_bodies" in source
+    assert "_scenario_external_material_source" in source
     assert "external_material_source=" in source
 
     for stale_policy in (
@@ -182,6 +183,8 @@ def test_domain_scenario_replay_uses_production_materializer_boundary():
         "evidence_ref_fingerprint",
         "_artifact_envelope_for_ref",
         "_artifact_body_for_ref",
+        "_scenario_external_artifact_bodies",
+        "dependency_artifact_bodies",
         "external_artifact_bodies=",
     ):
         assert stale_policy not in source

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -925,7 +925,7 @@ def test_artifact_envelope_builder_contract_separates_coverage_from_materializat
         "not an authority source",
         "It must not mint receipts, call `build_public_output(...)`, record",
         "Domain Scenario Lab replay must exercise the same path:",
-        "must pass them through `ExternalArtifactMaterialSource`",
+        "must expose it as `ExternalArtifactMaterialSource`",
         "must not recreate `ArtifactEnvelope` construction or receipt-ref coverage",
         "`tests/test_artifact_envelope_builder.py`",
         "`tests/test_compiler_run_artifact_materializer.py`",

--- a/tests/test_synthetic_scenario_generator.py
+++ b/tests/test_synthetic_scenario_generator.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from comp.compiler_tool import resolve_reference_grounded_calculation
+from comp.persistence import ArtifactRef
+from comp.runtime import ExternalArtifactMaterialSource
 from comp.scenarios.synthetic import (
     SyntheticInputLoadError,
     SyntheticPcfAdapter,
@@ -635,8 +637,9 @@ def test_synthetic_adapter_cites_loaded_sources_as_dependencies(
     adapter = SyntheticPcfAdapter(load_synthetic_input_bundle(run_dir))
 
     fingerprints = adapter.dependency_fingerprints()
-    bodies = adapter.dependency_artifact_bodies()
+    external_material_source = adapter.external_material_source()
 
+    assert isinstance(external_material_source, ExternalArtifactMaterialSource)
     assert [
         (fingerprint.dependency_kind, fingerprint.dependency_id)
         for fingerprint in fingerprints
@@ -675,7 +678,12 @@ def test_synthetic_adapter_cites_loaded_sources_as_dependencies(
         ),
     ]
     for fingerprint in fingerprints:
-        body = bodies[(fingerprint.dependency_kind, fingerprint.dependency_id)]
+        body = external_material_source.body_for(
+            ArtifactRef(
+                artifact_id=fingerprint.dependency_id,
+                artifact_kind=fingerprint.dependency_kind,
+            )
+        )
         assert body["fingerprint"] == fingerprint.fingerprint
         assert body["digest_alg"] == fingerprint.digest_alg
 


### PR DESCRIPTION
## Summary
- Replace the remaining domain scenario `dependency_artifact_bodies` fixture boundary with `ExternalArtifactMaterialSource`.
- Teach the synthetic PCF adapter to expose an `external_material_source()` directly, and pass that through synthetic/domain replay helpers.
- Update artifact-envelope contract docs and smoke tests so scenario helpers expose fixture-owned material as the named source instead of raw body mappings.

## Validation
- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_synthetic_scenario_generator.py::test_synthetic_adapter_cites_loaded_sources_as_dependencies tests/test_synthetic_run_harness.py tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py tests/test_compiler_run_artifact_materializer.py tests/test_package_smoke.py -q`
- `python -m tests.domain_scenarios run-all`
- `python -m pytest tests/test_authority_import_boundaries.py -q`
- `python -m pytest -q`
- `git diff --check origin/main...HEAD`