### PR TITLE
CI: wait for MySQL readiness; add internal execution map and test updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,27 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[test,db]"
 
+      - name: Wait for MySQL service readiness
+        run: |
+          python - <<'PY'
+          import socket
+          import time
+
+          host = "127.0.0.1"
+          port = 3306
+          deadline = time.time() + 90
+          last_error = None
+          while time.time() < deadline:
+              try:
+                  with socket.create_connection((host, port), timeout=2):
+                      print("MySQL port is reachable.")
+                      raise SystemExit(0)
+              except OSError as exc:
+                  last_error = exc
+                  time.sleep(2)
+          raise SystemExit(f"MySQL did not become reachable in time: {last_error}")
+          PY
+
       - name: Run unit and scenario tests
         env:
           COMP_TEST_MYSQL_HOST: 127.0.0.1

--- a/docs/architecture/maps/internal-execution-design-map.md
+++ b/docs/architecture/maps/internal-execution-design-map.md
@@ -1,8 +1,9 @@
 # Internal Execution Design Map
 
-Status: planning-map
-Owner: compiler
-Can block PRs: no
+Status: implementation-map
+Owner: trust-kernel
+Last checked against code: 2026-05-23
+Can block PRs: limited
 
 This document is a top-level map for discussing `comp` internal execution
 capabilities before they become implementation work, API contracts, or PR-sized

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ when the PR changes the mapped area but leaves the map stale.
 
 1. `architecture/maps/obligation-kernel-working-theory.md`
 2. `architecture/maps/domain-scenario-pack-generation.md`
+3. `architecture/maps/internal-execution-design-map.md`
 
 ### North Stars
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = .
 xfail_strict = true
 markers =
     mysql: tests that require COMP_TEST_MYSQL_* connection settings

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -594,6 +594,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "limited",
             "2026-05-21",
         ),
+        "internal-execution-design-map.md": (
+            "implementation-map",
+            "trust-kernel",
+            "limited",
+            "2026-05-23",
+        ),
         "extension-port-contracts.md": (
             "active-contract",
             "trust-kernel",


### PR DESCRIPTION
### Motivation

- Prevent intermittent CI failures by ensuring the MySQL service is actually reachable before running tests.  
- Surface the new internal execution design map as an implementation map in the documentation and navigation index.  
- Make tests reliably import package code by ensuring the test runner includes the project root on `PYTHONPATH` and by updating expectations for the new doc entry.

### Description

- Added a `Wait for MySQL service readiness` step to `.github/workflows/ci.yml` that uses a short Python socket loop to wait up to 90 seconds for `127.0.0.1:3306` to become reachable.  
- Kept the package install step (`python -m pip install -e ".[test,db]"`) and test invocation (`python -m pytest -q`) in CI; added the new wait step before tests.  
- Updated `pytest.ini` to include `pythonpath = .` so tests can import package modules from the repository root.  
- Updated `docs/architecture/maps/internal-execution-design-map.md` metadata to `Status: implementation-map`, `Owner: trust-kernel`, added `Last checked against code: 2026-05-23`, and adjusted `Can block PRs`.  
- Added the new map to `docs/index.md` implementation maps list and updated `tests/test_package_smoke.py` expected entries to include `internal-execution-design-map.md` with its metadata and date.

### Testing

- Ran unit tests with `pytest -q` and the suite completed successfully.  
- Ran the domain scenario registry command `python -m tests.domain_scenarios list` and the scenario contract gate `python -m tests.domain_scenarios run-all`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ef53a9f88327a517c828b25d51ce)