### PR TITLE
[codex] add compiler tool stable surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PublicOutputReceipt == projection gate
 <!-- compiler-tool-quickstart:start -->
 ```python
 from comp import PublicOutputBlocked, PublicOutputSpec, build_public_output
-from comp.compiler_tool import (
+from comp.compiler_tool.stable import (
     ClaimCandidate,
     CompilerTool,
     EvidenceRef,
@@ -132,14 +132,14 @@ from comp import SelectionReceipt, PublicOutputReceipt
 from comp import PublicOutputSpec, build_public_output
 ```
 
-`comp.compiler_tool`은 현재 deterministic publication kernel surface를
-노출한다.
+`comp.compiler_tool.stable`은 현재 deterministic publication kernel의 stable
+onboarding surface를 노출한다.
 
 ```python
-from comp.compiler_tool import CompilerTool, ValidationReport
-from comp.compiler_tool import resolver_tasks_from_report
-from comp.compiler_tool import prepare_commit, build_public_output_receipt
-from comp.compiler_tool import compile_report_to_facts
+from comp.compiler_tool.stable import CompilerTool, ValidationReport
+from comp.compiler_tool.stable import resolver_tasks_from_report
+from comp.compiler_tool.stable import prepare_commit, build_public_output_receipt
+from comp.compiler_tool.stable import compile_report_to_facts
 ```
 
 `docs/api/compiler-tool.md` classifies this stable quickstart surface separately

--- a/comp/compiler_tool/stable.py
+++ b/comp/compiler_tool/stable.py
@@ -1,0 +1,25 @@
+"""Stable compiler-tool onboarding surface."""
+
+from comp.compiler_tool.commit_flow import prepare_commit
+from comp.compiler_tool.judgment_adapter import compile_report_to_facts
+from comp.compiler_tool.models import (
+    ClaimCandidate,
+    EvidenceRef,
+    InterpretationHypothesis,
+    ValidationReport,
+)
+from comp.compiler_tool.receipt_builder import build_public_output_receipt
+from comp.compiler_tool.resolver_tasks import resolver_tasks_from_report
+from comp.compiler_tool.tool import CompilerTool
+
+__all__ = [
+    "InterpretationHypothesis",
+    "ClaimCandidate",
+    "EvidenceRef",
+    "CompilerTool",
+    "ValidationReport",
+    "resolver_tasks_from_report",
+    "prepare_commit",
+    "build_public_output_receipt",
+    "compile_report_to_facts",
+]

--- a/docs/api/compiler-tool.md
+++ b/docs/api/compiler-tool.md
@@ -14,7 +14,8 @@ comp.compiler_tool.__all__ is not the stability contract.
 Broad `comp.compiler_tool` imports are compatibility imports, not stable API signals.
 `comp.compiler_tool` may export advanced or experimental symbols to keep tests,
 examples, and migration code readable. Exported does not mean permanently stable.
-A future narrow stable import surface may re-export only this section without breaking broad compatibility imports.
+`comp.compiler_tool.stable` re-exports only this section without breaking broad compatibility imports.
+comp.compiler_tool.stable.__all__ is the stability contract for the stable onboarding surface.
 
 ## Stable public API
 
@@ -23,11 +24,11 @@ quickstarts.
 New users should treat this Stable public API section as the only default onboarding surface.
 
 ```python
-from comp.compiler_tool import InterpretationHypothesis, ClaimCandidate, EvidenceRef
-from comp.compiler_tool import CompilerTool, ValidationReport
-from comp.compiler_tool import resolver_tasks_from_report
-from comp.compiler_tool import prepare_commit, build_public_output_receipt
-from comp.compiler_tool import compile_report_to_facts
+from comp.compiler_tool.stable import InterpretationHypothesis, ClaimCandidate, EvidenceRef
+from comp.compiler_tool.stable import CompilerTool, ValidationReport
+from comp.compiler_tool.stable import resolver_tasks_from_report
+from comp.compiler_tool.stable import prepare_commit, build_public_output_receipt
+from comp.compiler_tool.stable import compile_report_to_facts
 ```
 
 ### Quickstart input models
@@ -65,8 +66,8 @@ compile_report_to_facts
 
 ### Quickstart companion gate from top-level `comp`
 
-README quickstarts may pair `comp.compiler_tool` with the top-level public-output
-gate:
+README quickstarts may pair `comp.compiler_tool.stable` with the top-level
+public-output gate:
 
 ```python
 from comp import PublicOutputBlocked, PublicOutputReceipt, PublicOutputSpec

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -229,7 +229,10 @@ def _readme_compiler_tool_quickstart():
     quickstart_section = readme.split(start, 1)[1].split(end, 1)[0]
     for block in quickstart_section.split("```python")[1:]:
         code = block.split("```", 1)[0]
-        if "from comp.compiler_tool import" in code:
+        if (
+            "from comp.compiler_tool.stable import" in code
+            or "from comp.compiler_tool import" in code
+        ):
             return code
     raise AssertionError("README quickstart marker does not include a python block.")
 
@@ -269,9 +272,31 @@ def test_compiler_tool_stable_public_surface_is_exported_and_documented():
         assert name in api_doc, name
 
 
+def test_compiler_tool_stable_import_surface_is_narrow_and_documented():
+    import comp.compiler_tool as compiler_tool
+    import comp.compiler_tool.stable as stable
+
+    api_doc = Path("docs/api/compiler-tool.md").read_text(encoding="utf-8")
+
+    assert "comp.compiler_tool.stable.__all__ is the stability contract" in api_doc
+    assert "from comp.compiler_tool.stable import" in api_doc
+    assert set(stable.__all__) == COMPILER_TOOL_STABLE_PUBLIC
+    for name in COMPILER_TOOL_STABLE_PUBLIC:
+        assert hasattr(stable, name), name
+        assert getattr(stable, name) is getattr(compiler_tool, name)
+    for name in (
+        COMPILER_TOOL_ADVANCED_PUBLIC
+        | COMPILER_TOOL_BEHAVIOR_DECLARATION_PUBLIC
+        | COMPILER_TOOL_EXPERIMENTAL_NOT_QUICKSTART
+    ):
+        assert name not in stable.__all__, name
+
+
 def test_readme_compiler_tool_quickstart_uses_required_public_path():
     quickstart = _readme_compiler_tool_quickstart()
 
+    assert "from comp.compiler_tool.stable import" in quickstart
+    assert "from comp.compiler_tool import" not in quickstart
     for name in COMPILER_TOOL_QUICKSTART_PATH:
         assert name in quickstart, name
     for name in TOP_LEVEL_QUICKSTART_GATE:
@@ -350,11 +375,12 @@ def test_compiler_tool_api_surface_boundary_discourages_broad_stability_signal()
         "Broad `comp.compiler_tool` imports are compatibility imports, not stable API signals.",
         "New users should treat this Stable public API section as the only default onboarding surface.",
         "Advanced and experimental names require explicit promotion before they become stable API.",
-        "A future narrow stable import surface may re-export only this section without breaking broad compatibility imports.",
+        "`comp.compiler_tool.stable` re-exports only this section without breaking broad compatibility imports.",
     ):
         assert line in api_doc
 
     assert "The README quickstart is the stable onboarding path." in readme
+    assert "from comp.compiler_tool.stable import" in readme
     assert (
         "`comp.compiler_tool.__all__` remains a broad compatibility surface, not a stable API signal."
         in readme


### PR DESCRIPTION
## Summary
- add `comp.compiler_tool.stable` as a narrow stable onboarding import surface
- move README quickstart and compiler-tool API examples to the stable import path
- keep broad `comp.compiler_tool` exports as compatibility/import-convenience while smoke tests lock `stable.__all__` to the documented stable API

## Tests
- `python -m pytest -q tests/test_package_smoke.py::test_compiler_tool_stable_import_surface_is_narrow_and_documented tests/test_package_smoke.py::test_readme_compiler_tool_quickstart_uses_required_public_path tests/test_package_smoke.py::test_readme_compiler_tool_quickstart_executes_receipt_gate_path tests/test_package_smoke.py::test_compiler_tool_api_surface_boundary_discourages_broad_stability_signal`
- `python -m pytest -q tests/test_package_smoke.py tests/test_authority_import_boundaries.py`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`
- `git diff --check`
- `git diff --cached --check`