### PR TITLE
[codex] add product facade verification bundle fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ policy-assembled-trust-kernel
 product-facade-observation
   docs/architecture/maps/product-facade-observation.md describes product-shaped
   facade observation outside comp; it does not make `comp.runtime` a production runtime.
+  It also tracks lab-only verification bundle fixtures and a fixture runner,
+  not a CLI or stable wire contract.
 ```
 
 현재 policy 이행축은 broad framework를 한 번에 세우는 것이 아니다.

--- a/docs/architecture/maps/product-facade-observation.md
+++ b/docs/architecture/maps/product-facade-observation.md
@@ -329,6 +329,30 @@ emits material and comp reconstructs the verification input.
 The lab may read the same fixture shape with `verify_verification_bundle(...)`
 or `verify_verification_bundle_file(...)`. These helpers are a conformance-lab observation path: they return comp verification output from exported material and do not trust a product-generated replay report.
 
+## Bundle Fixture Observations
+
+Checked-in verification bundle fixtures may live under
+`examples/product_facade_lab/fixtures`. They let comp read stored
+product-shaped material without constructing a product runtime:
+
+```text
+canonical_verification_bundle.json
+  expected replay_status: verified
+
+missing_artifact_verification_bundle.json
+  expected replay_status: blocked
+```
+
+The lab-only fixture runner may expose `run_fixture(...)` and
+`run_all_fixtures(...)` for tests that load those files and return compact conformance results.
+This is not a CLI, production verifier, stable wire contract, or stable bundle runner.
+It exists only to observe that a checked-in bundle can be verified or blocked by
+comp after export.
+
+The missing artifact fixture is intentionally broken so comp proves it can
+reject replayable-state claims when receipt-cited `ArtifactEnvelope` material is
+absent.
+
 ## Non-Goals
 
 This map deliberately avoids:

--- a/examples/product_facade_lab/README.md
+++ b/examples/product_facade_lab/README.md
@@ -73,6 +73,12 @@ observation. The bundle is not a stable wire contract or artifact registry.
 read that fixture shape and return comp verification output; they do not trust
 or import a product-generated replay report.
 
+Checked-in fixture bundles live under `fixtures/`. The lab-only fixture runner
+exposes `run_fixture(...)` and `run_all_fixtures(...)` so tests can verify that
+stored product-shaped material still replays through comp without constructing a
+`ProductFacadeRuntime`. The fixture runner is not a CLI, production verifier, or
+stable bundle runner.
+
 `compare_touch_logs` can compare two logs from the same operation, such as
 canonical `submit` and policy preflight `submit`. The comparison is an
 observation summary for spotting ceremony deltas; it is not a lifecycle

--- a/examples/product_facade_lab/__init__.py
+++ b/examples/product_facade_lab/__init__.py
@@ -6,6 +6,11 @@ from examples.product_facade_lab.bundle import (
     verification_input_from_bundle,
     verification_input_to_bundle,
 )
+from examples.product_facade_lab.runner import (
+    VerificationBundleFixtureResult,
+    run_all_fixtures,
+    run_fixture,
+)
 from examples.product_facade_lab.runtime import (
     ArtifactTouchLog,
     ArtifactTouchLogComparison,
@@ -36,7 +41,10 @@ __all__ = [
     "ProductRequiredAction",
     "ProductRun",
     "ProductWitness",
+    "VerificationBundleFixtureResult",
     "compare_touch_logs",
+    "run_all_fixtures",
+    "run_fixture",
     "verify_comp_compatible_input",
     "verify_verification_bundle",
     "verify_verification_bundle_file",

--- a/examples/product_facade_lab/fixtures/canonical_verification_bundle.json
+++ b/examples/product_facade_lab/fixtures/canonical_verification_bundle.json
@@ -1,0 +1,399 @@
+{
+  "artifact_envelopes": [
+    {
+      "artifact_id": "commit-package:facility-fixture-canonical",
+      "artifact_kind": "commit_package",
+      "body": {
+        "calculation_trace_ids": {
+          "__tuple__": []
+        },
+        "checked_claim_fields": {
+          "__tuple__": [
+            "amount",
+            "unit"
+          ]
+        },
+        "checked_claim_witness_ids": {
+          "__tuple__": [
+            "witness:amount",
+            "witness:unit"
+          ]
+        },
+        "complete": true,
+        "dependency_fingerprints": {
+          "__tuple__": []
+        },
+        "derived_claim_fields": {
+          "__tuple__": []
+        },
+        "derived_claim_ids": {
+          "__tuple__": []
+        },
+        "formula_ids": {
+          "__tuple__": []
+        },
+        "hazard_ids": {
+          "__tuple__": []
+        },
+        "open_obligation_ids": {
+          "__tuple__": []
+        },
+        "package_id": "commit-package:facility-fixture-canonical",
+        "profile_id": null,
+        "projection_value_commitments": {
+          "__tuple__": [
+            {
+              "digest_alg": "sha256",
+              "field": "amount",
+              "source_id": "checked_claim:amount:witness:amount",
+              "source_kind": "checked_claim",
+              "value_digest": "sha256:7aa3fcfca9c3b08fbec22b363aa33f2f23d6dbecf3cb935c06c6900cb24d91bb"
+            },
+            {
+              "digest_alg": "sha256",
+              "field": "unit",
+              "source_id": "checked_claim:unit:witness:unit",
+              "source_kind": "checked_claim",
+              "value_digest": "sha256:2cfbd63a5121d265558a28fe2b7b85adc69b95493b333175893559a43dc8b41a"
+            }
+          ]
+        },
+        "reference_binding_ids": {
+          "__tuple__": []
+        },
+        "report_status": "accepted",
+        "resolved_obligation_ids": {
+          "__tuple__": []
+        },
+        "semantic_judgment_ids": {
+          "__tuple__": []
+        },
+        "subject_id": "facility-fixture-canonical"
+      },
+      "body_digest": "sha256:42b49874471ecf7c2344bfe8c0a18fd96f0483ccf52815de3ed4f4ac2f30c2af",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "governance-decision:commit-package:facility-fixture-canonical",
+      "artifact_kind": "governance_decision",
+      "body": {
+        "decision_id": "governance-decision:commit-package:facility-fixture-canonical",
+        "package_id": "commit-package:facility-fixture-canonical",
+        "profile_id": null,
+        "reasons": {
+          "__tuple__": [
+            "commit_package_complete"
+          ]
+        },
+        "status": "commit",
+        "subject_id": "facility-fixture-canonical"
+      },
+      "body_digest": "sha256:cc7a18f5e329b0614403876927928a743c7e2ae863636c5ab7893ade1c955e7a",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "checked_claim:amount:witness:amount",
+      "artifact_kind": "checked_claim",
+      "body": {
+        "claim_id": "checked_claim:amount:witness:amount",
+        "field": "amount",
+        "origin": "product_facade_canonical_input",
+        "value": 1200,
+        "witness_id": "witness:amount"
+      },
+      "body_digest": "sha256:277112dafa45dc05eba7037f898760c3c7dd3f0c76004e142b6d137d6ba43bfb",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "checked_claim:unit:witness:unit",
+      "artifact_kind": "checked_claim",
+      "body": {
+        "claim_id": "checked_claim:unit:witness:unit",
+        "field": "unit",
+        "origin": "product_facade_canonical_input",
+        "value": "kWh",
+        "witness_id": "witness:unit"
+      },
+      "body_digest": "sha256:aa98a211fc3754d174ebef6281be1b478433a09f85780f0d83a4dc6ae376371a",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "witness:amount",
+      "artifact_kind": "evidence_witness",
+      "body": {
+        "dependency_id": "witness:amount",
+        "dependency_kind": "evidence_witness",
+        "digest_alg": "sha256",
+        "field": "amount",
+        "fingerprint": "sha256:f61cbbfc0ffe6b3fd13522c8f2277008bf577d375deacdf862eb9abbc2c7bc57",
+        "source": "fixture-invoice.pdf",
+        "span": "p1: electricity amount",
+        "text": "1200",
+        "witness_id": "witness:amount"
+      },
+      "body_digest": "sha256:feae9b3f13384a474f65644d2aab1310a6d0842742f09436315d692c5aa3b0cb",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "witness:unit",
+      "artifact_kind": "evidence_witness",
+      "body": {
+        "dependency_id": "witness:unit",
+        "dependency_kind": "evidence_witness",
+        "digest_alg": "sha256",
+        "field": "unit",
+        "fingerprint": "sha256:7ed5af484e93f6c91c68f70c9a17b036fbd7b3b720d5ac98603a0d3c73bb6e7a",
+        "source": "fixture-invoice.pdf",
+        "span": "p1: electricity unit",
+        "text": "kWh",
+        "witness_id": "witness:unit"
+      },
+      "body_digest": "sha256:c0ccd18d92536de2434b7fbd397153659bc9a68d7a3cfb61d19699d43a26488b",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    }
+  ],
+  "bundle_kind": "comp_compatible_verification_input",
+  "explanation_hints": [],
+  "omitted_verification_outputs": [
+    "ProjectionReplayReport",
+    "ProofGraph"
+  ],
+  "product_only_excluded": [
+    "ProductInput",
+    "ProductPolicyPreflightInput",
+    "ProductRun",
+    "ProductPublicRow",
+    "ProductAudit",
+    "touch_log"
+  ],
+  "projection": {
+    "output_fields": [
+      "amount",
+      "unit"
+    ],
+    "projection_id": "public-row"
+  },
+  "public_output_receipt": {
+    "authorized_fields": [
+      "amount",
+      "unit"
+    ],
+    "barrier_snapshot": [
+      [
+        "governance_decision_id",
+        "governance-decision:commit-package:facility-fixture-canonical"
+      ],
+      [
+        "governance_status",
+        "commit"
+      ],
+      [
+        "governance_reasons",
+        [
+          "commit_package_complete"
+        ]
+      ],
+      [
+        "commit_package_id",
+        "commit-package:facility-fixture-canonical"
+      ],
+      [
+        "commit_package_complete",
+        true
+      ],
+      [
+        "subject_id",
+        "facility-fixture-canonical"
+      ],
+      [
+        "projection_id",
+        "public-row"
+      ],
+      [
+        "authorized_fields",
+        [
+          "amount",
+          "unit"
+        ]
+      ],
+      [
+        "profile_id",
+        null
+      ],
+      [
+        "report_status",
+        "accepted"
+      ],
+      [
+        "checked_claim_fields",
+        [
+          "amount",
+          "unit"
+        ]
+      ],
+      [
+        "checked_claim_witness_ids",
+        [
+          "witness:amount",
+          "witness:unit"
+        ]
+      ],
+      [
+        "semantic_judgment_ids",
+        []
+      ],
+      [
+        "reference_binding_ids",
+        []
+      ],
+      [
+        "derived_claim_fields",
+        []
+      ],
+      [
+        "derived_claim_ids",
+        []
+      ],
+      [
+        "calculation_trace_ids",
+        []
+      ],
+      [
+        "formula_ids",
+        []
+      ],
+      [
+        "resolved_obligation_ids",
+        []
+      ],
+      [
+        "open_obligation_ids",
+        []
+      ],
+      [
+        "hazard_ids",
+        []
+      ],
+      [
+        "projection_value_commitments",
+        [
+          {
+            "digest_alg": "sha256",
+            "field": "amount",
+            "source_id": "checked_claim:amount:witness:amount",
+            "source_kind": "checked_claim",
+            "value_digest": "sha256:7aa3fcfca9c3b08fbec22b363aa33f2f23d6dbecf3cb935c06c6900cb24d91bb"
+          },
+          {
+            "digest_alg": "sha256",
+            "field": "unit",
+            "source_id": "checked_claim:unit:witness:unit",
+            "source_kind": "checked_claim",
+            "value_digest": "sha256:2cfbd63a5121d265558a28fe2b7b85adc69b95493b333175893559a43dc8b41a"
+          }
+        ]
+      ],
+      [
+        "dependency_fingerprints",
+        []
+      ]
+    ],
+    "citations": {
+      "authorized_fields": [
+        "amount",
+        "unit"
+      ],
+      "calculation_trace_ids": [],
+      "checked_claim_fields": [
+        "amount",
+        "unit"
+      ],
+      "checked_claim_witness_ids": [
+        "witness:amount",
+        "witness:unit"
+      ],
+      "commit_package_complete": true,
+      "commit_package_id": "commit-package:facility-fixture-canonical",
+      "dependency_fingerprints": [],
+      "derived_claim_fields": [],
+      "derived_claim_ids": [],
+      "formula_ids": [],
+      "governance_decision_id": "governance-decision:commit-package:facility-fixture-canonical",
+      "governance_reasons": [
+        "commit_package_complete"
+      ],
+      "governance_status": "commit",
+      "hazard_ids": [],
+      "open_obligation_ids": [],
+      "profile_id": null,
+      "projection_id": "public-row",
+      "projection_value_commitments": [
+        {
+          "digest_alg": "sha256",
+          "field": "amount",
+          "source_id": "checked_claim:amount:witness:amount",
+          "source_kind": "checked_claim",
+          "value_digest": "sha256:7aa3fcfca9c3b08fbec22b363aa33f2f23d6dbecf3cb935c06c6900cb24d91bb"
+        },
+        {
+          "digest_alg": "sha256",
+          "field": "unit",
+          "source_id": "checked_claim:unit:witness:unit",
+          "source_kind": "checked_claim",
+          "value_digest": "sha256:2cfbd63a5121d265558a28fe2b7b85adc69b95493b333175893559a43dc8b41a"
+        }
+      ],
+      "reference_binding_ids": [],
+      "report_status": "accepted",
+      "resolved_obligation_ids": [],
+      "semantic_judgment_ids": [],
+      "subject_id": "facility-fixture-canonical"
+    },
+    "draft_id": "commit-package:facility-fixture-canonical",
+    "projection_id": "public-row",
+    "public_row_id": "public-row-fixture-canonical",
+    "winner_receipt_ids": [
+      "governance-decision:commit-package:facility-fixture-canonical"
+    ]
+  },
+  "public_row": {
+    "amount": 1200,
+    "unit": "kWh"
+  },
+  "public_row_id": "public-row-fixture-canonical",
+  "receipt_handle": "receipt:commit-package:facility-fixture-canonical",
+  "schema_version": "product_facade_verification_bundle.v0",
+  "validation_summary": {
+    "calculated_claim_fields": [],
+    "checked_claim_fields": [
+      "amount",
+      "unit"
+    ],
+    "status": "accepted",
+    "validation_requirement_count": 0
+  }
+}

--- a/examples/product_facade_lab/fixtures/missing_artifact_verification_bundle.json
+++ b/examples/product_facade_lab/fixtures/missing_artifact_verification_bundle.json
@@ -1,0 +1,378 @@
+{
+  "artifact_envelopes": [
+    {
+      "artifact_id": "commit-package:facility-fixture-missing-artifact",
+      "artifact_kind": "commit_package",
+      "body": {
+        "calculation_trace_ids": {
+          "__tuple__": []
+        },
+        "checked_claim_fields": {
+          "__tuple__": [
+            "amount",
+            "unit"
+          ]
+        },
+        "checked_claim_witness_ids": {
+          "__tuple__": [
+            "witness:amount",
+            "witness:unit"
+          ]
+        },
+        "complete": true,
+        "dependency_fingerprints": {
+          "__tuple__": []
+        },
+        "derived_claim_fields": {
+          "__tuple__": []
+        },
+        "derived_claim_ids": {
+          "__tuple__": []
+        },
+        "formula_ids": {
+          "__tuple__": []
+        },
+        "hazard_ids": {
+          "__tuple__": []
+        },
+        "open_obligation_ids": {
+          "__tuple__": []
+        },
+        "package_id": "commit-package:facility-fixture-missing-artifact",
+        "profile_id": null,
+        "projection_value_commitments": {
+          "__tuple__": [
+            {
+              "digest_alg": "sha256",
+              "field": "amount",
+              "source_id": "checked_claim:amount:witness:amount",
+              "source_kind": "checked_claim",
+              "value_digest": "sha256:7aa3fcfca9c3b08fbec22b363aa33f2f23d6dbecf3cb935c06c6900cb24d91bb"
+            },
+            {
+              "digest_alg": "sha256",
+              "field": "unit",
+              "source_id": "checked_claim:unit:witness:unit",
+              "source_kind": "checked_claim",
+              "value_digest": "sha256:2cfbd63a5121d265558a28fe2b7b85adc69b95493b333175893559a43dc8b41a"
+            }
+          ]
+        },
+        "reference_binding_ids": {
+          "__tuple__": []
+        },
+        "report_status": "accepted",
+        "resolved_obligation_ids": {
+          "__tuple__": []
+        },
+        "semantic_judgment_ids": {
+          "__tuple__": []
+        },
+        "subject_id": "facility-fixture-missing-artifact"
+      },
+      "body_digest": "sha256:7d3aac561532cfcb012751c173021cb4ff8bbf2aa0ecac1bf39cf3d143a06d1a",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "governance-decision:commit-package:facility-fixture-missing-artifact",
+      "artifact_kind": "governance_decision",
+      "body": {
+        "decision_id": "governance-decision:commit-package:facility-fixture-missing-artifact",
+        "package_id": "commit-package:facility-fixture-missing-artifact",
+        "profile_id": null,
+        "reasons": {
+          "__tuple__": [
+            "commit_package_complete"
+          ]
+        },
+        "status": "commit",
+        "subject_id": "facility-fixture-missing-artifact"
+      },
+      "body_digest": "sha256:f4bf195cd292b82b33fec73c05064bf49ba7e371b375ed8d3f2a09e1b09fc279",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "checked_claim:amount:witness:amount",
+      "artifact_kind": "checked_claim",
+      "body": {
+        "claim_id": "checked_claim:amount:witness:amount",
+        "field": "amount",
+        "origin": "product_facade_canonical_input",
+        "value": 1200,
+        "witness_id": "witness:amount"
+      },
+      "body_digest": "sha256:277112dafa45dc05eba7037f898760c3c7dd3f0c76004e142b6d137d6ba43bfb",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "checked_claim:unit:witness:unit",
+      "artifact_kind": "checked_claim",
+      "body": {
+        "claim_id": "checked_claim:unit:witness:unit",
+        "field": "unit",
+        "origin": "product_facade_canonical_input",
+        "value": "kWh",
+        "witness_id": "witness:unit"
+      },
+      "body_digest": "sha256:aa98a211fc3754d174ebef6281be1b478433a09f85780f0d83a4dc6ae376371a",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    },
+    {
+      "artifact_id": "witness:amount",
+      "artifact_kind": "evidence_witness",
+      "body": {
+        "dependency_id": "witness:amount",
+        "dependency_kind": "evidence_witness",
+        "digest_alg": "sha256",
+        "field": "amount",
+        "fingerprint": "sha256:f61cbbfc0ffe6b3fd13522c8f2277008bf577d375deacdf862eb9abbc2c7bc57",
+        "source": "fixture-invoice.pdf",
+        "span": "p1: electricity amount",
+        "text": "1200",
+        "witness_id": "witness:amount"
+      },
+      "body_digest": "sha256:feae9b3f13384a474f65644d2aab1310a6d0842742f09436315d692c5aa3b0cb",
+      "meta": {
+        "__tuple__": []
+      },
+      "schema_version": "compiler-run-v1",
+      "source_refs": []
+    }
+  ],
+  "bundle_kind": "comp_compatible_verification_input",
+  "explanation_hints": [],
+  "omitted_verification_outputs": [
+    "ProjectionReplayReport",
+    "ProofGraph"
+  ],
+  "product_only_excluded": [
+    "ProductInput",
+    "ProductPolicyPreflightInput",
+    "ProductRun",
+    "ProductPublicRow",
+    "ProductAudit",
+    "touch_log"
+  ],
+  "projection": {
+    "output_fields": [
+      "amount",
+      "unit"
+    ],
+    "projection_id": "public-row"
+  },
+  "public_output_receipt": {
+    "authorized_fields": [
+      "amount",
+      "unit"
+    ],
+    "barrier_snapshot": [
+      [
+        "governance_decision_id",
+        "governance-decision:commit-package:facility-fixture-missing-artifact"
+      ],
+      [
+        "governance_status",
+        "commit"
+      ],
+      [
+        "governance_reasons",
+        [
+          "commit_package_complete"
+        ]
+      ],
+      [
+        "commit_package_id",
+        "commit-package:facility-fixture-missing-artifact"
+      ],
+      [
+        "commit_package_complete",
+        true
+      ],
+      [
+        "subject_id",
+        "facility-fixture-missing-artifact"
+      ],
+      [
+        "projection_id",
+        "public-row"
+      ],
+      [
+        "authorized_fields",
+        [
+          "amount",
+          "unit"
+        ]
+      ],
+      [
+        "profile_id",
+        null
+      ],
+      [
+        "report_status",
+        "accepted"
+      ],
+      [
+        "checked_claim_fields",
+        [
+          "amount",
+          "unit"
+        ]
+      ],
+      [
+        "checked_claim_witness_ids",
+        [
+          "witness:amount",
+          "witness:unit"
+        ]
+      ],
+      [
+        "semantic_judgment_ids",
+        []
+      ],
+      [
+        "reference_binding_ids",
+        []
+      ],
+      [
+        "derived_claim_fields",
+        []
+      ],
+      [
+        "derived_claim_ids",
+        []
+      ],
+      [
+        "calculation_trace_ids",
+        []
+      ],
+      [
+        "formula_ids",
+        []
+      ],
+      [
+        "resolved_obligation_ids",
+        []
+      ],
+      [
+        "open_obligation_ids",
+        []
+      ],
+      [
+        "hazard_ids",
+        []
+      ],
+      [
+        "projection_value_commitments",
+        [
+          {
+            "digest_alg": "sha256",
+            "field": "amount",
+            "source_id": "checked_claim:amount:witness:amount",
+            "source_kind": "checked_claim",
+            "value_digest": "sha256:7aa3fcfca9c3b08fbec22b363aa33f2f23d6dbecf3cb935c06c6900cb24d91bb"
+          },
+          {
+            "digest_alg": "sha256",
+            "field": "unit",
+            "source_id": "checked_claim:unit:witness:unit",
+            "source_kind": "checked_claim",
+            "value_digest": "sha256:2cfbd63a5121d265558a28fe2b7b85adc69b95493b333175893559a43dc8b41a"
+          }
+        ]
+      ],
+      [
+        "dependency_fingerprints",
+        []
+      ]
+    ],
+    "citations": {
+      "authorized_fields": [
+        "amount",
+        "unit"
+      ],
+      "calculation_trace_ids": [],
+      "checked_claim_fields": [
+        "amount",
+        "unit"
+      ],
+      "checked_claim_witness_ids": [
+        "witness:amount",
+        "witness:unit"
+      ],
+      "commit_package_complete": true,
+      "commit_package_id": "commit-package:facility-fixture-missing-artifact",
+      "dependency_fingerprints": [],
+      "derived_claim_fields": [],
+      "derived_claim_ids": [],
+      "formula_ids": [],
+      "governance_decision_id": "governance-decision:commit-package:facility-fixture-missing-artifact",
+      "governance_reasons": [
+        "commit_package_complete"
+      ],
+      "governance_status": "commit",
+      "hazard_ids": [],
+      "open_obligation_ids": [],
+      "profile_id": null,
+      "projection_id": "public-row",
+      "projection_value_commitments": [
+        {
+          "digest_alg": "sha256",
+          "field": "amount",
+          "source_id": "checked_claim:amount:witness:amount",
+          "source_kind": "checked_claim",
+          "value_digest": "sha256:7aa3fcfca9c3b08fbec22b363aa33f2f23d6dbecf3cb935c06c6900cb24d91bb"
+        },
+        {
+          "digest_alg": "sha256",
+          "field": "unit",
+          "source_id": "checked_claim:unit:witness:unit",
+          "source_kind": "checked_claim",
+          "value_digest": "sha256:2cfbd63a5121d265558a28fe2b7b85adc69b95493b333175893559a43dc8b41a"
+        }
+      ],
+      "reference_binding_ids": [],
+      "report_status": "accepted",
+      "resolved_obligation_ids": [],
+      "semantic_judgment_ids": [],
+      "subject_id": "facility-fixture-missing-artifact"
+    },
+    "draft_id": "commit-package:facility-fixture-missing-artifact",
+    "projection_id": "public-row",
+    "public_row_id": "public-row-fixture-missing-artifact",
+    "winner_receipt_ids": [
+      "governance-decision:commit-package:facility-fixture-missing-artifact"
+    ]
+  },
+  "public_row": {
+    "amount": 1200,
+    "unit": "kWh"
+  },
+  "public_row_id": "public-row-fixture-missing-artifact",
+  "receipt_handle": "receipt:commit-package:facility-fixture-missing-artifact",
+  "schema_version": "product_facade_verification_bundle.v0",
+  "validation_summary": {
+    "calculated_claim_fields": [],
+    "checked_claim_fields": [
+      "amount",
+      "unit"
+    ],
+    "status": "accepted",
+    "validation_requirement_count": 0
+  }
+}

--- a/examples/product_facade_lab/runner.py
+++ b/examples/product_facade_lab/runner.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from examples.product_facade_lab.bundle import verify_verification_bundle_file
+
+
+FIXTURE_EXPECTED_REPLAY_STATUS = {
+    "canonical_verification_bundle.json": "verified",
+    "missing_artifact_verification_bundle.json": "blocked",
+}
+
+
+@dataclass(frozen=True)
+class VerificationBundleFixtureResult:
+    fixture_name: str
+    path: Path
+    expected_replay_status: str
+    replay_status: str
+    public_row_id: str
+    artifact_count: int
+    verification_errors: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return self.replay_status == self.expected_replay_status
+
+
+def run_fixture(path: str | Path) -> VerificationBundleFixtureResult:
+    fixture_path = Path(path)
+    expected_status = _expected_replay_status(fixture_path)
+    output = verify_verification_bundle_file(fixture_path)
+    return VerificationBundleFixtureResult(
+        fixture_name=fixture_path.name,
+        path=fixture_path,
+        expected_replay_status=expected_status,
+        replay_status=output.replay_status,
+        public_row_id=output.public_row_id,
+        artifact_count=output.artifact_count,
+        verification_errors=output.verification_errors,
+    )
+
+
+def run_all_fixtures(
+    fixture_dir: str | Path = Path(__file__).with_name("fixtures"),
+) -> tuple[VerificationBundleFixtureResult, ...]:
+    root = Path(fixture_dir)
+    return tuple(run_fixture(path) for path in sorted(root.glob("*.json")))
+
+
+def _expected_replay_status(path: Path) -> str:
+    try:
+        return FIXTURE_EXPECTED_REPLAY_STATUS[path.name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown product facade bundle fixture: {path.name}") from exc
+
+
+__all__ = [
+    "VerificationBundleFixtureResult",
+    "run_all_fixtures",
+    "run_fixture",
+]

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -764,6 +764,18 @@ def test_product_facade_observation_map_defines_lab_without_contracting_lifecycl
         "`verify_verification_bundle_file(...)`",
         "conformance-lab observation path",
         "do not trust a product-generated replay report",
+        "## Bundle Fixture Observations",
+        "Checked-in verification bundle fixtures",
+        "`examples/product_facade_lab/fixtures`",
+        "canonical_verification_bundle.json",
+        "missing_artifact_verification_bundle.json",
+        "`run_fixture(...)`",
+        "`run_all_fixtures(...)`",
+        "compact conformance results",
+        "not a CLI",
+        "stable wire contract",
+        "stable bundle runner",
+        "missing artifact fixture",
         "not a stable wire contract",
         "no artifact registry yet",
         "no Artifact Passport schema yet",
@@ -779,6 +791,8 @@ def test_product_facade_observation_map_defines_lab_without_contracting_lifecycl
 
     assert "product-facade-observation.md" in readme
     assert "does not make `comp.runtime` a production runtime" in readme
+    assert "lab-only verification bundle fixtures" in readme
+    assert "not a CLI or stable wire contract" in readme
 
 
 def test_artifact_lifecycle_boundary_defines_state_transition_requirements():

--- a/tests/test_product_facade_bundle_fixtures.py
+++ b/tests/test_product_facade_bundle_fixtures.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from examples.product_facade_lab.runner import run_all_fixtures, run_fixture
+
+
+FIXTURE_DIR = Path("examples/product_facade_lab/fixtures")
+
+
+def test_canonical_verification_bundle_fixture_is_verified():
+    result = run_fixture(FIXTURE_DIR / "canonical_verification_bundle.json")
+
+    assert result.fixture_name == "canonical_verification_bundle.json"
+    assert result.expected_replay_status == "verified"
+    assert result.replay_status == "verified"
+    assert result.passed is True
+    assert result.verification_errors == ()
+    assert result.public_row_id == "public-row-fixture-canonical"
+    assert result.artifact_count > 0
+
+
+def test_missing_artifact_verification_bundle_fixture_is_blocked():
+    result = run_fixture(FIXTURE_DIR / "missing_artifact_verification_bundle.json")
+
+    assert result.fixture_name == "missing_artifact_verification_bundle.json"
+    assert result.expected_replay_status == "blocked"
+    assert result.replay_status == "blocked"
+    assert result.passed is True
+    assert result.verification_errors
+    assert "Projection replay missing artifact" in result.verification_errors[0]
+    assert result.public_row_id == "public-row-fixture-missing-artifact"
+
+
+def test_run_all_fixtures_reports_compact_conformance_results():
+    results = run_all_fixtures(FIXTURE_DIR)
+
+    assert tuple(result.fixture_name for result in results) == (
+        "canonical_verification_bundle.json",
+        "missing_artifact_verification_bundle.json",
+    )
+    assert tuple(result.replay_status for result in results) == (
+        "verified",
+        "blocked",
+    )
+    assert all(result.passed for result in results)
+
+
+def test_unknown_bundle_fixture_requires_explicit_expectation():
+    with pytest.raises(ValueError, match="Unknown product facade bundle fixture"):
+        run_fixture(FIXTURE_DIR / "new_unclassified_fixture.json")

--- a/tests/test_product_facade_lab.py
+++ b/tests/test_product_facade_lab.py
@@ -591,6 +591,10 @@ def test_observation_map_points_to_canonical_lab_without_promoting_runtime():
     assert "product_facade_verification_bundle.v0" in lab_readme
     assert "verify_verification_bundle_file" in lab_readme
     assert "not a stable wire contract" in lab_readme
+    assert "fixtures/" in lab_readme
+    assert "run_fixture" in lab_readme
+    assert "run_all_fixtures" in lab_readme
+    assert "not a CLI" in lab_readme
     assert "native production authority engine" in lab_readme
 
 


### PR DESCRIPTION
## Summary
- add checked-in product facade verification bundle fixtures for verified and blocked replay outcomes
- add a lab-only fixture runner that verifies stored bundle files without constructing ProductFacadeRuntime
- document the runner as fixture observation, not a CLI or stable wire contract

## Tests
- `python -m pytest -q tests/test_product_facade_bundle_fixtures.py`
- `python -m pytest -q tests/test_product_facade_bundle_fixtures.py tests/test_product_facade_lab.py tests/test_package_smoke.py::test_product_facade_observation_map_defines_lab_without_contracting_lifecycle`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`
- `git diff --check`