### PR TITLE
[codex] guard product facade bundle promotion

### DIFF
--- a/docs/architecture/contracts/artifact-lifecycle-boundary.md
+++ b/docs/architecture/contracts/artifact-lifecycle-boundary.md
@@ -143,6 +143,7 @@ claim lifecycle finality through an artifact registry or passport schema here
 
 This contract may later inform an artifact registry or wire contract. That
 promotion requires a separate PR with its own tests and migration rationale.
+Bundle helper promotion requires a separate active-contract PR.
 
 ## Artifact Registry Promotion Gate
 

--- a/docs/architecture/maps/product-facade-observation.md
+++ b/docs/architecture/maps/product-facade-observation.md
@@ -325,6 +325,7 @@ The lab may serialize this shape with `export_verification_bundle(...)` or
 observation format, not a stable wire contract. JSON round-trip verification is
 useful because it exercises the future external boundary where a product app
 emits material and comp reconstructs the verification input.
+product_facade_verification_bundle.v0 is not a stability promise.
 
 The lab may read the same fixture shape with `verify_verification_bundle(...)`
 or `verify_verification_bundle_file(...)`. These helpers are a conformance-lab observation path: they return comp verification output from exported material and do not trust a product-generated replay report.
@@ -390,6 +391,7 @@ The current lab evidence supports the external-contract shape at the fixture
 level only: a product-shaped exporter can emit replayable material, and comp can
 verify or block that material later. It does not yet justify a stable bundle
 schema, CLI surface, registry, or replacement production authority engine.
+Bundle helper promotion requires a separate active-contract PR.
 
 ## Non-Goals
 

--- a/examples/product_facade_lab/README.md
+++ b/examples/product_facade_lab/README.md
@@ -72,6 +72,9 @@ observation. The bundle is not a stable wire contract or artifact registry.
 `verify_verification_bundle(...)` and `verify_verification_bundle_file(...)`
 read that fixture shape and return comp verification output; they do not trust
 or import a product-generated replay report.
+Do not promote `examples.product_facade_lab.bundle` into `comp`,
+`comp.runtime`, or `comp.scenario_contracts` from this lab.
+Do not add a product facade console script from this lab.
 
 Checked-in fixture bundles live under `fixtures/`. The lab-only fixture runner
 exposes `run_fixture(...)` and `run_all_fixtures(...)` so tests can verify that

--- a/tests/test_product_facade_lab.py
+++ b/tests/test_product_facade_lab.py
@@ -601,6 +601,36 @@ def test_observation_map_points_to_canonical_lab_without_promoting_runtime():
     assert "native production authority engine" in lab_readme
 
 
+def test_verification_bundle_helpers_have_explicit_promotion_guardrails():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    product_map = Path(
+        "docs/architecture/maps/product-facade-observation.md"
+    ).read_text(encoding="utf-8")
+    lifecycle_boundary = _artifact_lifecycle_boundary()
+    lab_readme = Path("examples/product_facade_lab/README.md").read_text(
+        encoding="utf-8"
+    )
+
+    scripts = pyproject["project"].get("scripts", {})
+    assert not any(
+        "product_facade_lab" in entrypoint
+        for entrypoint in scripts.values()
+    )
+    assert "product_facade_verification_bundle.v0 is not a stability promise." in (
+        product_map
+    )
+    assert "Bundle helper promotion requires a separate active-contract PR." in (
+        product_map
+    )
+    assert "Bundle helper promotion requires a separate active-contract PR." in (
+        lifecycle_boundary
+    )
+    assert "Do not promote `examples.product_facade_lab.bundle` into `comp`" in (
+        lab_readme
+    )
+    assert "Do not add a product facade console script from this lab." in lab_readme
+
+
 def _artifact_lifecycle_boundary() -> str:
     return Path("docs/architecture/contracts/artifact-lifecycle-boundary.md").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary

- Add a product facade lab test that keeps verification bundle helpers out of packaged `comp` surfaces and console scripts.
- Clarify that `product_facade_verification_bundle.v0` is fixture observation material, not a stability promise.
- Require a separate active-contract PR before promoting bundle helpers into a stable boundary.

## Why

The product facade verification bundle is useful as lab evidence, but it should not quietly become a stable wire contract, artifact registry, production verifier, or product CLI. This keeps the lab observation-only while preserving a clear promotion path if that boundary is ever intentionally changed.

## Validation

- `python -m pytest -q` -> `580 passed, 13 skipped`
- `python -m tests.domain_scenarios run-all` -> `18/18 passed`