### PR TITLE
[codex] add shadow policy comparison vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,15 @@ from comp.persistence import replay_public_projection
 `comp.policy`는 pre-validation policy boundary vocabulary를 노출한다. 이
 표면은 validation handoff 전 material, policy effect, scoped grant,
 conflict resolver, policy assembly, selection decision, decision ledger,
-selected validation contract를 설명하기 위한 것이다. validation authority,
-receipt authority, replay authority가 아니다.
+selected validation contract, shadow policy comparison을 설명하기 위한 것이다.
+validation authority, receipt authority, replay authority가 아니다.
 
 ```python
 from comp.policy import MaterialDescriptor, PolicyEffect
 from comp.policy import PolicyAssembly, PolicyAssemblySubject, ConflictResolver
 from comp.policy import ScopedGrant, SelectionDecision, DecisionLedger
 from comp.policy import SelectedValidationContract
-from comp.policy import policy_artifact_digest
+from comp.policy import ShadowPolicyComparison, policy_artifact_digest
 ```
 
 `PolicyAssembly` can assemble a `DecisionLedger` and matching
@@ -177,8 +177,13 @@ Pipeline scope changes are represented only by `grant_scope` or
 `restrict_scope` `PolicyEffect`s; status effects such as `select` and `hold`
 do not carry scope.
 `policy_artifact_digest(...)`, `DecisionLedger.digest()`, and
-`SelectedValidationContract.digest()` provide stable audit identifiers only;
-they are not receipt authority or replay proof.
+`SelectedValidationContract.digest()`, and `ShadowPolicyComparison.digest()`
+provide stable audit identifiers only; they are not receipt authority or replay
+proof.
+`ShadowPolicyComparison` can compare actual and counterfactual policy outputs
+by selected, held, rejected, and projection-candidate deltas. It is audit
+material only and cannot compile, mint receipts, replay, or authorize public
+projection.
 
 `comp.runtime.ValidationHandoff`는 selected validation contract를
 `InterpretationHypothesis`로 옮기는 얇은 runtime bridge다. contract에 포함된

--- a/comp/policy/__init__.py
+++ b/comp/policy/__init__.py
@@ -16,12 +16,14 @@ from comp.policy.boundary import (
     PipelineScope,
     PolicyAssembly,
     PolicyAssemblySubject,
+    PolicyDecisionDelta,
     PolicyEffect,
     PolicyEffectKind,
     ScopedGrant,
     SelectionDecision,
     SelectionStatus,
     SelectedValidationContract,
+    ShadowPolicyComparison,
     policy_artifact_digest,
 )
 
@@ -35,11 +37,13 @@ __all__ = [
     "PipelineScope",
     "PolicyAssembly",
     "PolicyAssemblySubject",
+    "PolicyDecisionDelta",
     "PolicyEffect",
     "PolicyEffectKind",
     "ScopedGrant",
     "SelectionDecision",
     "SelectionStatus",
     "SelectedValidationContract",
+    "ShadowPolicyComparison",
     "policy_artifact_digest",
 ]

--- a/comp/policy/boundary.py
+++ b/comp/policy/boundary.py
@@ -367,6 +367,140 @@ class SelectedValidationContract:
 
 
 @dataclass(frozen=True, slots=True)
+class PolicyDecisionDelta:
+    actual_only: tuple[str, ...] = field(default_factory=tuple)
+    shadow_only: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        for decision_id in self.actual_only:
+            _require_non_empty("actual_only decision id", decision_id)
+        for decision_id in self.shadow_only:
+            _require_non_empty("shadow_only decision id", decision_id)
+        _require_unique("duplicate actual-only decision id", self.actual_only)
+        _require_unique("duplicate shadow-only decision id", self.shadow_only)
+        object.__setattr__(self, "actual_only", tuple(self.actual_only))
+        object.__setattr__(self, "shadow_only", tuple(self.shadow_only))
+
+    @property
+    def has_delta(self) -> bool:
+        return bool(self.actual_only or self.shadow_only)
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowPolicyComparison:
+    comparison_id: str
+    basis: str
+    actual_policy_profile_id: str
+    shadow_policy_profile_id: str
+    actual_ledger_id: str
+    shadow_ledger_id: str
+    actual_contract_id: str
+    shadow_contract_id: str
+    actual_ledger_digest: str
+    shadow_ledger_digest: str
+    actual_contract_digest: str
+    shadow_contract_digest: str
+    selected_delta: PolicyDecisionDelta = field(default_factory=PolicyDecisionDelta)
+    held_delta: PolicyDecisionDelta = field(default_factory=PolicyDecisionDelta)
+    rejected_delta: PolicyDecisionDelta = field(default_factory=PolicyDecisionDelta)
+    projection_candidate_delta: PolicyDecisionDelta = field(
+        default_factory=PolicyDecisionDelta
+    )
+    comparison_version: str = "policy-boundary-shadow-comparison-v1"
+    meta: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_non_empty("comparison_id", self.comparison_id)
+        _require_non_empty("basis", self.basis)
+        _require_non_empty(
+            "actual_policy_profile_id",
+            self.actual_policy_profile_id,
+        )
+        _require_non_empty(
+            "shadow_policy_profile_id",
+            self.shadow_policy_profile_id,
+        )
+        _require_non_empty("actual_ledger_id", self.actual_ledger_id)
+        _require_non_empty("shadow_ledger_id", self.shadow_ledger_id)
+        _require_non_empty("actual_contract_id", self.actual_contract_id)
+        _require_non_empty("shadow_contract_id", self.shadow_contract_id)
+        _require_non_empty("actual_ledger_digest", self.actual_ledger_digest)
+        _require_non_empty("shadow_ledger_digest", self.shadow_ledger_digest)
+        _require_non_empty("actual_contract_digest", self.actual_contract_digest)
+        _require_non_empty("shadow_contract_digest", self.shadow_contract_digest)
+        _require_non_empty("comparison_version", self.comparison_version)
+        object.__setattr__(self, "meta", tuple(self.meta))
+
+    @classmethod
+    def from_artifacts(
+        cls,
+        *,
+        comparison_id: str,
+        basis: str,
+        actual_ledger: DecisionLedger,
+        actual_contract: SelectedValidationContract,
+        shadow_ledger: DecisionLedger,
+        shadow_contract: SelectedValidationContract,
+        comparison_version: str = "policy-boundary-shadow-comparison-v1",
+        meta: tuple[tuple[str, Any], ...] = (),
+    ) -> ShadowPolicyComparison:
+        _validate_contract_bound_to_ledger("actual", actual_ledger, actual_contract)
+        _validate_contract_bound_to_ledger("shadow", shadow_ledger, shadow_contract)
+
+        return cls(
+            comparison_id=comparison_id,
+            basis=basis,
+            actual_policy_profile_id=actual_ledger.policy_profile_id,
+            shadow_policy_profile_id=shadow_ledger.policy_profile_id,
+            actual_ledger_id=actual_ledger.ledger_id,
+            shadow_ledger_id=shadow_ledger.ledger_id,
+            actual_contract_id=actual_contract.contract_id,
+            shadow_contract_id=shadow_contract.contract_id,
+            actual_ledger_digest=actual_ledger.digest(),
+            shadow_ledger_digest=shadow_ledger.digest(),
+            actual_contract_digest=actual_contract.digest(),
+            shadow_contract_digest=shadow_contract.digest(),
+            selected_delta=_decision_delta(
+                _decision_ids_by_status(actual_ledger, "selected"),
+                _decision_ids_by_status(shadow_ledger, "selected"),
+            ),
+            held_delta=_decision_delta(
+                _decision_ids_by_status(actual_ledger, "held"),
+                _decision_ids_by_status(shadow_ledger, "held"),
+            ),
+            rejected_delta=_decision_delta(
+                _decision_ids_by_status(actual_ledger, "rejected"),
+                _decision_ids_by_status(shadow_ledger, "rejected"),
+            ),
+            projection_candidate_delta=_decision_delta(
+                actual_contract.projection_candidate_decision_ids,
+                shadow_contract.projection_candidate_decision_ids,
+            ),
+            comparison_version=comparison_version,
+            meta=meta,
+        )
+
+    @property
+    def has_delta(self) -> bool:
+        return any(
+            delta.has_delta
+            for delta in (
+                self.selected_delta,
+                self.held_delta,
+                self.rejected_delta,
+                self.projection_candidate_delta,
+            )
+        )
+
+    def digest(self) -> str:
+        return policy_artifact_digest("ShadowPolicyComparison", self)
+
+    @property
+    def authorizes_public_projection(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True, slots=True)
 class ConflictResolver:
     status_priority: tuple[PolicyEffectKind, ...] = _STATUS_EFFECT_PRIORITY
 
@@ -594,6 +728,51 @@ def _retention_from_effects(
     return default
 
 
+def _decision_ids_by_status(
+    ledger: DecisionLedger,
+    status: SelectionStatus,
+) -> tuple[str, ...]:
+    return tuple(
+        decision.decision_id
+        for decision in ledger.decisions
+        if decision.status == status
+    )
+
+
+def _decision_delta(
+    actual_decision_ids: tuple[str, ...],
+    shadow_decision_ids: tuple[str, ...],
+) -> PolicyDecisionDelta:
+    actual_set = frozenset(actual_decision_ids)
+    shadow_set = frozenset(shadow_decision_ids)
+    return PolicyDecisionDelta(
+        actual_only=tuple(
+            decision_id
+            for decision_id in actual_decision_ids
+            if decision_id not in shadow_set
+        ),
+        shadow_only=tuple(
+            decision_id
+            for decision_id in shadow_decision_ids
+            if decision_id not in actual_set
+        ),
+    )
+
+
+def _validate_contract_bound_to_ledger(
+    label: str,
+    ledger: DecisionLedger,
+    contract: SelectedValidationContract,
+) -> None:
+    if contract.ledger_id != ledger.ledger_id:
+        raise ValueError(f"{label} contract ledger mismatch")
+    if contract.policy_profile_id != ledger.policy_profile_id:
+        raise ValueError(f"{label} contract policy profile mismatch")
+    ledger_digest = ledger.digest()
+    if contract.ledger_digest is not None and contract.ledger_digest != ledger_digest:
+        raise ValueError(f"{label} contract ledger digest mismatch")
+
+
 def policy_artifact_digest(artifact_kind: str, payload: Any) -> str:
     _require_non_empty("artifact_kind", artifact_kind)
     digest_payload = {
@@ -653,11 +832,13 @@ __all__ = [
     "PipelineScope",
     "PolicyAssembly",
     "PolicyAssemblySubject",
+    "PolicyDecisionDelta",
     "PolicyEffect",
     "PolicyEffectKind",
     "ScopedGrant",
     "SelectionDecision",
     "SelectionStatus",
     "SelectedValidationContract",
+    "ShadowPolicyComparison",
     "policy_artifact_digest",
 ]

--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -106,6 +106,11 @@ Policy artifact digests may identify a `DecisionLedger` or
 `SelectedValidationContract` for audit linkage. A digest is not a receipt,
 replay proof, validation result, or public projection authority.
 
+`ShadowPolicyComparison` compares actual and counterfactual policy outputs by
+selected, held, rejected, and projection-candidate deltas. It is audit material
+only. It must not compile, mint receipts, replay, or authorize public
+projection.
+
 `ValidationHandoff` may translate a selected validation contract into
 compiler-facing input. If the selected contract freezes a decision target, the
 handoff claim field must match that target before it can cross the bridge. It
@@ -216,12 +221,15 @@ implemented, these terms are architectural contract vocabulary.
 
 The first implementation slices live in `comp.policy`. They expose
 `MaterialDescriptor`, `PolicyEffect`, `ConflictResolver`, `PolicyAssembly`,
-`ScopedGrant`, `SelectionDecision`, and `DecisionLedger` as pre-validation
+`ScopedGrant`, `SelectionDecision`, `DecisionLedger`,
+`SelectedValidationContract`, and `ShadowPolicyComparison` as pre-validation
 vocabulary only. `ConflictResolver` may compose effects into decisions and
 scoped grants, and `PolicyAssembly` may assemble a `DecisionLedger` and matching
 `SelectedValidationContract`, but neither validates claims or authorizes
-projection. `policy_artifact_digest(...)`, `DecisionLedger.digest()`, and
-`SelectedValidationContract.digest()` expose stable audit identifiers without
+projection. `ShadowPolicyComparison` may compare actual and counterfactual
+policy outputs, but it is audit material only. `policy_artifact_digest(...)`,
+`DecisionLedger.digest()`, `SelectedValidationContract.digest()`, and
+`ShadowPolicyComparison.digest()` expose stable audit identifiers without
 minting receipt, replay, validation, or public projection authority.
 The current selected-contract slice keeps `SelectedValidationContract` as compiler-facing input shape, not validation authority.
 `comp.runtime.ValidationHandoff` bridges selected validation contracts into

--- a/docs/architecture/maps/policy-assembled-trust-kernel.md
+++ b/docs/architecture/maps/policy-assembled-trust-kernel.md
@@ -313,6 +313,9 @@ ScopedGrant
 SelectedValidationContract
   Compiler-facing contract.
 
+ShadowPolicyComparison
+  Actual-vs-counterfactual audit comparison.
+
 ValidationHandoff
   Runtime bridge from selected contract to compiler input.
 
@@ -356,7 +359,9 @@ Slice 4: Selected validation contract and validation handoff
 
 Slice 5: Retention, shadow policy, and counterfactual replay support
   Preserve enough policy-decision material to compare policy behavior without
-  changing receipt authority.
+  changing receipt authority. The first implemented part is
+  ShadowPolicyComparison, which records decision deltas without replaying or
+  authorizing projection.
 ```
 
 Each slice should come with tests that protect the authority boundary it
@@ -378,6 +383,7 @@ comp.policy.ScopedGrant
 comp.policy.SelectionDecision
 comp.policy.DecisionLedger
 comp.policy.SelectedValidationContract
+comp.policy.ShadowPolicyComparison
 comp.policy.policy_artifact_digest
 comp.runtime.ValidationHandoff
 CompilerProfile
@@ -391,13 +397,14 @@ replay_public_projection(...)
 ```
 
 `comp.policy.MaterialDescriptor`, `PolicyEffect`, `ConflictResolver`,
-`PolicyAssembly`, `ScopedGrant`, `SelectionDecision`, `DecisionLedger`, and
-`SelectedValidationContract` are the first minimal vocabulary slices. They
+`PolicyAssembly`, `ScopedGrant`, `SelectionDecision`, `DecisionLedger`,
+`SelectedValidationContract`, and `ShadowPolicyComparison` are the first
+minimal vocabulary slices. They
 describe pre-validation material, policy effects, effect composition, ledger
 and selected-contract assembly, scoped pipeline access, selection status,
-decision audit records, stable policy artifact digests, and the
-compiler-facing contract shape. They do not validate claims, authorize
-projection, or replay receipts. A selected decision still requires a
+decision audit records, stable policy artifact digests, the compiler-facing
+contract shape, and actual-vs-counterfactual policy deltas. They do not
+validate claims, authorize projection, or replay receipts. A selected decision still requires a
 `validation_handoff` grant before it can be included in a selected validation
 contract, and that contract remains pre-validation.
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -389,10 +389,13 @@ def test_readme_tracks_policy_boundary_vocabulary_surface():
     assert "SelectionDecision" in readme
     assert "DecisionLedger" in readme
     assert "SelectedValidationContract" in readme
+    assert "ShadowPolicyComparison" in readme
     assert "policy_artifact_digest" in readme
     assert "PolicyAssembly` can assemble a `DecisionLedger` and matching" in readme
     assert "Pipeline scope changes are represented only by `grant_scope`" in readme
     assert "`restrict_scope` `PolicyEffect`s" in readme
+    assert "actual and counterfactual policy outputs" in readme
+    assert "selected, held, rejected, and projection-candidate deltas" in readme
     assert "provide stable audit identifiers only" in readme
     assert "pre-validation and non-authoritative" in readme
     assert "validation" in readme
@@ -624,7 +627,11 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "`PolicyAssembly` groups descriptors, effects, assembly subjects, and resolver",
         "`PolicyAssembly` may also build a matching `SelectedValidationContract`",
         "`PolicyAssembly` may assemble a `DecisionLedger` and matching",
-        "`policy_artifact_digest(...)`, `DecisionLedger.digest()`, and",
+        "`ShadowPolicyComparison` compares actual and counterfactual policy outputs",
+        "`ShadowPolicyComparison` may compare actual and counterfactual",
+        "policy outputs, but it is audit material only. `policy_artifact_digest(...)`,",
+        "`DecisionLedger.digest()`, `SelectedValidationContract.digest()`, and",
+        "`ShadowPolicyComparison.digest()` expose stable audit identifiers",
         "Policy artifact digest is not PublicOutputReceipt.",
         "Pipeline scope may appear",
         "only on `grant_scope` and `restrict_scope` effects",
@@ -670,17 +677,23 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         "`DecisionLedger` is the audit spine for policy assembly.",
         "PublicOutputReceipt",
         "Runtime bridge from selected contract to compiler input.",
+        "Actual-vs-counterfactual audit comparison.",
         "`comp.runtime.ValidationHandoff` is the first bridge",
         "`CompilerTool`, commit, receipt, projection, or replay authority.",
         "policy artifact digest",
+        "comp.policy.ShadowPolicyComparison",
         "comp.policy.policy_artifact_digest",
+        "The first implemented part is",
+        "ShadowPolicyComparison, which records decision deltas without replaying",
         "stable policy artifact digests",
+        "actual-vs-counterfactual policy deltas",
         "Future policy work should connect to that direction instead of introducing a",
         "parallel source of selection truth, validation truth, receipt truth, or",
         "projection truth.",
         "This map does not prescribe:",
         "`comp.policy.MaterialDescriptor`, `PolicyEffect`, `ConflictResolver`,",
-        "`PolicyAssembly`, `ScopedGrant`, `SelectionDecision`, `DecisionLedger`, and",
+        "`PolicyAssembly`, `ScopedGrant`, `SelectionDecision`, `DecisionLedger`,",
+        "`SelectedValidationContract`, and `ShadowPolicyComparison` are the first",
     ):
         assert line in policy_map
 
@@ -1189,10 +1202,12 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
         MaterialDescriptor,
         PolicyAssembly,
         PolicyAssemblySubject,
+        PolicyDecisionDelta,
         PolicyEffect,
         ScopedGrant,
         SelectionDecision,
         SelectedValidationContract,
+        ShadowPolicyComparison,
         policy_artifact_digest,
     )
 
@@ -1248,11 +1263,13 @@ def test_pyproject_packages_comp_core_scenarios_and_agent_layer():
     assert MaterialDescriptor is not None
     assert PolicyAssembly is not None
     assert PolicyAssemblySubject is not None
+    assert PolicyDecisionDelta is not None
     assert PolicyEffect is not None
     assert policy_artifact_digest is not None
     assert ScopedGrant is not None
     assert SelectionDecision is not None
     assert SelectedValidationContract is not None
+    assert ShadowPolicyComparison is not None
     assert ArtifactMaterial is not None
     assert ArtifactRef is not None
     assert InMemoryArtifactStore is not None

--- a/tests/test_policy_boundary_vocabulary.py
+++ b/tests/test_policy_boundary_vocabulary.py
@@ -917,6 +917,223 @@ def test_policy_assembly_rejects_unassembled_effects_and_duplicate_subjects():
         )
 
 
+def test_shadow_policy_comparison_records_counterfactual_deltas_without_authority():
+    from comp.policy import (
+        PolicyAssembly,
+        PolicyAssemblySubject,
+        PolicyEffect,
+        ShadowPolicyComparison,
+    )
+
+    subjects = (
+        PolicyAssemblySubject(
+            decision_id="decision:plant->site",
+            subject_id="material:plant",
+            target_id="field:site",
+        ),
+        PolicyAssemblySubject(
+            decision_id="decision:fuel_used->amount",
+            subject_id="material:fuel_used",
+            target_id="field:amount",
+        ),
+        PolicyAssemblySubject(
+            decision_id="decision:supplier->supplier_id",
+            subject_id="material:supplier",
+            target_id="field:supplier_id",
+        ),
+    )
+    actual_ledger, actual_contract = PolicyAssembly(
+        policy_profile_id="profile:strict-public",
+    ).assemble_selected_validation_contract(
+        ledger_id="ledger:actual",
+        contract_id="selected-contract:actual",
+        contract_basis="actual policy result",
+        subjects=subjects,
+        effects=(
+            PolicyEffect(
+                effect_id="effect:select:plant",
+                effect_kind="select",
+                subject_id="material:plant",
+                basis="declared alias",
+            ),
+            PolicyEffect(
+                effect_id="effect:grant:plant:validation-handoff",
+                effect_kind="grant_scope",
+                subject_id="material:plant",
+                basis="declared alias selected",
+                scope="validation_handoff",
+            ),
+            PolicyEffect(
+                effect_id="effect:grant:plant:projection-candidate",
+                effect_kind="grant_scope",
+                subject_id="material:plant",
+                basis="eligible for later receipt consideration",
+                scope="projection_candidate",
+            ),
+            PolicyEffect(
+                effect_id="effect:hold:fuel-used",
+                effect_kind="hold",
+                subject_id="material:fuel_used",
+                basis="unit evidence required",
+            ),
+            PolicyEffect(
+                effect_id="effect:reject:supplier",
+                effect_kind="reject",
+                subject_id="material:supplier",
+                basis="unsupported supplier alias",
+            ),
+        ),
+    )
+    shadow_ledger, shadow_contract = PolicyAssembly(
+        policy_profile_id="profile:shadow-relaxed",
+    ).assemble_selected_validation_contract(
+        ledger_id="ledger:shadow",
+        contract_id="selected-contract:shadow",
+        contract_basis="shadow policy result",
+        subjects=subjects,
+        effects=(
+            PolicyEffect(
+                effect_id="effect:select:plant:shadow",
+                effect_kind="select",
+                subject_id="material:plant",
+                basis="declared alias",
+            ),
+            PolicyEffect(
+                effect_id="effect:grant:plant:validation-handoff:shadow",
+                effect_kind="grant_scope",
+                subject_id="material:plant",
+                basis="declared alias selected",
+                scope="validation_handoff",
+            ),
+            PolicyEffect(
+                effect_id="effect:grant:plant:projection-candidate:shadow",
+                effect_kind="grant_scope",
+                subject_id="material:plant",
+                basis="eligible for later receipt consideration",
+                scope="projection_candidate",
+            ),
+            PolicyEffect(
+                effect_id="effect:select:fuel-used:shadow",
+                effect_kind="select",
+                subject_id="material:fuel_used",
+                basis="shadow accepted unit inference",
+            ),
+            PolicyEffect(
+                effect_id="effect:grant:fuel-used:validation-handoff:shadow",
+                effect_kind="grant_scope",
+                subject_id="material:fuel_used",
+                basis="shadow accepted unit inference",
+                scope="validation_handoff",
+            ),
+            PolicyEffect(
+                effect_id="effect:grant:fuel-used:projection-candidate:shadow",
+                effect_kind="grant_scope",
+                subject_id="material:fuel_used",
+                basis="shadow eligible for later receipt consideration",
+                scope="projection_candidate",
+            ),
+            PolicyEffect(
+                effect_id="effect:hold:supplier:shadow",
+                effect_kind="hold",
+                subject_id="material:supplier",
+                basis="shadow requires supplier review",
+            ),
+        ),
+    )
+
+    comparison = ShadowPolicyComparison.from_artifacts(
+        comparison_id="shadow-comparison:run-1",
+        basis="counterfactual policy evaluation",
+        actual_ledger=actual_ledger,
+        actual_contract=actual_contract,
+        shadow_ledger=shadow_ledger,
+        shadow_contract=shadow_contract,
+        meta=(("run_id", "run-1"),),
+    )
+
+    assert comparison.actual_policy_profile_id == "profile:strict-public"
+    assert comparison.shadow_policy_profile_id == "profile:shadow-relaxed"
+    assert comparison.actual_ledger_digest == actual_ledger.digest()
+    assert comparison.shadow_ledger_digest == shadow_ledger.digest()
+    assert comparison.actual_contract_digest == actual_contract.digest()
+    assert comparison.shadow_contract_digest == shadow_contract.digest()
+    assert comparison.selected_delta.actual_only == ()
+    assert comparison.selected_delta.shadow_only == ("decision:fuel_used->amount",)
+    assert comparison.held_delta.actual_only == ("decision:fuel_used->amount",)
+    assert comparison.held_delta.shadow_only == ("decision:supplier->supplier_id",)
+    assert comparison.rejected_delta.actual_only == ("decision:supplier->supplier_id",)
+    assert comparison.rejected_delta.shadow_only == ()
+    assert comparison.projection_candidate_delta.actual_only == ()
+    assert comparison.projection_candidate_delta.shadow_only == (
+        "decision:fuel_used->amount",
+    )
+    assert comparison.has_delta is True
+    assert comparison.digest().startswith("sha256:")
+    assert comparison.authorizes_public_projection is False
+    assert not hasattr(comparison, "compile")
+    assert not hasattr(comparison, "build_public_output_receipt")
+    assert not hasattr(comparison, "replay_public_projection")
+
+
+def test_shadow_policy_comparison_rejects_unbound_contracts():
+    from comp.policy import (
+        PolicyAssembly,
+        PolicyAssemblySubject,
+        PolicyEffect,
+        SelectedValidationContract,
+        ShadowPolicyComparison,
+    )
+
+    ledger, contract = PolicyAssembly(
+        policy_profile_id="profile:strict-public",
+    ).assemble_selected_validation_contract(
+        ledger_id="ledger:run-1",
+        contract_id="selected-contract:run-1",
+        contract_basis="policy result",
+        subjects=(
+            PolicyAssemblySubject(
+                decision_id="decision:plant->site",
+                subject_id="material:plant",
+                target_id="field:site",
+            ),
+        ),
+        effects=(
+            PolicyEffect(
+                effect_id="effect:select:plant",
+                effect_kind="select",
+                subject_id="material:plant",
+                basis="declared alias",
+            ),
+            PolicyEffect(
+                effect_id="effect:grant:plant:validation-handoff",
+                effect_kind="grant_scope",
+                subject_id="material:plant",
+                basis="declared alias selected",
+                scope="validation_handoff",
+            ),
+        ),
+    )
+    stale_contract = SelectedValidationContract(
+        contract_id="selected-contract:stale",
+        policy_profile_id="profile:strict-public",
+        ledger_id=ledger.ledger_id,
+        basis="stale policy result",
+        selected_decision_ids=contract.selected_decision_ids,
+        selected_decision_targets=contract.selected_decision_targets,
+        ledger_digest="sha256:" + "0" * 64,
+    )
+
+    with pytest.raises(ValueError, match="actual contract ledger digest mismatch"):
+        ShadowPolicyComparison.from_artifacts(
+            comparison_id="shadow-comparison:run-1",
+            basis="counterfactual policy evaluation",
+            actual_ledger=ledger,
+            actual_contract=stale_contract,
+            shadow_ledger=ledger,
+            shadow_contract=contract,
+        )
+
+
 def test_policy_package_does_not_expose_projection_or_replay_authority():
     import comp.policy as policy
 


### PR DESCRIPTION
## Summary

Adds the first shadow/counterfactual policy comparison vocabulary slice.

This keeps shadow policy evaluation outside the authority path: it records actual-vs-counterfactual decision deltas and stable policy artifact digests, but it cannot compile, mint receipts, replay, or authorize public projection.

## Changes

- Adds `PolicyDecisionDelta` and `ShadowPolicyComparison` to `comp.policy`.
- Compares selected, held, rejected, and projection-candidate deltas across actual and shadow policy artifacts.
- Validates that compared contracts are bound to their ledgers before recording comparison digests.
- Updates README and policy architecture docs to classify the new surface as audit-only.
- Adds regression tests and package smoke coverage for the new vocabulary.

## Validation

- `python -m pytest tests/test_policy_boundary_vocabulary.py::test_shadow_policy_comparison_records_counterfactual_deltas_without_authority tests/test_policy_boundary_vocabulary.py::test_shadow_policy_comparison_rejects_unbound_contracts -q` -> 2 passed
- `python -m pytest tests/test_policy_boundary_vocabulary.py tests/test_package_smoke.py::test_readme_tracks_policy_boundary_vocabulary_surface tests/test_package_smoke.py::test_policy_boundary_contract_keeps_policy_non_authoritative tests/test_package_smoke.py::test_policy_assembled_trust_kernel_map_tracks_growth_shape tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer -q` -> 24 passed
- `python -m pytest tests/test_policy_boundary_vocabulary.py tests/test_validation_handoff.py tests/test_authority_import_boundaries.py tests/test_package_smoke.py -q` -> 73 passed
- `python -m pytest -q` -> 558 passed, 13 skipped
- `git diff --check` -> passed