### PR TITLE
[codex] add document refresh queue

### DIFF
--- a/docs/architecture/document-governance.md
+++ b/docs/architecture/document-governance.md
@@ -170,6 +170,21 @@ state changes that should cause a reviewer to re-check the document.
 A trigger does not automatically make a PR invalid. It tells reviewers when a
 document may need refresh, confirmation, or demotion.
 
+## Refresh Queue
+
+A refresh queue may live under `docs/archive/plans/` when stale candidates are
+known but should not interrupt the current PR.
+
+Refresh queue entries cannot block PRs. They are a non-authoritative maintenance
+list for follow-up work. A queue entry is not proof that a document is stale and
+must not be cited as current guidance.
+
+Each queue item should name the document, the suspected issue, the anchor check
+needed before changing it, and the target action: refresh, confirm no drift, or
+demote/archive.
+
+The allowed queue outcomes are refresh, confirm no drift, or demote/archive.
+
 ## Body Freshness Rules
 
 Status controls how much current-state evidence a document should carry:

--- a/docs/archive/plans/2026-05-28-doc-refresh-queue.md
+++ b/docs/archive/plans/2026-05-28-doc-refresh-queue.md
@@ -1,0 +1,37 @@
+# 2026-05-28 Document Refresh Queue
+
+Authority: none
+
+This queue cannot block PRs. This queue must not be cited as current guidance.
+
+This queue records suspected refresh candidates after the document lifecycle
+ratchet. A queue entry is a maintenance signal, not proof that the document is
+wrong. Close an entry by refreshing the document, confirming no drift, or
+demoting/archiving the document if it no longer carries current guidance.
+
+## Handling Rules
+
+```text
+Queue item -> anchor check -> one of:
+  refresh
+  confirm no drift
+  demote/archive
+```
+
+Do not use this queue as an authority contract. If a queue item needs enforceable
+review behavior, move that behavior into a governed architecture document and its
+tests.
+
+## Refresh Candidates
+
+| doc | issue | required anchor check | target action |
+|---|---|---|---|
+| `docs/architecture/contracts/trust-kernel-hardening.md` | active contract last checked before the lifecycle ratchet | `tests/test_package_smoke.py` trust-kernel hardening checks and receipt/projection public surfaces | confirm no drift or refresh |
+| `docs/architecture/contracts/extension-port-contracts.md` | active contract has older metadata and no checked anchors yet | `tests/test_authority_import_boundaries.py` and public import/export expectations | confirm no drift or refresh |
+| `docs/architecture/contracts/artifact-envelope-builder.md` | active contract should adopt anchors after materializer cleanup | `tests/test_artifact_envelope_builder.py` and `tests/test_compiler_run_artifact_materializer.py` | confirm no drift or refresh |
+| `docs/architecture/contracts/persistence-ledger-boundary.md` | persistence contract may need checked anchors around MySQL and replay behavior | `tests/test_mysql_persistence_spine.py`, `tests/test_mysql_operating_contract.py`, and replay persistence tests | confirm no drift or refresh |
+| `docs/architecture/contracts/receipt-proof-graph.md` | explanation contract should verify current proof-graph export and render boundaries | `tests/test_receipt_proof_graph.py`, `tests/test_receipt_proof_graph_cli.py`, and `tests/test_receipt_graph_views.py` | confirm no drift or refresh |
+| `docs/architecture/north-stars/retrieval-fabric-north-star.md` | north-star may contain items that have since landed in retrieval implementation maps | `comp/compiler_tool/retrieval.py`, `comp/compiler_tool/resolver_retrieval.py`, and `tests/test_resolver_retrieval.py` | refresh or demote/archive landed fragments |
+| `docs/architecture/north-stars/production-trust-spine-database.md` | north-star should stay direction-only as MySQL backend behavior grows | `comp/persistence/mysql.py`, `tests/test_mysql_persistence_spine.py`, and `tests/test_mysql_operating_contract.py` | confirm no drift or refresh |
+| `docs/architecture/north-stars/llm-worker-orchestration.md` | north-star should not read like current agent authority | `comp/compiler_tool/resolver_tasks.py` and agent-facing public boundary tests | confirm no drift or demote/archive |
+

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -29,6 +29,7 @@ REFRESHED_CURRENT_GUIDANCE_DOCS = {
     Path("docs/architecture/maps/product-facade-conformance-runner.md"),
     Path("docs/architecture/north-stars/scenario-trust-runtime-bridge.md"),
 }
+DOC_REFRESH_QUEUE = Path("docs/archive/plans/2026-05-28-doc-refresh-queue.md")
 
 
 def _governed_architecture_docs():
@@ -151,3 +152,28 @@ def test_historical_notes_declare_they_are_not_current_guidance():
 
         text = path.read_text(encoding="utf-8")
         assert HISTORICAL_NON_CURRENT_GUIDANCE in text, path
+
+
+def test_document_governance_defines_refresh_queue_boundary():
+    governance = Path("docs/architecture/document-governance.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Refresh Queue" in governance
+    assert "`docs/archive/plans/`" in governance
+    assert "Refresh queue entries cannot block PRs." in governance
+    assert "refresh, confirm no drift, or demote" in governance
+
+
+def test_doc_refresh_queue_is_non_authoritative():
+    text = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
+
+    assert "Authority: none" in text
+    assert "This queue cannot block PRs." in text
+    assert "This queue must not be cited as current guidance." in text
+    assert "Status: active-contract" not in text
+    assert "Can block PRs: yes" not in text
+    assert "| doc | issue | required anchor check | target action |" in text
+    assert "refresh" in text
+    assert "confirm no drift" in text
+    assert "demote/archive" in text

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1238,6 +1238,7 @@ def test_historical_notes_and_plans_live_in_archive_locations():
         "2026-05-21-production-trust-spine-db-v1.md",
         "2026-05-21-raw-claim-promotion-boundary.md",
         "2026-05-22-receipt-proof-graph-boundary-prework.md",
+        "2026-05-28-doc-refresh-queue.md",
     }
 
     assert not [


### PR DESCRIPTION
## Summary
- Add a non-authoritative document refresh queue under `docs/archive/plans/` for suspected stale candidates that should not interrupt active PRs.
- Extend document governance with refresh-queue rules: queue entries cannot block PRs and close via refresh, confirm no drift, or demote/archive.
- Ratchet lifecycle/package smoke tests so the queue stays archived and cannot present itself as current guidance.

## Boundary Notes
- This does not refresh the queued docs yet.
- This queue is not an active contract and must not be cited as current guidance.
- The queue is a maintenance signal for follow-up slices, not a PR-blocking mechanism.

## Validation
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> `53 passed`
- `python -m pytest -q` -> `608 passed, 13 skipped`
- `python -m tests.domain_scenarios run-all` -> `18/18 passed`