### PR TITLE
[codex] add validation handoff bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ from comp.policy import ScopedGrant, SelectionDecision, DecisionLedger
 from comp.policy import SelectedValidationContract
 ```
 
+`comp.runtime.ValidationHandoff`는 selected validation contract를
+`InterpretationHypothesis`로 옮기는 얇은 runtime bridge다. contract에 포함된
+selected decision만 compiler-facing hypothesis로 넘길 수 있다. It has no
+compile, commit, receipt, or replay authority.
+
+```python
+from comp.runtime import ValidationHandoff, ValidationHandoffClaim
+```
+
 legacy pipeline runner, pass-pipeline module, compatibility facade는 active
 package source가 아니다. 과거 pass-pipeline snapshot은 repository history에서만
 확인하고, 현재 tree에는 reference copy를 유지하지 않는다.

--- a/comp/runtime/__init__.py
+++ b/comp/runtime/__init__.py
@@ -7,11 +7,14 @@ from comp.runtime.compiler_run_artifacts import (
     materialize_compiler_run_artifacts,
 )
 from comp.runtime.trust_runtime import TrustRuntime
+from comp.runtime.validation_handoff import ValidationHandoff, ValidationHandoffClaim
 
 __all__ = [
     "CompilerRunArtifactMaterializationError",
     "ExternalArtifactMaterial",
     "ExternalArtifactMaterialSource",
     "TrustRuntime",
+    "ValidationHandoff",
+    "ValidationHandoffClaim",
     "materialize_compiler_run_artifacts",
 ]

--- a/comp/runtime/validation_handoff.py
+++ b/comp/runtime/validation_handoff.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from comp.compiler_tool.models import ClaimCandidate, EvidenceRef, InterpretationHypothesis
+from comp.policy import SelectedValidationContract
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationHandoffClaim:
+    decision_id: str
+    claim: ClaimCandidate
+
+    def __post_init__(self) -> None:
+        _require_non_empty("decision_id", self.decision_id)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationHandoff:
+    handoff_id: str
+    contract: SelectedValidationContract
+    hypothesis_id: str
+    subject_id: str
+    claims: tuple[ValidationHandoffClaim, ...] = field(default_factory=tuple)
+    witnesses: tuple[EvidenceRef, ...] = field(default_factory=tuple)
+    meta: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("handoff_id", self.handoff_id)
+        _require_non_empty("hypothesis_id", self.hypothesis_id)
+        _require_non_empty("subject_id", self.subject_id)
+        object.__setattr__(self, "claims", tuple(self.claims))
+        object.__setattr__(self, "witnesses", tuple(self.witnesses))
+        object.__setattr__(self, "meta", tuple(self.meta))
+        self._validate_claim_decisions()
+
+    @property
+    def policy_profile_id(self) -> str:
+        return self.contract.policy_profile_id
+
+    @property
+    def ledger_id(self) -> str:
+        return self.contract.ledger_id
+
+    @property
+    def selected_decision_ids(self) -> tuple[str, ...]:
+        return self.contract.selected_decision_ids
+
+    def to_interpretation_hypothesis(self) -> InterpretationHypothesis:
+        return InterpretationHypothesis(
+            hypothesis_id=self.hypothesis_id,
+            subject_id=self.subject_id,
+            claims=tuple(handoff_claim.claim for handoff_claim in self.claims),
+            witnesses=self.witnesses,
+        )
+
+    @property
+    def authorizes_public_projection(self) -> bool:
+        return False
+
+    def _validate_claim_decisions(self) -> None:
+        claim_decision_ids = tuple(claim.decision_id for claim in self.claims)
+        if len(claim_decision_ids) != len(set(claim_decision_ids)):
+            raise ValueError("duplicate handoff claim decision id")
+
+        selected_decision_ids = set(self.contract.selected_decision_ids)
+        for decision_id in claim_decision_ids:
+            if decision_id not in selected_decision_ids:
+                raise ValueError(
+                    f"handoff claim decision is not selected for validation handoff: "
+                    f"{decision_id}"
+                )
+
+        missing = tuple(
+            decision_id
+            for decision_id in self.contract.selected_decision_ids
+            if decision_id not in claim_decision_ids
+        )
+        if missing:
+            raise ValueError(f"missing handoff claim for selected decision: {missing[0]}")
+
+
+def _require_non_empty(field_name: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{field_name} is required.")
+
+
+__all__ = ["ValidationHandoff", "ValidationHandoffClaim"]

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -91,6 +91,10 @@ rejection, hold, and escalation decisions are auditable.
 policy decisions and grants. It selects what may be handed to compiler
 validation. It does not validate the selected material.
 
+`ValidationHandoff` may translate a selected validation contract into
+compiler-facing input. It is a bridge, not compiler validation, receipt
+authority, or replay authority.
+
 ## Grant Scopes
 
 The initial policy vocabulary may use these scopes:
@@ -192,8 +196,10 @@ The first implementation slices live in `comp.policy`. They expose
 `MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`, `SelectionDecision`, and
 `DecisionLedger` as pre-validation vocabulary only. The next slice exposes
 `SelectedValidationContract` as compiler-facing input shape, not validation
-authority. These slices do not expose receipt builders, projection gates, or
-replay authority.
+authority. `comp.runtime.ValidationHandoff` bridges selected validation
+contracts into compiler-facing hypotheses without compiling, committing,
+building receipts, or replaying. These slices do not expose receipt builders,
+projection gates, or replay authority.
 
 Existing `CompilerProfile`, `DomainPack`, `RetrievalQueryPolicy`,
 reference-selection, resolver-task, and profile/schema selection-tier surfaces

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -299,6 +299,9 @@ ScopedGrant
 SelectedValidationContract
   Compiler-facing contract.
 
+ValidationHandoff
+  Runtime bridge from selected contract to compiler input.
+
 ValidationReport
   Compiler judgment.
 
@@ -359,6 +362,7 @@ comp.policy.ScopedGrant
 comp.policy.SelectionDecision
 comp.policy.DecisionLedger
 comp.policy.SelectedValidationContract
+comp.runtime.ValidationHandoff
 CompilerProfile
 DomainPack
 RetrievalQueryPolicy
@@ -377,6 +381,11 @@ the compiler-facing contract shape. They do not validate claims, authorize
 projection, or replay receipts. A selected decision still requires a
 `validation_handoff` grant before it can be included in a selected validation
 contract, and that contract remains pre-validation.
+
+`comp.runtime.ValidationHandoff` is the first bridge from selected validation
+contract to compiler-facing `InterpretationHypothesis`. It only carries
+contract-selected claims and witnesses across the handoff boundary. It has no
+`CompilerTool`, commit, receipt, projection, or replay authority.
 
 The other surfaces show the existing authority direction: profiles declare
 behavior, retrieval produces candidates, deterministic selectors bind

--- a/tests/test_authority_import_boundaries.py
+++ b/tests/test_authority_import_boundaries.py
@@ -82,6 +82,30 @@ AUTHORITY_BOUNDARY_RULES = (
         ),
     ),
     ImportBoundaryRule(
+        label="validation handoff bridge",
+        paths=(Path("comp/runtime/validation_handoff.py"),),
+        forbidden_prefixes=(
+            "comp.persistence",
+            "comp.explanation",
+            "comp.views",
+            "comp.schema_labels",
+            "comp.user_messages",
+            "comp.scenario_contracts",
+            "comp.scenarios",
+            "minchoagnt",
+        ),
+        forbidden_imports=(
+            "comp.compiler_tool:CompilerTool",
+            "comp.compiler_tool:CommitPreparation",
+            "comp.compiler_tool:ReviewPackage",
+            "comp.compiler_tool:PublicOutputReceipt",
+            "comp.compiler_tool:build_public_output_receipt",
+            "comp.compiler_tool:prepare_commit",
+            "comp.persistence:replay_public_projection",
+            "comp.persistence.replay:replay_public_projection",
+        ),
+    ),
+    ImportBoundaryRule(
         label="receipt proof graph exporter",
         paths=(Path("comp/explanation/receipt_graph.py"),),
         forbidden_prefixes=(

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -391,6 +391,16 @@ def test_readme_tracks_policy_boundary_vocabulary_surface():
     assert "replay authority가 아니다" in readme
 
 
+def test_readme_tracks_validation_handoff_runtime_bridge():
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    assert "comp.runtime.ValidationHandoff" in readme
+    assert "selected validation contract를" in readme
+    assert "`InterpretationHypothesis`로 옮기는 얇은 runtime bridge" in readme
+    assert "compile, commit, receipt, or replay authority" in readme
+    assert "ValidationHandoffClaim" in readme
+
+
 def test_readme_routes_new_work_through_current_architecture_entrypoints():
     readme = Path("README.md").read_text(encoding="utf-8")
 
@@ -601,6 +611,7 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "The first implementation slices live in `comp.policy`.",
         "`MaterialDescriptor`, `PolicyEffect`, `ScopedGrant`, `SelectionDecision`, and",
         "`SelectedValidationContract` as compiler-facing input shape, not validation",
+        "`comp.runtime.ValidationHandoff` bridges selected validation",
     ):
         assert line in policy_boundary
 
@@ -626,6 +637,9 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "`ScopedGrant` is pipeline access, not trust authority.",
         "`DecisionLedger` is the audit spine for policy assembly.",
         "PublicOutputReceipt",
+        "Runtime bridge from selected contract to compiler input.",
+        "`comp.runtime.ValidationHandoff` is the first bridge",
+        "`CompilerTool`, commit, receipt, projection, or replay authority.",
         "Future policy work should connect to that direction instead of introducing a",
         "parallel source of selection truth, validation truth, receipt truth, or",
         "projection truth.",
@@ -1130,6 +1144,8 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         ExternalArtifactMaterial,
         ExternalArtifactMaterialSource,
         TrustRuntime,
+        ValidationHandoff,
+        ValidationHandoffClaim,
         materialize_compiler_run_artifacts,
     )
     from comp.policy import (
@@ -1208,6 +1224,8 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert ExternalArtifactMaterial is not None
     assert ExternalArtifactMaterialSource is not None
     assert TrustRuntime is not None
+    assert ValidationHandoff is not None
+    assert ValidationHandoffClaim is not None
     assert materialize_compiler_run_artifacts is not None
 
 

--- a/tests/test_validation_handoff.py
+++ b/tests/test_validation_handoff.py
@@ -1,0 +1,116 @@
+import pytest
+
+
+def test_validation_handoff_builds_hypothesis_from_selected_contract_claims():
+    from comp.compiler_tool import ClaimCandidate, EvidenceRef, InterpretationHypothesis
+    from comp.policy import SelectedValidationContract
+    from comp.runtime import ValidationHandoff, ValidationHandoffClaim
+
+    contract = SelectedValidationContract(
+        contract_id="selected-contract:run-1",
+        policy_profile_id="profile:strict-public",
+        ledger_id="ledger:run-1",
+        basis="policy resolver finalized validation handoff",
+        selected_decision_ids=("decision:plant->site",),
+        projection_candidate_decision_ids=("decision:fuel_used->amount",),
+        ledger_digest="digest:ledger-run-1",
+    )
+    claim = ClaimCandidate(
+        field="site",
+        value="Plant A",
+        witness_id="w-plant",
+        origin="policy_handoff",
+    )
+    witness = EvidenceRef(
+        witness_id="w-plant",
+        field="site",
+        source="source:invoice-1",
+        span="Plant A",
+        text="Plant A used 1200 L diesel",
+    )
+
+    handoff = ValidationHandoff(
+        handoff_id="handoff:run-1",
+        contract=contract,
+        hypothesis_id="hypothesis:run-1",
+        subject_id="subject:facility-1",
+        claims=(
+            ValidationHandoffClaim(
+                decision_id="decision:plant->site",
+                claim=claim,
+            ),
+        ),
+        witnesses=(witness,),
+    )
+
+    hypothesis = handoff.to_interpretation_hypothesis()
+
+    assert isinstance(hypothesis, InterpretationHypothesis)
+    assert hypothesis.hypothesis_id == "hypothesis:run-1"
+    assert hypothesis.subject_id == "subject:facility-1"
+    assert hypothesis.claims == (claim,)
+    assert hypothesis.witnesses == (witness,)
+    assert handoff.policy_profile_id == "profile:strict-public"
+    assert handoff.ledger_id == "ledger:run-1"
+    assert handoff.selected_decision_ids == ("decision:plant->site",)
+    assert handoff.authorizes_public_projection is False
+    assert not hasattr(handoff, "compile")
+    assert not hasattr(handoff, "prepare_commit")
+    assert not hasattr(handoff, "build_public_output_receipt")
+
+
+def test_validation_handoff_rejects_claims_outside_selected_contract():
+    from comp.compiler_tool import ClaimCandidate
+    from comp.policy import SelectedValidationContract
+    from comp.runtime import ValidationHandoff, ValidationHandoffClaim
+
+    contract = SelectedValidationContract(
+        contract_id="selected-contract:run-1",
+        policy_profile_id="profile:strict-public",
+        ledger_id="ledger:run-1",
+        basis="policy resolver finalized validation handoff",
+        selected_decision_ids=("decision:plant->site",),
+        projection_candidate_decision_ids=("decision:fuel_used->amount",),
+    )
+
+    with pytest.raises(ValueError, match="not selected for validation handoff"):
+        ValidationHandoff(
+            handoff_id="handoff:run-1",
+            contract=contract,
+            hypothesis_id="hypothesis:run-1",
+            subject_id="subject:facility-1",
+            claims=(
+                ValidationHandoffClaim(
+                    decision_id="decision:fuel_used->amount",
+                    claim=ClaimCandidate(field="amount", value=1200),
+                ),
+            ),
+        )
+
+
+def test_validation_handoff_requires_claims_for_each_selected_decision():
+    from comp.compiler_tool import ClaimCandidate
+    from comp.policy import SelectedValidationContract
+    from comp.runtime import ValidationHandoff, ValidationHandoffClaim
+
+    contract = SelectedValidationContract(
+        contract_id="selected-contract:run-1",
+        policy_profile_id="profile:strict-public",
+        ledger_id="ledger:run-1",
+        basis="policy resolver finalized validation handoff",
+        selected_decision_ids=("decision:plant->site", "decision:unit->unit"),
+    )
+
+    with pytest.raises(ValueError, match="missing handoff claim"):
+        ValidationHandoff(
+            handoff_id="handoff:run-1",
+            contract=contract,
+            hypothesis_id="hypothesis:run-1",
+            subject_id="subject:facility-1",
+            claims=(
+                ValidationHandoffClaim(
+                    decision_id="decision:plant->site",
+                    claim=ClaimCandidate(field="site", value="Plant A"),
+                ),
+            ),
+        )


### PR DESCRIPTION
## Summary
- add comp.runtime.ValidationHandoff as the thin bridge from SelectedValidationContract to InterpretationHypothesis
- require handoff claims to match selected validation decision ids and reject projection-candidate-only decisions
- document the bridge as non-authoritative and add import-boundary coverage so it cannot call commit, receipt, projection, or replay authority

## Validation
- python -m pytest tests/test_validation_handoff.py tests/test_authority_import_boundaries.py tests/test_package_smoke.py::test_readme_tracks_validation_handoff_runtime_bridge tests/test_package_smoke.py::test_policy_boundary_contract_keeps_policy_non_authoritative tests/test_package_smoke.py::test_policy_assembled_trust_kernel_map_tracks_growth_shape tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer -q
- python -m pytest tests/test_package_smoke.py tests/test_authority_import_boundaries.py tests/test_policy_boundary_vocabulary.py tests/test_validation_handoff.py -q
- python -m pytest -q
- python -m tests.domain_scenarios run-all