### PR TITLE
[codex] restrict policy effect scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ from comp.policy import policy_artifact_digest
 `PolicyAssembly` can assemble a `DecisionLedger` and matching
 `SelectedValidationContract` together, while keeping both artifacts
 pre-validation and non-authoritative.
+Pipeline scope changes are represented only by `grant_scope` or
+`restrict_scope` `PolicyEffect`s; status effects such as `select` and `hold`
+do not carry scope.
 `policy_artifact_digest(...)`, `DecisionLedger.digest()`, and
 `SelectedValidationContract.digest()` provide stable audit identifiers only;
 they are not receipt authority or replay proof.

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -107,6 +107,10 @@ class PolicyEffect:
             raise ValueError(f"unknown policy effect kind: {self.effect_kind}")
         if self.scope is not None and self.scope not in PIPELINE_SCOPES:
             raise ValueError(f"unknown pipeline scope: {self.scope}")
+        if self.scope is not None and self.effect_kind not in _SCOPED_EFFECT_KINDS:
+            raise ValueError(
+                "scope is only allowed for grant_scope or restrict_scope effects"
+            )
         if self.effect_kind in _SCOPED_EFFECT_KINDS and self.scope is None:
             raise ValueError(f"scope is required for {self.effect_kind}")
         object.__setattr__(self, "payload", tuple(self.payload))

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -76,7 +76,9 @@ context, or evidence-request material. It is not authority.
 
 `PolicyEffect` is the common intermediate representation produced by policies.
 Effects may propose, hold, reject, request evidence, restrict scope, require
-review, set retention, or request replay material.
+review, set retention, or request replay material. Pipeline scope may appear
+only on `grant_scope` and `restrict_scope` effects; status effects such as
+`select`, `propose`, `hold`, and `reject` must not carry scope.
 
 `ConflictResolver` combines policy effects into final decisions. It applies
 kernel invariants first and profile-specific composition rules second.
@@ -126,6 +128,10 @@ audit_only
 `validation_handoff` means the material or decision may be passed to compiler
 validation. It does not mean the material is valid.
 
+`PolicyEffect.scope` is valid only on `grant_scope` and `restrict_scope`.
+Selection status is not pipeline access; a selected decision still needs a
+scoped grant before crossing a pipeline boundary.
+
 `projection_candidate` means pre-authority eligibility for later receipt
 consideration. It does not authorize public projection. `PublicOutputReceipt`
 remains the only public projection authority.
@@ -146,6 +152,7 @@ No selected material becomes public output without PublicOutputReceipt.
 No policy assembly may bypass receipt or replay boundaries.
 ScopedGrant is not PublicOutputReceipt.
 Policy artifact digest is not PublicOutputReceipt.
+Status effects must not carry pipeline scope.
 ```
 
 The policy boundary may restrict access to later pipeline stages. It may not

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -297,7 +297,8 @@ The assembled architecture should keep these roles separate:
 
 ```text
 PolicyEffect
-  Decision material.
+  Decision material. Status and evidence effects are unscoped; pipeline scope
+  is carried only by grant_scope and restrict_scope effects.
 
 ConflictResolver
   Composition step from effects to decisions and scoped grants.

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -391,6 +391,8 @@ def test_readme_tracks_policy_boundary_vocabulary_surface():
     assert "SelectedValidationContract" in readme
     assert "policy_artifact_digest" in readme
     assert "PolicyAssembly` can assemble a `DecisionLedger` and matching" in readme
+    assert "Pipeline scope changes are represented only by `grant_scope`" in readme
+    assert "`restrict_scope` `PolicyEffect`s" in readme
     assert "provide stable audit identifiers only" in readme
     assert "pre-validation and non-authoritative" in readme
     assert "validation" in readme
@@ -624,6 +626,11 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "`PolicyAssembly` may assemble a `DecisionLedger` and matching",
         "`policy_artifact_digest(...)`, `DecisionLedger.digest()`, and",
         "Policy artifact digest is not PublicOutputReceipt.",
+        "Pipeline scope may appear",
+        "only on `grant_scope` and `restrict_scope` effects",
+        "`PolicyEffect.scope` is valid only on `grant_scope` and `restrict_scope`.",
+        "Selection status is not pipeline access",
+        "Status effects must not carry pipeline scope.",
         "selected decision target snapshots",
         "handoff claim field must match that target",
         "`SelectedValidationContract` as compiler-facing input shape, not validation",
@@ -654,6 +661,9 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "bind each handoff claim field to the frozen target",
         "selected for validation != selected for projection",
         "`ScopedGrant` is pipeline access, not trust authority.",
+        "Status and evidence effects are unscoped",
+        "pipeline scope",
+        "grant_scope and restrict_scope effects",
         "Composition step from effects to decisions and scoped grants.",
         "Ledger and selected-contract assembly step from descriptors, effects, and",
         "and selected-contract assembly, scoped pipeline access, selection status,",

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -41,21 +41,21 @@ def test_policy_effect_records_scope_and_basis_without_authority():
     )
 
     effect = PolicyEffect(
-        effect_id="effect:hold:fuel_used",
-        effect_kind="hold",
+        effect_id="effect:grant:fuel_used:selection",
+        effect_kind="grant_scope",
         subject_id="material:fuel_used",
-        basis="unit evidence required",
+        basis="selection evaluation allowed",
         scope="selection_evaluation",
-        reason="missing unit witness",
-        payload=(("required_evidence", "unit_witness"),),
+        reason="observed source attribute",
+        payload=(("retention", "decision_audit"),),
     )
 
-    assert "hold" in POLICY_EFFECT_KINDS
+    assert "grant_scope" in POLICY_EFFECT_KINDS
     assert "validation_handoff" in PIPELINE_SCOPES
-    assert effect.effect_kind == "hold"
+    assert effect.effect_kind == "grant_scope"
     assert effect.scope == "selection_evaluation"
-    assert effect.basis == "unit evidence required"
-    assert effect.payload == (("required_evidence", "unit_witness"),)
+    assert effect.basis == "selection evaluation allowed"
+    assert effect.payload == (("retention", "decision_audit"),)
     assert PipelineScope is not None
     assert PolicyEffectKind is not None
 
@@ -86,6 +86,15 @@ def test_policy_vocabulary_rejects_authority_shaped_effects_and_scopes():
             effect_kind="grant_scope",
             subject_id="material:fuel_used",
             basis="selection allowed",
+        )
+
+    with pytest.raises(ValueError, match="scope is only allowed"):
+        PolicyEffect(
+            effect_id="effect:hold:scoped",
+            effect_kind="hold",
+            subject_id="material:fuel_used",
+            basis="unit evidence required",
+            scope="validation_handoff",
         )
 
 
@@ -191,7 +200,6 @@ def test_decision_ledger_lists_grants_and_validation_handoff_subjects():
         effect_kind="select",
         subject_id="material:fuel_used",
         basis="declared alias",
-        scope="validation_handoff",
     )
     grant = ScopedGrant(
         grant_id="grant:fuel_used:validation-handoff",
@@ -546,7 +554,6 @@ def test_conflict_resolver_holds_selected_candidate_when_restricted_by_policy():
                 effect_kind="select",
                 subject_id="material:fuel_used",
                 basis="embedding score 0.96",
-                scope="validation_handoff",
             ),
             PolicyEffect(
                 effect_id="effect:grant:fuel_used:validation-handoff",


### PR DESCRIPTION
## Summary
- reject `PolicyEffect.scope` unless the effect is `grant_scope` or `restrict_scope`
- update policy vocabulary tests so status effects stay unscoped while scoped effects carry pipeline access/restriction
- document the rule in README, the policy-boundary active contract, and the policy-assembled trust-kernel map

## Validation
- `python -m pytest tests/test_policy_boundary_vocabulary.py::test_policy_effect_records_scope_and_basis_without_authority tests/test_policy_boundary_vocabulary.py::test_policy_vocabulary_rejects_authority_shaped_effects_and_scopes tests/test_policy_boundary_vocabulary.py::test_decision_ledger_lists_grants_and_validation_handoff_subjects tests/test_policy_boundary_vocabulary.py::test_conflict_resolver_holds_selected_candidate_when_restricted_by_policy -q`
- `python -m pytest tests/test_policy_boundary_vocabulary.py -q`
- `python -m pytest tests/test_package_smoke.py tests/test_authority_import_boundaries.py tests/test_policy_boundary_vocabulary.py tests/test_validation_handoff.py -q`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`