### PR TITLE
[codex] harden import boundary classification

### DIFF
--- a/docs/architecture/contracts/trust-kernel-extension-rings.md
+++ b/docs/architecture/contracts/trust-kernel-extension-rings.md
@@ -2,7 +2,7 @@
 
 Status: active-contract
 Owner: trust-kernel
-Last checked against code: 2026-05-22
+Last checked against code: 2026-05-26
 Can block PRs: yes
 
 This document names the outer shape of the `comp` rebuild. The core is a small
@@ -282,6 +282,16 @@ The compiler/domain import boundary is consolidated in
 `compiler-domain-boundary.md`.
 
 ```text
+comp top-level package must remain a judgment facade
+comp must not import comp.cli
+comp must not import comp.compiler_tool
+comp must not import comp.persistence
+comp must not import comp.policy
+comp must not import comp.runtime
+comp must not import comp.scenario_contracts
+comp must not import comp.scenarios
+comp must not import minchoagnt
+
 comp.judgment must not import comp.compiler_tool
 comp.judgment must not import comp.persistence
 comp.judgment must not import comp.explanation
@@ -320,6 +330,24 @@ The proof graph exporter may read receipt, replay-report, and artifact-store
 types, but it must not call replay or public-output authorization. Renderers may
 format existing graph payloads, but they must not export graphs, replay
 projections, or authorize public rows.
+
+Every packaged surface has an explicit boundary role:
+
+```text
+comp: top-level judgment facade
+comp.cli: outer command adapter
+comp.compiler_tool: compiler authority path
+comp.explanation: explanation-only graph exporter
+comp.judgment: judgment kernel
+comp.persistence: persistence replay path
+comp.policy: pre-validation policy vocabulary
+comp.runtime: scenario runtime adapter
+comp.scenario_contracts: scenario contract harness
+comp.scenarios: minimal scenario package namespace
+comp.scenarios.synthetic: synthetic scenario fixture adapter
+comp.views: render-only view layer
+minchoagnt: agent orchestration layer
+```
 
 ## Review Rules
 

--- a/tests/test_authority_import_boundaries.py
+++ b/tests/test_authority_import_boundaries.py
@@ -1,4 +1,5 @@
 import ast
+import tomllib
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,7 +13,42 @@ class ImportBoundaryRule:
     forbidden_imports: tuple[str, ...] = ()
 
 
+PACKAGE_BOUNDARY_ROLES = {
+    "comp": "top-level judgment facade",
+    "comp.cli": "outer command adapter",
+    "comp.compiler_tool": "compiler authority path",
+    "comp.explanation": "explanation-only graph exporter",
+    "comp.judgment": "judgment kernel",
+    "comp.persistence": "persistence replay path",
+    "comp.policy": "pre-validation policy vocabulary",
+    "comp.runtime": "scenario runtime adapter",
+    "comp.scenario_contracts": "scenario contract harness",
+    "comp.scenarios": "minimal scenario package namespace",
+    "comp.scenarios.synthetic": "synthetic scenario fixture adapter",
+    "comp.views": "render-only view layer",
+    "minchoagnt": "agent orchestration layer",
+}
+
+
 AUTHORITY_BOUNDARY_RULES = (
+    ImportBoundaryRule(
+        label="top-level judgment facade",
+        paths=(Path("comp/__init__.py"),),
+        forbidden_prefixes=(
+            "comp.cli",
+            "comp.compiler_tool",
+            "comp.explanation",
+            "comp.persistence",
+            "comp.policy",
+            "comp.runtime",
+            "comp.scenario_contracts",
+            "comp.scenarios",
+            "comp.views",
+            "comp.schema_labels",
+            "comp.user_messages",
+            "minchoagnt",
+        ),
+    ),
     ImportBoundaryRule(
         label="judgment kernel",
         paths=(Path("comp/judgment"),),
@@ -141,6 +177,37 @@ AUTHORITY_BOUNDARY_RULES = (
         ),
     ),
 )
+
+
+def test_top_level_comp_facade_has_machine_checked_boundary():
+    labels = {rule.label for rule in AUTHORITY_BOUNDARY_RULES}
+    assert "top-level judgment facade" in labels
+
+    contract = Path(
+        "docs/architecture/contracts/trust-kernel-extension-rings.md"
+    ).read_text(encoding="utf-8")
+
+    expected_lines = (
+        "comp top-level package must remain a judgment facade",
+        "comp must not import comp.compiler_tool",
+        "comp must not import comp.policy",
+        "Every packaged surface has an explicit boundary role",
+    )
+    for line in expected_lines:
+        assert line in contract
+
+
+def test_packaged_surfaces_have_explicit_boundary_roles_documented():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    packages = set(pyproject["tool"]["setuptools"]["packages"])
+
+    assert set(PACKAGE_BOUNDARY_ROLES) == packages
+
+    contract = Path(
+        "docs/architecture/contracts/trust-kernel-extension-rings.md"
+    ).read_text(encoding="utf-8")
+    for package, role in PACKAGE_BOUNDARY_ROLES.items():
+        assert f"{package}: {role}" in contract
 
 
 def test_authority_modules_do_not_import_presentation_or_explanation_layers():

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -790,7 +790,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "trust-kernel",
             "yes",
-            "2026-05-22",
+            "2026-05-26",
         ),
         "trust-kernel-hardening.md": (
             "active-contract",


### PR DESCRIPTION
## Summary

Hardens the trust-kernel import boundary surface before the next implementation axis expands.

This keeps the top-level `comp` package from growing into a broad authority facade and records an explicit boundary role for every packaged surface in `pyproject.toml`.

## Changes

- Adds a machine-checked import rule that keeps top-level `comp` as a judgment facade only.
- Adds package boundary role coverage so newly packaged surfaces cannot appear without an explicit trust-kernel role.
- Updates `trust-kernel-extension-rings.md` with the top-level facade rule and package role snapshot.
- Updates smoke coverage for the refreshed trust-kernel contract date.

## Validation

- `python -m pytest tests/test_authority_import_boundaries.py::test_top_level_comp_facade_has_machine_checked_boundary tests/test_authority_import_boundaries.py::test_packaged_surfaces_have_explicit_boundary_roles_documented -q` -> 2 passed
- `python -m pytest tests/test_authority_import_boundaries.py tests/test_package_smoke.py -q` -> 47 passed
- `python -m pytest -q` -> 538 passed, 13 skipped
- `git diff --check` -> passed