### PR TITLE
CI: wait for MySQL TCP readiness, expose pythonpath, and update docs/tests for internal execution map

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,27 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[test,db]"
 
+      - name: Wait for MySQL TCP readiness
+        run: |
+          python - <<'PY'
+          import socket
+          import time
+
+          host = "127.0.0.1"
+          port = 3306
+          deadline = time.time() + 90
+          last_error = None
+          while time.time() < deadline:
+              try:
+                  with socket.create_connection((host, port), timeout=2):
+                      print("MySQL TCP port is reachable.")
+                      raise SystemExit(0)
+              except OSError as exc:
+                  last_error = exc
+                  time.sleep(2)
+          raise SystemExit(f"MySQL did not become reachable in time: {last_error}")
+          PY
+
       - name: Run unit and scenario tests
         env:
           COMP_TEST_MYSQL_HOST: 127.0.0.1

--- a/docs/architecture/maps/internal-execution-design-map.md
+++ b/docs/architecture/maps/internal-execution-design-map.md
@@ -1,8 +1,9 @@
 # Internal Execution Design Map
 
-Status: planning-map
-Owner: compiler
-Can block PRs: no
+Status: implementation-map
+Owner: trust-kernel
+Last checked against code: 2026-05-23
+Can block PRs: limited
 
 This document is a top-level map for discussing `comp` internal execution
 capabilities before they become implementation work, API contracts, or PR-sized

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ when the PR changes the mapped area but leaves the map stale.
 
 1. `architecture/maps/obligation-kernel-working-theory.md`
 2. `architecture/maps/domain-scenario-pack-generation.md`
+3. `architecture/maps/internal-execution-design-map.md`
 
 ### North Stars
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = .
 xfail_strict = true
 markers =
     mysql: tests that require COMP_TEST_MYSQL_* connection settings

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -594,6 +594,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "limited",
             "2026-05-21",
         ),
+        "internal-execution-design-map.md": (
+            "implementation-map",
+            "trust-kernel",
+            "limited",
+            "2026-05-23",
+        ),
         "extension-port-contracts.md": (
             "active-contract",
             "trust-kernel",


### PR DESCRIPTION
### Motivation
- Ensure CI does not proceed before the MySQL server is actually accepting TCP connections to avoid spurious connection failures during tests.
- Make the repository importable by test runs by adding `pythonpath = .` to `pytest.ini` so tests can find local packages.
- Record and expose the new internal execution implementation map in the docs and update test expectations to reflect the new document metadata.

### Description
- Added a CI step in `.github/workflows/ci.yml` named `Wait for MySQL TCP readiness` which runs an inline Python script that polls `127.0.0.1:3306` with a 90 second deadline and fails the job if the port never becomes reachable.
- Updated `pytest.ini` to add `pythonpath = .` so the test runner can import project modules from the repository root.
- Updated `docs/architecture/maps/internal-execution-design-map.md` to change the `Status` to `implementation-map`, set `Owner` to `trust-kernel`, add `Last checked against code` metadata, and mark `Can block PRs` as `limited`.
- Added the new map to `docs/index.md` under Implementation Maps and updated `tests/test_package_smoke.py` to include the new `internal-execution-design-map.md` expectations.

### Testing
- Ran unit and integration tests with `python -m pytest -q`, which exercised the updated `test_package_smoke` expectations and completed successfully.
- Ran the domain scenario commands `python -m tests.domain_scenarios list` and `python -m tests.domain_scenarios run-all` as part of the CI flow, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ef53a9f88327a517c828b25d51ce)