### PR TITLE
[codex] add product facade case manifest runner

### DIFF
--- a/docs/architecture/maps/product-facade-conformance-runner.md
+++ b/docs/architecture/maps/product-facade-conformance-runner.md
@@ -32,14 +32,22 @@ fixture runner
   no CLI surface
 
 scenario-style conformance runner
-  next possible layer
-  not implemented by the current lab
+  conformance_cases.json
+  run_case_manifest(...)
+  run_conformance_cases(...)
+  lab-only case manifest
+  not a product export schema
 ```
 
 The current fixture runner proves that comp can read stored product-shaped
 material and produce verification output without constructing a
 `ProductFacadeRuntime`. It does not yet prove that a downstream product app has
 a stable export contract.
+
+The lab-only case manifest is the first step toward a scenario-style runner: it
+lists existing verification bundle fixtures and their expected replay and
+receipt-authenticity outcomes. It is not a new bundle schema and must not be
+read as a product export format.
 
 ## Layer Boundaries
 
@@ -59,9 +67,9 @@ Lab Fixture Runner
   must remain lab-only until promotion criteria are met.
 
 Scenario-Style Conformance Runner
-  would run named product-shaped cases across fixture directories.
-  would compare expected verified/blocked/authenticity outcomes.
-  would still be an observation harness before stable export promotion.
+  runs named product-shaped cases across fixture directories.
+  compares expected verified/blocked/authenticity outcomes.
+  remains an observation harness before stable export promotion.
 
 comp verifier
   produces replay_status, receipt_authenticity_status, verification_errors,
@@ -108,13 +116,16 @@ not a product-generated replay report authority
 
 ## First PR Boundary
 
-The first PR on this axis should be a map or test guard only.
+The first implementation PR on this axis should consume existing fixture
+material only.
 
 ```text
 No new command surface.
 No new bundle schema.
 No movement into `comp.runtime`.
 No trust in product-generated replay reports.
+lab-only case manifest
+not a product export schema
 ```
 
 After that, a small scenario-style runner may be considered only if it consumes

--- a/examples/product_facade_lab/README.md
+++ b/examples/product_facade_lab/README.md
@@ -86,6 +86,12 @@ stored product-shaped material still replays through comp without constructing a
 `ProductFacadeRuntime`. The fixture runner is not a CLI, production verifier, or
 stable bundle runner.
 
+`fixtures/conformance_cases.json` is a lab-only case manifest. It lists existing
+fixture bundles and their expected `replay_status` and
+`receipt_authenticity_status` values. `run_case_manifest(...)` reads that
+manifest, and `run_conformance_cases(...)` can run the same case shape from
+memory. The manifest is not a product export schema or stable wire contract.
+
 Verification bundle lab summary: the lab has observed export via
 `export_verification_bundle(...)`, file persistence via
 `write_verification_bundle(...)`, file verification via

--- a/examples/product_facade_lab/__init__.py
+++ b/examples/product_facade_lab/__init__.py
@@ -7,8 +7,12 @@ from examples.product_facade_lab.bundle import (
     verification_input_to_bundle,
 )
 from examples.product_facade_lab.runner import (
+    CONFORMANCE_CASES_SCHEMA_VERSION,
+    VerificationBundleCaseResult,
     VerificationBundleFixtureResult,
     run_all_fixtures,
+    run_case_manifest,
+    run_conformance_cases,
     run_fixture,
 )
 from examples.product_facade_lab.runtime import (
@@ -31,6 +35,7 @@ from examples.product_facade_lab.runtime import (
 __all__ = [
     "ArtifactTouchLog",
     "ArtifactTouchLogComparison",
+    "CONFORMANCE_CASES_SCHEMA_VERSION",
     "CompCompatibleVerificationInput",
     "CompVerificationOutput",
     "ProductAudit",
@@ -41,9 +46,12 @@ __all__ = [
     "ProductRequiredAction",
     "ProductRun",
     "ProductWitness",
+    "VerificationBundleCaseResult",
     "VerificationBundleFixtureResult",
     "compare_touch_logs",
     "run_all_fixtures",
+    "run_case_manifest",
+    "run_conformance_cases",
     "run_fixture",
     "verify_comp_compatible_input",
     "verify_verification_bundle",

--- a/examples/product_facade_lab/fixtures/conformance_cases.json
+++ b/examples/product_facade_lab/fixtures/conformance_cases.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "product_facade_conformance_cases.v0",
+  "cases": [
+    {
+      "case_id": "canonical_fixture_verified",
+      "bundle": "canonical_verification_bundle.json",
+      "expected_replay_status": "verified",
+      "expected_receipt_authenticity_status": "unsigned_legacy"
+    },
+    {
+      "case_id": "missing_artifact_fixture_blocked",
+      "bundle": "missing_artifact_verification_bundle.json",
+      "expected_replay_status": "blocked",
+      "expected_receipt_authenticity_status": "unsigned_legacy",
+      "expected_verification_error_contains": "Projection replay missing artifact"
+    }
+  ]
+}

--- a/examples/product_facade_lab/runner.py
+++ b/examples/product_facade_lab/runner.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import json
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from examples.product_facade_lab.bundle import verify_verification_bundle_file
 
+
+CONFORMANCE_CASES_SCHEMA_VERSION = "product_facade_conformance_cases.v0"
 
 FIXTURE_EXPECTED_REPLAY_STATUS = {
     "canonical_verification_bundle.json": "verified",
@@ -27,6 +32,39 @@ class VerificationBundleFixtureResult:
     @property
     def passed(self) -> bool:
         return self.replay_status == self.expected_replay_status
+
+
+@dataclass(frozen=True)
+class VerificationBundleCaseResult:
+    case_id: str
+    bundle_name: str
+    path: Path
+    expected_replay_status: str
+    replay_status: str
+    expected_receipt_authenticity_status: str
+    receipt_authenticity_status: str
+    expected_verification_error_contains: str | None
+    public_row_id: str
+    artifact_count: int
+    verification_errors: tuple[str, ...]
+    receipt_authenticity_errors: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        replay_matches = self.replay_status == self.expected_replay_status
+        authenticity_matches = (
+            self.receipt_authenticity_status
+            == self.expected_receipt_authenticity_status
+        )
+        return replay_matches and authenticity_matches and self._expected_error_matches()
+
+    def _expected_error_matches(self) -> bool:
+        if self.expected_verification_error_contains is None:
+            return True
+        return any(
+            self.expected_verification_error_contains in error
+            for error in self.verification_errors
+        )
 
 
 def run_fixture(
@@ -58,7 +96,39 @@ def run_all_fixtures(
     root = Path(fixture_dir)
     return tuple(
         run_fixture(path, key_registry=key_registry)
-        for path in sorted(root.glob("*.json"))
+        for path in sorted(root.glob("*_verification_bundle.json"))
+    )
+
+
+def run_case_manifest(
+    path: str | Path,
+    *,
+    key_registry=None,
+) -> tuple[VerificationBundleCaseResult, ...]:
+    manifest_path = Path(path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != CONFORMANCE_CASES_SCHEMA_VERSION:
+        raise ValueError(
+            "Product facade conformance case manifest must use "
+            f"{CONFORMANCE_CASES_SCHEMA_VERSION}."
+        )
+    return run_conformance_cases(
+        manifest["cases"],
+        fixture_dir=manifest_path.parent,
+        key_registry=key_registry,
+    )
+
+
+def run_conformance_cases(
+    cases: Iterable[Mapping[str, Any]],
+    *,
+    fixture_dir: str | Path = Path(__file__).with_name("fixtures"),
+    key_registry=None,
+) -> tuple[VerificationBundleCaseResult, ...]:
+    root = Path(fixture_dir)
+    return tuple(
+        _run_conformance_case(case, fixture_dir=root, key_registry=key_registry)
+        for case in cases
     )
 
 
@@ -69,8 +139,67 @@ def _expected_replay_status(path: Path) -> str:
         raise ValueError(f"Unknown product facade bundle fixture: {path.name}") from exc
 
 
+def _run_conformance_case(
+    case: Mapping[str, Any],
+    *,
+    fixture_dir: Path,
+    key_registry,
+) -> VerificationBundleCaseResult:
+    _reject_product_generated_replay_report(case)
+    bundle_path = _bundle_path(case["bundle"], fixture_dir=fixture_dir)
+    output = verify_verification_bundle_file(bundle_path, key_registry=key_registry)
+    return VerificationBundleCaseResult(
+        case_id=str(case["case_id"]),
+        bundle_name=bundle_path.name,
+        path=bundle_path,
+        expected_replay_status=str(case["expected_replay_status"]),
+        replay_status=output.replay_status,
+        expected_receipt_authenticity_status=str(
+            case["expected_receipt_authenticity_status"]
+        ),
+        receipt_authenticity_status=output.receipt_authenticity_status,
+        expected_verification_error_contains=_optional_string(
+            case.get("expected_verification_error_contains")
+        ),
+        public_row_id=output.public_row_id,
+        artifact_count=output.artifact_count,
+        verification_errors=output.verification_errors,
+        receipt_authenticity_errors=output.receipt_authenticity_errors,
+    )
+
+
+def _bundle_path(bundle: object, *, fixture_dir: Path) -> Path:
+    path = Path(str(bundle))
+    if path.is_absolute():
+        return path
+    return fixture_dir / path
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _reject_product_generated_replay_report(case: Mapping[str, Any]) -> None:
+    forbidden = {
+        "expected_projection_replay_report",
+        "projection_replay_report",
+        "replay_report",
+    }
+    if forbidden.intersection(case):
+        raise ValueError(
+            "Product facade conformance cases must not include "
+            "product-generated replay reports."
+        )
+
+
 __all__ = [
+    "CONFORMANCE_CASES_SCHEMA_VERSION",
+    "VerificationBundleCaseResult",
     "VerificationBundleFixtureResult",
     "run_all_fixtures",
+    "run_case_manifest",
+    "run_conformance_cases",
     "run_fixture",
 ]

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -906,6 +906,9 @@ def test_product_facade_conformance_runner_map_positions_next_layer():
         "product facade lab",
         "fixture runner",
         "scenario-style conformance runner",
+        "conformance_cases.json",
+        "run_case_manifest(...)",
+        "run_conformance_cases(...)",
         "## Layer Boundaries",
         "Production App",
         "Comp-Compatible Verification Input",
@@ -927,6 +930,8 @@ def test_product_facade_conformance_runner_map_positions_next_layer():
         "No new bundle schema.",
         "No movement into `comp.runtime`.",
         "No trust in product-generated replay reports.",
+        "lab-only case manifest",
+        "not a product export schema",
     ):
         assert line in runner_map
 

--- a/tests/test_product_facade_bundle_fixtures.py
+++ b/tests/test_product_facade_bundle_fixtures.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from examples.product_facade_lab.runner import run_all_fixtures, run_fixture
+from examples.product_facade_lab.runner import (
+    run_all_fixtures,
+    run_case_manifest,
+    run_conformance_cases,
+    run_fixture,
+)
 
 
 FIXTURE_DIR = Path("examples/product_facade_lab/fixtures")
@@ -52,6 +57,70 @@ def test_run_all_fixtures_reports_compact_conformance_results():
     assert all(result.passed for result in results)
 
 
+def test_case_manifest_runs_named_fixture_expectations():
+    results = run_case_manifest(FIXTURE_DIR / "conformance_cases.json")
+
+    assert tuple(result.case_id for result in results) == (
+        "canonical_fixture_verified",
+        "missing_artifact_fixture_blocked",
+    )
+    assert tuple(result.bundle_name for result in results) == (
+        "canonical_verification_bundle.json",
+        "missing_artifact_verification_bundle.json",
+    )
+    assert tuple(result.replay_status for result in results) == (
+        "verified",
+        "blocked",
+    )
+    assert tuple(result.receipt_authenticity_status for result in results) == (
+        "unsigned_legacy",
+        "unsigned_legacy",
+    )
+    assert all(result.passed for result in results)
+    assert "Projection replay missing artifact" in results[1].verification_errors[0]
+
+
+def test_run_conformance_cases_accepts_in_memory_case_definitions():
+    cases = (
+        {
+            "case_id": "canonical_inline",
+            "bundle": "canonical_verification_bundle.json",
+            "expected_replay_status": "verified",
+            "expected_receipt_authenticity_status": "unsigned_legacy",
+        },
+    )
+
+    results = run_conformance_cases(cases, fixture_dir=FIXTURE_DIR)
+
+    assert len(results) == 1
+    assert results[0].case_id == "canonical_inline"
+    assert results[0].passed is True
+    assert results[0].public_row_id == "public-row-fixture-canonical"
+
+
 def test_unknown_bundle_fixture_requires_explicit_expectation():
     with pytest.raises(ValueError, match="Unknown product facade bundle fixture"):
         run_fixture(FIXTURE_DIR / "new_unclassified_fixture.json")
+
+
+def test_case_manifest_rejects_product_generated_replay_reports(tmp_path):
+    manifest = tmp_path / "cases.json"
+    manifest.write_text(
+        """{
+  "schema_version": "product_facade_conformance_cases.v0",
+  "cases": [
+    {
+      "case_id": "bad_case",
+      "bundle": "canonical_verification_bundle.json",
+      "expected_replay_status": "verified",
+      "expected_receipt_authenticity_status": "unsigned_legacy",
+      "expected_projection_replay_report": "product-owned"
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="product-generated replay reports"):
+        run_case_manifest(manifest)


### PR DESCRIPTION
﻿## Summary
- add a lab-only `conformance_cases.json` manifest for product facade verification bundle fixtures
- add `run_case_manifest(...)` and `run_conformance_cases(...)` to execute named fixture cases and compare expected replay/authenticity outcomes
- keep `run_all_fixtures(...)` focused on `*_verification_bundle.json` files so manifests are not treated as bundles
- document that the case manifest is not a product export schema, CLI, stable wire contract, or product-generated replay report authority

## Boundary Notes
- this consumes existing fixture material only; it does not add a command surface or stable bundle schema
- comp remains the verifier for `replay_status`, `receipt_authenticity_status`, and replay reports
- product-generated replay reports are rejected from manifest cases

## Verification
- `python -m pytest -q tests/test_product_facade_bundle_fixtures.py tests/test_package_smoke.py::test_product_facade_conformance_runner_map_positions_next_layer` -> 8 passed
- `python -m pytest -q` -> 598 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> Passed: 18/18
- `git diff --check` / `git diff --cached --check` -> exit 0, line-ending warnings only
