### PR TITLE
[codex] add artifact registry promotion gate

### DIFF
--- a/docs/architecture/contracts/artifact-lifecycle-boundary.md
+++ b/docs/architecture/contracts/artifact-lifecycle-boundary.md
@@ -143,3 +143,28 @@ claim lifecycle finality through an artifact registry or passport schema here
 
 This contract may later inform an artifact registry or wire contract. That
 promotion requires a separate PR with its own tests and migration rationale.
+
+## Artifact Registry Promotion Gate
+
+A machine-readable artifact registry is allowed only when:
+
+```text
+the lifecycle boundary has at least one executable conformance guard
+at least two real consumers need machine-readable artifact metadata
+artifact kinds are stable across canonical, policy preflight, publish, and audit flows
+the registry removes duplication or prevents drift
+the registry does not create new authority
+```
+
+A registry is not allowed when:
+
+```text
+it only documents imagined future artifacts
+it introduces Artifact Passport metadata before consumers need it
+product-only state is being smuggled into `comp`
+policy artifacts are being upgraded into authority
+```
+
+Registry promotion must preserve the existing authority model: receipts
+authorize projection, replay verifies receipt-cited material, policy shapes
+pre-validation admission, and explanations remain non-authoritative.

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -790,6 +790,18 @@ def test_artifact_lifecycle_boundary_defines_state_transition_requirements():
         "`ProofGraph` is not required for replay.",
         "Product-only state must stay outside `comp` artifacts.",
         "tests/test_product_facade_lab.py::test_product_facade_lab_conforms_to_artifact_lifecycle_boundary",
+        "## Artifact Registry Promotion Gate",
+        "A machine-readable artifact registry is allowed only when:",
+        "the lifecycle boundary has at least one executable conformance guard",
+        "at least two real consumers need machine-readable artifact metadata",
+        "artifact kinds are stable across canonical, policy preflight, publish, and audit flows",
+        "the registry removes duplication or prevents drift",
+        "the registry does not create new authority",
+        "A registry is not allowed when:",
+        "it only documents imagined future artifacts",
+        "it introduces Artifact Passport metadata before consumers need it",
+        "product-only state is being smuggled into `comp`",
+        "policy artifacts are being upgraded into authority",
     ):
         assert line in boundary_doc
 


### PR DESCRIPTION
## Summary
- add an Artifact Registry Promotion Gate to `artifact-lifecycle-boundary.md`
- require executable conformance coverage, at least two real consumers, stable artifact kinds, drift reduction, and no new authority before a registry is allowed
- lock the gate with package smoke coverage

## Notes
- This PR does not create a registry, Artifact Passport schema, `comp.contracts` package, or product runtime surface.
- The gate explicitly blocks imagined future artifacts, premature Passport metadata, product-only state entering `comp`, and policy artifacts becoming authority.

## Validation
- python -m pytest -q tests/test_package_smoke.py::test_artifact_lifecycle_boundary_defines_state_transition_requirements
- python -m pytest -q tests/test_package_smoke.py tests/test_product_facade_lab.py
- python -m pytest -q
- python -m tests.domain_scenarios run-all
- git diff --check