### PR TITLE
[codex] refresh stale current guidance maps

### DIFF
--- a/docs/architecture/contracts/policy-boundary.md
+++ b/docs/architecture/contracts/policy-boundary.md
@@ -2,8 +2,24 @@
 
 Status: active-contract
 Owner: trust-kernel
-Last checked against code: 2026-05-26
+Last checked against code: 2026-05-28
 Can block PRs: yes
+
+Checked anchors:
+- code: comp/policy/boundary.py
+- code: comp/runtime/validation_handoff.py
+- test: tests/test_policy_boundary_vocabulary.py
+- test: tests/test_validation_handoff.py
+
+Freshness triggers:
+- comp.policy boundary vocabulary or digest behavior changes
+- comp.runtime.ValidationHandoff bridge behavior changes
+- selected validation contract target snapshot matching changes
+- policy boundary smoke expectations change
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit future, non-requirement, or promotion sections
 
 This contract defines the security boundary between external material and
 compiler-facing validation input.
@@ -214,12 +230,13 @@ strategies must obey.
 
 ## Current Implementation Status
 
-This document defines a boundary contract for upcoming policy work.
+This document defines the current boundary contract for policy-shaped material
+before compiler validation.
 
 Not every term in this document is currently a public Python API. Until
 implemented, these terms are architectural contract vocabulary.
 
-The first implementation slices live in `comp.policy`. They expose
+The current implementation slices live in `comp.policy`. They expose
 `MaterialDescriptor`, `PolicyEffect`, `ConflictResolver`, `PolicyAssembly`,
 `ScopedGrant`, `SelectionDecision`, `DecisionLedger`,
 `SelectedValidationContract`, and `ShadowPolicyComparison` as pre-validation
@@ -243,6 +260,6 @@ reference-selection, resolver-task, and profile/schema selection-tier surfaces
 remain precursor surfaces. They are not the full policy boundary
 implementation.
 
-New implementation slices should start small. A first slice should prefer
-policy effects, conflict resolution, scoped pipeline grants, decision-ledger
-records, and selected validation contracts over broad policy taxonomies.
+Additional implementation slices should stay small and prefer policy effects,
+conflict resolution, scoped pipeline grants, decision-ledger records, and
+selected validation contracts over broad policy taxonomies.

--- a/docs/architecture/maps/domain-scenario-pack-generation.md
+++ b/docs/architecture/maps/domain-scenario-pack-generation.md
@@ -2,8 +2,25 @@
 
 Status: implementation-map
 Owner: scenario-lab
-Last checked against code: 2026-05-21
+Last checked against code: 2026-05-28
 Can block PRs: limited
+
+Checked anchors:
+- code: tests/domain_scenarios/core.py
+- code: tests/domain_scenarios/registry.py
+- code: tests/domain_scenarios/tiny_pcf/scenario.py
+- code: tests/domain_scenarios/l_energy_pcf_governance/scenario.py
+- test: tests/test_domain_scenario_lab.py
+
+Freshness triggers:
+- tests/domain_scenarios registry or ScenarioDefinition shape changes
+- l_energy_pcf_governance scenario coverage changes
+- tiny_pcf scenario residency or registration changes
+- domain scenario contract assertion behavior changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under review, known-gap, or promotion sections
 
 This document defines how to add larger domain scenarios without turning them
 into hard-coded golden blobs. A scenario is not a one-off test file. It is a
@@ -83,9 +100,9 @@ tests/domain_scenarios/
     expected.py
 ```
 
-The current `tiny_pcf` module predates the registry layer and can be migrated
-incrementally. New scenarios should be written as if they are packs, even before
-the shared registry exists.
+The current `tiny_pcf` module is registered through the shared scenario registry
+and exposes a `ScenarioDefinition`. New scenarios should keep that explicit,
+reviewable registration shape.
 
 ---
 
@@ -260,7 +277,7 @@ ScenarioDefinition
 -> optional viewer payload
 ```
 
-The tests should eventually look like:
+The shared contract tests follow this shape:
 
 ```python
 @pytest.mark.parametrize("scenario", registered_scenarios())
@@ -277,10 +294,10 @@ should be deliberate, versioned, and reviewable.
 
 ## L-Energy PCF Governance Pack
 
-The next large scenario should use `minntcho/esg-platform` case
-`001-l-energy-pcf-governance` as its source. The first pack should not implement
-a full PCF SaaS workflow. It should prove that the platform case can be
-represented as `comp` authority artifacts.
+The internal L-Energy scenario pack uses `minntcho/esg-platform` case
+`001-l-energy-pcf-governance` as its source. The pack does not implement a full
+PCF SaaS workflow. It proves that the platform case can be represented as
+`comp` authority artifacts.
 
 Recommended first contract:
 
@@ -310,11 +327,10 @@ summary:
   kgco2e_per_kwh = 26.66
 ```
 
-The first implementation may use precomputed derived claims from the platform
-receipt. That is acceptable if the pack clearly labels them as fixture-derived
-claims and still verifies receipt-gated projection.
+The current implementation uses fixture-derived values where needed and keeps
+them labeled as scenario material while still verifying receipt-gated projection.
 
-Non-goals for the first L-Energy pack:
+Non-goals for the current L-Energy pack:
 
 ```text
 No economic allocation engine.
@@ -347,14 +363,15 @@ fixtures.
 
 ---
 
-## Suggested Work Order
+## Implemented Work Order
 
 ```text
-1. Add ScenarioDefinition / ScenarioContract / SourceRef test-support models.
-2. Migrate tiny_pcf to the shared registry without changing its behavior.
-3. Add l_energy_pcf_governance as a source-referenced scenario pack.
-4. Add targeted contract assertions for receipt trace completeness.
-5. Add optional static viewer payload only after contracts are stable.
+1. ScenarioDefinition / ScenarioContract / SourceRef test-support models exist.
+2. tiny_pcf is registered without changing its behavior.
+3. l_energy_pcf_governance is a source-referenced scenario pack.
+4. Registered scenarios run through shared contract assertions.
+5. Optional viewer payloads remain observation material.
 ```
 
-The order matters. First create the slot, then plug in the larger scenario.
+The ordering still matters for new packs: create the explicit slot, then plug in
+the larger scenario.

--- a/docs/architecture/maps/obligation-kernel-working-theory.md
+++ b/docs/architecture/maps/obligation-kernel-working-theory.md
@@ -2,8 +2,24 @@
 
 Status: implementation-map
 Owner: trust-kernel
-Last checked against code: 2026-05-20
+Last checked against code: 2026-05-28
 Can block PRs: limited
+
+Checked anchors:
+- code: comp/compiler_tool/retrieval.py
+- code: comp/compiler_tool/resolver_retrieval.py
+- code: comp/compiler_tool/profiles.py
+- test: tests/test_resolver_retrieval.py
+
+Freshness triggers:
+- retrieval lens, ReferenceQuery, or ReferenceResolver behavior changes
+- resolver retrieval policy builder behavior changes
+- CompilerProfile or DomainPack retrieval policy fields change
+- resolver retrieval tests add or remove authority-boundary guarantees
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under open-question, revision, or remaining-work sections
 
 This document captures the current direction for the rebuild branch after the
 receipt-gated projection slice. It is intentionally not an ADR. The goal is to
@@ -926,25 +942,10 @@ domain scenarios
 
 ---
 
-## 14. Retrieval Implementation Slice
+## 14. Retrieval Implementation Status
 
-The retrieval north star should enter the codebase in small slices. The first
-slice is:
-
-```text
-feat: add retrieval lens interface and embedding resolver stub
-```
-
-Purpose:
-
-```text
-Turn the retrieval north star into a small deterministic interface.
-Keep embedding as candidate recall, not authority.
-Let obligations choose a retrieval lens before candidate generation.
-Preserve the ReferenceOption != CanonicalReference boundary.
-```
-
-Candidate deliverables:
+The retrieval north star has entered the codebase as deterministic, candidate-only
+interfaces:
 
 ```text
 ReferenceQuery
@@ -962,73 +963,25 @@ Lens names:
   memory/skill
 ```
 
-Acceptance criteria:
-
-```text
-Retrieval lens interface can return candidate_only artifacts.
-EmbeddingResolverStub can produce deterministic candidates for tests.
-Retrieval score is never enough to create CanonicalReference.
-Top-1 retrieval cannot authorize calculation.
-No vector DB dependency is introduced.
-No real LLM call is introduced.
-```
-
-The bridge slice is:
-
-```text
-feat: add retrieval resolver bridge
-```
-
-Purpose:
-
-```text
-Connect reference_search_required obligations to ReferenceResolver.search.
-Add candidate_only ReferenceOption artifacts to ValidationReport.
-Resolve only the search obligation, not calculation or publication authority.
-Leave CanonicalReference to deterministic reference selection.
-Leave CalculatedClaim to deterministic calculation retry.
-```
-
-Acceptance criteria:
+The retrieval resolver bridge connects `reference_search_required` obligations to
+`ReferenceResolver.search(...)` and records candidate-only `ReferenceOption`
+artifacts on `ValidationReport`. It must resolve only the search obligation; it
+does not create `CanonicalReference`, `CalculatedClaim`, or public projection
+authority.
 
 ```text
 ValidationRequirement(reference_search_required)
 -> ReferenceQuery
 -> ReferenceResolver.search(...)
 -> ValidationReport.reference_options
-
-No CanonicalReference is created by retrieval.
-No CalculatedClaim is created by retrieval.
-No public projection authority is created by retrieval.
-No vector DB dependency is introduced.
-No real LLM call is introduced.
 ```
 
-The profile-pinning slice is:
+Profile-pinned retrieval query policies are part of the current profile behavior
+lock. `DomainPack` declares retrieval query policies, `CompilerProfile` activates
+them by id, unknown active ids are rejected during profile validation, and
+profile-aware query builders reject inactive policy ids.
 
-```text
-feat: pin retrieval query policies in CompilerProfile
-```
-
-Purpose:
-
-```text
-Make RetrievalQueryPolicy part of the active profile behavior lock.
-Reject unknown active retrieval policy ids during profile validation.
-Let resolver query builders use only profile-active retrieval policies.
-Keep retrieved candidates non-authoritative until deterministic selection.
-```
-
-Acceptance criteria:
-
-```text
-DomainPack can declare retrieval query policies.
-CompilerProfile can activate retrieval query policies by id and order.
-Unknown or duplicate retrieval policy ids are rejected.
-Profile-aware query builders reject inactive policy ids.
-```
-
-Non-goals:
+Current non-goals:
 
 ```text
 No production embedding model.
@@ -1039,7 +992,7 @@ No retrieval staging area implementation.
 No UI viewer yet.
 ```
 
-Future retrieval work can then add:
+Remaining retrieval work can add:
 
 ```text
 near-miss / negative retrieval fixtures

--- a/docs/architecture/maps/product-facade-conformance-runner.md
+++ b/docs/architecture/maps/product-facade-conformance-runner.md
@@ -2,8 +2,24 @@
 
 Status: implementation-map
 Owner: scenario-lab
-Last checked against code: 2026-05-27
+Last checked against code: 2026-05-28
 Can block PRs: limited
+
+Checked anchors:
+- code: examples/product_facade_lab/runner.py
+- code: examples/product_facade_lab/runtime.py
+- code: examples/product_facade_lab/fixtures/conformance_cases.json
+- test: tests/test_product_facade_bundle_fixtures.py
+
+Freshness triggers:
+- examples/product_facade_lab runner behavior changes
+- conformance case manifest shape changes
+- verification bundle suite summary behavior changes
+- receipt authenticity observation behavior changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under promotion or non-promotion sections
 
 This map positions the next layer after the product facade verification-bundle
 observations.
@@ -129,10 +145,9 @@ not a comp.runtime workflow shell
 not a product-generated replay report authority
 ```
 
-## First PR Boundary
+## Current Lab Boundary
 
-The first implementation PR on this axis should consume existing fixture
-material only.
+The current lab boundary consumes existing fixture material only.
 
 ```text
 No new command surface.
@@ -143,5 +158,5 @@ lab-only case manifest
 not a product export schema
 ```
 
-After that, a small scenario-style runner may be considered only if it consumes
-existing fixture material and keeps all verification output produced by comp.
+Promotion beyond this lab boundary may proceed only if it consumes existing
+fixture material and keeps all verification output produced by comp.

--- a/docs/architecture/north-stars/scenario-trust-runtime-bridge.md
+++ b/docs/architecture/north-stars/scenario-trust-runtime-bridge.md
@@ -2,15 +2,31 @@
 
 Status: north-star
 Owner: scenario-lab
-Last checked against code: 2026-05-22
+Last checked against code: 2026-05-28
 Can block PRs: limited
+
+Checked anchors:
+- code: comp/scenario_contracts/runner.py
+- code: comp/runtime/trust_runtime.py
+- code: comp/cli/scenario.py
+- test: tests/test_scenario_contracts.py
+
+Freshness triggers:
+- comp/scenario_contracts public imports or manifest behavior changes
+- comp/runtime/trust_runtime.py accepted input or invariant behavior changes
+- comp/cli/scenario.py command surface changes
+- external scenario packs need new public comp surfaces
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under goal, review, open-question, or promotion sections
 
 This document sketches the public bridge that external scenario packs should use
 when they need to pressure-test `comp` without importing `tests.*` or turning the
 trust kernel into a product workflow engine.
 
-It is a direction document for the scenario-runtime bridge. The first
-implementation slice is intentionally small and should not be treated as a final
+It is a direction document for the scenario-runtime bridge. The implemented
+public bridge is intentionally small and should not be treated as a final
 scenario pack API.
 
 The stable boundary is:
@@ -74,9 +90,9 @@ Those capabilities may exist in downstream products or external scenario packs.
 They may prepare inputs for `comp`, but they must not become responsibilities of
 the trust kernel.
 
-## 3. Proposed Public Surface
+## 3. Current Public Surface
 
-The first public bridge can be small:
+The current public bridge is deliberately small:
 
 ```text
 comp/scenario_contracts/
@@ -94,18 +110,19 @@ comp/cli/
   scenario.py
 ```
 
-The intended user-facing imports are:
+The current user-facing imports are:
 
 ```python
 from comp.scenario_contracts import ScenarioManifest, RuntimeCase
 from comp.scenario_contracts import ScenarioResult, run_scenario
 ```
 
-The intended CLI shape is:
+The current CLI shape is:
 
 ```bash
 comp scenario validate path/to/scenario.yaml
 comp scenario run path/to/scenario.yaml --report reports/latest.json
+comp scenario init path/to/output-dir
 ```
 
 `comp scenario run` should execute the trust path only. It should not execute
@@ -304,8 +321,9 @@ private helper modules
 legacy archived runner modules
 ```
 
-The bridge should eventually be covered by import-boundary smoke tests so a pack
-can consume the same public surface that internal smoke scenarios use.
+The bridge is covered by public API and CLI tests. Import-boundary coverage should
+stay aligned with the public surface that internal smoke scenarios and external
+packs consume.
 
 ## 10. Internal Smoke Path
 
@@ -328,10 +346,10 @@ external packs use comp.scenario_contracts.run_scenario or comp scenario run
 This proves the bridge is real and prevents the public API from becoming a
 documentation-only facade.
 
-## 11. First Slice
+## 11. Implemented Initial Slice
 
-The first implementation slice should avoid benchmarks, raw ingestion, MySQL
-query profiling, and schema migration.
+The implemented bridge slice avoids benchmarks, raw ingestion, MySQL query
+profiling, and schema migration.
 
 Start with:
 
@@ -347,7 +365,7 @@ comp scenario run
 one internal smoke scenario using the public runner
 ```
 
-The first invariants should be small:
+The current invariants are small:
 
 ```text
 receipt_exists
@@ -357,9 +375,9 @@ projection_values_are_committed
 blocking_hazards_absent
 ```
 
-Once the bridge is stable, external scenario packs can add large domain data,
-materialized projection benchmarks, migration rehearsal cases, and agent-produced
-candidate tests without loading that material into the core repository.
+External scenario packs can add large domain data, materialized projection
+benchmarks, migration rehearsal cases, and agent-produced candidate tests without
+loading that material into the core repository.
 
 ## 12. Review Checklist
 
@@ -378,7 +396,7 @@ Does any new scenario code avoid importing tests.* from external packages?
 
 ## 13. Current Implementation Status
 
-The first public bridge slice is implemented:
+The public bridge slice is implemented:
 
 ```text
 comp.scenario_contracts

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -22,6 +22,13 @@ STRICT_CURRENT_HEADINGS = {
     "Authority Boundary",
     "State Transition Requirements",
 }
+REFRESHED_CURRENT_GUIDANCE_DOCS = {
+    Path("docs/architecture/contracts/policy-boundary.md"),
+    Path("docs/architecture/maps/domain-scenario-pack-generation.md"),
+    Path("docs/architecture/maps/obligation-kernel-working-theory.md"),
+    Path("docs/architecture/maps/product-facade-conformance-runner.md"),
+    Path("docs/architecture/north-stars/scenario-trust-runtime-bridge.md"),
+}
 
 
 def _governed_architecture_docs():
@@ -102,6 +109,17 @@ def test_checked_anchors_point_to_existing_paths_when_declared():
             assert Path(anchor_path).exists(), f"{path}: missing anchor {target!r}"
 
     assert Path("docs/architecture/document-governance.md") in docs_with_anchors
+
+
+def test_refreshed_current_guidance_docs_declare_lifecycle_metadata():
+    for path in REFRESHED_CURRENT_GUIDANCE_DOCS:
+        text = path.read_text(encoding="utf-8")
+        header = _doc_header(path)
+
+        assert header["Last checked against code"] == "2026-05-28", path
+        assert _list_block(text, "Checked anchors"), path
+        assert _list_block(text, "Freshness triggers"), path
+        assert "Stale-language policy:" in text, path
 
 
 def test_strict_current_sections_do_not_use_known_stale_phrases_when_policy_declared():

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -693,7 +693,7 @@ def test_policy_boundary_contract_keeps_policy_non_authoritative():
         "ScopedGrant is not PublicOutputReceipt.",
         "Capabilities may recommend. Policies may issue scoped access.",
         "Not every term in this document is currently a public Python API.",
-        "The first implementation slices live in `comp.policy`.",
+        "The current implementation slices live in `comp.policy`.",
         "`MaterialDescriptor`, `PolicyEffect`, `ConflictResolver`, `PolicyAssembly`,",
         "`PolicyAssembly` groups descriptors, effects, assembly subjects, and resolver",
         "`PolicyAssembly` may also build a matching `SelectedValidationContract`",
@@ -899,7 +899,7 @@ def test_product_facade_conformance_runner_map_positions_next_layer():
     for line in (
         "Status: implementation-map",
         "Owner: scenario-lab",
-        "Last checked against code: 2026-05-27",
+        "Last checked against code: 2026-05-28",
         "Can block PRs: limited",
         "This map is a runner-direction map, not a runner contract.",
         "## Current Position",
@@ -933,7 +933,7 @@ def test_product_facade_conformance_runner_map_positions_next_layer():
         "not a product runtime",
         "not a native authority engine",
         "not production cryptography integration",
-        "## First PR Boundary",
+        "## Current Lab Boundary",
         "No new command surface.",
         "No new bundle schema.",
         "No movement into `comp.runtime`.",
@@ -1074,7 +1074,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "implementation-map",
             "scenario-lab",
             "limited",
-            "2026-05-21",
+            "2026-05-28",
         ),
         "internal-execution-design-map.md": (
             "implementation-map",
@@ -1122,7 +1122,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "implementation-map",
             "trust-kernel",
             "limited",
-            "2026-05-20",
+            "2026-05-28",
         ),
         "policy-assembled-trust-kernel.md": (
             "implementation-map",
@@ -1140,7 +1140,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "implementation-map",
             "scenario-lab",
             "limited",
-            "2026-05-27",
+            "2026-05-28",
         ),
         "persistence-ledger-boundary.md": (
             "active-contract",
@@ -1152,7 +1152,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "trust-kernel",
             "yes",
-            "2026-05-26",
+            "2026-05-28",
         ),
         "production-trust-spine-database.md": (
             "north-star",
@@ -1182,7 +1182,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "north-star",
             "scenario-lab",
             "limited",
-            "2026-05-22",
+            "2026-05-28",
         ),
         "trust-kernel-extension-rings.md": (
             "active-contract",


### PR DESCRIPTION
## Summary
- Refresh high-risk governed docs that still described landed work with future or initial-slice language.
- Add lifecycle metadata to refreshed current-guidance docs: checked anchors, freshness triggers, and stale-language policy blocks.
- Ratchet doc lifecycle tests so the refreshed docs must keep that metadata and strict current sections stay free of known stale-current phrases.

## Notes
This is stacked on #362 so the PR only contains the document refresh slice that applies the lifecycle contract introduced there.

Refreshed docs:
- `docs/architecture/contracts/policy-boundary.md`
- `docs/architecture/maps/domain-scenario-pack-generation.md`
- `docs/architecture/maps/obligation-kernel-working-theory.md`
- `docs/architecture/maps/product-facade-conformance-runner.md`
- `docs/architecture/north-stars/scenario-trust-runtime-bridge.md`

## Validation
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> `51 passed`
- `python -m pytest -q` -> `606 passed, 13 skipped`
- `python -m tests.domain_scenarios run-all` -> `18/18 passed`
- stale-current grep over refreshed docs -> no matches