### PR TITLE
[codex] add selected contract assembly helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ from comp.policy import ScopedGrant, SelectionDecision, DecisionLedger
 from comp.policy import SelectedValidationContract
 ```
 
+`PolicyAssembly` can assemble a `DecisionLedger` and matching
+`SelectedValidationContract` together, while keeping both artifacts
+pre-validation and non-authoritative.
+
 `comp.runtime.ValidationHandoff`는 selected validation contract를
 `InterpretationHypothesis`로 옮기는 얇은 runtime bridge다. contract에 포함된
 selected decision만 compiler-facing hypothesis로 넘길 수 있다. It has no

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -449,6 +449,37 @@ class PolicyAssembly:
             meta=tuple(meta),
         )
 
+    def assemble_selected_validation_contract(
+        self,
+        *,
+        ledger_id: str,
+        contract_id: str,
+        contract_basis: str,
+        subjects: tuple[PolicyAssemblySubject, ...],
+        effects: tuple[PolicyEffect, ...],
+        descriptors: tuple[MaterialDescriptor, ...] = (),
+        ledger_meta: tuple[tuple[str, Any], ...] = (),
+        contract_meta: tuple[tuple[str, Any], ...] = (),
+        ledger_digest: str | None = None,
+        contract_version: str = "policy-boundary-selected-validation-contract-v1",
+    ) -> tuple[DecisionLedger, SelectedValidationContract]:
+        ledger = self.assemble_ledger(
+            ledger_id=ledger_id,
+            subjects=subjects,
+            effects=effects,
+            descriptors=descriptors,
+            meta=ledger_meta,
+        )
+        contract = SelectedValidationContract.from_ledger(
+            contract_id=contract_id,
+            ledger=ledger,
+            basis=contract_basis,
+            ledger_digest=ledger_digest,
+            contract_version=contract_version,
+            meta=contract_meta,
+        )
+        return ledger, contract
+
     def _resolve_subject(
         self,
         subject: PolicyAssemblySubject,

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -85,6 +85,10 @@ kernel invariants first and profile-specific composition rules second.
 output into a `DecisionLedger`. It preserves audit material; it does not
 validate claims, authorize projection, or replay receipt paths.
 
+`PolicyAssembly` may also build a matching `SelectedValidationContract` from the
+assembled ledger. This is a handoff-shaping convenience, not validation
+authority.
+
 `ScopedGrant` records which pipeline scope a subject may enter, under which
 basis and conditions. It is not a receipt, validation result, or replay proof.
 
@@ -200,8 +204,9 @@ The first implementation slices live in `comp.policy`. They expose
 `MaterialDescriptor`, `PolicyEffect`, `ConflictResolver`, `PolicyAssembly`,
 `ScopedGrant`, `SelectionDecision`, and `DecisionLedger` as pre-validation
 vocabulary only. `ConflictResolver` may compose effects into decisions and
-scoped grants, and `PolicyAssembly` may assemble a `DecisionLedger`, but neither
-validates claims or authorizes projection. The next slice exposes
+scoped grants, and `PolicyAssembly` may assemble a `DecisionLedger` and matching
+`SelectedValidationContract`, but neither validates claims or authorizes
+projection. The next slice exposes
 `SelectedValidationContract` as compiler-facing input shape, not validation
 authority. `comp.runtime.ValidationHandoff` bridges selected validation
 contracts into compiler-facing hypotheses without compiling, committing,

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -297,7 +297,8 @@ ConflictResolver
   Composition step from effects to decisions and scoped grants.
 
 PolicyAssembly
-  Ledger assembly step from descriptors, effects, and decision subjects.
+  Ledger and selected-contract assembly step from descriptors, effects, and
+  decision subjects.
 
 ScopedGrant
   Pipeline access.
@@ -385,9 +386,10 @@ replay_public_projection(...)
 `PolicyAssembly`, `ScopedGrant`, `SelectionDecision`, `DecisionLedger`, and
 `SelectedValidationContract` are the first minimal vocabulary slices. They
 describe pre-validation material, policy effects, effect composition, ledger
-assembly, scoped pipeline access, selection status, decision audit records, and
-the compiler-facing contract shape. They do not validate claims, authorize
-projection, or replay receipts. A selected decision still requires a
+and selected-contract assembly, scoped pipeline access, selection status,
+decision audit records, and the compiler-facing contract shape. They do not
+validate claims, authorize projection, or replay receipts. A selected decision
+still requires a
 `validation_handoff` grant before it can be included in a selected validation
 contract, and that contract remains pre-validation.
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -389,6 +389,8 @@ def test_readme_tracks_policy_boundary_vocabulary_surface():
     assert "SelectionDecision" in readme
     assert "DecisionLedger" in readme
     assert "SelectedValidationContract" in readme
+    assert "PolicyAssembly` can assemble a `DecisionLedger` and matching" in readme
+    assert "pre-validation and non-authoritative" in readme
     assert "validation" in readme
     assert "receipt authority" in readme
     assert "replay authority가 아니다" in readme
@@ -614,7 +616,8 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "The first implementation slices live in `comp.policy`.",
         "`MaterialDescriptor`, `PolicyEffect`, `ConflictResolver`, `PolicyAssembly`,",
         "`PolicyAssembly` groups descriptors, effects, assembly subjects, and resolver",
-        "`PolicyAssembly` may assemble a `DecisionLedger`, but neither",
+        "`PolicyAssembly` may also build a matching `SelectedValidationContract`",
+        "`PolicyAssembly` may assemble a `DecisionLedger` and matching",
         "`SelectedValidationContract` as compiler-facing input shape, not validation",
         "`comp.runtime.ValidationHandoff` bridges selected validation",
     ):
@@ -641,7 +644,8 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "selected for validation != selected for projection",
         "`ScopedGrant` is pipeline access, not trust authority.",
         "Composition step from effects to decisions and scoped grants.",
-        "Ledger assembly step from descriptors, effects, and decision subjects.",
+        "Ledger and selected-contract assembly step from descriptors, effects, and",
+        "and selected-contract assembly, scoped pipeline access, selection status,",
         "`DecisionLedger` is the audit spine for policy assembly.",
         "PublicOutputReceipt",
         "Runtime bridge from selected contract to compiler input.",

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -580,6 +580,85 @@ def test_policy_assembly_builds_decision_ledger_from_subject_effects():
     assert contract.authorizes_public_projection is False
 
 
+def test_policy_assembly_builds_selected_contract_with_ledger():
+    from comp.policy import PolicyAssembly, PolicyAssemblySubject, PolicyEffect
+
+    effects = (
+        PolicyEffect(
+            effect_id="effect:select:plant",
+            effect_kind="select",
+            subject_id="material:plant",
+            basis="declared alias",
+        ),
+        PolicyEffect(
+            effect_id="effect:grant:plant:validation-handoff",
+            effect_kind="grant_scope",
+            subject_id="material:plant",
+            basis="declared alias selected",
+            scope="validation_handoff",
+        ),
+        PolicyEffect(
+            effect_id="effect:grant:plant:projection-candidate",
+            effect_kind="grant_scope",
+            subject_id="material:plant",
+            basis="eligible for later receipt consideration",
+            scope="projection_candidate",
+        ),
+        PolicyEffect(
+            effect_id="effect:select:fuel_used",
+            effect_kind="select",
+            subject_id="material:fuel_used",
+            basis="embedding score 0.96",
+        ),
+        PolicyEffect(
+            effect_id="effect:hold:fuel_used",
+            effect_kind="hold",
+            subject_id="material:fuel_used",
+            basis="unit evidence required",
+        ),
+    )
+
+    ledger, contract = PolicyAssembly(
+        policy_profile_id="profile:strict-public",
+    ).assemble_selected_validation_contract(
+        ledger_id="ledger:run-1",
+        contract_id="selected-contract:run-1",
+        contract_basis="assembly finalized validation handoff",
+        ledger_digest="digest:ledger-run-1",
+        effects=effects,
+        subjects=(
+            PolicyAssemblySubject(
+                decision_id="decision:plant->site",
+                subject_id="material:plant",
+                target_id="field:site",
+            ),
+            PolicyAssemblySubject(
+                decision_id="decision:fuel_used->amount",
+                subject_id="material:fuel_used",
+                target_id="field:amount",
+            ),
+        ),
+        ledger_meta=(("run_id", "run-1"),),
+        contract_meta=(("assembly_id", "assembly:run-1"),),
+    )
+
+    assert ledger.ledger_id == "ledger:run-1"
+    assert tuple(decision.status for decision in ledger.decisions) == (
+        "selected",
+        "held",
+    )
+    assert contract.contract_id == "selected-contract:run-1"
+    assert contract.policy_profile_id == "profile:strict-public"
+    assert contract.ledger_id == "ledger:run-1"
+    assert contract.ledger_digest == "digest:ledger-run-1"
+    assert contract.basis == "assembly finalized validation handoff"
+    assert contract.selected_decision_ids == ("decision:plant->site",)
+    assert contract.projection_candidate_decision_ids == ("decision:plant->site",)
+    assert contract.meta == (("assembly_id", "assembly:run-1"),)
+    assert contract.authorizes_public_projection is False
+    assert ledger.authorizes_public_projection is False
+
+
 def test_policy_assembly_rejects_unassembled_effects_and_duplicate_subjects():
     from comp.policy import PolicyAssembly, PolicyAssemblySubject, PolicyEffect
 


### PR DESCRIPTION
## Summary
- add PolicyAssembly.assemble_selected_validation_contract to build a DecisionLedger and matching SelectedValidationContract together
- preserve ledger audit material while deriving selected validation and projection-candidate decision ids from the ledger
- document the helper as pre-validation and non-authoritative

## Validation
- python -m pytest tests/test_policy_boundary_vocabulary.py tests/test_package_smoke.py::test_readme_tracks_policy_boundary_vocabulary_surface tests/test_package_smoke.py::test_policy_boundary_contract_keeps_policy_non_authoritative tests/test_package_smoke.py::test_policy_assembled_trust_kernel_map_tracks_growth_shape tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer tests/test_authority_import_boundaries.py -q
- python -m pytest tests/test_package_smoke.py tests/test_authority_import_boundaries.py tests/test_policy_boundary_vocabulary.py tests/test_validation_handoff.py -q
- python -m pytest -q
- python -m tests.domain_scenarios run-all