### PR TITLE
[codex] encode downstream scenario boundary policy

### DIFF
--- a/docs/extensions/downstream-registry.json
+++ b/docs/extensions/downstream-registry.json
@@ -2,6 +2,34 @@
   "schema_version": 1,
   "owner": "scenario-lab",
   "description": "Downstream scenario-pack repositories that consume comp as a public authority kernel.",
+  "boundary_policy": {
+    "comp_owns": [
+      "authority_contracts",
+      "receipts",
+      "projection_gates",
+      "replay_validation",
+      "minimal_kernel_e2e_scenarios"
+    ],
+    "downstream_owns": [
+      "large_domain_workflows",
+      "product_platform_fixtures",
+      "importers",
+      "ui_viewer_flows",
+      "supplier_workflows"
+    ],
+    "comp_must_not": [
+      "clone_downstream_repositories_for_pr_ci",
+      "use_git_submodules_for_scenario_packs",
+      "import_downstream_scenario_code_in_production",
+      "require_large_downstream_scenarios_before_v1"
+    ],
+    "cutover_sequence": [
+      "copy_or_reconstruct",
+      "external_run",
+      "parallel_validation",
+      "internal_shrink_or_remove"
+    ]
+  },
   "packs": [
     {
       "id": "comp-scenario-packs",

--- a/docs/extensions/scenario-packs.md
+++ b/docs/extensions/scenario-packs.md
@@ -115,6 +115,27 @@ downstream-candidate
 This metadata is not a runtime authority source. It is a maintenance signal for
 reviewing whether a scenario still belongs in the `comp` repo.
 
+`docs/extensions/downstream-registry.json` also records the outer boundary as a
+Machine-readable boundary policy:
+
+```text
+comp_owns
+  authority contracts, receipts, projection gates, replay validation, and
+  minimal kernel e2e scenarios.
+
+downstream_owns
+  large domain workflows, product/platform fixtures, importers, UI/viewer flows,
+  and supplier workflows.
+
+comp_must_not
+  clone downstream repositories for PR CI, use scenario-pack git submodules,
+  import downstream scenario code in production, or require large downstream
+  scenarios before v1.
+
+cutover_sequence
+  copy_or_reconstruct -> external_run -> parallel_validation -> internal_shrink_or_remove
+```
+
 `downstream-candidate` does not mean immediate deletion. Candidate scenarios
 should move through this sequence:
 

--- a/tests/test_domain_scenario_pack_diet.py
+++ b/tests/test_domain_scenario_pack_diet.py
@@ -342,3 +342,51 @@ def test_downstream_registry_records_active_pack_cutover_state():
             "covers_comp_scenario_ids": ["synthetic_pcf.smoke.v1"],
         },
     ]
+
+
+def test_downstream_registry_records_machine_readable_boundary_policy():
+    registry = json.loads(
+        Path("docs/extensions/downstream-registry.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    boundary_policy = registry["boundary_policy"]
+    extension_doc = Path("docs/extensions/scenario-packs.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert boundary_policy["comp_owns"] == [
+        "authority_contracts",
+        "receipts",
+        "projection_gates",
+        "replay_validation",
+        "minimal_kernel_e2e_scenarios",
+    ]
+    assert boundary_policy["downstream_owns"] == [
+        "large_domain_workflows",
+        "product_platform_fixtures",
+        "importers",
+        "ui_viewer_flows",
+        "supplier_workflows",
+    ]
+    assert boundary_policy["comp_must_not"] == [
+        "clone_downstream_repositories_for_pr_ci",
+        "use_git_submodules_for_scenario_packs",
+        "import_downstream_scenario_code_in_production",
+        "require_large_downstream_scenarios_before_v1",
+    ]
+    assert boundary_policy["cutover_sequence"] == [
+        "copy_or_reconstruct",
+        "external_run",
+        "parallel_validation",
+        "internal_shrink_or_remove",
+    ]
+
+    for phrase in (
+        "Machine-readable boundary policy",
+        "comp_owns",
+        "downstream_owns",
+        "comp_must_not",
+        "cutover_sequence",
+    ):
+        assert phrase in extension_doc


### PR DESCRIPTION
## Summary

Encodes the downstream scenario-pack outer boundary as machine-readable registry policy.

This keeps the existing scenario-pack guidance from living only in prose: `comp` owns authority contracts, receipts, projection gates, replay validation, and minimal kernel e2e scenarios, while downstream packs own large domain/product/platform/importer/UI workflows.

## Changes

- Adds a `boundary_policy` block to `docs/extensions/downstream-registry.json`.
- Documents that registry policy in `docs/extensions/scenario-packs.md`.
- Adds a regression test that locks the comp/downstream ownership split, forbidden dependency patterns, and cutover sequence.

## Validation

- `python -m pytest tests/test_domain_scenario_pack_diet.py::test_downstream_registry_records_machine_readable_boundary_policy -q` -> 1 passed
- `python -m pytest tests/test_domain_scenario_pack_diet.py tests/test_package_smoke.py -q` -> 49 passed
- `python -m pytest -q` -> 552 passed, 13 skipped
- `git diff --check` -> passed