### PR TITLE
[codex] clarify compiler tool API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ from comp.compiler_tool import compile_report_to_facts
 `docs/api/compiler-tool.md` classifies this stable quickstart surface separately
 from advanced and experimental helper exports. `comp.compiler_tool.__all__` is
 an import-convenience surface, not the stability contract.
+The README quickstart is the stable onboarding path.
+`comp.compiler_tool.__all__` remains a broad compatibility surface, not a stable API signal.
 
 `comp.persistence`는 replayable artifact record와 receipt ledger surface를
 노출한다. persisted row는 authority가 아니라 receipt로 재검증되어야 하는

--- a/docs/api/compiler-tool.md
+++ b/docs/api/compiler-tool.md
@@ -11,13 +11,16 @@ comp.compiler_tool.__all__ is an import-convenience surface.
 comp.compiler_tool.__all__ is not the stability contract.
 ```
 
+Broad `comp.compiler_tool` imports are compatibility imports, not stable API signals.
 `comp.compiler_tool` may export advanced or experimental symbols to keep tests,
 examples, and migration code readable. Exported does not mean permanently stable.
+A future narrow stable import surface may re-export only this section without breaking broad compatibility imports.
 
 ## Stable public API
 
 These names are the preferred import surface for package users and README
 quickstarts.
+New users should treat this Stable public API section as the only default onboarding surface.
 
 ```python
 from comp.compiler_tool import InterpretationHypothesis, ClaimCandidate, EvidenceRef
@@ -97,6 +100,7 @@ teaching an advanced compiler-tool layer.
 These names are useful for tests, adapters, resolver integrations, and review
 tools. They are public enough to import intentionally, but they should not appear
 in README quickstarts as the default user path.
+Advanced and experimental names require explicit promotion before they become stable API.
 
 ```text
 SemanticJudgment

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -342,6 +342,25 @@ def test_compiler_tool_advanced_surface_is_documented():
     assert "__all__ is not the stability contract" in api_doc
 
 
+def test_compiler_tool_api_surface_boundary_discourages_broad_stability_signal():
+    api_doc = Path("docs/api/compiler-tool.md").read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    for line in (
+        "Broad `comp.compiler_tool` imports are compatibility imports, not stable API signals.",
+        "New users should treat this Stable public API section as the only default onboarding surface.",
+        "Advanced and experimental names require explicit promotion before they become stable API.",
+        "A future narrow stable import surface may re-export only this section without breaking broad compatibility imports.",
+    ):
+        assert line in api_doc
+
+    assert "The README quickstart is the stable onboarding path." in readme
+    assert (
+        "`comp.compiler_tool.__all__` remains a broad compatibility surface, not a stable API signal."
+        in readme
+    )
+
+
 def test_compiler_tool_behavior_declaration_surface_is_documented():
     import comp.compiler_tool as compiler_tool
 


### PR DESCRIPTION
## Summary
- clarify that broad `comp.compiler_tool` imports and `__all__` are compatibility signals, not the stable API contract
- make the Stable public API section the default onboarding surface for new users
- add smoke coverage so advanced/experimental names require explicit promotion before being treated as stable

## Tests
- `python -m pytest -q tests/test_package_smoke.py::test_compiler_tool_api_surface_boundary_discourages_broad_stability_signal`
- `python -m pytest -q tests/test_package_smoke.py::test_compiler_tool_stable_public_surface_is_exported_and_documented tests/test_package_smoke.py::test_readme_compiler_tool_quickstart_uses_required_public_path tests/test_package_smoke.py::test_compiler_tool_advanced_surface_is_documented tests/test_package_smoke.py::test_compiler_tool_api_surface_boundary_discourages_broad_stability_signal tests/test_package_smoke.py::test_compiler_tool_behavior_declaration_surface_is_documented tests/test_package_smoke.py::test_compiler_tool_experimental_surface_is_not_in_readme_quickstart`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`
- `git diff --check`