### PR TITLE
[codex] add product facade canonical lab

### DIFF
--- a/docs/architecture/maps/product-facade-observation.md
+++ b/docs/architecture/maps/product-facade-observation.md
@@ -54,6 +54,10 @@ publish(run_id)
 audit(public_row_id)
 ```
 
+The first canonical fast-path observation lab lives at
+`examples/product_facade_lab`. That lab is comp-backed and remains outside the
+packaged `comp` surface.
+
 The first facade must be comp-backed because the goal is ceremony measurement, not independent authority reimplementation.
 A native production authority engine
 can only be considered after the facade shows which artifacts are required for

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Repository examples that are not part of the packaged comp surface."""

--- a/examples/product_facade_lab/README.md
+++ b/examples/product_facade_lab/README.md
@@ -1,0 +1,15 @@
+# Product Facade Lab
+
+This example is a comp-backed observation lab, not a production runtime.
+
+It exposes a small product-shaped surface:
+
+```text
+submit(input)
+publish(run_id)
+audit(public_row_id)
+```
+
+The lab records an artifact touch log for the canonical fast path. It does not
+introduce a native production authority engine, artifact registry, Artifact
+Passport schema, or `comp.contracts` extraction.

--- a/examples/product_facade_lab/__init__.py
+++ b/examples/product_facade_lab/__init__.py
@@ -1,0 +1,21 @@
+"""Comp-backed product facade observation lab."""
+
+from examples.product_facade_lab.runtime import (
+    ArtifactTouchLog,
+    ProductAudit,
+    ProductFacadeRuntime,
+    ProductInput,
+    ProductPublicRow,
+    ProductRun,
+    ProductWitness,
+)
+
+__all__ = [
+    "ArtifactTouchLog",
+    "ProductAudit",
+    "ProductFacadeRuntime",
+    "ProductInput",
+    "ProductPublicRow",
+    "ProductRun",
+    "ProductWitness",
+]

--- a/examples/product_facade_lab/runtime.py
+++ b/examples/product_facade_lab/runtime.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from comp import PublicOutputSpec, build_public_output
+from comp.compiler_tool import (
+    ClaimCandidate,
+    CompilerTool,
+    CommitPreparation,
+    EvidenceRef,
+    InterpretationHypothesis,
+    ValidationReport,
+    prepare_commit,
+)
+from comp.persistence import (
+    InMemoryArtifactStore,
+    ProjectionReplayReport,
+    build_receipt_envelope_set,
+    replay_public_projection,
+)
+from comp.runtime import materialize_compiler_run_artifacts
+
+ProductRunStatus = Literal["publishable", "needs_evidence", "blocked"]
+
+
+@dataclass(frozen=True)
+class ProductWitness:
+    field: str
+    source: str
+    span: str
+    text: str = ""
+
+    @property
+    def witness_id(self) -> str:
+        return f"witness:{self.field}"
+
+
+@dataclass(frozen=True)
+class ProductInput:
+    run_id: str
+    subject_id: str
+    public_row_id: str
+    projection_id: str
+    projection_fields: tuple[str, ...]
+    values: Mapping[str, Any]
+    witnesses: tuple[ProductWitness, ...]
+    known_fields: frozenset[str]
+    allowed_units: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class ArtifactTouchLog:
+    flow: str
+    operation: str
+    sync_required: tuple[str, ...] = ()
+    sync_required_if_publishing: tuple[str, ...] = ()
+    deferred: tuple[str, ...] = ()
+    not_used: tuple[str, ...] = ()
+    product_only: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "flow": self.flow,
+            "operation": self.operation,
+            "sync_required": list(self.sync_required),
+            "sync_required_if_publishing": list(self.sync_required_if_publishing),
+            "deferred": list(self.deferred),
+            "not_used": list(self.not_used),
+            "product_only": list(self.product_only),
+            "notes": list(self.notes),
+        }
+
+
+@dataclass(frozen=True)
+class ProductRun:
+    run_id: str
+    public_row_id: str
+    status: ProductRunStatus
+    required_actions: tuple[str, ...]
+    touch_log: ArtifactTouchLog
+
+
+@dataclass(frozen=True)
+class ProductPublicRow:
+    run_id: str
+    public_row_id: str
+    public_row: dict[str, Any]
+    touch_log: ArtifactTouchLog
+
+
+@dataclass(frozen=True)
+class ProductAudit:
+    public_row_id: str
+    replay_report: ProjectionReplayReport
+    artifact_count: int
+    touch_log: ArtifactTouchLog
+
+
+@dataclass
+class _RunRecord:
+    product_input: ProductInput
+    projection: PublicOutputSpec
+    report: ValidationReport
+    preparation: CommitPreparation | None = None
+    public_row: dict[str, Any] | None = None
+
+
+class ProductFacadeRuntime:
+    """Small comp-backed lab for observing product-shaped submit/publish/audit."""
+
+    def __init__(self) -> None:
+        self._runs: dict[str, _RunRecord] = {}
+        self._public_row_to_run: dict[str, str] = {}
+
+    def submit(self, product_input: ProductInput) -> ProductRun:
+        hypothesis = _canonical_hypothesis(product_input)
+        report = CompilerTool(
+            known_fields=product_input.known_fields,
+            allowed_units=product_input.allowed_units,
+        ).compile_interpretation(hypothesis)
+        projection = PublicOutputSpec(
+            product_input.projection_id,
+            product_input.projection_fields,
+        )
+        self._runs[product_input.run_id] = _RunRecord(
+            product_input=product_input,
+            projection=projection,
+            report=report,
+        )
+        status = _product_status(report)
+        return ProductRun(
+            run_id=product_input.run_id,
+            public_row_id=product_input.public_row_id,
+            status=status,
+            required_actions=_required_actions(report),
+            touch_log=_submit_touch_log(product_input),
+        )
+
+    def publish(self, run_id: str) -> ProductPublicRow:
+        record = self._runs[run_id]
+        preparation = prepare_commit(
+            record.report,
+            subject_id=record.product_input.subject_id,
+            public_row_id=record.product_input.public_row_id,
+            projection_id=record.product_input.projection_id,
+        )
+        if preparation.receipt is None:
+            raise RuntimeError("Product facade publish requires a receipt.")
+        source_row = _projection_source(record.report)
+        public_row = build_public_output(
+            source_row,
+            record.projection,
+            receipt=preparation.receipt,
+        )
+        record.preparation = preparation
+        record.public_row = public_row
+        self._public_row_to_run[record.product_input.public_row_id] = run_id
+        return ProductPublicRow(
+            run_id=run_id,
+            public_row_id=record.product_input.public_row_id,
+            public_row=public_row,
+            touch_log=_publish_touch_log(),
+        )
+
+    def audit(self, public_row_id: str) -> ProductAudit:
+        run_id = self._public_row_to_run[public_row_id]
+        record = self._runs[run_id]
+        if record.preparation is None or record.preparation.receipt is None:
+            raise RuntimeError("Product facade audit requires a published receipt.")
+        if record.public_row is None:
+            raise RuntimeError("Product facade audit requires a public row.")
+        materials = materialize_compiler_run_artifacts(
+            record.report,
+            record.preparation,
+        )
+        artifact_store = InMemoryArtifactStore()
+        envelopes = build_receipt_envelope_set(
+            record.preparation.receipt,
+            materials,
+            record_to=artifact_store,
+        )
+        replay_report = replay_public_projection(
+            record.public_row,
+            record.projection,
+            receipt=record.preparation.receipt,
+            artifacts=artifact_store,
+        )
+        return ProductAudit(
+            public_row_id=public_row_id,
+            replay_report=replay_report,
+            artifact_count=len(envelopes),
+            touch_log=_audit_touch_log(),
+        )
+
+
+def _canonical_hypothesis(product_input: ProductInput) -> InterpretationHypothesis:
+    witnesses = tuple(
+        EvidenceRef(
+            witness_id=witness.witness_id,
+            field=witness.field,
+            source=witness.source,
+            span=witness.span,
+            text=witness.text,
+        )
+        for witness in product_input.witnesses
+    )
+    return InterpretationHypothesis(
+        hypothesis_id=product_input.run_id,
+        subject_id=product_input.subject_id,
+        claims=tuple(
+            ClaimCandidate(
+                field=field,
+                value=value,
+                witness_id=f"witness:{field}",
+                origin="product_facade_canonical_input",
+            )
+            for field, value in product_input.values.items()
+        ),
+        witnesses=witnesses,
+    )
+
+
+def _product_status(report: ValidationReport) -> ProductRunStatus:
+    if report.status == "accepted":
+        return "publishable"
+    if report.validation_requirements:
+        return "needs_evidence"
+    return "blocked"
+
+
+def _required_actions(report: ValidationReport) -> tuple[str, ...]:
+    return tuple(
+        f"{requirement.kind}:{requirement.field}:{requirement.reason}"
+        for requirement in report.validation_requirements
+    )
+
+
+def _projection_source(report: ValidationReport) -> dict[str, Any]:
+    values = {claim.field: claim.value for claim in report.checked_claims}
+    values.update({claim.field: claim.value for claim in report.calculated_claims})
+    return values
+
+
+def _submit_touch_log(product_input: ProductInput) -> ArtifactTouchLog:
+    return ArtifactTouchLog(
+        flow="canonical_fast_path",
+        operation="submit",
+        sync_required=("InterpretationHypothesis", "ValidationReport"),
+        sync_required_if_publishing=("PublicOutputReceipt",),
+        deferred=("ArtifactEnvelope", "ProjectionReplayReport"),
+        not_used=(
+            "DecisionLedger",
+            "SelectedValidationContract",
+            "ValidationHandoff",
+        ),
+        product_only=("ProductInput",),
+        notes=(
+            "Canonical input had grounded witnesses and known field/unit coverage.",
+            f"Projection fields: {', '.join(product_input.projection_fields)}",
+        ),
+    )
+
+
+def _publish_touch_log() -> ArtifactTouchLog:
+    return ArtifactTouchLog(
+        flow="canonical_fast_path",
+        operation="publish",
+        sync_required=(
+            "ValidationReport",
+            "ReviewPackage",
+            "ReviewDecision",
+            "PublicOutputReceipt",
+            "PublicOutputSpec",
+        ),
+        deferred=("ArtifactEnvelope", "ProjectionReplayReport"),
+        not_used=(
+            "DecisionLedger",
+            "SelectedValidationContract",
+            "ValidationHandoff",
+        ),
+    )
+
+
+def _audit_touch_log() -> ArtifactTouchLog:
+    return ArtifactTouchLog(
+        flow="canonical_fast_path",
+        operation="audit",
+        sync_required=("ArtifactEnvelope", "ProjectionReplayReport"),
+        not_used=("ProofGraph",),
+    )
+
+
+__all__ = [
+    "ArtifactTouchLog",
+    "ProductAudit",
+    "ProductFacadeRuntime",
+    "ProductInput",
+    "ProductPublicRow",
+    "ProductRun",
+    "ProductWitness",
+]

--- a/tests/test_product_facade_lab.py
+++ b/tests/test_product_facade_lab.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from examples.product_facade_lab import (
+    ProductFacadeRuntime,
+    ProductInput,
+    ProductWitness,
+)
+
+
+def test_canonical_fast_path_submit_publish_audit_records_touch_log():
+    runtime = ProductFacadeRuntime()
+
+    run = runtime.submit(
+        ProductInput(
+            run_id="run-1",
+            subject_id="facility-1",
+            public_row_id="public-row-1",
+            projection_id="public-row",
+            projection_fields=("amount", "unit"),
+            values={"amount": 1200, "unit": "kWh"},
+            witnesses=(
+                ProductWitness(
+                    field="amount",
+                    source="invoice.pdf",
+                    span="p1: electricity amount",
+                    text="1200",
+                ),
+                ProductWitness(
+                    field="unit",
+                    source="invoice.pdf",
+                    span="p1: electricity unit",
+                    text="kWh",
+                ),
+            ),
+            known_fields=frozenset({"amount", "unit"}),
+            allowed_units=frozenset({"kWh"}),
+        )
+    )
+
+    assert run.status == "publishable"
+    assert run.required_actions == ()
+    assert run.touch_log.flow == "canonical_fast_path"
+    assert run.touch_log.operation == "submit"
+    assert run.touch_log.sync_required == (
+        "InterpretationHypothesis",
+        "ValidationReport",
+    )
+    assert run.touch_log.sync_required_if_publishing == ("PublicOutputReceipt",)
+    assert "ArtifactEnvelope" in run.touch_log.deferred
+    assert "ProjectionReplayReport" in run.touch_log.deferred
+    assert run.touch_log.not_used == (
+        "DecisionLedger",
+        "SelectedValidationContract",
+        "ValidationHandoff",
+    )
+
+    public = runtime.publish(run.run_id)
+
+    assert public.public_row == {"amount": 1200, "unit": "kWh"}
+    assert public.touch_log.operation == "publish"
+    assert "PublicOutputReceipt" in public.touch_log.sync_required
+    assert "ArtifactEnvelope" in public.touch_log.deferred
+    assert "DecisionLedger" in public.touch_log.not_used
+
+    audit = runtime.audit(public.public_row_id)
+
+    assert audit.replay_report.public_row == public.public_row
+    assert audit.touch_log.operation == "audit"
+    assert audit.touch_log.sync_required == (
+        "ArtifactEnvelope",
+        "ProjectionReplayReport",
+    )
+    assert audit.touch_log.not_used == ("ProofGraph",)
+    assert audit.artifact_count == len(audit.replay_report.artifact_refs)
+
+
+def test_product_facade_lab_stays_outside_packaged_comp_surface():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    packages = set(pyproject["tool"]["setuptools"]["packages"])
+    source = Path("examples/product_facade_lab/runtime.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "examples" not in packages
+    assert "examples.product_facade_lab" not in packages
+    assert "from comp.policy" not in source
+    assert "import comp.policy" not in source
+    assert "from comp.runtime import ValidationHandoff" not in source
+    assert "SelectedValidationContract(" not in source
+    assert "DecisionLedger(" not in source
+
+
+def test_observation_map_points_to_canonical_lab_without_promoting_runtime():
+    product_map = Path(
+        "docs/architecture/maps/product-facade-observation.md"
+    ).read_text(encoding="utf-8")
+    lab_readme = Path("examples/product_facade_lab/README.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "examples/product_facade_lab" in product_map
+    assert "comp-backed observation lab" in lab_readme
+    assert "not a production runtime" in lab_readme
+    assert "native production authority engine" in lab_readme


### PR DESCRIPTION
﻿## Summary

- Adds `examples/product_facade_lab`, a comp-backed canonical fast-path lab outside the packaged `comp` surface.
- Exposes a small product-shaped `submit`, `publish`, and `audit` API while preserving compiler validation, receipt-gated projection, and replay.
- Records artifact touch logs showing which artifacts are sync-required, deferred, and not used for the canonical path.
- Updates the product facade observation map to point at the first canonical lab.

## Why

The previous map defined the observation boundary. This slice starts measuring the canonical fast path without introducing a native production authority engine, artifact registry, `comp.contracts` extraction, or product runtime inside `comp.runtime`.

## Validation

- `python -m pytest tests/test_product_facade_lab.py tests/test_package_smoke.py::test_product_facade_observation_map_defines_lab_without_contracting_lifecycle tests/test_package_smoke.py::test_pyproject_packages_comp_core_scenarios_and_agent_layer -q`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`
