### PR TITLE
[codex] Update materializer contract current state

### DIFF
--- a/docs/architecture/contracts/artifact-envelope-builder.md
+++ b/docs/architecture/contracts/artifact-envelope-builder.md
@@ -77,9 +77,11 @@ ArtifactMaterial items keyed by artifact_kind and artifact_id
 optional ArtifactStore target
 ```
 
-The current Domain Scenario Lab already has a fixture-shaped version of this
-materializer boundary in `tests/domain_scenarios/persistence.py`.
-Production code should generalize the materializer contract without making scenario fixtures authoritative.
+Domain Scenario Lab replay uses the production compiler-run materializer boundary.
+Scenario fixture material must remain external material, not builder policy.
+`tests/domain_scenarios/persistence.py` may enrich fixture-owned material as
+`ExternalArtifactMaterialSource`, but it must not own receipt coverage,
+`ArtifactEnvelope` construction, or projection authority.
 
 A compiler-run materializer may accept the smallest compiler-aware set needed
 to produce those materials:

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -915,7 +915,8 @@ def test_artifact_envelope_builder_contract_separates_coverage_from_materializat
         "It must not accept `ValidationReport`, `CommitPreparation`, or `EvidenceRef` as direct inputs.",
         "A compiler-run materializer may read compiler objects and produce artifact material.",
         "The materializer is outside `comp.persistence` and must not mint receipts, discharge requirements, or decide projection authority.",
-        "Production code should generalize the materializer contract without making scenario fixtures authoritative.",
+        "Domain Scenario Lab replay uses the production compiler-run materializer boundary.",
+        "Scenario fixture material must remain external material, not builder policy.",
         "## Current Implementation Status",
         "`comp.persistence.envelope_builder`",
         "`build_receipt_envelope_set(...)`",
@@ -936,6 +937,8 @@ def test_artifact_envelope_builder_contract_separates_coverage_from_materializat
         "This document defines the contract for turning a completed compiler run into",
         "The production builder should accept the smallest set that can explain a",
         "compiler-aware materializer remains a later adapter slice",
+        "The current Domain Scenario Lab already has a fixture-shaped version",
+        "Production code should generalize the materializer contract",
     ):
         assert stale_line not in builder_doc
 


### PR DESCRIPTION
## Summary
- Replace stale fixture-shaped materializer language with the current production compiler-run materializer boundary.
- Clarify that scenario fixture material may be enriched as `ExternalArtifactMaterialSource` but must not own receipt coverage, envelope construction, or projection authority.
- Extend package smoke coverage so older roadmap wording does not return.

## Validation
- `python -m pytest tests/test_package_smoke.py::test_artifact_envelope_builder_contract_separates_coverage_from_materialization -q`
- `python -m pytest tests/test_package_smoke.py tests/test_domain_scenario_pack_diet.py -q`
- `python -m pytest -q`
- `git diff --check`