### PR TITLE
[codex] Require typed external artifact materials

### DIFF
--- a/comp/runtime/compiler_run_artifacts.py
+++ b/comp/runtime/compiler_run_artifacts.py
@@ -39,20 +39,6 @@ class ExternalArtifactMaterialSource:
         object.__setattr__(self, "materials", material_tuple)
         object.__setattr__(self, "_bodies", _external_bodies_by_key(material_tuple))
 
-    @classmethod
-    def from_bodies(
-        cls,
-        bodies: Mapping[tuple[str, str], Mapping[str, Any]],
-    ) -> "ExternalArtifactMaterialSource":
-        return cls(
-            ExternalArtifactMaterial(
-                artifact_kind=artifact_kind,
-                artifact_id=artifact_id,
-                body=body,
-            )
-            for (artifact_kind, artifact_id), body in bodies.items()
-        )
-
     def body_for(self, ref: ArtifactRef) -> Mapping[str, Any]:
         try:
             return dict(self._bodies[(ref.artifact_kind, ref.artifact_id)])

--- a/tests/test_compiler_run_artifact_materializer.py
+++ b/tests/test_compiler_run_artifact_materializer.py
@@ -41,9 +41,7 @@ def test_materialize_compiler_run_artifacts_builds_replayable_materials():
     materials = materialize_compiler_run_artifacts(
         report,
         preparation,
-        external_material_source=ExternalArtifactMaterialSource.from_bodies(
-            external_bodies
-        ),
+        external_material_source=_external_material_source(external_bodies),
     )
     assert all(isinstance(material, ArtifactMaterial) for material in materials)
     assert {
@@ -106,10 +104,12 @@ def test_materialize_compiler_run_artifacts_requires_external_dependency_body():
         materialize_compiler_run_artifacts(
             report,
             preparation,
-            external_material_source=ExternalArtifactMaterialSource.from_bodies(
-                missing_reference_record
-            ),
+            external_material_source=_external_material_source(missing_reference_record),
         )
+
+
+def test_external_artifact_material_source_accepts_typed_materials_only():
+    assert not hasattr(ExternalArtifactMaterialSource, "from_bodies")
 
 
 def test_external_artifact_material_source_rejects_conflicting_materials():
@@ -240,6 +240,19 @@ def _accepted_compiler_run():
         ): _catalog_snapshot_body(snapshot, snapshot_fingerprint),
     }
     return report, preparation, external_bodies
+
+
+def _external_material_source(
+    bodies: dict[tuple[str, str], dict],
+) -> ExternalArtifactMaterialSource:
+    return ExternalArtifactMaterialSource(
+        ExternalArtifactMaterial(
+            artifact_kind=artifact_kind,
+            artifact_id=artifact_id,
+            body=body,
+        )
+        for (artifact_kind, artifact_id), body in bodies.items()
+    )
 
 
 def _fingerprint_from_body(body):


### PR DESCRIPTION
## Summary
- Remove `ExternalArtifactMaterialSource.from_bodies(...)` so the public source boundary only accepts typed `ExternalArtifactMaterial` items.
- Update compiler-run materializer tests to construct explicit external materials instead of raw body mappings.
- Add a guard that keeps the raw-body convenience constructor from returning as an endorsed API.

## Validation
- `python -m pytest tests/test_compiler_run_artifact_materializer.py -q`
- `python -m pytest tests/test_compiler_run_artifact_materializer.py tests/test_domain_scenario_pack_diet.py tests/test_package_smoke.py tests/test_synthetic_run_harness.py tests/test_canonical_working_loop_scenario.py tests/test_l_energy_pcf_scenario.py -q`
- `python -m tests.domain_scenarios run-all`
- `python -m pytest tests/test_authority_import_boundaries.py -q`
- `python -m pytest -q`
- `git diff --check`