### PR TITLE
[codex] define document authority lifecycle checks

### DIFF
--- a/docs/architecture/document-governance.md
+++ b/docs/architecture/document-governance.md
@@ -2,8 +2,24 @@
 
 Status: active-contract
 Owner: trust-kernel
-Last checked against code: 2026-05-22
+Last checked against code: 2026-05-28
 Can block PRs: yes
+
+Checked anchors:
+- doc: docs/architecture/document-governance.md
+- doc: docs/index.md
+- test: tests/test_package_smoke.py::test_document_governance_defines_authority_lifecycle_locations
+- test: tests/test_doc_lifecycle.py
+
+Freshness triggers:
+- governed architecture document header rules change
+- docs/index.md architecture routing changes
+- tests/test_package_smoke.py governance expectations change
+- tests/test_doc_lifecycle.py lifecycle gate behavior changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit future, promotion, open-question, or historical sections
 
 This document defines how architecture documents gain or lose authority in the
 `comp` rebuild. Its goal is to keep docs useful as constraints without letting
@@ -110,6 +126,91 @@ Can block PRs: yes | limited | no
 `Last checked against code` means a human or agent compared the document against
 the code shape on that date. It is not a promise that the document will remain
 fresh forever.
+
+## Document Authority Lifecycle
+
+A governed document may be useful as current authority, a current implementation
+map, future direction, or historical context.
+
+A document that claims current guidance should carry enough evidence for a
+reviewer to know what was checked. A document that describes future work should
+isolate that language under an explicit future, promotion, open-question, or
+historical section. A historical document must not be cited as current guidance.
+
+This lifecycle is a review aid, not a second authority source over code. Its job
+is to keep helpful documents trustworthy without making every small PR perform a
+full-document refresh.
+
+## Checked Anchors
+
+`Checked anchors` list the code, tests, or docs that were checked when the
+document was last refreshed.
+
+Use this item format:
+
+```text
+- code: comp/runtime/validation_handoff.py
+- test: tests/test_policy_boundary.py
+- test: tests/test_package_smoke.py::test_document_governance_defines_authority_lifecycle_locations
+- doc: docs/api/compiler-tool.md
+```
+
+Anchors are not proof that the document will stay fresh. They are a review aid
+and a future stale-detection hook.
+
+Existing documents may adopt checked anchors incrementally. New or meaningfully
+updated governed documents should add them when the document claims current
+guidance.
+
+## Freshness Triggers
+
+`Freshness triggers` name the code paths, tests, public surfaces, or external
+state changes that should cause a reviewer to re-check the document.
+
+A trigger does not automatically make a PR invalid. It tells reviewers when a
+document may need refresh, confirmation, or demotion.
+
+## Body Freshness Rules
+
+Status controls how much current-state evidence a document should carry:
+
+```text
+active-contract
+  states current invariants, prohibitions, authority boundaries, and blocking
+  rules. Planning language belongs only in explicit future or promotion sections.
+
+implementation-map
+  tracks the current implementation shape, mapped paths, mapped tests, known
+  gaps, and promotion paths. Current-state sections should not read like an
+  unlanded plan.
+
+north-star
+  may discuss direction and candidates. Landed work should move into an
+  implemented or current-status section, or into an implementation map.
+
+historical-note
+  preserves context. It must not be cited as current guidance.
+```
+
+## Document Change Definition of Done
+
+A PR that changes governed architecture meaning should update, or explicitly
+confirm no update is needed for:
+
+```text
+1. The governed document body.
+2. The required header.
+3. Checked anchors.
+4. Freshness triggers.
+5. docs/index.md when document routing changes.
+6. Smoke or lifecycle tests when authority rules change.
+7. Related API docs or README authority surfaces when public import or
+   user-facing guidance changes.
+```
+
+A code PR that changes a declared checked anchor or freshness trigger should
+either update the governed document, refresh its checked date with an explicit
+no-drift note, or explain why the document is no longer current guidance.
 
 ## Location Rules
 

--- a/docs/archive/architecture/active-surface-cutover.md
+++ b/docs/archive/architecture/active-surface-cutover.md
@@ -5,6 +5,8 @@ Owner: docs
 Last checked against code: 2026-05-20
 Can block PRs: no
 
+Historical note. This document cannot block PRs and must not be cited as current guidance.
+
 이 문서는 rebuild branch에서 **active package surface**를 legacy pipeline에서 judgment/compiler-tool loop 중심으로 전환하는 첫 번째 cutover 기준을 정의한다.
 
 이 문서의 목적은 legacy 파일을 즉시 삭제하는 것이 아니다. 목적은 다음을 명확히 하는 것이다.

--- a/docs/archive/architecture/legacy-archive-cutover-plan.md
+++ b/docs/archive/architecture/legacy-archive-cutover-plan.md
@@ -5,6 +5,8 @@ Owner: docs
 Last checked against code: 2026-05-20
 Can block PRs: no
 
+Historical note. This document cannot block PRs and must not be cited as current guidance.
+
 This document defines the PR sequence for moving `comp` from the legacy
 pass-pipeline surface toward the authority-first compiler-tool architecture.
 

--- a/docs/archive/architecture/llm-orchestrated-compiler-tool-loop.md
+++ b/docs/archive/architecture/llm-orchestrated-compiler-tool-loop.md
@@ -5,6 +5,8 @@ Owner: agent-layer
 Last checked against code: 2026-05-20
 Can block PRs: no
 
+Historical note. This document cannot block PRs and must not be cited as current guidance.
+
 이 문서는 `comp`의 장기 방향 중 하나인 **LLM 주도 해석 루프와 compiler tool 검증 구조**를 계획 수준에서 고정한다.
 
 핵심 아이디어는 컴파일러가 전체 루프를 직접 주도하는 것이 아니라, **LLM agent가 컴파일러를 하나의 tool로 반복 호출하면서 해석을 안정화한다**는 점이다.

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+
+ANCHOR_PREFIXES = ("code:", "test:", "doc:")
+HISTORICAL_NON_CURRENT_GUIDANCE = (
+    "Historical note. This document cannot block PRs and must not be cited as "
+    "current guidance."
+)
+STALE_PHRASES = (
+    "first PR",
+    "first slice",
+    "upcoming",
+    "should eventually",
+    "can be migrated",
+    "future implementation",
+)
+STRICT_CURRENT_HEADINGS = {
+    "Current Architecture",
+    "Current Position",
+    "Current Implementation Status",
+    "Core Rule",
+    "Authority Boundary",
+    "State Transition Requirements",
+}
+
+
+def _governed_architecture_docs():
+    governed_dirs = (
+        Path("docs/architecture"),
+        Path("docs/architecture/contracts"),
+        Path("docs/architecture/maps"),
+        Path("docs/architecture/north-stars"),
+        Path("docs/archive/architecture"),
+    )
+    return sorted(path for directory in governed_dirs for path in directory.glob("*.md"))
+
+
+def _doc_header(path):
+    header = {}
+    for line in path.read_text(encoding="utf-8").splitlines()[:8]:
+        if ": " in line:
+            key, value = line.split(": ", 1)
+            header[key] = value
+    return header
+
+
+def _list_block(text, title):
+    lines = text.splitlines()
+    start = f"{title}:"
+    for index, line in enumerate(lines):
+        if line.strip() != start:
+            continue
+        items = []
+        for item in lines[index + 1 :]:
+            stripped = item.strip()
+            if not stripped:
+                break
+            if not stripped.startswith("- "):
+                break
+            items.append(stripped[2:].strip())
+        return tuple(items)
+    return ()
+
+
+def _local_anchor_path(target):
+    path = target.strip().strip("`")
+    return path.split("::", 1)[0]
+
+
+def _sections(text):
+    current_heading = None
+    body = []
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if current_heading is not None:
+                yield current_heading, "\n".join(body)
+            current_heading = line.removeprefix("## ").strip()
+            body = []
+            continue
+        body.append(line)
+    if current_heading is not None:
+        yield current_heading, "\n".join(body)
+
+
+def test_checked_anchors_point_to_existing_paths_when_declared():
+    docs_with_anchors = []
+
+    for path in _governed_architecture_docs():
+        text = path.read_text(encoding="utf-8")
+        anchors = _list_block(text, "Checked anchors")
+        if not anchors:
+            continue
+        docs_with_anchors.append(path)
+
+        for anchor in anchors:
+            matching_prefixes = [
+                prefix for prefix in ANCHOR_PREFIXES if anchor.startswith(prefix)
+            ]
+            assert len(matching_prefixes) == 1, f"{path}: invalid anchor {anchor!r}"
+            target = anchor.split(":", 1)[1].strip()
+            anchor_path = _local_anchor_path(target)
+            assert Path(anchor_path).exists(), f"{path}: missing anchor {target!r}"
+
+    assert Path("docs/architecture/document-governance.md") in docs_with_anchors
+
+
+def test_strict_current_sections_do_not_use_known_stale_phrases_when_policy_declared():
+    docs_with_policy = []
+
+    for path in _governed_architecture_docs():
+        text = path.read_text(encoding="utf-8")
+        if "Stale-language policy:" not in text:
+            continue
+        docs_with_policy.append(path)
+
+        for heading, body in _sections(text):
+            if heading not in STRICT_CURRENT_HEADINGS:
+                continue
+            lowered_body = body.lower()
+            for phrase in STALE_PHRASES:
+                assert phrase.lower() not in lowered_body, (
+                    f"{path}:{heading} uses stale phrase {phrase!r}"
+                )
+
+    assert Path("docs/architecture/document-governance.md") in docs_with_policy
+
+
+def test_historical_notes_declare_they_are_not_current_guidance():
+    for path in _governed_architecture_docs():
+        header = _doc_header(path)
+        if header.get("Status") != "historical-note":
+            continue
+
+        text = path.read_text(encoding="utf-8")
+        assert HISTORICAL_NON_CURRENT_GUIDANCE in text, path

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1062,7 +1062,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "trust-kernel",
             "yes",
-            "2026-05-22",
+            "2026-05-28",
         ),
         "compiler-domain-boundary.md": (
             "active-contract",


### PR DESCRIPTION
## Summary
- Extend document governance with Document Authority Lifecycle rules, checked anchors, freshness triggers, body freshness guidance, and a document-change Definition of Done.
- Add opt-in lifecycle tests for checked anchor path validity, stale phrase checks in declared strict current sections, and historical-note non-current guidance disclaimers.
- Mark archived architecture notes as non-current guidance and update the governance checked-date smoke expectation.

## Why
The existing governance layer guarded document headers, location, and index inclusion, but did not provide a lightweight way to show what made a document safe to cite as current guidance. This adds a small ratcheting layer without forcing every governed document to refresh in one PR.

## Validation
- `python -m pytest tests/test_doc_lifecycle.py -q` -> `3 passed`
- `python -m pytest tests/test_package_smoke.py -q` -> `47 passed`
- `python -m pytest -q` -> `605 passed, 13 skipped`