### PR TITLE
[codex] add policy boundary vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ from comp.persistence import InMemoryReceiptLedger
 from comp.persistence import replay_public_projection
 ```
 
+`comp.policy`는 pre-validation policy boundary vocabulary를 노출한다. 이
+표면은 validation handoff 전 material과 policy effect를 설명하기 위한 것이며,
+validation authority, receipt authority, replay authority가 아니다.
+
+```python
+from comp.policy import MaterialDescriptor, PolicyEffect
+```
+
 legacy pipeline runner, pass-pipeline module, compatibility facade는 active
 package source가 아니다. 과거 pass-pipeline snapshot은 repository history에서만
 확인하고, 현재 tree에는 reference copy를 유지하지 않는다.

--- a/comp/policy/__init__.py
+++ b/comp/policy/__init__.py
@@ -1,0 +1,24 @@
+"""Pre-validation policy boundary vocabulary.
+
+This package models policy-side descriptors and effects. It must remain
+non-authoritative: policy vocabulary can shape validation handoff, but it does
+not validate claims, authorize public projection, or replay receipts.
+"""
+
+from comp.policy.boundary import (
+    PIPELINE_SCOPES,
+    POLICY_EFFECT_KINDS,
+    MaterialDescriptor,
+    PipelineScope,
+    PolicyEffect,
+    PolicyEffectKind,
+)
+
+__all__ = [
+    "PIPELINE_SCOPES",
+    "POLICY_EFFECT_KINDS",
+    "MaterialDescriptor",
+    "PipelineScope",
+    "PolicyEffect",
+    "PolicyEffectKind",
+]

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+PolicyEffectKind = Literal[
+    "select",
+    "propose",
+    "hold",
+    "reject",
+    "escalate",
+    "request_evidence",
+    "grant_scope",
+    "restrict_scope",
+    "require_review",
+    "require_replay_material",
+    "set_retention",
+]
+
+PipelineScope = Literal[
+    "candidate_generation",
+    "selection_evaluation",
+    "validation_context",
+    "validation_handoff",
+    "projection_candidate",
+    "replay_support",
+    "audit_only",
+]
+
+POLICY_EFFECT_KINDS = frozenset(
+    (
+        "select",
+        "propose",
+        "hold",
+        "reject",
+        "escalate",
+        "request_evidence",
+        "grant_scope",
+        "restrict_scope",
+        "require_review",
+        "require_replay_material",
+        "set_retention",
+    )
+)
+
+PIPELINE_SCOPES = frozenset(
+    (
+        "candidate_generation",
+        "selection_evaluation",
+        "validation_context",
+        "validation_handoff",
+        "projection_candidate",
+        "replay_support",
+        "audit_only",
+    )
+)
+
+_SCOPED_EFFECT_KINDS = frozenset(("grant_scope", "restrict_scope"))
+
+
+@dataclass(frozen=True, slots=True)
+class MaterialDescriptor:
+    material_id: str
+    material_kind: str = "external_material"
+    field_knownness: str = "unknown"
+    risk_tier: str = "unknown"
+    projection_sensitivity: str = "unknown"
+    evidence_availability: str = "unknown"
+    source_ref: str | None = None
+    attributes: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("material_id", self.material_id)
+        _require_non_empty("material_kind", self.material_kind)
+        object.__setattr__(self, "attributes", tuple(self.attributes))
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyEffect:
+    effect_id: str
+    effect_kind: PolicyEffectKind
+    subject_id: str
+    basis: str
+    scope: PipelineScope | None = None
+    reason: str = ""
+    payload: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("effect_id", self.effect_id)
+        _require_non_empty("subject_id", self.subject_id)
+        _require_non_empty("basis", self.basis)
+        if self.effect_kind not in POLICY_EFFECT_KINDS:
+            raise ValueError(f"unknown policy effect kind: {self.effect_kind}")
+        if self.scope is not None and self.scope not in PIPELINE_SCOPES:
+            raise ValueError(f"unknown pipeline scope: {self.scope}")
+        if self.effect_kind in _SCOPED_EFFECT_KINDS and self.scope is None:
+            raise ValueError(f"scope is required for {self.effect_kind}")
+        object.__setattr__(self, "payload", tuple(self.payload))
+
+
+def _require_non_empty(field_name: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{field_name} is required.")
+
+
+__all__ = [
+    "PIPELINE_SCOPES",
+    "POLICY_EFFECT_KINDS",
+    "MaterialDescriptor",
+    "PipelineScope",
+    "PolicyEffect",
+    "PolicyEffectKind",
+]

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -188,9 +188,15 @@ This document defines a boundary contract for upcoming policy work.
 Not every term in this document is currently a public Python API. Until
 implemented, these terms are architectural contract vocabulary.
 
+The first implementation slice lives in `comp.policy`. It exposes
+`MaterialDescriptor` and `PolicyEffect` as pre-validation vocabulary only. It
+does not expose `ScopedGrant`, `DecisionLedger`, `SelectedValidationContract`,
+receipt builders, projection gates, or replay authority.
+
 Existing `CompilerProfile`, `DomainPack`, `RetrievalQueryPolicy`,
 reference-selection, resolver-task, and profile/schema selection-tier surfaces
-are precursor surfaces. They are not the full policy boundary implementation.
+remain precursor surfaces. They are not the full policy boundary
+implementation.
 
 New implementation slices should start small. A first slice should prefer
 policy effects, conflict resolution, scoped pipeline grants, decision-ledger

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -353,6 +353,8 @@ This map describes intended architecture shape, not a completed implementation.
 The current codebase already has precursor surfaces:
 
 ```text
+comp.policy.MaterialDescriptor
+comp.policy.PolicyEffect
 CompilerProfile
 DomainPack
 RetrievalQueryPolicy
@@ -363,10 +365,15 @@ PublicOutputReceipt
 replay_public_projection(...)
 ```
 
-Those surfaces show the existing authority direction: profiles declare behavior,
-retrieval produces candidates, deterministic selectors bind references,
-compiler validation judges claims, receipts authorize projection, and replay
-verifies the receipt path.
+`comp.policy.MaterialDescriptor` and `comp.policy.PolicyEffect` are the first
+minimal vocabulary slice. They describe pre-validation material and policy
+effects, but they do not grant validation handoff, validate claims, authorize
+projection, or replay receipts.
+
+The other surfaces show the existing authority direction: profiles declare
+behavior, retrieval produces candidates, deterministic selectors bind
+references, compiler validation judges claims, receipts authorize projection,
+and replay verifies the receipt path.
 
 Future policy work should connect to that direction instead of introducing a
 parallel source of selection truth, validation truth, receipt truth, or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ packages = [
   "comp.explanation",
   "comp.judgment",
   "comp.persistence",
+  "comp.policy",
   "comp.runtime",
   "comp.scenario_contracts",
   "comp.scenarios",

--- a/tests/test_authority_import_boundaries.py
+++ b/tests/test_authority_import_boundaries.py
@@ -65,6 +65,23 @@ AUTHORITY_BOUNDARY_RULES = (
         ),
     ),
     ImportBoundaryRule(
+        label="policy boundary vocabulary",
+        paths=(Path("comp/policy"),),
+        forbidden_prefixes=(
+            "comp.compiler_tool",
+            "comp.judgment",
+            "comp.persistence",
+            "comp.explanation",
+            "comp.views",
+            "comp.schema_labels",
+            "comp.user_messages",
+            "comp.scenario_contracts",
+            "comp.scenarios",
+            "comp.runtime",
+            "minchoagnt",
+        ),
+    ),
+    ImportBoundaryRule(
         label="receipt proof graph exporter",
         paths=(Path("comp/explanation/receipt_graph.py"),),
         forbidden_prefixes=(

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -375,6 +375,16 @@ def test_readme_tracks_persistence_active_surface():
     assert "replay_public_projection" in readme
 
 
+def test_readme_tracks_policy_boundary_vocabulary_surface():
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    assert "comp.policy" in readme
+    assert "pre-validation policy boundary vocabulary" in readme
+    assert "MaterialDescriptor" in readme
+    assert "PolicyEffect" in readme
+    assert "validation authority, receipt authority, replay authority가 아니다" in readme
+
+
 def test_persistence_exports_mysql_backend_surface():
     from comp.persistence import (
         MySQLArtifactStore,
@@ -553,6 +563,7 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "ScopedGrant is not PublicOutputReceipt.",
         "Capabilities may recommend. Policies may issue scoped access.",
         "Not every term in this document is currently a public Python API.",
+        "The first implementation slice lives in `comp.policy`.",
     ):
         assert line in policy_boundary
 
@@ -582,6 +593,7 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "parallel source of selection truth, validation truth, receipt truth, or",
         "projection truth.",
         "This map does not prescribe:",
+        "`comp.policy.MaterialDescriptor` and `comp.policy.PolicyEffect` are the first",
     ):
         assert line in policy_map
 
@@ -1082,6 +1094,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         TrustRuntime,
         materialize_compiler_run_artifacts,
     )
+    from comp.policy import MaterialDescriptor, PolicyEffect
 
     assert pyproject["project"]["description"] == (
         "Receipt-gated proof package compiler for obligation, reference, "
@@ -1096,6 +1109,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         "comp.explanation",
         "comp.judgment",
         "comp.persistence",
+        "comp.policy",
         "comp.runtime",
         "comp.scenario_contracts",
         "comp.scenarios",
@@ -1129,6 +1143,8 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert export_receipt_proof_graph is not None
     assert ArtifactStore is not None
     assert ArtifactEnvelope is not None
+    assert MaterialDescriptor is not None
+    assert PolicyEffect is not None
     assert ArtifactMaterial is not None
     assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -1,0 +1,101 @@
+import pytest
+
+
+def test_material_descriptor_captures_pre_validation_metadata():
+    from comp.policy import MaterialDescriptor
+
+    descriptor = MaterialDescriptor(
+        material_id="material:fuel_used",
+        material_kind="source_attribute",
+        field_knownness="unknown",
+        risk_tier="medium",
+        projection_sensitivity="public_possible",
+        evidence_availability="context_only",
+        source_ref="source:invoice-1",
+        attributes=(
+            ("raw_field", "fuel_used"),
+            ("raw_value", 1200),
+        ),
+    )
+
+    assert descriptor.material_id == "material:fuel_used"
+    assert descriptor.material_kind == "source_attribute"
+    assert descriptor.field_knownness == "unknown"
+    assert descriptor.risk_tier == "medium"
+    assert descriptor.projection_sensitivity == "public_possible"
+    assert descriptor.evidence_availability == "context_only"
+    assert descriptor.source_ref == "source:invoice-1"
+    assert descriptor.attributes == (
+        ("raw_field", "fuel_used"),
+        ("raw_value", 1200),
+    )
+
+
+def test_policy_effect_records_scope_and_basis_without_authority():
+    from comp.policy import (
+        PIPELINE_SCOPES,
+        POLICY_EFFECT_KINDS,
+        PipelineScope,
+        PolicyEffect,
+        PolicyEffectKind,
+    )
+
+    effect = PolicyEffect(
+        effect_id="effect:hold:fuel_used",
+        effect_kind="hold",
+        subject_id="material:fuel_used",
+        basis="unit evidence required",
+        scope="selection_evaluation",
+        reason="missing unit witness",
+        payload=(("required_evidence", "unit_witness"),),
+    )
+
+    assert "hold" in POLICY_EFFECT_KINDS
+    assert "validation_handoff" in PIPELINE_SCOPES
+    assert effect.effect_kind == "hold"
+    assert effect.scope == "selection_evaluation"
+    assert effect.basis == "unit evidence required"
+    assert effect.payload == (("required_evidence", "unit_witness"),)
+    assert PipelineScope is not None
+    assert PolicyEffectKind is not None
+
+
+def test_policy_vocabulary_rejects_authority_shaped_effects_and_scopes():
+    from comp.policy import PolicyEffect
+
+    with pytest.raises(ValueError, match="unknown policy effect kind"):
+        PolicyEffect(
+            effect_id="effect:authorize",
+            effect_kind="authorize_public_projection",
+            subject_id="material:fuel_used",
+            basis="not allowed",
+        )
+
+    with pytest.raises(ValueError, match="unknown pipeline scope"):
+        PolicyEffect(
+            effect_id="effect:public",
+            effect_kind="grant_scope",
+            subject_id="material:fuel_used",
+            basis="not allowed",
+            scope="public_projection",
+        )
+
+    with pytest.raises(ValueError, match="scope is required"):
+        PolicyEffect(
+            effect_id="effect:grant",
+            effect_kind="grant_scope",
+            subject_id="material:fuel_used",
+            basis="selection allowed",
+        )
+
+
+def test_policy_package_does_not_expose_projection_or_replay_authority():
+    import comp.policy as policy
+
+    for name in (
+        "PublicOutputReceipt",
+        "build_public_output",
+        "build_public_output_receipt",
+        "replay_public_projection",
+    ):
+        assert not hasattr(policy, name)


### PR DESCRIPTION
## Summary

Adds the first small implementation slice for the policy-assembled trust-kernel plan: a new `comp.policy` package with pre-validation `MaterialDescriptor` and `PolicyEffect` vocabulary.

The package is intentionally non-authoritative. It records material descriptors and policy effects before validation handoff, while avoiding compiler, receipt, projection, replay, explanation, or agent-layer imports.

## Changes

- Adds `comp.policy.MaterialDescriptor`, `PolicyEffect`, `PolicyEffectKind`, `PipelineScope`, and vocabulary constants.
- Registers `comp.policy` in packaging and README active package surface.
- Adds focused tests for descriptor/effect behavior and forbidden authority-shaped effects/scopes.
- Adds import-boundary coverage so `comp.policy` cannot import compiler, receipt, replay, explanation, runtime, scenario, or agent layers.
- Updates policy architecture docs to mark `comp.policy` as the first minimal vocabulary slice.

## Validation

- `python -m pytest tests/test_policy_boundary_vocabulary.py -q` -> 4 passed
- `python -m pytest tests/test_policy_boundary_vocabulary.py tests/test_authority_import_boundaries.py tests/test_package_smoke.py -q` -> 48 passed
- `python -m pytest -q` -> 532 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18