### PR TITLE
[codex] define artifact lifecycle boundary v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ artifact를 제출할 수 있지만, commit receipt를 만들 권한은 없다.
 docs/index.md
 docs/architecture/document-governance.md
 docs/architecture/contracts/policy-boundary.md
+docs/architecture/contracts/artifact-lifecycle-boundary.md
 docs/architecture/maps/policy-assembled-trust-kernel.md
 ```
 
@@ -268,6 +269,11 @@ policy-boundary
   pre-validation policy가 할 수 있는 일과 할 수 없는 일을 고정하는 active
   contract다. Policy may shape validation input. Policy may not validate.
   Policy may not authorize public projection. Policy may not replace replay.
+
+artifact-lifecycle-boundary
+  docs/architecture/contracts/artifact-lifecycle-boundary.md defines current
+  state-transition artifact requirements without creating an artifact registry,
+  Artifact Passport schema, or production runtime.
 
 policy-assembled-trust-kernel
   policy-boundary를 넘지 않는 선에서 MaterialDescriptor, PolicyEffect,

--- a/docs/architecture/contracts/artifact-lifecycle-boundary.md
+++ b/docs/architecture/contracts/artifact-lifecycle-boundary.md
@@ -1,0 +1,135 @@
+# Artifact Lifecycle Boundary
+
+Status: active-contract
+Owner: trust-kernel
+Last checked against code: 2026-05-27
+Can block PRs: yes
+
+This contract defines the current state-transition artifact requirements
+grounded in the first product facade lab observations.
+
+This is not an artifact registry.
+This is not an Artifact Passport schema.
+This does not extract `comp.contracts`.
+This does not define a native production runtime, product database shape,
+export bundle format, or product workflow shell.
+
+The goal is narrower: identify which artifacts are required for current
+trust-state transitions, and which artifacts must not be treated as universal
+requirements, authority sources, or product-owned state.
+
+## State Transition Requirements
+
+Compact summary:
+
+- canonical submit -> validation: `InterpretationHypothesis`, `ValidationReport`.
+- policy preflight submit -> validation: `MaterialDescriptor`, `PolicyEffect`, `PolicyAssembly`, `DecisionLedger`, `SelectedValidationContract`, `ValidationHandoff`, `InterpretationHypothesis`, `ValidationReport`.
+- validated -> published: `ValidationReport`, `ReviewPackage`, `ReviewDecision`, `PublicOutputReceipt`, `PublicOutputSpec`.
+- published -> replayable/auditable: `ArtifactEnvelope`, `ProjectionReplayReport`.
+- replayable/auditable -> explainable: `ProofGraph` is optional and non-authoritative.
+
+### canonical submit -> validation
+
+Synchronous requirements:
+
+```text
+InterpretationHypothesis
+ValidationReport
+```
+
+Canonical submit may skip policy preflight only when the input already has the
+minimum compiler-facing evidence shape. It must not skip compiler validation.
+
+### policy preflight submit -> validation
+
+Synchronous requirements:
+
+```text
+MaterialDescriptor
+PolicyEffect
+PolicyAssembly
+DecisionLedger
+SelectedValidationContract
+ValidationHandoff
+InterpretationHypothesis
+ValidationReport
+```
+
+These artifacts shape validation admission for raw-ish external material. They
+do not validate claims, authorize projection, or replace receipt replay.
+
+### validated -> published
+
+Synchronous requirements:
+
+```text
+ValidationReport
+ReviewPackage
+ReviewDecision
+PublicOutputReceipt
+PublicOutputSpec
+```
+
+`PublicOutputReceipt` is the projection authority. Policy selection,
+validation handoff, replay reports, and explanation views must not be treated
+as substitutes for receipt-gated projection.
+
+### published -> replayable/auditable
+
+Synchronous requirements when replayable/auditable state is claimed:
+
+```text
+ArtifactEnvelope
+ProjectionReplayReport
+```
+
+`ArtifactEnvelope` material may be deferred from the publish path when the
+runtime is only publishing and is not yet claiming replayable state. Once the
+system claims replayable or auditable state, receipt-cited envelope material and
+successful replay are required.
+
+### replayable/auditable -> explainable
+
+Optional, non-authoritative material:
+
+```text
+ProofGraph
+field explanation
+rendered view
+```
+
+`ProofGraph` is optional and non-authoritative. Explanation may inspect replay
+results and artifact references, but it must not authorize projection, repair
+missing replay material, or replace receipt verification.
+
+## Non-Requirements
+
+`DecisionLedger` is not required to publish canonical fast-path output.
+Policy artifacts must not authorize public projection.
+`ArtifactEnvelope` is not publish-path synchronous unless replayable state is claimed at publish time.
+`ProofGraph` is not required for replay.
+Product-only state must stay outside `comp` artifacts.
+
+Examples of product-only state include importer state, OCR intermediates, UI
+action logs, supplier workflow state, and customer-specific product database
+rows. Those may be useful to a product runtime, but they are not `comp`
+authority artifacts.
+
+## Review Rules
+
+Changes that alter these state-transition requirements must update this
+contract and its smoke coverage in the same PR.
+
+Reviewers should reject changes that:
+
+```text
+make policy artifacts projection authority
+require DecisionLedger for canonical publish
+require ArtifactEnvelope before publish when replayable state is not claimed
+make ProofGraph mandatory for replay
+move product workflow state into comp artifacts
+claim lifecycle finality through an artifact registry or passport schema here
+```
+
+This contract may later inform an artifact registry or wire contract. That
+promotion requires a separate PR with its own tests and migration rationale.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,14 +36,15 @@ without explicitly updating the contract.
 1. `architecture/document-governance.md`
 2. `architecture/contracts/trust-kernel-extension-rings.md`
 3. `architecture/contracts/policy-boundary.md`
-4. `architecture/contracts/compiler-domain-boundary.md`
-5. `architecture/contracts/extension-port-contracts.md`
-6. `architecture/contracts/artifact-envelope-builder.md`
-7. `architecture/contracts/persistence-ledger-boundary.md`
-8. `architecture/contracts/receipt-proof-graph.md`
-9. `architecture/contracts/trust-kernel-hardening.md`
-10. `architecture/contracts/memory-assisted-compiler-loop.md`
-11. `architecture/contracts/friendly-authority-vocabulary.md`
+4. `architecture/contracts/artifact-lifecycle-boundary.md`
+5. `architecture/contracts/compiler-domain-boundary.md`
+6. `architecture/contracts/extension-port-contracts.md`
+7. `architecture/contracts/artifact-envelope-builder.md`
+8. `architecture/contracts/persistence-ledger-boundary.md`
+9. `architecture/contracts/receipt-proof-graph.md`
+10. `architecture/contracts/trust-kernel-hardening.md`
+11. `architecture/contracts/memory-assisted-compiler-loop.md`
+12. `architecture/contracts/friendly-authority-vocabulary.md`
 
 ### Implementation Maps
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -747,6 +747,54 @@ def test_product_facade_observation_map_defines_lab_without_contracting_lifecycl
     assert "does not make `comp.runtime` a production runtime" in readme
 
 
+def test_artifact_lifecycle_boundary_defines_state_transition_requirements():
+    boundary_doc = Path(
+        "docs/architecture/contracts/artifact-lifecycle-boundary.md"
+    ).read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    for line in (
+        "Status: active-contract",
+        "Owner: trust-kernel",
+        "Last checked against code: 2026-05-27",
+        "Can block PRs: yes",
+        "This is not an artifact registry.",
+        "This is not an Artifact Passport schema.",
+        "This does not extract `comp.contracts`.",
+        "grounded in the first product facade lab observations",
+        "## State Transition Requirements",
+        "canonical submit -> validation",
+        "`InterpretationHypothesis`",
+        "`ValidationReport`",
+        "policy preflight submit -> validation",
+        "`MaterialDescriptor`",
+        "`PolicyEffect`",
+        "`PolicyAssembly`",
+        "`DecisionLedger`",
+        "`SelectedValidationContract`",
+        "`ValidationHandoff`",
+        "validated -> published",
+        "`ReviewPackage`",
+        "`ReviewDecision`",
+        "`PublicOutputReceipt`",
+        "`PublicOutputSpec`",
+        "published -> replayable/auditable",
+        "`ArtifactEnvelope`",
+        "`ProjectionReplayReport`",
+        "replayable/auditable -> explainable",
+        "`ProofGraph` is optional and non-authoritative.",
+        "## Non-Requirements",
+        "`DecisionLedger` is not required to publish canonical fast-path output.",
+        "Policy artifacts must not authorize public projection.",
+        "`ArtifactEnvelope` is not publish-path synchronous unless replayable state is claimed at publish time.",
+        "`ProofGraph` is not required for replay.",
+        "Product-only state must stay outside `comp` artifacts.",
+    ):
+        assert line in boundary_doc
+
+    assert "artifact-lifecycle-boundary.md" in readme
+
+
 def test_governed_architecture_docs_have_valid_machine_readable_headers():
     for path in _governed_architecture_docs():
         header = _doc_header(path)
@@ -790,6 +838,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "persistence",
             "yes",
             "2026-05-22",
+        ),
+        "artifact-lifecycle-boundary.md": (
+            "active-contract",
+            "trust-kernel",
+            "yes",
+            "2026-05-27",
         ),
         "document-governance.md": (
             "active-contract",
@@ -994,6 +1048,7 @@ def test_docs_index_groups_architecture_docs_by_governance_authority():
     )
     assert "archive/architecture/active-surface-cutover.md" in docs_index
     assert "architecture/contracts/compiler-domain-boundary.md" in docs_index
+    assert "architecture/contracts/artifact-lifecycle-boundary.md" in docs_index
     assert "architecture/contracts/policy-boundary.md" in docs_index
     assert "architecture/maps/policy-assembled-trust-kernel.md" in docs_index
     assert "architecture/maps/product-facade-observation.md" in docs_index


### PR DESCRIPTION
## Summary
- add `artifact-lifecycle-boundary.md` as a narrow active contract grounded in the product facade lab observations
- define current state-transition artifact requirements for canonical submit, policy preflight submit, publish, replay/audit, and explanation
- route the new contract through `docs/index.md`, README, and smoke coverage

## Notes
- This is not an artifact registry, Artifact Passport schema, `comp.contracts` extraction, export bundle format, or product runtime design.
- The contract explicitly keeps policy artifacts out of projection authority, keeps `DecisionLedger` out of canonical publish requirements, keeps `ArtifactEnvelope` deferred unless replayable state is claimed, and keeps `ProofGraph` optional/non-authoritative.

## Validation
- python -m pytest -q tests/test_package_smoke.py::test_artifact_lifecycle_boundary_defines_state_transition_requirements tests/test_package_smoke.py::test_architecture_docs_are_classified_by_governance_status tests/test_package_smoke.py::test_docs_index_groups_architecture_docs_by_governance_authority
- python -m pytest -q tests/test_package_smoke.py tests/test_product_facade_lab.py
- python -m pytest -q
- python -m tests.domain_scenarios run-all
- git diff --check