### PR TITLE
[codex] define receipt authenticity boundary

### DIFF
--- a/docs/api/public-output-gate.md
+++ b/docs/api/public-output-gate.md
@@ -17,6 +17,11 @@ compiler reports, review packages, review decisions, replay reports, or product
 UI state. A public projection must pass through a clean
 `PublicOutputReceipt`.
 
+`docs/architecture/contracts/receipt-authenticity-boundary.md` defines the
+issuer/signature boundary for this gate. A receipt signature can verify issuer
+authenticity for the receipt body, but it does not replace receipt-gated
+projection or replay verification.
+
 ## Stable public API
 
 Use these names for public-output examples and package users:

--- a/docs/architecture/contracts/receipt-authenticity-boundary.md
+++ b/docs/architecture/contracts/receipt-authenticity-boundary.md
@@ -1,0 +1,196 @@
+# Receipt Authenticity Boundary
+
+Status: active-contract
+Owner: trust-kernel
+Last checked against code: 2026-05-27
+Can block PRs: yes
+
+This contract defines where issuer and signature semantics belong around
+`PublicOutputReceipt`.
+
+It does not add a cryptography dependency.
+It does not define a stable external wire format.
+It does not make product exports authoritative.
+It does not change replay into projection authority.
+
+The goal is narrower: prepare the issuer/signature model without confusing
+three separate checks that must stay separate.
+
+```text
+PublicOutputReceipt is projection authority.
+ReceiptSignature is issuer authenticity.
+ProjectionReplayReport is replay verification output.
+```
+
+## Core Rule
+
+`PublicOutputReceipt` remains the only public projection authority.
+
+A future signature layer can attest that a receipt body came from a known
+issuer and has not been changed since signing. That authenticity check is
+important, but it is not a second projection gate.
+
+Replay remains separate. Replay checks that the public row and receipt-cited
+artifact material still match the receipt. A valid signature does not prove
+that replay material is complete. A successful replay does not prove the
+receipt came from a known issuer.
+
+The boundary is:
+
+```text
+receipt authorizes projection
+signature verifies receipt issuer authenticity
+replay verifies receipt-cited material
+explanation renders replayable context
+```
+
+## Receipt Authenticity Concepts
+
+The issuer/signature layer should use explicit concepts when it is implemented:
+
+```text
+ReceiptIssuer
+  issuer_id
+  key_id
+  algorithm identifier
+
+ReceiptSignature
+  issuer_id
+  key_id
+  algorithm identifier
+  signed_body_digest
+  signature value
+
+ReceiptVerificationResult
+  status
+  issuer_id
+  key_id
+  signed_body_digest
+  errors
+```
+
+These names are boundary vocabulary until the code slice promotes them into a
+public API. They reserve the meaning of the layer; they do not require a real
+crypto library in the first implementation PR.
+
+## Signed Body
+
+The signed body must be the canonical receipt authority body, not a product
+wrapper and not a replay report.
+
+The signed body should cover:
+
+```text
+receipt identity
+public_row_id
+projection_id
+authorized_fields
+barrier_snapshot
+PublicOutputReceiptCitations
+projection value commitments
+dependency fingerprints
+```
+
+The signed body must not include:
+
+```text
+ProjectionReplayReport
+ReceiptProofGraph
+field explanations
+rendered views
+product export bundle wrapper
+product UI state
+product database rows
+materialized public row
+```
+
+The materialized public row is verified against the receipt by the projection
+gate and replay path. It is not the thing that defines receipt authenticity.
+
+## Verification API Direction
+
+The verification API should make authenticity status explicit instead of
+returning a bare boolean.
+
+Expected statuses:
+
+```text
+verified
+unsigned_legacy
+unknown_issuer
+invalid_signature
+unsupported_algorithm
+malformed_signature
+```
+
+`verify_public_output_receipt(receipt, key_registry)` is the intended shape,
+but the first code slice may use a wrapper or result type if that keeps legacy
+receipts compatible. The API must verify receipt authenticity only. It must not
+call `build_public_output(...)`, run replay, or inspect product bundle state.
+
+## Legacy Receipt Policy
+
+Unsigned legacy receipts remain replayable.
+
+Older receipt bodies without issuer/signature material must continue to round
+trip through persistence and replay unless their receipt-cited material fails
+normal replay checks. Authenticity verification should report them as
+`unsigned_legacy`, not as `invalid_signature`.
+
+Strict deployments may later reject unsigned legacy receipts at their product
+or policy boundary, but that is a deployment rule. The trust kernel must keep
+the distinction visible:
+
+```text
+unsigned legacy receipt
+  no issuer authenticity claim
+  may still authorize projection under legacy compatibility
+  may still replay if cited material is present and valid
+```
+
+## Product Export Boundary
+
+Product exports may carry replayable material, but comp produces replay verification output.
+
+A product app may export:
+
+```text
+public row
+PublicOutputReceipt
+receipt signature material, when available
+ArtifactEnvelope set
+optional explanation hints
+```
+
+The product app must not ask `comp` to trust a product-produced replay result
+as authority. `comp` can read exported replayable material and produce its own
+`ProjectionReplayReport`.
+
+Reviewers should reject changes that:
+
+```text
+treat a product replay report as comp verification
+sign a product bundle wrapper instead of the receipt authority body
+make a valid signature replace replay
+make a successful replay replace issuer authenticity verification
+make ReceiptSignature projection authority
+block all legacy replay only because a receipt is unsigned
+```
+
+## Migration And Test Expectations
+
+The code slice that implements this contract should add tests for:
+
+```text
+old unsigned receipt body still round-trips
+old unsigned receipt can still replay when artifacts are valid
+unsigned authenticity verification returns unsigned_legacy
+valid signed receipt returns verified
+unknown issuer returns unknown_issuer
+changed receipt body returns invalid_signature
+replay failure remains separate from signature failure
+```
+
+Real cryptographic verification can arrive after the contract shape exists. The
+first implementation may use a test verifier or key-registry protocol, but it
+must keep the signed body and status model compatible with this boundary.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,10 +41,11 @@ without explicitly updating the contract.
 6. `architecture/contracts/extension-port-contracts.md`
 7. `architecture/contracts/artifact-envelope-builder.md`
 8. `architecture/contracts/persistence-ledger-boundary.md`
-9. `architecture/contracts/receipt-proof-graph.md`
-10. `architecture/contracts/trust-kernel-hardening.md`
-11. `architecture/contracts/memory-assisted-compiler-loop.md`
-12. `architecture/contracts/friendly-authority-vocabulary.md`
+9. `architecture/contracts/receipt-authenticity-boundary.md`
+10. `architecture/contracts/receipt-proof-graph.md`
+11. `architecture/contracts/trust-kernel-hardening.md`
+12. `architecture/contracts/memory-assisted-compiler-loop.md`
+13. `architecture/contracts/friendly-authority-vocabulary.md`
 
 ### Implementation Maps
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -314,6 +314,9 @@ def test_readme_compiler_tool_quickstart_executes_receipt_gate_path():
 
 def test_public_output_gate_api_reference_is_documented():
     api_doc = Path("docs/api/public-output-gate.md").read_text(encoding="utf-8")
+    authenticity_doc = Path(
+        "docs/architecture/contracts/receipt-authenticity-boundary.md"
+    ).read_text(encoding="utf-8")
     compiler_tool_doc = Path("docs/api/compiler-tool.md").read_text(
         encoding="utf-8"
     )
@@ -325,6 +328,12 @@ def test_public_output_gate_api_reference_is_documented():
     assert "ValidationReport is not public-output authority" in api_doc
     assert "build_public_output(..., receipt=...)" in api_doc
     assert "materialized view, not authority" in api_doc
+    assert "receipt-authenticity-boundary.md" in api_doc
+    assert "PublicOutputReceipt is projection authority" in authenticity_doc
+    assert "ReceiptSignature is issuer authenticity" in authenticity_doc
+    assert "ProjectionReplayReport is replay verification output" in authenticity_doc
+    assert "Unsigned legacy receipts remain replayable" in authenticity_doc
+    assert "Product exports may carry replayable material, but comp produces replay verification output." in authenticity_doc
     for name in PUBLIC_OUTPUT_GATE_PUBLIC:
         assert hasattr(comp, name), name
         assert name in api_doc, name
@@ -1068,6 +1077,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "yes",
             "2026-05-22",
         ),
+        "receipt-authenticity-boundary.md": (
+            "active-contract",
+            "trust-kernel",
+            "yes",
+            "2026-05-27",
+        ),
         "retrieval-fabric-north-star.md": (
             "north-star",
             "retrieval",
@@ -1170,6 +1185,7 @@ def test_docs_index_groups_architecture_docs_by_governance_authority():
     assert "archive/architecture/active-surface-cutover.md" in docs_index
     assert "architecture/contracts/compiler-domain-boundary.md" in docs_index
     assert "architecture/contracts/artifact-lifecycle-boundary.md" in docs_index
+    assert "architecture/contracts/receipt-authenticity-boundary.md" in docs_index
     assert "architecture/contracts/policy-boundary.md" in docs_index
     assert "architecture/maps/policy-assembled-trust-kernel.md" in docs_index
     assert "architecture/maps/product-facade-observation.md" in docs_index


### PR DESCRIPTION
﻿## Summary
- add an active receipt authenticity boundary contract for issuer/signature semantics
- link the public-output gate API reference to that boundary
- extend smoke coverage so the new contract stays governed and authority-safe

## Boundary
- `PublicOutputReceipt` remains projection authority
- `ReceiptSignature` is issuer authenticity, not a second projection gate
- `ProjectionReplayReport` is comp-produced replay verification output
- unsigned legacy receipts remain replayable under compatibility policy

## Verification
- `python -m pytest -q tests/test_package_smoke.py::test_public_output_gate_api_reference_is_documented tests/test_package_smoke.py::test_governed_architecture_docs_have_valid_machine_readable_headers tests/test_package_smoke.py::test_governed_architecture_docs_match_index_and_lifecycle_location tests/test_package_smoke.py::test_architecture_docs_are_classified_by_governance_status tests/test_package_smoke.py::test_docs_index_groups_architecture_docs_by_governance_authority`
- `python -m pytest -q`
- `python -m tests.domain_scenarios run-all`
- `git diff --cached --check`
