### PR TITLE
[codex] add policy audit digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,15 @@ from comp.policy import MaterialDescriptor, PolicyEffect
 from comp.policy import PolicyAssembly, PolicyAssemblySubject, ConflictResolver
 from comp.policy import ScopedGrant, SelectionDecision, DecisionLedger
 from comp.policy import SelectedValidationContract
+from comp.policy import policy_artifact_digest
 ```
 
 `PolicyAssembly` can assemble a `DecisionLedger` and matching
 `SelectedValidationContract` together, while keeping both artifacts
 pre-validation and non-authoritative.
+`policy_artifact_digest(...)`, `DecisionLedger.digest()`, and
+`SelectedValidationContract.digest()` provide stable audit identifiers only;
+they are not receipt authority or replay proof.
 
 `comp.runtime.ValidationHandoff`는 selected validation contract를
 `InterpretationHypothesis`로 옮기는 얇은 runtime bridge다. contract에 포함된

--- a/comp/policy/__init__.py
+++ b/comp/policy/__init__.py
@@ -22,6 +22,7 @@ from comp.policy.boundary import (
     SelectionDecision,
     SelectionStatus,
     SelectedValidationContract,
+    policy_artifact_digest,
 )
 
 __all__ = [
@@ -40,4 +41,5 @@ __all__ = [
     "SelectionDecision",
     "SelectionStatus",
     "SelectedValidationContract",
+    "policy_artifact_digest",
 ]

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import hashlib
+import json
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, Literal
 
 PolicyEffectKind = Literal[
@@ -220,6 +222,9 @@ class DecisionLedger:
             and decision.allows_scope("validation_handoff")
         )
 
+    def digest(self) -> str:
+        return policy_artifact_digest("DecisionLedger", self)
+
     @property
     def authorizes_public_projection(self) -> bool:
         return False
@@ -299,13 +304,18 @@ class SelectedValidationContract:
                 if decision.status == "selected"
                 and decision.allows_scope("projection_candidate")
             ),
-            ledger_digest=ledger_digest,
+            ledger_digest=(
+                ledger_digest if ledger_digest is not None else ledger.digest()
+            ),
             contract_version=contract_version,
             meta=meta,
         )
 
     def allows_validation_decision(self, decision_id: str) -> bool:
         return decision_id in self.selected_decision_ids
+
+    def digest(self) -> str:
+        return policy_artifact_digest("SelectedValidationContract", self)
 
     @property
     def authorizes_public_projection(self) -> bool:
@@ -540,6 +550,55 @@ def _retention_from_effects(
     return default
 
 
+def policy_artifact_digest(artifact_kind: str, payload: Any) -> str:
+    _require_non_empty("artifact_kind", artifact_kind)
+    digest_payload = {
+        "artifact_kind": artifact_kind,
+        "payload": _canonical_policy_payload(payload),
+    }
+    encoded = json.dumps(
+        digest_payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _canonical_policy_payload(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            field_info.name: _canonical_policy_payload(
+                getattr(value, field_info.name)
+            )
+            for field_info in fields(value)
+        }
+    if isinstance(value, dict):
+        return {
+            str(key): _canonical_policy_payload(value[key])
+            for key in sorted(value, key=str)
+        }
+    if isinstance(value, (tuple, list)):
+        return [_canonical_policy_payload(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(
+            (_canonical_policy_payload(item) for item in value),
+            key=_canonical_sort_key,
+        )
+    if isinstance(value, bytes):
+        return {"bytes_hex": value.hex()}
+    return value
+
+
+def _canonical_sort_key(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
 __all__ = [
     "PIPELINE_SCOPES",
     "POLICY_EFFECT_KINDS",
@@ -556,4 +615,5 @@ __all__ = [
     "SelectionDecision",
     "SelectionStatus",
     "SelectedValidationContract",
+    "policy_artifact_digest",
 ]

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -99,6 +99,10 @@ rejection, hold, and escalation decisions are auditable.
 policy decisions and grants. It selects what may be handed to compiler
 validation. It does not validate the selected material.
 
+Policy artifact digests may identify a `DecisionLedger` or
+`SelectedValidationContract` for audit linkage. A digest is not a receipt,
+replay proof, validation result, or public projection authority.
+
 `ValidationHandoff` may translate a selected validation contract into
 compiler-facing input. It is a bridge, not compiler validation, receipt
 authority, or replay authority.
@@ -139,6 +143,7 @@ No embedding or LLM output enters validation_handoff without selection basis.
 No selected material becomes public output without PublicOutputReceipt.
 No policy assembly may bypass receipt or replay boundaries.
 ScopedGrant is not PublicOutputReceipt.
+Policy artifact digest is not PublicOutputReceipt.
 ```
 
 The policy boundary may restrict access to later pipeline stages. It may not
@@ -206,12 +211,14 @@ The first implementation slices live in `comp.policy`. They expose
 vocabulary only. `ConflictResolver` may compose effects into decisions and
 scoped grants, and `PolicyAssembly` may assemble a `DecisionLedger` and matching
 `SelectedValidationContract`, but neither validates claims or authorizes
-projection. The next slice exposes
-`SelectedValidationContract` as compiler-facing input shape, not validation
-authority. `comp.runtime.ValidationHandoff` bridges selected validation
-contracts into compiler-facing hypotheses without compiling, committing,
-building receipts, or replaying. These slices do not expose receipt builders,
-projection gates, or replay authority.
+projection. `policy_artifact_digest(...)`, `DecisionLedger.digest()`, and
+`SelectedValidationContract.digest()` expose stable audit identifiers without
+minting receipt, replay, validation, or public projection authority.
+The current selected-contract slice keeps `SelectedValidationContract` as compiler-facing input shape, not validation authority.
+`comp.runtime.ValidationHandoff` bridges selected validation contracts into
+compiler-facing hypotheses without compiling, committing, building receipts, or
+replaying. These slices do not expose receipt builders, projection gates, or
+replay authority.
 
 Existing `CompilerProfile`, `DomainPack`, `RetrievalQueryPolicy`,
 reference-selection, resolver-task, and profile/schema selection-tier surfaces

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -245,11 +245,14 @@ scoped grants
 denied scopes
 retention class
 selected validation contract digest
+policy artifact digest
 policy profile id
 policy assembly version
 ```
 
 The ledger is explanation and audit material. It is not authority by itself.
+Its digest is an audit identifier, not a receipt, replay proof, or validation
+result.
 Its value is that future replay, review, debugging, shadow-policy comparison,
 or counterfactual analysis can see why a run shaped validation input the way it
 did.
@@ -371,6 +374,7 @@ comp.policy.ScopedGrant
 comp.policy.SelectionDecision
 comp.policy.DecisionLedger
 comp.policy.SelectedValidationContract
+comp.policy.policy_artifact_digest
 comp.runtime.ValidationHandoff
 CompilerProfile
 DomainPack
@@ -387,9 +391,9 @@ replay_public_projection(...)
 `SelectedValidationContract` are the first minimal vocabulary slices. They
 describe pre-validation material, policy effects, effect composition, ledger
 and selected-contract assembly, scoped pipeline access, selection status,
-decision audit records, and the compiler-facing contract shape. They do not
-validate claims, authorize projection, or replay receipts. A selected decision
-still requires a
+decision audit records, stable policy artifact digests, and the
+compiler-facing contract shape. They do not validate claims, authorize
+projection, or replay receipts. A selected decision still requires a
 `validation_handoff` grant before it can be included in a selected validation
 contract, and that contract remains pre-validation.
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -389,7 +389,9 @@ def test_readme_tracks_policy_boundary_vocabulary_surface():
     assert "SelectionDecision" in readme
     assert "DecisionLedger" in readme
     assert "SelectedValidationContract" in readme
+    assert "policy_artifact_digest" in readme
     assert "PolicyAssembly` can assemble a `DecisionLedger` and matching" in readme
+    assert "provide stable audit identifiers only" in readme
     assert "pre-validation and non-authoritative" in readme
     assert "validation" in readme
     assert "receipt authority" in readme
@@ -618,6 +620,8 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "`PolicyAssembly` groups descriptors, effects, assembly subjects, and resolver",
         "`PolicyAssembly` may also build a matching `SelectedValidationContract`",
         "`PolicyAssembly` may assemble a `DecisionLedger` and matching",
+        "`policy_artifact_digest(...)`, `DecisionLedger.digest()`, and",
+        "Policy artifact digest is not PublicOutputReceipt.",
         "`SelectedValidationContract` as compiler-facing input shape, not validation",
         "`comp.runtime.ValidationHandoff` bridges selected validation",
     ):
@@ -651,6 +655,9 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "Runtime bridge from selected contract to compiler input.",
         "`comp.runtime.ValidationHandoff` is the first bridge",
         "`CompilerTool`, commit, receipt, projection, or replay authority.",
+        "policy artifact digest",
+        "comp.policy.policy_artifact_digest",
+        "stable policy artifact digests",
         "Future policy work should connect to that direction instead of introducing a",
         "parallel source of selection truth, validation truth, receipt truth, or",
         "projection truth.",
@@ -1169,6 +1176,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         ScopedGrant,
         SelectionDecision,
         SelectedValidationContract,
+        policy_artifact_digest,
     )
 
     assert pyproject["project"]["description"] == (
@@ -1224,6 +1232,7 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert PolicyAssembly is not None
     assert PolicyAssemblySubject is not None
     assert PolicyEffect is not None
+    assert policy_artifact_digest is not None
     assert ScopedGrant is not None
     assert SelectionDecision is not None
     assert SelectedValidationContract is not None

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -226,6 +226,98 @@ def test_decision_ledger_lists_grants_and_validation_handoff_subjects():
     assert ledger.authorizes_public_projection is False
 
 
+def test_policy_artifact_digest_is_stable_and_non_authoritative():
+    from comp.policy import (
+        DecisionLedger,
+        MaterialDescriptor,
+        PolicyEffect,
+        ScopedGrant,
+        SelectionDecision,
+        policy_artifact_digest,
+    )
+
+    descriptor = MaterialDescriptor(
+        material_id="material:fuel_used",
+        material_kind="source_attribute",
+        attributes=(("raw_field", "fuel_used"),),
+    )
+    effect = PolicyEffect(
+        effect_id="effect:select:fuel_used",
+        effect_kind="select",
+        subject_id="material:fuel_used",
+        basis="declared alias",
+    )
+    grant = ScopedGrant(
+        grant_id="grant:fuel_used:validation-handoff",
+        subject_id="decision:fuel_used->amount",
+        scope="validation_handoff",
+        basis="declared alias selected",
+    )
+    decision = SelectionDecision(
+        decision_id="decision:fuel_used->amount",
+        subject_id="material:fuel_used",
+        status="selected",
+        basis="declared alias",
+        target_id="field:amount",
+        grants=(grant,),
+    )
+    ledger = DecisionLedger(
+        ledger_id="ledger:run-1",
+        policy_profile_id="profile:strict-public",
+        descriptors=(descriptor,),
+        effects=(effect,),
+        decisions=(decision,),
+        meta=(("run_id", "run-1"),),
+    )
+    same_ledger = DecisionLedger(
+        ledger_id="ledger:run-1",
+        policy_profile_id="profile:strict-public",
+        descriptors=[descriptor],
+        effects=[effect],
+        decisions=[decision],
+        meta=[("run_id", "run-1")],
+    )
+    changed_ledger = DecisionLedger(
+        ledger_id="ledger:run-1",
+        policy_profile_id="profile:strict-public",
+        descriptors=(descriptor,),
+        effects=(effect,),
+        decisions=(decision,),
+        meta=(("run_id", "run-2"),),
+    )
+
+    digest = ledger.digest()
+
+    assert digest == ledger.digest()
+    assert digest == same_ledger.digest()
+    assert digest == policy_artifact_digest("DecisionLedger", ledger)
+    assert digest.startswith("sha256:")
+    assert len(digest) == len("sha256:") + 64
+    assert all(character in "0123456789abcdef" for character in digest[7:])
+    assert changed_ledger.digest() != digest
+    assert ledger.authorizes_public_projection is False
+
+
+def test_policy_artifact_digest_canonicalizes_payload_without_minting_authority():
+    from comp.policy import policy_artifact_digest
+
+    digest = policy_artifact_digest(
+        "policy-artifact",
+        {"scope": "validation_handoff", "basis": ("declared_alias", "reviewed")},
+    )
+
+    assert digest == policy_artifact_digest(
+        "policy-artifact",
+        {"basis": ["declared_alias", "reviewed"], "scope": "validation_handoff"},
+    )
+    assert digest != policy_artifact_digest(
+        "other-policy-artifact",
+        {"basis": ["declared_alias", "reviewed"], "scope": "validation_handoff"},
+    )
+    with pytest.raises(ValueError, match="artifact_kind is required"):
+        policy_artifact_digest("", {"scope": "validation_handoff"})
+
+
 def test_selected_validation_contract_freezes_handoff_decisions_from_ledger():
     from comp.policy import (
         DecisionLedger,
@@ -305,6 +397,70 @@ def test_selected_validation_contract_freezes_handoff_decisions_from_ledger():
     assert contract.allows_validation_decision("decision:plant->site") is True
     assert contract.allows_validation_decision("decision:fuel_used->amount") is False
     assert contract.authorizes_public_projection is False
+
+
+def test_selected_validation_contract_digest_tracks_ledger_without_authority():
+    from comp.policy import PolicyAssembly, PolicyAssemblySubject, PolicyEffect
+
+    effects = (
+        PolicyEffect(
+            effect_id="effect:select:plant",
+            effect_kind="select",
+            subject_id="material:plant",
+            basis="declared alias",
+        ),
+        PolicyEffect(
+            effect_id="effect:grant:plant:validation-handoff",
+            effect_kind="grant_scope",
+            subject_id="material:plant",
+            basis="declared alias selected",
+            scope="validation_handoff",
+        ),
+    )
+    subjects = (
+        PolicyAssemblySubject(
+            decision_id="decision:plant->site",
+            subject_id="material:plant",
+            target_id="field:site",
+        ),
+    )
+    ledger, contract = PolicyAssembly(
+        policy_profile_id="profile:strict-public",
+    ).assemble_selected_validation_contract(
+        ledger_id="ledger:run-1",
+        contract_id="selected-contract:run-1",
+        contract_basis="assembly finalized validation handoff",
+        effects=effects,
+        subjects=subjects,
+    )
+    same_ledger, same_contract = PolicyAssembly(
+        policy_profile_id="profile:strict-public",
+    ).assemble_selected_validation_contract(
+        ledger_id="ledger:run-1",
+        contract_id="selected-contract:run-1",
+        contract_basis="assembly finalized validation handoff",
+        effects=effects,
+        subjects=subjects,
+    )
+
+    digest = contract.digest()
+
+    assert contract.ledger_digest == ledger.digest()
+    assert digest == contract.digest()
+    assert digest == same_contract.digest()
+    assert same_contract.ledger_digest == same_ledger.digest()
+    assert digest.startswith("sha256:")
+    assert contract.authorizes_public_projection is False
+    assert ledger.authorizes_public_projection is False
+    assert PolicyAssembly(
+        policy_profile_id="profile:strict-public",
+    ).assemble_selected_validation_contract(
+        ledger_id="ledger:run-1",
+        contract_id="selected-contract:run-1",
+        contract_basis="different handoff basis",
+        effects=effects,
+        subjects=subjects,
+    )[1].digest() != digest
 
 
 def test_selected_validation_contract_rejects_authority_shaped_scopes():


### PR DESCRIPTION
## Summary
- add `policy_artifact_digest(...)` and `digest()` helpers for `DecisionLedger` and `SelectedValidationContract`
- default selected validation contracts to the assembled ledger digest when one is not supplied
- document that policy artifact digests are audit identifiers, not receipt, replay, validation, or projection authority

## Validation
- `python -m pytest tests/test_policy_boundary_vocabulary.py tests/test_package_smoke.py::test_readme_tracks_policy_boundary_vocabulary_surface tests/test_package_smoke.py::test_policy_boundary_contract_keeps_policy_non_authoritative tests/test_package_smoke.py::test_policy_assembled_trust_kernel_map_tracks_growth_shape tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer tests/test_authority_import_boundaries.py -q`
- `python -m pytest tests/test_package_smoke.py tests/test_authority_import_boundaries.py tests/test_policy_boundary_vocabulary.py tests/test_validation_handoff.py -q`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`