### PR TITLE
[codex] map product facade conformance runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ product-facade-observation
   facade observation outside comp; it does not make `comp.runtime` a production runtime.
   It also tracks lab-only verification bundle fixtures and a fixture runner,
   not a CLI or stable wire contract.
+
+product-facade-conformance-runner
+  docs/architecture/maps/product-facade-conformance-runner.md positions the
+  fixture runner as a lab-only step toward scenario-style conformance, not a
+  product runtime, CLI, stable wire contract, or native authority engine.
 ```
 
 현재 policy 이행축은 broad framework를 한 번에 세우는 것이 아니다.

--- a/docs/architecture/maps/product-facade-conformance-runner.md
+++ b/docs/architecture/maps/product-facade-conformance-runner.md
@@ -1,0 +1,121 @@
+# Product Facade Conformance Runner Map
+
+Status: implementation-map
+Owner: scenario-lab
+Last checked against code: 2026-05-27
+Can block PRs: limited
+
+This map positions the next layer after the product facade verification-bundle
+observations.
+
+This map is a runner-direction map, not a runner contract. It does not define a
+CLI, stable wire contract, product runtime, native authority engine, or
+production cryptography integration.
+
+## Current Position
+
+The current product facade lab is an observation instrument under
+`examples/product_facade_lab`.
+
+```text
+product facade lab
+  submit / publish / audit surface
+  artifact touch logs
+  verification bundle export/write/verify helpers
+  checked-in bundle fixtures
+  optional ReceiptSignature authenticity observation
+
+fixture runner
+  run_fixture(...)
+  run_all_fixtures(...)
+  compact conformance results
+  no CLI surface
+
+scenario-style conformance runner
+  next possible layer
+  not implemented by the current lab
+```
+
+The current fixture runner proves that comp can read stored product-shaped
+material and produce verification output without constructing a
+`ProductFacadeRuntime`. It does not yet prove that a downstream product app has
+a stable export contract.
+
+## Layer Boundaries
+
+```text
+Production App
+  owns importers, OCR, UI, supplier workflow, product database rows,
+  product policy choices, and product-facing language.
+
+Comp-Compatible Verification Input
+  carries validation summary, public row, PublicOutputSpec shape,
+  PublicOutputReceipt, optional ReceiptSignature, ArtifactEnvelope material,
+  and omitted verification output markers.
+
+Lab Fixture Runner
+  reads checked-in lab fixture bundles.
+  returns compact conformance results for tests.
+  must remain lab-only until promotion criteria are met.
+
+Scenario-Style Conformance Runner
+  would run named product-shaped cases across fixture directories.
+  would compare expected verified/blocked/authenticity outcomes.
+  would still be an observation harness before stable export promotion.
+
+comp verifier
+  produces replay_status, receipt_authenticity_status, verification_errors,
+  and ProjectionReplayReport when verified.
+  does not trust product-generated replay reports.
+```
+
+The authority direction is one-way: product-shaped material is emitted or
+stored, then comp verifies it. The runner does not mint receipts, repair missing
+artifacts, or treat product replay reports as authority.
+
+## Promotion Path
+
+```text
+Fixture runner -> scenario-style conformance runner
+  allowed when multiple fixture cases need shared execution and reporting.
+  still not a CLI, stable bundle schema, or product runtime.
+
+Scenario-style runner -> shared behavioral contract
+  allowed when a downstream or product-shaped exporter can emit comparable
+  material without importing the lab runtime.
+
+Shared behavioral contract -> stable export contract
+  requires a separate active-contract PR after real consumers expose repeated
+  schema pressure and the lifecycle boundary remains intact.
+```
+
+Promotion must preserve the split between projection authority, replay
+verification, receipt authenticity, and product shell state.
+
+## Non-Promotions
+
+This direction does not promote:
+
+```text
+not a CLI
+not a stable wire contract
+not a product runtime
+not a native authority engine
+not production cryptography integration
+not a comp.runtime workflow shell
+not a product-generated replay report authority
+```
+
+## First PR Boundary
+
+The first PR on this axis should be a map or test guard only.
+
+```text
+No new command surface.
+No new bundle schema.
+No movement into `comp.runtime`.
+No trust in product-generated replay reports.
+```
+
+After that, a small scenario-style runner may be considered only if it consumes
+existing fixture material and keeps all verification output produced by comp.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ when the PR changes the mapped area but leaves the map stale.
 3. `architecture/maps/internal-execution-design-map.md`
 4. `architecture/maps/policy-assembled-trust-kernel.md`
 5. `architecture/maps/product-facade-observation.md`
+6. `architecture/maps/product-facade-conformance-runner.md`
 
 ### North Stars
 

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -889,6 +889,51 @@ def test_product_facade_observation_map_defines_lab_without_contracting_lifecycl
     assert "not a CLI or stable wire contract" in readme
 
 
+def test_product_facade_conformance_runner_map_positions_next_layer():
+    runner_map = Path(
+        "docs/architecture/maps/product-facade-conformance-runner.md"
+    ).read_text(encoding="utf-8")
+    docs_index = Path("docs/index.md").read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    for line in (
+        "Status: implementation-map",
+        "Owner: scenario-lab",
+        "Last checked against code: 2026-05-27",
+        "Can block PRs: limited",
+        "This map is a runner-direction map, not a runner contract.",
+        "## Current Position",
+        "product facade lab",
+        "fixture runner",
+        "scenario-style conformance runner",
+        "## Layer Boundaries",
+        "Production App",
+        "Comp-Compatible Verification Input",
+        "Lab Fixture Runner",
+        "Scenario-Style Conformance Runner",
+        "comp verifier",
+        "## Promotion Path",
+        "Fixture runner -> scenario-style conformance runner",
+        "Scenario-style runner -> shared behavioral contract",
+        "Shared behavioral contract -> stable export contract",
+        "## Non-Promotions",
+        "not a CLI",
+        "not a stable wire contract",
+        "not a product runtime",
+        "not a native authority engine",
+        "not production cryptography integration",
+        "## First PR Boundary",
+        "No new command surface.",
+        "No new bundle schema.",
+        "No movement into `comp.runtime`.",
+        "No trust in product-generated replay reports.",
+    ):
+        assert line in runner_map
+
+    assert "architecture/maps/product-facade-conformance-runner.md" in docs_index
+    assert "product-facade-conformance-runner" in readme
+
+
 def test_artifact_lifecycle_boundary_defines_state_transition_requirements():
     boundary_doc = Path(
         "docs/architecture/contracts/artifact-lifecycle-boundary.md"
@@ -1078,6 +1123,12 @@ def test_architecture_docs_are_classified_by_governance_status():
             "limited",
             "2026-05-27",
         ),
+        "product-facade-conformance-runner.md": (
+            "implementation-map",
+            "scenario-lab",
+            "limited",
+            "2026-05-27",
+        ),
         "persistence-ledger-boundary.md": (
             "active-contract",
             "persistence",
@@ -1214,6 +1265,7 @@ def test_docs_index_groups_architecture_docs_by_governance_authority():
     assert "architecture/contracts/policy-boundary.md" in docs_index
     assert "architecture/maps/policy-assembled-trust-kernel.md" in docs_index
     assert "architecture/maps/product-facade-observation.md" in docs_index
+    assert "architecture/maps/product-facade-conformance-runner.md" in docs_index
     assert "architecture/contracts/friendly-authority-vocabulary.md" in docs_index
     assert "archive/architecture/legacy-archive-cutover-plan.md" in docs_index
     assert "archive/architecture/llm-orchestrated-compiler-tool-loop.md" in docs_index


### PR DESCRIPTION
﻿## Summary
- add `product-facade-conformance-runner.md` as an implementation map for the next layer after the product facade bundle lab
- position the current fixture runner between product-shaped exports and a future scenario-style conformance runner
- document the promotion path from fixture runner to shared behavioral contract to stable export contract
- keep the guardrails explicit: no CLI, no stable wire contract, no product runtime, no native authority engine, and no trust in product-generated replay reports

## Boundary Notes
- this PR adds a map only; it does not add a command surface or bundle schema
- `comp` remains the verifier for replay and receipt authenticity outputs
- the product facade lab remains an observation instrument under `examples/product_facade_lab`

## Verification
- `python -m pytest -q` -> 595 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `git diff --cached --check` -> exit 0, line-ending warnings only
