### PR TITLE
[codex] add product facade observation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ policy-assembled-trust-kernel
   policy-boundary를 넘지 않는 선에서 MaterialDescriptor, PolicyEffect,
   scoped grant, decision ledger, selected validation contract가 어떻게 조립될 수
   있는지 설명하는 implementation map이다.
+
+product-facade-observation
+  docs/architecture/maps/product-facade-observation.md describes product-shaped
+  facade observation outside comp; it does not make `comp.runtime` a production runtime.
 ```
 
 현재 policy 이행축은 broad framework를 한 번에 세우는 것이 아니다.

--- a/docs/architecture/maps/product-facade-observation.md
+++ b/docs/architecture/maps/product-facade-observation.md
@@ -1,0 +1,260 @@
+# Product Facade Observation Map
+
+Status: implementation-map
+Owner: trust-kernel
+Last checked against code: 2026-05-26
+Can block PRs: limited
+
+This map defines the first observation boundary for product-shaped facade work
+around `comp`.
+
+This map is observational, not prescriptive. It is not an artifact lifecycle contract,
+final product runtime design, native production engine design, or comp-compatible
+export format. It defines the first lab boundary for discovering
+which `comp` artifacts are actually required, optional, deferred, or unused in
+product-shaped flows.
+
+## Purpose
+
+The product facade experiment should measure ceremony before promoting new
+contracts.
+
+The goal is to learn which artifacts a user-facing runtime actually needs for:
+
+```text
+submit
+publish
+audit
+```
+
+The goal is not to design a new authority engine or to freeze artifact lifecycle
+metadata before a product-shaped flow has been exercised.
+
+## Core Rule
+
+`comp` remains a reference trust kernel and conformance oracle.
+
+comp.runtime is not production runtime. It is a reference/conformance runtime surface
+that may support scenario execution, replay harnesses, and comp-backed
+experiments. It must not become the product workflow shell for importers, UI
+state, supplier workflows, product database orchestration, or customer-specific
+policy.
+
+Product facade lab work should live outside the `comp` package. It may start as
+a sibling experiment, downstream repository, or examples lab, but it must not add
+product workflow code under `comp.runtime` or `comp.scenario_contracts`.
+
+## First Lab Shape
+
+The first facade should expose a small product-shaped surface:
+
+```text
+submit(input)
+publish(run_id)
+audit(public_row_id)
+```
+
+The first facade must be comp-backed because the goal is ceremony measurement, not independent authority reimplementation.
+A native production authority engine
+can only be considered after the facade shows which artifacts are required for
+product-shaped flows.
+
+The facade should hide most `comp` terms from callers while preserving the
+authority chain internally:
+
+```text
+product-shaped API
+-> comp-backed adapter
+-> CompilerTool / prepare_commit / build_public_output / replay
+-> artifact touch log
+-> later artifact lifecycle boundary
+```
+
+## Observation Flows
+
+These flows are initial observation hypotheses, not lifecycle rules.
+
+### canonical_fast_path
+
+Working expectation:
+
+```text
+likely sync
+  InterpretationHypothesis
+  ValidationReport
+  PublicOutputReceipt, if publishing
+
+likely omitted
+  DecisionLedger
+  SelectedValidationContract
+  ValidationHandoff
+```
+
+Observation goal:
+
+```text
+Can canonical input bypass policy preflight without weakening authority?
+Which compiler-facing evidence shape is the real minimum?
+Which user-facing status maps cleanly to ValidationReport status?
+```
+
+Fast path may skip policy preflight only when input is already canonicalized and
+has the minimum compiler-facing evidence shape. It must never skip compiler validation,
+receipt-gated projection, or replay requirements when those states are claimed.
+
+### policy_preflight_path
+
+Working expectation:
+
+```text
+likely sync
+  MaterialDescriptor
+  PolicyEffect
+  SelectedValidationContract
+  ValidationHandoff
+  ValidationReport
+
+likely audit or deferred
+  full DecisionLedger
+```
+
+Observation goal:
+
+```text
+Which raw-ish inputs require policy admission before validation?
+What is the minimum selected contract needed for handoff?
+When is DecisionLedger useful audit material instead of submit-path ceremony?
+```
+
+### publish_path
+
+Working expectation:
+
+```text
+likely sync
+  clean ValidationReport
+  ReviewPackage
+  ReviewDecision
+  PublicOutputReceipt
+  PublicOutputSpec
+
+under observation
+  ArtifactEnvelope materialization timing
+```
+
+Observation goal:
+
+```text
+When is PublicOutputReceipt synchronously required?
+What minimum source row and projection data does build_public_output need?
+Can ArtifactEnvelope materialization move to audit/replay without claiming
+replayable state too early?
+```
+
+### audit_path
+
+Working expectation:
+
+```text
+likely sync or deferred
+  ArtifactEnvelope set
+  ProjectionReplayReport
+
+likely omitted from basic UI
+  proof graph
+```
+
+Observation goal:
+
+```text
+Is replay required immediately after publish, or sufficient as a later audit?
+When must ArtifactEnvelope material exist?
+Can ProofGraph stay out of the basic product UI path?
+```
+
+## Artifact Touch Log
+
+The lab should record an artifact touch log for each operation. The log exists
+to support later contract work; it is not itself a stable contract.
+
+Example:
+
+```json
+{
+  "flow": "canonical_fast_path",
+  "operation": "submit",
+  "sync_required": [
+    "InterpretationHypothesis",
+    "ValidationReport"
+  ],
+  "sync_required_if_publishing": [
+    "PublicOutputReceipt"
+  ],
+  "deferred": [
+    "ArtifactEnvelope",
+    "ProjectionReplayReport"
+  ],
+  "not_used": [
+    "DecisionLedger",
+    "SelectedValidationContract",
+    "ValidationHandoff"
+  ],
+  "product_only": [
+    "form_state"
+  ],
+  "notes": [
+    "Canonical input had grounded witnesses and known field/unit coverage."
+  ]
+}
+```
+
+This shape is illustrative. It is not a stable artifact registry or passport schema.
+The lab may change the log shape as observations become clearer.
+
+## Non-Goals
+
+This map deliberately avoids:
+
+```text
+no artifact registry yet
+no Artifact Passport schema yet
+no comp.contracts extraction yet
+no native production authority engine yet
+no product runtime inside comp package
+```
+
+It also avoids promoting `DecisionLedger`, `SelectedValidationContract`,
+`ValidationHandoff`, `ArtifactEnvelope`, proof graphs, or replay reports into
+universal synchronous requirements before product-shaped observations justify
+that move.
+
+## Promotion Criteria
+
+Promotion to Artifact Lifecycle Boundary requires:
+
+```text
+1. At least one canonical fast path run with touch log.
+2. At least one policy preflight path run with touch log.
+3. At least one publish path run showing receipt requirements.
+4. At least one audit path run showing replay/artifact requirements.
+5. A short comparison identifying sync required artifacts, deferred artifacts,
+   omitted ceremony, and product-only state that must stay outside comp.
+```
+
+Only after those observations exist should `comp` consider an artifact lifecycle
+active contract, artifact registry, Artifact Passport schema, or `comp.contracts`
+extraction.
+
+## Review Checklist
+
+Use these questions when reviewing product facade observation work:
+
+```text
+Does this PR keep product workflow outside the comp package?
+Does it preserve compiler validation, receipt authority, projection gate, and
+replay requirements when those states are claimed?
+Does it avoid declaring final artifact lifecycle rules?
+Does it record artifact touch observations instead of assuming them?
+Does it keep comp.runtime as a reference/conformance surface?
+Does it avoid creating a native production authority engine?
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ when the PR changes the mapped area but leaves the map stale.
 2. `architecture/maps/domain-scenario-pack-generation.md`
 3. `architecture/maps/internal-execution-design-map.md`
 4. `architecture/maps/policy-assembled-trust-kernel.md`
+5. `architecture/maps/product-facade-observation.md`
 
 ### North Stars
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -698,6 +698,45 @@ def test_policy_assembled_trust_kernel_map_tracks_growth_shape():
         assert line in policy_map
 
 
+def test_product_facade_observation_map_defines_lab_without_contracting_lifecycle():
+    product_map = Path(
+        "docs/architecture/maps/product-facade-observation.md"
+    ).read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    for line in (
+        "Status: implementation-map",
+        "This map is observational, not prescriptive.",
+        "not an artifact lifecycle contract",
+        "comp.runtime is not production runtime",
+        "reference/conformance runtime surface",
+        "outside the `comp` package",
+        "first facade must be comp-backed",
+        "ceremony measurement, not independent authority reimplementation",
+        "submit(input)",
+        "publish(run_id)",
+        "audit(public_row_id)",
+        "canonical_fast_path",
+        "policy_preflight_path",
+        "artifact touch log",
+        "This shape is illustrative.",
+        "not a stable artifact registry or passport schema",
+        "no artifact registry yet",
+        "no Artifact Passport schema yet",
+        "no comp.contracts extraction yet",
+        "no native production authority engine yet",
+        "Fast path may skip policy preflight",
+        "must never skip compiler validation",
+        "receipt-gated projection",
+        "replay requirements when those states are claimed",
+        "Promotion to Artifact Lifecycle Boundary requires",
+    ):
+        assert line in product_map
+
+    assert "product-facade-observation.md" in readme
+    assert "does not make `comp.runtime` a production runtime" in readme
+
+
 def test_governed_architecture_docs_have_valid_machine_readable_headers():
     for path in _governed_architecture_docs():
         header = _doc_header(path)
@@ -809,6 +848,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "2026-05-20",
         ),
         "policy-assembled-trust-kernel.md": (
+            "implementation-map",
+            "trust-kernel",
+            "limited",
+            "2026-05-26",
+        ),
+        "product-facade-observation.md": (
             "implementation-map",
             "trust-kernel",
             "limited",
@@ -941,6 +986,7 @@ def test_docs_index_groups_architecture_docs_by_governance_authority():
     assert "architecture/contracts/compiler-domain-boundary.md" in docs_index
     assert "architecture/contracts/policy-boundary.md" in docs_index
     assert "architecture/maps/policy-assembled-trust-kernel.md" in docs_index
+    assert "architecture/maps/product-facade-observation.md" in docs_index
     assert "architecture/contracts/friendly-authority-vocabulary.md" in docs_index
     assert "archive/architecture/legacy-archive-cutover-plan.md" in docs_index
     assert "archive/architecture/llm-orchestrated-compiler-tool-loop.md" in docs_index


### PR DESCRIPTION
﻿## Summary

- Adds `product-facade-observation.md` as an implementation map for product-shaped facade experiments outside `comp`.
- Defines the lab boundary: `comp.runtime` is reference/conformance runtime, the first facade stays comp-backed, and no native production authority engine or artifact registry is introduced yet.
- Adds smoke coverage so the map remains observational rather than an artifact lifecycle contract.

## Why

The next product facade experiment needs a clear observation boundary before implementation. This keeps the experiment focused on measuring which artifacts are sync-required, deferred, or unused in `submit`, `publish`, and `audit` flows without prematurely freezing artifact lifecycle contracts.

## Validation

- `python -m pytest tests/test_package_smoke.py::test_product_facade_observation_map_defines_lab_without_contracting_lifecycle tests/test_package_smoke.py::test_architecture_docs_are_classified_by_governance_status tests/test_package_smoke.py::test_governed_architecture_docs_match_index_and_lifecycle_location tests/test_package_smoke.py::test_docs_index_groups_architecture_docs_by_governance_authority -q`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`
