### PR TITLE
[codex] compare product facade touch logs

### DIFF
--- a/docs/architecture/maps/product-facade-observation.md
+++ b/docs/architecture/maps/product-facade-observation.md
@@ -221,6 +221,11 @@ Example:
 This shape is illustrative. It is not a stable artifact registry or passport schema.
 The lab may change the log shape as observations become clearer.
 
+The lab may also produce a touch log comparison observation summary for two
+logs with the same operation. That summary exists to identify ceremony deltas
+between flows before any lifecycle contract is promoted; it is not an artifact
+registry, passport schema, or final product runtime interface.
+
 ## Non-Goals
 
 This map deliberately avoids:

--- a/examples/product_facade_lab/README.md
+++ b/examples/product_facade_lab/README.md
@@ -33,3 +33,8 @@ policy preflight path
 The policy preflight path is intentionally comp-backed. It measures ceremony
 around pre-validation admission; it does not add a product policy engine or let
 policy artifacts authorize public projection.
+
+`compare_touch_logs` can compare two logs from the same operation, such as
+canonical `submit` and policy preflight `submit`. The comparison is an
+observation summary for spotting ceremony deltas; it is not a lifecycle
+contract, artifact registry, or Artifact Passport.

--- a/examples/product_facade_lab/__init__.py
+++ b/examples/product_facade_lab/__init__.py
@@ -2,6 +2,7 @@
 
 from examples.product_facade_lab.runtime import (
     ArtifactTouchLog,
+    ArtifactTouchLogComparison,
     ProductAudit,
     ProductFacadeRuntime,
     ProductInput,
@@ -9,10 +10,12 @@ from examples.product_facade_lab.runtime import (
     ProductPublicRow,
     ProductRun,
     ProductWitness,
+    compare_touch_logs,
 )
 
 __all__ = [
     "ArtifactTouchLog",
+    "ArtifactTouchLogComparison",
     "ProductAudit",
     "ProductFacadeRuntime",
     "ProductInput",
@@ -20,4 +23,5 @@ __all__ = [
     "ProductPublicRow",
     "ProductRun",
     "ProductWitness",
+    "compare_touch_logs",
 ]

--- a/examples/product_facade_lab/runtime.py
+++ b/examples/product_facade_lab/runtime.py
@@ -105,6 +105,38 @@ class ArtifactTouchLog:
 
 
 @dataclass(frozen=True)
+class ArtifactTouchLogComparison:
+    baseline_flow: str
+    candidate_flow: str
+    operation: str
+    shared_sync_required: tuple[str, ...] = ()
+    baseline_sync_only: tuple[str, ...] = ()
+    candidate_sync_only: tuple[str, ...] = ()
+    baseline_omitted_but_candidate_sync: tuple[str, ...] = ()
+    deferred_in_both: tuple[str, ...] = ()
+    baseline_product_only: tuple[str, ...] = ()
+    candidate_product_only: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "baseline_flow": self.baseline_flow,
+            "candidate_flow": self.candidate_flow,
+            "operation": self.operation,
+            "shared_sync_required": list(self.shared_sync_required),
+            "baseline_sync_only": list(self.baseline_sync_only),
+            "candidate_sync_only": list(self.candidate_sync_only),
+            "baseline_omitted_but_candidate_sync": list(
+                self.baseline_omitted_but_candidate_sync
+            ),
+            "deferred_in_both": list(self.deferred_in_both),
+            "baseline_product_only": list(self.baseline_product_only),
+            "candidate_product_only": list(self.candidate_product_only),
+            "notes": list(self.notes),
+        }
+
+
+@dataclass(frozen=True)
 class ProductRun:
     run_id: str
     public_row_id: str
@@ -489,8 +521,68 @@ def _audit_touch_log(flow: ProductRunFlow) -> ArtifactTouchLog:
     )
 
 
+def compare_touch_logs(
+    baseline: ArtifactTouchLog,
+    candidate: ArtifactTouchLog,
+) -> ArtifactTouchLogComparison:
+    if baseline.operation != candidate.operation:
+        raise ValueError("touch log comparison requires matching operations")
+
+    shared_sync_required = _ordered_intersection(
+        baseline.sync_required,
+        candidate.sync_required,
+    )
+    baseline_sync_only = _ordered_difference(
+        baseline.sync_required,
+        candidate.sync_required,
+    )
+    candidate_sync_only = _ordered_difference(
+        candidate.sync_required,
+        baseline.sync_required,
+    )
+    baseline_omitted_but_candidate_sync = _ordered_intersection(
+        baseline.not_used,
+        candidate.sync_required,
+    )
+    deferred_in_both = _ordered_intersection(baseline.deferred, candidate.deferred)
+    return ArtifactTouchLogComparison(
+        baseline_flow=baseline.flow,
+        candidate_flow=candidate.flow,
+        operation=baseline.operation,
+        shared_sync_required=shared_sync_required,
+        baseline_sync_only=baseline_sync_only,
+        candidate_sync_only=candidate_sync_only,
+        baseline_omitted_but_candidate_sync=baseline_omitted_but_candidate_sync,
+        deferred_in_both=deferred_in_both,
+        baseline_product_only=baseline.product_only,
+        candidate_product_only=candidate.product_only,
+        notes=(
+            "This is a lab observation summary, not an artifact lifecycle "
+            "contract or registry.",
+            "Compare observed ceremony before promoting any lifecycle rule.",
+        ),
+    )
+
+
+def _ordered_intersection(
+    left: tuple[str, ...],
+    right: tuple[str, ...],
+) -> tuple[str, ...]:
+    right_values = set(right)
+    return tuple(value for value in left if value in right_values)
+
+
+def _ordered_difference(
+    left: tuple[str, ...],
+    right: tuple[str, ...],
+) -> tuple[str, ...]:
+    right_values = set(right)
+    return tuple(value for value in left if value not in right_values)
+
+
 __all__ = [
     "ArtifactTouchLog",
+    "ArtifactTouchLogComparison",
     "ProductAudit",
     "ProductFacadeRuntime",
     "ProductInput",
@@ -498,4 +590,5 @@ __all__ = [
     "ProductPublicRow",
     "ProductRun",
     "ProductWitness",
+    "compare_touch_logs",
 ]

--- a/tests/test_product_facade_lab.py
+++ b/tests/test_product_facade_lab.py
@@ -8,6 +8,7 @@ from examples.product_facade_lab import (
     ProductInput,
     ProductPolicyPreflightInput,
     ProductWitness,
+    compare_touch_logs,
 )
 
 
@@ -162,6 +163,103 @@ def test_policy_preflight_path_records_policy_handoff_before_validation():
     assert audit.artifact_count == len(audit.replay_report.artifact_refs)
 
 
+def test_submit_touch_log_comparison_summarizes_observed_ceremony_delta():
+    runtime = ProductFacadeRuntime()
+    canonical_run = runtime.submit(
+        ProductInput(
+            run_id="run-compare-canonical",
+            subject_id="facility-1",
+            public_row_id="public-row-compare-canonical",
+            projection_id="public-row",
+            projection_fields=("amount", "unit"),
+            values={"amount": 1200, "unit": "kWh"},
+            witnesses=(
+                ProductWitness(
+                    field="amount",
+                    source="invoice.pdf",
+                    span="p1: electricity amount",
+                    text="1200",
+                ),
+                ProductWitness(
+                    field="unit",
+                    source="invoice.pdf",
+                    span="p1: electricity unit",
+                    text="kWh",
+                ),
+            ),
+            known_fields=frozenset({"amount", "unit"}),
+            allowed_units=frozenset({"kWh"}),
+        )
+    )
+    policy_run = runtime.submit_policy_preflight(
+        ProductPolicyPreflightInput(
+            run_id="run-compare-policy",
+            subject_id="facility-1",
+            public_row_id="public-row-compare-policy",
+            projection_id="public-row",
+            projection_fields=("amount", "unit"),
+            material_id="material:invoice-compare",
+            source_ref="invoice.pdf",
+            values={"amount": 1200, "unit": "kWh"},
+            witnesses=(
+                ProductWitness(
+                    field="amount",
+                    source="invoice.pdf",
+                    span="p1: electricity amount",
+                    text="1200",
+                ),
+                ProductWitness(
+                    field="unit",
+                    source="invoice.pdf",
+                    span="p1: electricity unit",
+                    text="kWh",
+                ),
+            ),
+            known_fields=frozenset({"amount", "unit"}),
+            allowed_units=frozenset({"kWh"}),
+        )
+    )
+
+    comparison = compare_touch_logs(
+        canonical_run.touch_log,
+        policy_run.touch_log,
+    )
+
+    assert comparison.baseline_flow == "canonical_fast_path"
+    assert comparison.candidate_flow == "policy_preflight_path"
+    assert comparison.operation == "submit"
+    assert comparison.shared_sync_required == (
+        "InterpretationHypothesis",
+        "ValidationReport",
+    )
+    assert comparison.candidate_sync_only == (
+        "MaterialDescriptor",
+        "PolicyEffect",
+        "PolicyAssembly",
+        "DecisionLedger",
+        "SelectedValidationContract",
+        "ValidationHandoff",
+    )
+    assert comparison.baseline_omitted_but_candidate_sync == (
+        "DecisionLedger",
+        "SelectedValidationContract",
+        "ValidationHandoff",
+    )
+    assert comparison.deferred_in_both == (
+        "ArtifactEnvelope",
+        "ProjectionReplayReport",
+    )
+    assert comparison.to_dict()["candidate_sync_only"] == [
+        "MaterialDescriptor",
+        "PolicyEffect",
+        "PolicyAssembly",
+        "DecisionLedger",
+        "SelectedValidationContract",
+        "ValidationHandoff",
+    ]
+    assert any("observation summary" in note for note in comparison.notes)
+
+
 def test_observation_map_points_to_canonical_lab_without_promoting_runtime():
     product_map = Path(
         "docs/architecture/maps/product-facade-observation.md"
@@ -174,4 +272,6 @@ def test_observation_map_points_to_canonical_lab_without_promoting_runtime():
     assert "comp-backed observation lab" in lab_readme
     assert "not a production runtime" in lab_readme
     assert "policy preflight path" in lab_readme
+    assert "compare_touch_logs" in lab_readme
+    assert "observation summary" in product_map
     assert "native production authority engine" in lab_readme


### PR DESCRIPTION
## Summary
- add a lab-only `ArtifactTouchLogComparison` and `compare_touch_logs` helper
- compare canonical submit vs policy preflight submit to expose shared sync artifacts, additional policy ceremony, common deferred artifacts, and fast-path omissions
- document the comparison as an observation summary, not an artifact lifecycle contract, registry, passport, or product runtime interface

## Notes
- The helper only compares logs with the same operation.
- The observed comparison keeps `InterpretationHypothesis` and `ValidationReport` as shared submit sync artifacts, while policy preflight adds MaterialDescriptor, PolicyEffect, PolicyAssembly, DecisionLedger, SelectedValidationContract, and ValidationHandoff.

## Validation
- python -m pytest -q tests/test_product_facade_lab.py
- python -m pytest -q tests/test_product_facade_lab.py tests/test_package_smoke.py
- python -m pytest -q
- python -m tests.domain_scenarios run-all
- git diff --check