### PR TITLE
[codex] add selected validation contract vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,13 @@ from comp.persistence import replay_public_projection
 
 `comp.policy`는 pre-validation policy boundary vocabulary를 노출한다. 이
 표면은 validation handoff 전 material, policy effect, scoped grant,
-selection decision, decision ledger를 설명하기 위한 것이며, validation
-authority, receipt authority, replay authority가 아니다.
+selection decision, decision ledger, selected validation contract를 설명하기
+위한 것이다. validation authority, receipt authority, replay authority가 아니다.
 
 ```python
 from comp.policy import MaterialDescriptor, PolicyEffect
 from comp.policy import ScopedGrant, SelectionDecision, DecisionLedger
+from comp.policy import SelectedValidationContract
 ```
 
 legacy pipeline runner, pass-pipeline module, compatibility facade는 active

--- a/comp/policy/__init__.py
+++ b/comp/policy/__init__.py
@@ -18,6 +18,7 @@ from comp.policy.boundary import (
     ScopedGrant,
     SelectionDecision,
     SelectionStatus,
+    SelectedValidationContract,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "ScopedGrant",
     "SelectionDecision",
     "SelectionStatus",
+    "SelectedValidationContract",
 ]

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -60,6 +60,7 @@ PIPELINE_SCOPES = frozenset(
 SELECTION_STATUSES = frozenset(("selected", "proposed", "held", "rejected"))
 
 _SCOPED_EFFECT_KINDS = frozenset(("grant_scope", "restrict_scope"))
+_VALIDATION_CONTRACT_SCOPES = frozenset(("validation_context", "validation_handoff"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -217,9 +218,101 @@ class DecisionLedger:
         return False
 
 
+@dataclass(frozen=True, slots=True)
+class SelectedValidationContract:
+    contract_id: str
+    policy_profile_id: str
+    ledger_id: str
+    basis: str
+    selected_decision_ids: tuple[str, ...] = field(default_factory=tuple)
+    validation_scopes: tuple[PipelineScope, ...] = ("validation_handoff",)
+    projection_candidate_decision_ids: tuple[str, ...] = field(default_factory=tuple)
+    ledger_digest: str | None = None
+    contract_version: str = "policy-boundary-selected-validation-contract-v1"
+    meta: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("contract_id", self.contract_id)
+        _require_non_empty("policy_profile_id", self.policy_profile_id)
+        _require_non_empty("ledger_id", self.ledger_id)
+        _require_non_empty("basis", self.basis)
+        _require_non_empty("contract_version", self.contract_version)
+        if self.ledger_digest is not None:
+            _require_non_empty("ledger_digest", self.ledger_digest)
+        for scope in self.validation_scopes:
+            if scope not in PIPELINE_SCOPES:
+                raise ValueError(f"unknown pipeline scope: {scope}")
+            if scope not in _VALIDATION_CONTRACT_SCOPES:
+                raise ValueError(f"{scope} is not a validation scope")
+        for decision_id in self.selected_decision_ids:
+            _require_non_empty("selected_decision_id", decision_id)
+        for decision_id in self.projection_candidate_decision_ids:
+            _require_non_empty("projection_candidate_decision_id", decision_id)
+        _require_unique(
+            "duplicate selected decision id",
+            self.selected_decision_ids,
+        )
+        _require_unique(
+            "duplicate projection candidate decision id",
+            self.projection_candidate_decision_ids,
+        )
+        object.__setattr__(
+            self,
+            "selected_decision_ids",
+            tuple(self.selected_decision_ids),
+        )
+        object.__setattr__(self, "validation_scopes", tuple(self.validation_scopes))
+        object.__setattr__(
+            self,
+            "projection_candidate_decision_ids",
+            tuple(self.projection_candidate_decision_ids),
+        )
+        object.__setattr__(self, "meta", tuple(self.meta))
+
+    @classmethod
+    def from_ledger(
+        cls,
+        *,
+        contract_id: str,
+        ledger: DecisionLedger,
+        basis: str,
+        ledger_digest: str | None = None,
+        contract_version: str = "policy-boundary-selected-validation-contract-v1",
+        meta: tuple[tuple[str, Any], ...] = (),
+    ) -> SelectedValidationContract:
+        return cls(
+            contract_id=contract_id,
+            policy_profile_id=ledger.policy_profile_id,
+            ledger_id=ledger.ledger_id,
+            basis=basis,
+            selected_decision_ids=ledger.selected_validation_decision_ids(),
+            projection_candidate_decision_ids=tuple(
+                decision.decision_id
+                for decision in ledger.decisions
+                if decision.status == "selected"
+                and decision.allows_scope("projection_candidate")
+            ),
+            ledger_digest=ledger_digest,
+            contract_version=contract_version,
+            meta=meta,
+        )
+
+    def allows_validation_decision(self, decision_id: str) -> bool:
+        return decision_id in self.selected_decision_ids
+
+    @property
+    def authorizes_public_projection(self) -> bool:
+        return False
+
+
 def _require_non_empty(field_name: str, value: str) -> None:
     if not value:
         raise ValueError(f"{field_name} is required.")
+
+
+def _require_unique(error_label: str, values: tuple[str, ...]) -> None:
+    if len(values) != len(set(values)):
+        raise ValueError(error_label)
 
 
 __all__ = [
@@ -234,4 +327,5 @@ __all__ = [
     "ScopedGrant",
     "SelectionDecision",
     "SelectionStatus",
+    "SelectedValidationContract",
 ]

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -190,9 +190,10 @@ implemented, these terms are architectural contract vocabulary.
 
 The first implementation slices live in `comp.policy`. They expose
 `MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`, `SelectionDecision`, and
-`DecisionLedger` as pre-validation vocabulary only. They do not expose
-`SelectedValidationContract`, receipt builders, projection gates, or replay
-authority.
+`DecisionLedger` as pre-validation vocabulary only. The next slice exposes
+`SelectedValidationContract` as compiler-facing input shape, not validation
+authority. These slices do not expose receipt builders, projection gates, or
+replay authority.
 
 Existing `CompilerProfile`, `DomainPack`, `RetrievalQueryPolicy`,
 reference-selection, resolver-task, and profile/schema selection-tier surfaces

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -358,6 +358,7 @@ comp.policy.PolicyEffect
 comp.policy.ScopedGrant
 comp.policy.SelectionDecision
 comp.policy.DecisionLedger
+comp.policy.SelectedValidationContract
 CompilerProfile
 DomainPack
 RetrievalQueryPolicy
@@ -369,12 +370,13 @@ replay_public_projection(...)
 ```
 
 `comp.policy.MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`,
-`SelectionDecision`, and `DecisionLedger` are the first minimal vocabulary
-slices. They describe pre-validation material, policy effects, scoped pipeline
-access, selection status, and decision audit records. They do not validate
-claims, authorize projection, or replay receipts. A selected decision still
-requires a `validation_handoff` grant before it can be considered for compiler
-handoff, and that handoff remains pre-validation.
+`SelectionDecision`, `DecisionLedger`, and `SelectedValidationContract` are the
+first minimal vocabulary slices. They describe pre-validation material, policy
+effects, scoped pipeline access, selection status, decision audit records, and
+the compiler-facing contract shape. They do not validate claims, authorize
+projection, or replay receipts. A selected decision still requires a
+`validation_handoff` grant before it can be included in a selected validation
+contract, and that contract remains pre-validation.
 
 The other surfaces show the existing authority direction: profiles declare
 behavior, retrieval produces candidates, deterministic selectors bind

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -385,6 +385,7 @@ def test_readme_tracks_policy_boundary_vocabulary_surface():
     assert "ScopedGrant" in readme
     assert "SelectionDecision" in readme
     assert "DecisionLedger" in readme
+    assert "SelectedValidationContract" in readme
     assert "validation" in readme
     assert "receipt authority" in readme
     assert "replay authority가 아니다" in readme
@@ -599,6 +600,7 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "Not every term in this document is currently a public Python API.",
         "The first implementation slices live in `comp.policy`.",
         "`MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`, `SelectionDecision`, and",
+        "`SelectedValidationContract` as compiler-facing input shape, not validation",
     ):
         assert line in policy_boundary
 
@@ -629,7 +631,7 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "projection truth.",
         "This map does not prescribe:",
         "`comp.policy.MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`,",
-        "`SelectionDecision`, and `DecisionLedger` are the first minimal vocabulary",
+        "`SelectionDecision`, `DecisionLedger`, and `SelectedValidationContract` are the",
     ):
         assert line in policy_map
 
@@ -1136,6 +1138,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         PolicyEffect,
         ScopedGrant,
         SelectionDecision,
+        SelectedValidationContract,
     )
 
     assert pyproject["project"]["description"] == (
@@ -1190,6 +1193,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert PolicyEffect is not None
     assert ScopedGrant is not None
     assert SelectionDecision is not None
+    assert SelectedValidationContract is not None
     assert ArtifactMaterial is not None
     assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -226,6 +226,121 @@ def test_decision_ledger_lists_grants_and_validation_handoff_subjects():
     assert ledger.authorizes_public_projection is False
 
 
+def test_selected_validation_contract_freezes_handoff_decisions_from_ledger():
+    from comp.policy import (
+        DecisionLedger,
+        ScopedGrant,
+        SelectionDecision,
+        SelectedValidationContract,
+    )
+
+    handoff_grant = ScopedGrant(
+        grant_id="grant:plant:validation-handoff",
+        subject_id="decision:plant->site",
+        scope="validation_handoff",
+        basis="declared alias selected",
+    )
+    projection_candidate_grant = ScopedGrant(
+        grant_id="grant:fuel_used:projection-candidate",
+        subject_id="decision:fuel_used->amount",
+        scope="projection_candidate",
+        basis="eligible for later receipt consideration",
+    )
+    selected_for_handoff = SelectionDecision(
+        decision_id="decision:plant->site",
+        subject_id="material:plant",
+        status="selected",
+        basis="declared alias",
+        target_id="field:site",
+        grants=(handoff_grant,),
+    )
+    selected_for_projection_consideration = SelectionDecision(
+        decision_id="decision:fuel_used->amount",
+        subject_id="material:fuel_used",
+        status="selected",
+        basis="embedding proposal retained for later receipt consideration",
+        target_id="field:amount",
+        grants=(projection_candidate_grant,),
+    )
+    held_handoff_candidate = SelectionDecision(
+        decision_id="decision:supplier_code->supplier_id",
+        subject_id="material:supplier_code",
+        status="held",
+        basis="review required",
+        target_id="field:supplier_id",
+        grants=(
+            ScopedGrant(
+                grant_id="grant:supplier_code:validation-handoff",
+                subject_id="decision:supplier_code->supplier_id",
+                scope="validation_handoff",
+                basis="blocked until reviewer approval",
+            ),
+        ),
+    )
+    ledger = DecisionLedger(
+        ledger_id="ledger:run-1",
+        policy_profile_id="profile:strict-public",
+        decisions=(
+            selected_for_handoff,
+            selected_for_projection_consideration,
+            held_handoff_candidate,
+        ),
+    )
+
+    contract = SelectedValidationContract.from_ledger(
+        contract_id="selected-contract:run-1",
+        ledger=ledger,
+        basis="policy resolver finalized validation handoff",
+        ledger_digest="digest:ledger-run-1",
+    )
+
+    assert contract.contract_id == "selected-contract:run-1"
+    assert contract.policy_profile_id == "profile:strict-public"
+    assert contract.ledger_id == "ledger:run-1"
+    assert contract.ledger_digest == "digest:ledger-run-1"
+    assert contract.selected_decision_ids == ("decision:plant->site",)
+    assert contract.projection_candidate_decision_ids == (
+        "decision:fuel_used->amount",
+    )
+    assert contract.allows_validation_decision("decision:plant->site") is True
+    assert contract.allows_validation_decision("decision:fuel_used->amount") is False
+    assert contract.authorizes_public_projection is False
+
+
+def test_selected_validation_contract_rejects_authority_shaped_scopes():
+    from comp.policy import SelectedValidationContract
+
+    with pytest.raises(ValueError, match="unknown pipeline scope"):
+        SelectedValidationContract(
+            contract_id="selected-contract:public",
+            policy_profile_id="profile:strict-public",
+            ledger_id="ledger:run-1",
+            basis="not allowed",
+            validation_scopes=("public_projection",),
+        )
+
+    with pytest.raises(ValueError, match="not a validation scope"):
+        SelectedValidationContract(
+            contract_id="selected-contract:projection",
+            policy_profile_id="profile:strict-public",
+            ledger_id="ledger:run-1",
+            basis="not allowed",
+            validation_scopes=("projection_candidate",),
+        )
+
+    with pytest.raises(ValueError, match="duplicate selected decision id"):
+        SelectedValidationContract(
+            contract_id="selected-contract:duplicate",
+            policy_profile_id="profile:strict-public",
+            ledger_id="ledger:run-1",
+            basis="duplicate handoff",
+            selected_decision_ids=(
+                "decision:plant->site",
+                "decision:plant->site",
+            ),
+        )
+
+
 def test_policy_package_does_not_expose_projection_or_replay_authority():
     import comp.policy as policy
 


### PR DESCRIPTION
## Summary
- add SelectedValidationContract to comp.policy as a pre-validation compiler-facing contract shape
- derive selected validation decisions from DecisionLedger validation_handoff grants while keeping projection candidates separate
- update README, policy-boundary, implementation-map, and smoke tests for the new vocabulary slice

## Validation
- python -m pytest tests/test_policy_boundary_vocabulary.py tests/test_package_smoke.py tests/test_authority_import_boundaries.py -q
- python -m pytest -q
- python -m tests.domain_scenarios run-all