### PR TITLE
[codex] add policy grant ledger vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,13 @@ from comp.persistence import replay_public_projection
 ```
 
 `comp.policy`는 pre-validation policy boundary vocabulary를 노출한다. 이
-표면은 validation handoff 전 material과 policy effect를 설명하기 위한 것이며,
-validation authority, receipt authority, replay authority가 아니다.
+표면은 validation handoff 전 material, policy effect, scoped grant,
+selection decision, decision ledger를 설명하기 위한 것이며, validation
+authority, receipt authority, replay authority가 아니다.
 
 ```python
 from comp.policy import MaterialDescriptor, PolicyEffect
+from comp.policy import ScopedGrant, SelectionDecision, DecisionLedger
 ```
 
 legacy pipeline runner, pass-pipeline module, compatibility facade는 active

--- a/comp/policy/__init__.py
+++ b/comp/policy/__init__.py
@@ -1,24 +1,35 @@
 """Pre-validation policy boundary vocabulary.
 
-This package models policy-side descriptors and effects. It must remain
-non-authoritative: policy vocabulary can shape validation handoff, but it does
-not validate claims, authorize public projection, or replay receipts.
+This package models policy-side descriptors, effects, scoped grants, selection
+decisions, and decision ledgers. It must remain non-authoritative: policy
+vocabulary can shape validation handoff, but it does not validate claims,
+authorize public projection, or replay receipts.
 """
 
 from comp.policy.boundary import (
     PIPELINE_SCOPES,
     POLICY_EFFECT_KINDS,
+    SELECTION_STATUSES,
+    DecisionLedger,
     MaterialDescriptor,
     PipelineScope,
     PolicyEffect,
     PolicyEffectKind,
+    ScopedGrant,
+    SelectionDecision,
+    SelectionStatus,
 )
 
 __all__ = [
     "PIPELINE_SCOPES",
     "POLICY_EFFECT_KINDS",
+    "SELECTION_STATUSES",
+    "DecisionLedger",
     "MaterialDescriptor",
     "PipelineScope",
     "PolicyEffect",
     "PolicyEffectKind",
+    "ScopedGrant",
+    "SelectionDecision",
+    "SelectionStatus",
 ]

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -27,6 +27,8 @@ PipelineScope = Literal[
     "audit_only",
 ]
 
+SelectionStatus = Literal["selected", "proposed", "held", "rejected"]
+
 POLICY_EFFECT_KINDS = frozenset(
     (
         "select",
@@ -54,6 +56,8 @@ PIPELINE_SCOPES = frozenset(
         "audit_only",
     )
 )
+
+SELECTION_STATUSES = frozenset(("selected", "proposed", "held", "rejected"))
 
 _SCOPED_EFFECT_KINDS = frozenset(("grant_scope", "restrict_scope"))
 
@@ -98,6 +102,121 @@ class PolicyEffect:
         object.__setattr__(self, "payload", tuple(self.payload))
 
 
+@dataclass(frozen=True, slots=True)
+class ScopedGrant:
+    grant_id: str
+    subject_id: str
+    scope: PipelineScope
+    basis: str
+    conditions: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+    retention: str = "decision_audit"
+
+    def __post_init__(self) -> None:
+        _require_non_empty("grant_id", self.grant_id)
+        _require_non_empty("subject_id", self.subject_id)
+        _require_non_empty("basis", self.basis)
+        if self.scope not in PIPELINE_SCOPES:
+            raise ValueError(f"unknown pipeline scope: {self.scope}")
+        object.__setattr__(self, "conditions", tuple(self.conditions))
+
+    @property
+    def authorizes_public_projection(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionDecision:
+    decision_id: str
+    subject_id: str
+    status: SelectionStatus
+    basis: str
+    target_id: str | None = None
+    grants: tuple[ScopedGrant, ...] = field(default_factory=tuple)
+    denied_scopes: tuple[PipelineScope, ...] = field(default_factory=tuple)
+    retention: str = "decision_audit"
+
+    def __post_init__(self) -> None:
+        _require_non_empty("decision_id", self.decision_id)
+        _require_non_empty("subject_id", self.subject_id)
+        _require_non_empty("basis", self.basis)
+        if self.status not in SELECTION_STATUSES:
+            raise ValueError(f"unknown selection status: {self.status}")
+        for scope in self.denied_scopes:
+            if scope not in PIPELINE_SCOPES:
+                raise ValueError(f"unknown pipeline scope: {scope}")
+        object.__setattr__(self, "grants", tuple(self.grants))
+        object.__setattr__(self, "denied_scopes", tuple(self.denied_scopes))
+
+    def allows_scope(self, scope: PipelineScope) -> bool:
+        if scope not in PIPELINE_SCOPES:
+            raise ValueError(f"unknown pipeline scope: {scope}")
+        if scope in self.denied_scopes:
+            return False
+        return any(grant.scope == scope for grant in self.grants)
+
+    @property
+    def authorizes_public_projection(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionLedger:
+    ledger_id: str
+    policy_profile_id: str
+    descriptors: tuple[MaterialDescriptor, ...] = field(default_factory=tuple)
+    effects: tuple[PolicyEffect, ...] = field(default_factory=tuple)
+    decisions: tuple[SelectionDecision, ...] = field(default_factory=tuple)
+    meta: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("ledger_id", self.ledger_id)
+        _require_non_empty("policy_profile_id", self.policy_profile_id)
+        object.__setattr__(self, "descriptors", tuple(self.descriptors))
+        object.__setattr__(self, "effects", tuple(self.effects))
+        object.__setattr__(self, "decisions", tuple(self.decisions))
+        object.__setattr__(self, "meta", tuple(self.meta))
+
+    def decision_for(self, decision_id: str) -> SelectionDecision | None:
+        return next(
+            (
+                decision
+                for decision in self.decisions
+                if decision.decision_id == decision_id
+            ),
+            None,
+        )
+
+    def grants_for(
+        self,
+        subject_id: str,
+        *,
+        scope: PipelineScope | None = None,
+    ) -> tuple[ScopedGrant, ...]:
+        if scope is not None and scope not in PIPELINE_SCOPES:
+            raise ValueError(f"unknown pipeline scope: {scope}")
+        grants = tuple(
+            grant
+            for decision in self.decisions
+            for grant in decision.grants
+            if grant.subject_id == subject_id
+        )
+        if scope is None:
+            return grants
+        return tuple(grant for grant in grants if grant.scope == scope)
+
+    def selected_validation_decision_ids(self) -> tuple[str, ...]:
+        return tuple(
+            decision.decision_id
+            for decision in self.decisions
+            if decision.status == "selected"
+            and decision.allows_scope("validation_handoff")
+        )
+
+    @property
+    def authorizes_public_projection(self) -> bool:
+        return False
+
+
 def _require_non_empty(field_name: str, value: str) -> None:
     if not value:
         raise ValueError(f"{field_name} is required.")
@@ -106,8 +225,13 @@ def _require_non_empty(field_name: str, value: str) -> None:
 __all__ = [
     "PIPELINE_SCOPES",
     "POLICY_EFFECT_KINDS",
+    "SELECTION_STATUSES",
+    "DecisionLedger",
     "MaterialDescriptor",
     "PipelineScope",
     "PolicyEffect",
     "PolicyEffectKind",
+    "ScopedGrant",
+    "SelectionDecision",
+    "SelectionStatus",
 ]

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -188,10 +188,11 @@ This document defines a boundary contract for upcoming policy work.
 Not every term in this document is currently a public Python API. Until
 implemented, these terms are architectural contract vocabulary.
 
-The first implementation slice lives in `comp.policy`. It exposes
-`MaterialDescriptor` and `PolicyEffect` as pre-validation vocabulary only. It
-does not expose `ScopedGrant`, `DecisionLedger`, `SelectedValidationContract`,
-receipt builders, projection gates, or replay authority.
+The first implementation slices live in `comp.policy`. They expose
+`MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`, `SelectionDecision`, and
+`DecisionLedger` as pre-validation vocabulary only. They do not expose
+`SelectedValidationContract`, receipt builders, projection gates, or replay
+authority.
 
 Existing `CompilerProfile`, `DomainPack`, `RetrievalQueryPolicy`,
 reference-selection, resolver-task, and profile/schema selection-tier surfaces

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -355,6 +355,9 @@ The current codebase already has precursor surfaces:
 ```text
 comp.policy.MaterialDescriptor
 comp.policy.PolicyEffect
+comp.policy.ScopedGrant
+comp.policy.SelectionDecision
+comp.policy.DecisionLedger
 CompilerProfile
 DomainPack
 RetrievalQueryPolicy
@@ -365,10 +368,13 @@ PublicOutputReceipt
 replay_public_projection(...)
 ```
 
-`comp.policy.MaterialDescriptor` and `comp.policy.PolicyEffect` are the first
-minimal vocabulary slice. They describe pre-validation material and policy
-effects, but they do not grant validation handoff, validate claims, authorize
-projection, or replay receipts.
+`comp.policy.MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`,
+`SelectionDecision`, and `DecisionLedger` are the first minimal vocabulary
+slices. They describe pre-validation material, policy effects, scoped pipeline
+access, selection status, and decision audit records. They do not validate
+claims, authorize projection, or replay receipts. A selected decision still
+requires a `validation_handoff` grant before it can be considered for compiler
+handoff, and that handoff remains pre-validation.
 
 The other surfaces show the existing authority direction: profiles declare
 behavior, retrieval produces candidates, deterministic selectors bind

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -382,7 +382,12 @@ def test_readme_tracks_policy_boundary_vocabulary_surface():
     assert "pre-validation policy boundary vocabulary" in readme
     assert "MaterialDescriptor" in readme
     assert "PolicyEffect" in readme
-    assert "validation authority, receipt authority, replay authority가 아니다" in readme
+    assert "ScopedGrant" in readme
+    assert "SelectionDecision" in readme
+    assert "DecisionLedger" in readme
+    assert "validation" in readme
+    assert "receipt authority" in readme
+    assert "replay authority가 아니다" in readme
 
 
 def test_persistence_exports_mysql_backend_surface():
@@ -563,7 +568,8 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "ScopedGrant is not PublicOutputReceipt.",
         "Capabilities may recommend. Policies may issue scoped access.",
         "Not every term in this document is currently a public Python API.",
-        "The first implementation slice lives in `comp.policy`.",
+        "The first implementation slices live in `comp.policy`.",
+        "`MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`, `SelectionDecision`, and",
     ):
         assert line in policy_boundary
 
@@ -593,7 +599,8 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "parallel source of selection truth, validation truth, receipt truth, or",
         "projection truth.",
         "This map does not prescribe:",
-        "`comp.policy.MaterialDescriptor` and `comp.policy.PolicyEffect` are the first",
+        "`comp.policy.MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`,",
+        "`SelectionDecision`, and `DecisionLedger` are the first minimal vocabulary",
     ):
         assert line in policy_map
 
@@ -1094,7 +1101,13 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         TrustRuntime,
         materialize_compiler_run_artifacts,
     )
-    from comp.policy import MaterialDescriptor, PolicyEffect
+    from comp.policy import (
+        DecisionLedger,
+        MaterialDescriptor,
+        PolicyEffect,
+        ScopedGrant,
+        SelectionDecision,
+    )
 
     assert pyproject["project"]["description"] == (
         "Receipt-gated proof package compiler for obligation, reference, "
@@ -1143,8 +1156,11 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert export_receipt_proof_graph is not None
     assert ArtifactStore is not None
     assert ArtifactEnvelope is not None
+    assert DecisionLedger is not None
     assert MaterialDescriptor is not None
     assert PolicyEffect is not None
+    assert ScopedGrant is not None
+    assert SelectionDecision is not None
     assert ArtifactMaterial is not None
     assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -89,6 +89,143 @@ def test_policy_vocabulary_rejects_authority_shaped_effects_and_scopes():
         )
 
 
+def test_scoped_grant_records_pipeline_access_without_projection_authority():
+    from comp.policy import ScopedGrant
+
+    grant = ScopedGrant(
+        grant_id="grant:fuel_used:selection",
+        subject_id="material:fuel_used",
+        scope="selection_evaluation",
+        basis="observed source attribute",
+        conditions=(("requires_review", False),),
+        retention="decision_audit",
+    )
+
+    assert grant.grant_id == "grant:fuel_used:selection"
+    assert grant.subject_id == "material:fuel_used"
+    assert grant.scope == "selection_evaluation"
+    assert grant.basis == "observed source attribute"
+    assert grant.conditions == (("requires_review", False),)
+    assert grant.retention == "decision_audit"
+    assert grant.authorizes_public_projection is False
+
+    projection_candidate = ScopedGrant(
+        grant_id="grant:fuel_used:projection-candidate",
+        subject_id="decision:fuel_used->amount",
+        scope="projection_candidate",
+        basis="selected for later receipt consideration",
+    )
+
+    assert projection_candidate.scope == "projection_candidate"
+    assert projection_candidate.authorizes_public_projection is False
+
+    with pytest.raises(ValueError, match="unknown pipeline scope"):
+        ScopedGrant(
+            grant_id="grant:public",
+            subject_id="material:fuel_used",
+            scope="public_projection",
+            basis="not allowed",
+        )
+
+
+def test_selection_decision_requires_grant_for_validation_handoff():
+    from comp.policy import ScopedGrant, SelectionDecision
+
+    selected_without_grant = SelectionDecision(
+        decision_id="decision:fuel_used->amount",
+        subject_id="material:fuel_used",
+        status="selected",
+        basis="declared alias",
+        target_id="field:amount",
+    )
+
+    assert selected_without_grant.status == "selected"
+    assert selected_without_grant.allows_scope("validation_handoff") is False
+    assert selected_without_grant.authorizes_public_projection is False
+
+    handoff_grant = ScopedGrant(
+        grant_id="grant:fuel_used:validation-handoff",
+        subject_id="decision:fuel_used->amount",
+        scope="validation_handoff",
+        basis="declared alias selected",
+    )
+    selected_with_grant = SelectionDecision(
+        decision_id="decision:fuel_used->amount",
+        subject_id="material:fuel_used",
+        status="selected",
+        basis="declared alias",
+        target_id="field:amount",
+        grants=(handoff_grant,),
+        denied_scopes=("projection_candidate",),
+    )
+
+    assert selected_with_grant.allows_scope("validation_handoff") is True
+    assert selected_with_grant.allows_scope("projection_candidate") is False
+    assert selected_with_grant.authorizes_public_projection is False
+
+    with pytest.raises(ValueError, match="unknown selection status"):
+        SelectionDecision(
+            decision_id="decision:validated",
+            subject_id="material:fuel_used",
+            status="validated",
+            basis="not allowed",
+        )
+
+
+def test_decision_ledger_lists_grants_and_validation_handoff_subjects():
+    from comp.policy import (
+        DecisionLedger,
+        MaterialDescriptor,
+        PolicyEffect,
+        ScopedGrant,
+        SelectionDecision,
+    )
+
+    descriptor = MaterialDescriptor(
+        material_id="material:fuel_used",
+        material_kind="source_attribute",
+        field_knownness="unknown",
+    )
+    effect = PolicyEffect(
+        effect_id="effect:select:fuel_used",
+        effect_kind="select",
+        subject_id="material:fuel_used",
+        basis="declared alias",
+        scope="validation_handoff",
+    )
+    grant = ScopedGrant(
+        grant_id="grant:fuel_used:validation-handoff",
+        subject_id="decision:fuel_used->amount",
+        scope="validation_handoff",
+        basis="declared alias selected",
+    )
+    decision = SelectionDecision(
+        decision_id="decision:fuel_used->amount",
+        subject_id="material:fuel_used",
+        status="selected",
+        basis="declared alias",
+        target_id="field:amount",
+        grants=(grant,),
+    )
+    ledger = DecisionLedger(
+        ledger_id="ledger:run-1",
+        policy_profile_id="profile:strict-public",
+        descriptors=(descriptor,),
+        effects=(effect,),
+        decisions=(decision,),
+    )
+
+    assert ledger.decision_for("decision:fuel_used->amount") == decision
+    assert ledger.grants_for("decision:fuel_used->amount") == (grant,)
+    assert ledger.grants_for("decision:fuel_used->amount", scope="validation_handoff") == (
+        grant,
+    )
+    assert ledger.selected_validation_decision_ids() == (
+        "decision:fuel_used->amount",
+    )
+    assert ledger.authorizes_public_projection is False
+
+
 def test_policy_package_does_not_expose_projection_or_replay_authority():
     import comp.policy as policy
 


### PR DESCRIPTION
## Summary

Continues the policy-assembled trust-kernel implementation by extending `comp.policy` beyond descriptors/effects with non-authoritative scoped pipeline access and decision audit vocabulary.

This adds `ScopedGrant`, `SelectionDecision`, and `DecisionLedger` while preserving the policy boundary: selected status alone is insufficient for validation handoff, scoped grants never authorize public projection, and decision ledgers remain audit material rather than receipt/replay authority.

## Changes

- Adds `ScopedGrant`, `SelectionDecision`, `SelectionStatus`, `DecisionLedger`, and selection status constants to `comp.policy`.
- Adds behavior tests showing selected material needs a `validation_handoff` grant and that `projection_candidate` is not public projection authority.
- Adds ledger helpers for looking up decisions, grants, and selected validation-handoff decisions.
- Updates README and architecture docs to mark grant/decision/ledger vocabulary as the next implemented policy slice.
- Keeps package smoke coverage aligned with the expanded `comp.policy` surface.

## Validation

- `python -m pytest tests/test_policy_boundary_vocabulary.py -q` -> 7 passed
- `python -m pytest tests/test_policy_boundary_vocabulary.py tests/test_authority_import_boundaries.py tests/test_package_smoke.py -q` -> 51 passed
- `python -m pytest -q` -> 535 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18