### PR TITLE
[codex] sync synthetic pcf downstream coverage

### DIFF
--- a/docs/extensions/downstream-registry.json
+++ b/docs/extensions/downstream-registry.json
@@ -103,6 +103,33 @@
           "covers_comp_scenario_ids": [
             "l_energy.tier0_physical_allocation.v1"
           ]
+        },
+        {
+          "id": "synthetic_pcf_anomaly",
+          "status": "seed",
+          "scope": "synthetic-generator-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "synthetic_pcf.anomaly.v1"
+          ]
+        },
+        {
+          "id": "synthetic_pcf_resolution",
+          "status": "seed",
+          "scope": "synthetic-generator-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "synthetic_pcf.resolution.v1"
+          ]
+        },
+        {
+          "id": "synthetic_pcf_smoke",
+          "status": "seed",
+          "scope": "synthetic-generator-e2e",
+          "cutover_state": "parallel-validation",
+          "covers_comp_scenario_ids": [
+            "synthetic_pcf.smoke.v1"
+          ]
         }
       ],
       "notes": [

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -46,6 +46,15 @@ l_energy_steel_frame_proxy_assignment
 
 l_energy_tier0_physical_allocation
   seeded accepted/projection pack in parallel validation for l_energy.tier0_physical_allocation.v1
+
+synthetic_pcf_anomaly
+  seeded blocked/no-projection pack in parallel validation for synthetic_pcf.anomaly.v1
+
+synthetic_pcf_resolution
+  seeded accepted/projection pack in parallel validation for synthetic_pcf.resolution.v1
+
+synthetic_pcf_smoke
+  seeded accepted/projection pack in parallel validation for synthetic_pcf.smoke.v1
 ```
 
 ## Boundary

--- a/tests/domain_scenarios/README.md
+++ b/tests/domain_scenarios/README.md
@@ -166,9 +166,9 @@ downstream-candidate
 Current core-kernel scenarios include `canonical_working_loop`, `tiny_pcf`,
 and the raw-claim boundary scenarios. Current downstream-candidate scenarios
 are the `l_energy.*` family, `l_energy_pcf_governance.v1`, and synthetic PCF smoke/anomaly/resolution.
-The blocked/accepted allocation pair and accepted L-Energy rollup-chain
-scenarios have seeded downstream packs in parallel validation; synthetic PCF
-scenarios remain pending external coverage.
+The blocked/accepted allocation pair, accepted L-Energy rollup-chain scenarios,
+and synthetic PCF smoke/anomaly/resolution scenarios have seeded downstream
+packs in parallel validation.
 
 Downstream-candidate is not a removal instruction. Keep the internal scenario
 until a downstream pack has copied or reconstructed the same trust meaning, run

--- a/tests/domain_scenarios/registry.py
+++ b/tests/domain_scenarios/registry.py
@@ -130,6 +130,20 @@ _ROLLUP_EXTERNAL_PACK_IDS = {
         "l_energy_final_bottom_up_pcf_rollup"
     ),
 }
+_SYNTHETIC_PCF_EXTERNAL_PACKS = {
+    SYNTHETIC_PCF_SMOKE_SCENARIO.scenario_id: (
+        "synthetic_pcf_smoke",
+        "canonical_projection_smoke",
+    ),
+    SYNTHETIC_PCF_ANOMALY_SCENARIO.scenario_id: (
+        "synthetic_pcf_anomaly",
+        "canonical_blocked_projection_smoke",
+    ),
+    SYNTHETIC_PCF_RESOLUTION_SCENARIO.scenario_id: (
+        "synthetic_pcf_resolution",
+        "canonical_projection_smoke",
+    ),
+}
 
 
 def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
@@ -193,6 +207,22 @@ def _scenario_residency_for(scenario_id: str) -> ScenarioResidency:
             reason=(
                 "large domain workflow fixture retained temporarily until the "
                 "downstream scenario pack owns it"
+            ),
+        )
+    if scenario_id in _SYNTHETIC_PCF_EXTERNAL_PACKS:
+        external_pack_id, external_contract_id = _SYNTHETIC_PCF_EXTERNAL_PACKS[
+            scenario_id
+        ]
+        return ScenarioResidency(
+            tier="downstream-candidate",
+            target_pack="comp-scenario-packs",
+            external_pack_id=external_pack_id,
+            external_contract_id=external_contract_id,
+            cutover_state="parallel-validation",
+            reason=(
+                "synthetic generator fixture has a seeded downstream canonical "
+                "bundle but remains internal until parallel validation covers "
+                "the same trust meaning"
             ),
         )
     if scenario_id in _SYNTHETIC_PCF_DOWNSTREAM_IDS:

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -27,6 +27,21 @@ ROLLUP_EXTERNAL_PACKS = {
     ),
 }
 
+SYNTHETIC_PCF_EXTERNAL_PACKS = {
+    "synthetic_pcf.smoke.v1": (
+        "synthetic_pcf_smoke",
+        "canonical_projection_smoke",
+    ),
+    "synthetic_pcf.anomaly.v1": (
+        "synthetic_pcf_anomaly",
+        "canonical_blocked_projection_smoke",
+    ),
+    "synthetic_pcf.resolution.v1": (
+        "synthetic_pcf_resolution",
+        "canonical_projection_smoke",
+    ),
+}
+
 
 def test_domain_scenario_registry_marks_core_and_downstream_candidate_sets():
     registered_ids = {scenario.scenario_id for scenario in registered_scenarios()}
@@ -93,7 +108,10 @@ def test_downstream_candidate_cutover_metadata_tracks_external_coverage():
         scenario_id: scenario_residency(scenario_id)
         for scenario_id in ROLLUP_EXTERNAL_PACKS
     }
-    synthetic = scenario_residency("synthetic_pcf.smoke.v1")
+    synthetic_residencies = {
+        scenario_id: scenario_residency(scenario_id)
+        for scenario_id in SYNTHETIC_PCF_EXTERNAL_PACKS
+    }
     raw_claim = scenario_residency(
         "synthetic.raw_claim_conflict_resolution.v1"
     )
@@ -130,9 +148,16 @@ def test_downstream_candidate_cutover_metadata_tracks_external_coverage():
         assert residency.external_contract_id == "canonical_projection_smoke"
         assert residency.cutover_state == "parallel-validation"
 
-    assert synthetic.tier == "downstream-candidate"
-    assert synthetic.external_pack_id is None
-    assert synthetic.cutover_state == "pending-external-coverage"
+    for scenario_id, (
+        external_pack_id,
+        external_contract_id,
+    ) in SYNTHETIC_PCF_EXTERNAL_PACKS.items():
+        residency = synthetic_residencies[scenario_id]
+        assert residency.tier == "downstream-candidate"
+        assert residency.target_pack == "comp-scenario-packs"
+        assert residency.external_pack_id == external_pack_id
+        assert residency.external_contract_id == external_contract_id
+        assert residency.cutover_state == "parallel-validation"
 
     assert raw_claim.tier == "core-kernel"
     assert raw_claim.cutover_state == "internal-kernel-regression"
@@ -158,6 +183,8 @@ def test_domain_scenario_docs_explain_residency_tiers():
     assert "l_energy_alpha_invalid_allocation_rfi" in extension_doc
     assert "l_energy_alpha_physical_allocation_correction" in extension_doc
     for external_pack_id in ROLLUP_EXTERNAL_PACKS.values():
+        assert external_pack_id in extension_doc
+    for external_pack_id, _contract_id in SYNTHETIC_PCF_EXTERNAL_PACKS.values():
         assert external_pack_id in extension_doc
     assert "registry exposes residency metadata" in extension_doc
     assert "Scenario replay uses the production materializer boundary" in readme
@@ -289,5 +316,26 @@ def test_downstream_registry_records_active_pack_cutover_state():
             "covers_comp_scenario_ids": [
                 "l_energy.tier0_physical_allocation.v1"
             ],
+        },
+        {
+            "id": "synthetic_pcf_anomaly",
+            "status": "seed",
+            "scope": "synthetic-generator-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": ["synthetic_pcf.anomaly.v1"],
+        },
+        {
+            "id": "synthetic_pcf_resolution",
+            "status": "seed",
+            "scope": "synthetic-generator-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": ["synthetic_pcf.resolution.v1"],
+        },
+        {
+            "id": "synthetic_pcf_smoke",
+            "status": "seed",
+            "scope": "synthetic-generator-e2e",
+            "cutover_state": "parallel-validation",
+            "covers_comp_scenario_ids": ["synthetic_pcf.smoke.v1"],
         },
     ]


### PR DESCRIPTION
## Summary

- Mark synthetic PCF smoke, anomaly, and resolution scenarios as `parallel-validation` downstream candidates.
- Point each residency entry at the matching `comp-scenario-packs` external pack and projection/blocked-projection contract.
- Sync downstream registry and scenario-pack docs with the synthetic PCF pack list.
- Keep raw-claim authority scenarios as `core-kernel` internal regressions.

## Dependency

Depends on downstream draft PR minntcho/comp-scenario-packs#29, which adds the runnable synthetic PCF packs. This PR should stay draft until that downstream evidence lands.

## Validation

- RED: `python -m pytest tests/test_domain_scenario_pack_diet.py -q` failed with synthetic PCF scenarios still pending external coverage and docs/registry missing the packs.
- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_package_smoke.py -q` -> 43 passed
- `python -m pytest -q` -> 522 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `git diff --check` -> no whitespace errors