### PR TITLE
[codex] bind validation handoff targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ they are not receipt authority or replay proof.
 
 `comp.runtime.ValidationHandoff`는 selected validation contract를
 `InterpretationHypothesis`로 옮기는 얇은 runtime bridge다. contract에 포함된
-selected decision만 compiler-facing hypothesis로 넘길 수 있다. It has no
+selected decision만 compiler-facing hypothesis로 넘길 수 있고, selected
+decision target snapshot이 있으면 claim field와도 맞아야 한다. It has no
 compile, commit, receipt, or replay authority.
 
 ```python

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -237,6 +237,9 @@ class SelectedValidationContract:
     ledger_id: str
     basis: str
     selected_decision_ids: tuple[str, ...] = field(default_factory=tuple)
+    selected_decision_targets: tuple[tuple[str, str], ...] = field(
+        default_factory=tuple
+    )
     validation_scopes: tuple[PipelineScope, ...] = ("validation_handoff",)
     projection_candidate_decision_ids: tuple[str, ...] = field(default_factory=tuple)
     ledger_digest: str | None = None
@@ -258,11 +261,24 @@ class SelectedValidationContract:
                 raise ValueError(f"{scope} is not a validation scope")
         for decision_id in self.selected_decision_ids:
             _require_non_empty("selected_decision_id", decision_id)
+        selected_decision_targets = tuple(
+            (decision_id, target_id)
+            for decision_id, target_id in self.selected_decision_targets
+        )
+        for decision_id, target_id in selected_decision_targets:
+            _require_non_empty("selected_decision_target_id", decision_id)
+            _require_non_empty("selected_decision_target", target_id)
+            if decision_id not in self.selected_decision_ids:
+                raise ValueError(f"target for unselected decision: {decision_id}")
         for decision_id in self.projection_candidate_decision_ids:
             _require_non_empty("projection_candidate_decision_id", decision_id)
         _require_unique(
             "duplicate selected decision id",
             self.selected_decision_ids,
+        )
+        _require_unique(
+            "duplicate selected decision target",
+            tuple(decision_id for decision_id, _ in selected_decision_targets),
         )
         _require_unique(
             "duplicate projection candidate decision id",
@@ -272,6 +288,11 @@ class SelectedValidationContract:
             self,
             "selected_decision_ids",
             tuple(self.selected_decision_ids),
+        )
+        object.__setattr__(
+            self,
+            "selected_decision_targets",
+            selected_decision_targets,
         )
         object.__setattr__(self, "validation_scopes", tuple(self.validation_scopes))
         object.__setattr__(
@@ -292,12 +313,25 @@ class SelectedValidationContract:
         contract_version: str = "policy-boundary-selected-validation-contract-v1",
         meta: tuple[tuple[str, Any], ...] = (),
     ) -> SelectedValidationContract:
+        selected_decisions = tuple(
+            decision
+            for decision in ledger.decisions
+            if decision.status == "selected"
+            and decision.allows_scope("validation_handoff")
+        )
         return cls(
             contract_id=contract_id,
             policy_profile_id=ledger.policy_profile_id,
             ledger_id=ledger.ledger_id,
             basis=basis,
-            selected_decision_ids=ledger.selected_validation_decision_ids(),
+            selected_decision_ids=tuple(
+                decision.decision_id for decision in selected_decisions
+            ),
+            selected_decision_targets=tuple(
+                (decision.decision_id, decision.target_id)
+                for decision in selected_decisions
+                if decision.target_id is not None
+            ),
             projection_candidate_decision_ids=tuple(
                 decision.decision_id
                 for decision in ledger.decisions
@@ -313,6 +347,12 @@ class SelectedValidationContract:
 
     def allows_validation_decision(self, decision_id: str) -> bool:
         return decision_id in self.selected_decision_ids
+
+    def target_for_validation_decision(self, decision_id: str) -> str | None:
+        for target_decision_id, target_id in self.selected_decision_targets:
+            if target_decision_id == decision_id:
+                return target_id
+        return None
 
     def digest(self) -> str:
         return policy_artifact_digest("SelectedValidationContract", self)

--- a/comp/runtime/validation_handoff.py
+++ b/comp/runtime/validation_handoff.py
@@ -65,11 +65,22 @@ class ValidationHandoff:
             raise ValueError("duplicate handoff claim decision id")
 
         selected_decision_ids = set(self.contract.selected_decision_ids)
-        for decision_id in claim_decision_ids:
+        for handoff_claim in self.claims:
+            decision_id = handoff_claim.decision_id
             if decision_id not in selected_decision_ids:
                 raise ValueError(
                     f"handoff claim decision is not selected for validation handoff: "
                     f"{decision_id}"
+                )
+            target_id = self.contract.target_for_validation_decision(decision_id)
+            if (
+                target_id is not None
+                and handoff_claim.claim.field != _field_name_from_target_id(target_id)
+            ):
+                raise ValueError(
+                    "handoff claim field does not match selected target: "
+                    f"{decision_id} expects {target_id}, "
+                    f"got {handoff_claim.claim.field}"
                 )
 
         missing = tuple(
@@ -84,6 +95,12 @@ class ValidationHandoff:
 def _require_non_empty(field_name: str, value: str) -> None:
     if not value:
         raise ValueError(f"{field_name} is required.")
+
+
+def _field_name_from_target_id(target_id: str) -> str:
+    if target_id.startswith("field:"):
+        return target_id.split(":", 1)[1]
+    return target_id
 
 
 __all__ = ["ValidationHandoff", "ValidationHandoffClaim"]

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -97,15 +97,17 @@ rejection, hold, and escalation decisions are auditable.
 
 `SelectedValidationContract` is the compiler-facing contract produced after
 policy decisions and grants. It selects what may be handed to compiler
-validation. It does not validate the selected material.
+validation and may freeze selected decision target snapshots. It does not
+validate the selected material.
 
 Policy artifact digests may identify a `DecisionLedger` or
 `SelectedValidationContract` for audit linkage. A digest is not a receipt,
 replay proof, validation result, or public projection authority.
 
 `ValidationHandoff` may translate a selected validation contract into
-compiler-facing input. It is a bridge, not compiler validation, receipt
-authority, or replay authority.
+compiler-facing input. If the selected contract freezes a decision target, the
+handoff claim field must match that target before it can cross the bridge. It
+is a bridge, not compiler validation, receipt authority, or replay authority.
 
 ## Grant Scopes
 
@@ -216,7 +218,8 @@ projection. `policy_artifact_digest(...)`, `DecisionLedger.digest()`, and
 minting receipt, replay, validation, or public projection authority.
 The current selected-contract slice keeps `SelectedValidationContract` as compiler-facing input shape, not validation authority.
 `comp.runtime.ValidationHandoff` bridges selected validation contracts into
-compiler-facing hypotheses without compiling, committing, building receipts, or
+compiler-facing hypotheses only when claim decision ids and selected decision
+target snapshots match, without compiling, committing, building receipts, or
 replaying. These slices do not expose receipt builders, projection gates, or
 replay authority.
 

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -270,6 +270,7 @@ active mappings
 active units
 active rules
 validation scope
+selected decision target snapshot
 projection candidate scope
 decision ledger digest
 policy profile id
@@ -277,7 +278,9 @@ contract version
 ```
 
 The selected validation contract is compiler-facing input shape, not validation
-authority.
+authority. When it carries selected decision target snapshots,
+`ValidationHandoff` must bind each handoff claim field to the frozen target
+before producing compiler input.
 
 The key distinction remains:
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -404,6 +404,8 @@ def test_readme_tracks_validation_handoff_runtime_bridge():
     assert "comp.runtime.ValidationHandoff" in readme
     assert "selected validation contract를" in readme
     assert "`InterpretationHypothesis`로 옮기는 얇은 runtime bridge" in readme
+    assert "decision target snapshot" in readme
+    assert "claim field" in readme
     assert "compile, commit, receipt, or replay authority" in readme
     assert "ValidationHandoffClaim" in readme
 
@@ -622,7 +624,10 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "`PolicyAssembly` may assemble a `DecisionLedger` and matching",
         "`policy_artifact_digest(...)`, `DecisionLedger.digest()`, and",
         "Policy artifact digest is not PublicOutputReceipt.",
+        "selected decision target snapshots",
+        "handoff claim field must match that target",
         "`SelectedValidationContract` as compiler-facing input shape, not validation",
+        "target snapshots match",
         "`comp.runtime.ValidationHandoff` bridges selected validation",
     ):
         assert line in policy_boundary
@@ -645,6 +650,8 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "Capability activation is artifact-conditioned.",
         "Authority boundaries are invariant.",
         "`SelectedValidationContract` freezes what the compiler is allowed to see",
+        "selected decision target snapshot",
+        "bind each handoff claim field to the frozen target",
         "selected for validation != selected for projection",
         "`ScopedGrant` is pipeline access, not trust authority.",
         "Composition step from effects to decisions and scoped grants.",

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -391,9 +391,16 @@ def test_selected_validation_contract_freezes_handoff_decisions_from_ledger():
     assert contract.ledger_id == "ledger:run-1"
     assert contract.ledger_digest == "digest:ledger-run-1"
     assert contract.selected_decision_ids == ("decision:plant->site",)
+    assert contract.selected_decision_targets == (
+        ("decision:plant->site", "field:site"),
+    )
     assert contract.projection_candidate_decision_ids == (
         "decision:fuel_used->amount",
     )
+    assert contract.target_for_validation_decision("decision:plant->site") == (
+        "field:site"
+    )
+    assert contract.target_for_validation_decision("decision:fuel_used->amount") is None
     assert contract.allows_validation_decision("decision:plant->site") is True
     assert contract.allows_validation_decision("decision:fuel_used->amount") is False
     assert contract.authorizes_public_projection is False
@@ -446,6 +453,9 @@ def test_selected_validation_contract_digest_tracks_ledger_without_authority():
     digest = contract.digest()
 
     assert contract.ledger_digest == ledger.digest()
+    assert contract.selected_decision_targets == (
+        ("decision:plant->site", "field:site"),
+    )
     assert digest == contract.digest()
     assert digest == same_contract.digest()
     assert same_contract.ledger_digest == same_ledger.digest()
@@ -493,6 +503,31 @@ def test_selected_validation_contract_rejects_authority_shaped_scopes():
             selected_decision_ids=(
                 "decision:plant->site",
                 "decision:plant->site",
+            ),
+        )
+
+    with pytest.raises(ValueError, match="target for unselected decision"):
+        SelectedValidationContract(
+            contract_id="selected-contract:target",
+            policy_profile_id="profile:strict-public",
+            ledger_id="ledger:run-1",
+            basis="target mismatch",
+            selected_decision_ids=("decision:plant->site",),
+            selected_decision_targets=(
+                ("decision:fuel_used->amount", "field:amount"),
+            ),
+        )
+
+    with pytest.raises(ValueError, match="duplicate selected decision target"):
+        SelectedValidationContract(
+            contract_id="selected-contract:duplicate-target",
+            policy_profile_id="profile:strict-public",
+            ledger_id="ledger:run-1",
+            basis="duplicate target",
+            selected_decision_ids=("decision:plant->site",),
+            selected_decision_targets=(
+                ("decision:plant->site", "field:site"),
+                ("decision:plant->site", "field:site"),
             ),
         )
 

--- a/tests/test_validation_handoff.py
+++ b/tests/test_validation_handoff.py
@@ -12,6 +12,7 @@ def test_validation_handoff_builds_hypothesis_from_selected_contract_claims():
         ledger_id="ledger:run-1",
         basis="policy resolver finalized validation handoff",
         selected_decision_ids=("decision:plant->site",),
+        selected_decision_targets=(("decision:plant->site", "field:site"),),
         projection_candidate_decision_ids=("decision:fuel_used->amount",),
         ledger_digest="digest:ledger-run-1",
     )
@@ -82,6 +83,35 @@ def test_validation_handoff_rejects_claims_outside_selected_contract():
             claims=(
                 ValidationHandoffClaim(
                     decision_id="decision:fuel_used->amount",
+                    claim=ClaimCandidate(field="amount", value=1200),
+                ),
+            ),
+        )
+
+
+def test_validation_handoff_rejects_claim_field_outside_selected_target():
+    from comp.compiler_tool import ClaimCandidate
+    from comp.policy import SelectedValidationContract
+    from comp.runtime import ValidationHandoff, ValidationHandoffClaim
+
+    contract = SelectedValidationContract(
+        contract_id="selected-contract:run-1",
+        policy_profile_id="profile:strict-public",
+        ledger_id="ledger:run-1",
+        basis="policy resolver finalized validation handoff",
+        selected_decision_ids=("decision:plant->site",),
+        selected_decision_targets=(("decision:plant->site", "field:site"),),
+    )
+
+    with pytest.raises(ValueError, match="claim field does not match selected target"):
+        ValidationHandoff(
+            handoff_id="handoff:run-1",
+            contract=contract,
+            hypothesis_id="hypothesis:run-1",
+            subject_id="subject:facility-1",
+            claims=(
+                ValidationHandoffClaim(
+                    decision_id="decision:plant->site",
                     claim=ClaimCandidate(field="amount", value=1200),
                 ),
             ),


### PR DESCRIPTION
## Summary
- add `SelectedValidationContract.selected_decision_targets` as the frozen target snapshot for selected validation decisions
- make `ValidationHandoff` reject claims whose `ClaimCandidate.field` does not match the selected decision target
- update policy-boundary docs, implementation map, README, and smoke tests for the target-binding rule

## Validation
- `python -m pytest tests/test_policy_boundary_vocabulary.py::test_selected_validation_contract_freezes_handoff_decisions_from_ledger tests/test_policy_boundary_vocabulary.py::test_selected_validation_contract_digest_tracks_ledger_without_authority tests/test_policy_boundary_vocabulary.py::test_selected_validation_contract_rejects_authority_shaped_scopes tests/test_validation_handoff.py -q`
- `python -m pytest tests/test_package_smoke.py tests/test_authority_import_boundaries.py tests/test_policy_boundary_vocabulary.py tests/test_validation_handoff.py -q`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`