### PR TITLE
[codex] snapshot package import boundaries

### DIFF
--- a/docs/architecture/contracts/trust-kernel-extension-rings.md
+++ b/docs/architecture/contracts/trust-kernel-extension-rings.md
@@ -349,6 +349,28 @@ comp.views: render-only view layer
 minchoagnt: agent orchestration layer
 ```
 
+Every packaged surface has a machine-checked import snapshot.
+
+```text
+comp -> comp.judgment
+comp.cli -> comp.scenario_contracts
+comp.compiler_tool -> comp.judgment
+comp.explanation -> comp.judgment, comp.persistence, comp.views
+comp.judgment -> (none)
+comp.persistence -> comp.judgment
+comp.policy -> (none)
+comp.runtime -> comp.compiler_tool, comp.persistence, comp.scenario_contracts
+comp.scenario_contracts -> comp.judgment, comp.persistence, comp.runtime
+comp.scenarios -> (none)
+comp.scenarios.synthetic -> comp.compiler_tool, comp.runtime
+comp.views -> comp, comp.compiler_tool
+minchoagnt -> comp.compiler_tool, comp.judgment
+```
+
+If a new package import appears, the PR should explain whether the package is
+moving closer to authority, farther from authority, or merely consuming a stable
+public surface. Update this snapshot in the same PR so drift is reviewable.
+
 ## Review Rules
 
 Use these rules when reviewing PRs:

--- a/tests/test_authority_import_boundaries.py
+++ b/tests/test_authority_import_boundaries.py
@@ -30,6 +30,31 @@ PACKAGE_BOUNDARY_ROLES = {
 }
 
 
+EXPECTED_PACKAGE_IMPORTS = {
+    "comp": ("comp.judgment",),
+    "comp.cli": ("comp.scenario_contracts",),
+    "comp.compiler_tool": ("comp.judgment",),
+    "comp.explanation": ("comp.judgment", "comp.persistence", "comp.views"),
+    "comp.judgment": (),
+    "comp.persistence": ("comp.judgment",),
+    "comp.policy": (),
+    "comp.runtime": (
+        "comp.compiler_tool",
+        "comp.persistence",
+        "comp.scenario_contracts",
+    ),
+    "comp.scenario_contracts": (
+        "comp.judgment",
+        "comp.persistence",
+        "comp.runtime",
+    ),
+    "comp.scenarios": (),
+    "comp.scenarios.synthetic": ("comp.compiler_tool", "comp.runtime"),
+    "comp.views": ("comp", "comp.compiler_tool"),
+    "minchoagnt": ("comp.compiler_tool", "comp.judgment"),
+}
+
+
 AUTHORITY_BOUNDARY_RULES = (
     ImportBoundaryRule(
         label="top-level judgment facade",
@@ -210,6 +235,22 @@ def test_packaged_surfaces_have_explicit_boundary_roles_documented():
         assert f"{package}: {role}" in contract
 
 
+def test_packaged_surfaces_match_expected_internal_import_snapshot():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    packages = tuple(pyproject["tool"]["setuptools"]["packages"])
+
+    assert set(EXPECTED_PACKAGE_IMPORTS) == set(packages)
+    assert _package_import_graph(packages) == EXPECTED_PACKAGE_IMPORTS
+
+    contract = Path(
+        "docs/architecture/contracts/trust-kernel-extension-rings.md"
+    ).read_text(encoding="utf-8")
+    assert "Every packaged surface has a machine-checked import snapshot." in contract
+    for package, imports in EXPECTED_PACKAGE_IMPORTS.items():
+        expected = ", ".join(imports) if imports else "(none)"
+        assert f"{package} -> {expected}" in contract
+
+
 def test_authority_modules_do_not_import_presentation_or_explanation_layers():
     violations = []
     for rule in AUTHORITY_BOUNDARY_RULES:
@@ -336,3 +377,39 @@ def _is_forbidden(imported: str, rule: ImportBoundaryRule) -> bool:
         imported == prefix or imported.startswith(f"{prefix}.")
         for prefix in rule.forbidden_prefixes
     )
+
+
+def _package_import_graph(packages: tuple[str, ...]) -> dict[str, tuple[str, ...]]:
+    graph = {package: set() for package in packages}
+    for source_path in _python_files((Path("comp"), Path("minchoagnt"))):
+        source_package = _package_for_path(source_path, packages)
+        if source_package is None:
+            continue
+        for imported in _imports(source_path):
+            target_package = _package_for_import(imported.split(":", 1)[0], packages)
+            if target_package is not None and target_package != source_package:
+                graph[source_package].add(target_package)
+    return {
+        package: tuple(sorted(imports))
+        for package, imports in graph.items()
+    }
+
+
+def _package_for_path(path: Path, packages: tuple[str, ...]) -> str | None:
+    module = ".".join(path.with_suffix("").parts)
+    return _longest_package_match(module, packages)
+
+
+def _package_for_import(imported: str, packages: tuple[str, ...]) -> str | None:
+    return _longest_package_match(imported, packages)
+
+
+def _longest_package_match(module: str, packages: tuple[str, ...]) -> str | None:
+    matches = tuple(
+        package
+        for package in packages
+        if module == package or module.startswith(f"{package}.")
+    )
+    if not matches:
+        return None
+    return max(matches, key=len)


### PR DESCRIPTION
## Summary

Adds a machine-checked package import snapshot for the current `comp` trust-kernel layout.

This continues the import-boundary hardening axis by making package-level dependency drift visible in review. If a package starts importing another packaged surface, the test now requires the snapshot and trust-kernel contract to be updated together.

## Changes

- Adds `EXPECTED_PACKAGE_IMPORTS` to `tests/test_authority_import_boundaries.py`.
- Computes package-level internal imports from the Python AST and compares them to the expected snapshot.
- Documents the current package import snapshot in `trust-kernel-extension-rings.md`.
- Adds review guidance for explaining whether a new import moves a package closer to authority, farther from authority, or only consumes a stable public surface.

## Validation

- `python -m pytest tests/test_authority_import_boundaries.py::test_packaged_surfaces_match_expected_internal_import_snapshot -q` -> 1 passed
- `python -m pytest tests/test_authority_import_boundaries.py tests/test_package_smoke.py -q` -> 48 passed
- `python -m pytest -q` -> 541 passed, 13 skipped
- `git diff --check` -> passed