### PR TITLE
[codex] refresh extension port contract metadata

### DIFF
--- a/docs/architecture/contracts/extension-port-contracts.md
+++ b/docs/architecture/contracts/extension-port-contracts.md
@@ -2,8 +2,28 @@
 
 Status: active-contract
 Owner: trust-kernel
-Last checked against code: 2026-05-20
+Last checked against code: 2026-05-28
 Can block PRs: yes
+
+Checked anchors:
+- doc: docs/architecture/contracts/trust-kernel-extension-rings.md
+- test: tests/test_authority_import_boundaries.py
+- test: tests/test_package_smoke.py::test_architecture_docs_are_classified_by_governance_status
+- code: comp/compiler_tool/retrieval.py
+- code: comp/persistence/envelope_builder.py
+- code: comp/persistence/ledger.py
+- code: comp/persistence/mysql.py
+- code: comp/runtime/validation_handoff.py
+
+Freshness triggers:
+- packaged authority import-boundary snapshots change
+- candidate-only retrieval or resolver output behavior changes
+- artifact store or receipt ledger persistence behavior changes
+- validation handoff or product-facing adapter behavior changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit review or promotion sections
 
 This document defines how outer-ring extensions attach to the `comp` trust
 kernel without gaining authority. It is a companion to

--- a/docs/archive/plans/2026-05-28-doc-refresh-queue.md
+++ b/docs/archive/plans/2026-05-28-doc-refresh-queue.md
@@ -27,7 +27,6 @@ tests.
 | doc | issue | required anchor check | target action |
 |---|---|---|---|
 | `docs/architecture/contracts/trust-kernel-hardening.md` | active contract last checked before the lifecycle ratchet | `tests/test_package_smoke.py` trust-kernel hardening checks and receipt/projection public surfaces | confirm no drift or refresh |
-| `docs/architecture/contracts/extension-port-contracts.md` | active contract has older metadata and no checked anchors yet | `tests/test_authority_import_boundaries.py` and public import/export expectations | confirm no drift or refresh |
 | `docs/architecture/contracts/artifact-envelope-builder.md` | active contract should adopt anchors after materializer cleanup | `tests/test_artifact_envelope_builder.py` and `tests/test_compiler_run_artifact_materializer.py` | confirm no drift or refresh |
 | `docs/architecture/contracts/persistence-ledger-boundary.md` | persistence contract may need checked anchors around MySQL and replay behavior | `tests/test_mysql_persistence_spine.py`, `tests/test_mysql_operating_contract.py`, and replay persistence tests | confirm no drift or refresh |
 | `docs/architecture/contracts/receipt-proof-graph.md` | explanation contract should verify current proof-graph export and render boundaries | `tests/test_receipt_proof_graph.py`, `tests/test_receipt_proof_graph_cli.py`, and `tests/test_receipt_graph_views.py` | confirm no drift or refresh |

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -23,6 +23,7 @@ STRICT_CURRENT_HEADINGS = {
     "State Transition Requirements",
 }
 REFRESHED_CURRENT_GUIDANCE_DOCS = {
+    Path("docs/architecture/contracts/extension-port-contracts.md"),
     Path("docs/architecture/contracts/policy-boundary.md"),
     Path("docs/architecture/maps/domain-scenario-pack-generation.md"),
     Path("docs/architecture/maps/obligation-kernel-working-theory.md"),
@@ -177,3 +178,9 @@ def test_doc_refresh_queue_is_non_authoritative():
     assert "refresh" in text
     assert "confirm no drift" in text
     assert "demote/archive" in text
+
+
+def test_extension_port_contract_refresh_queue_item_is_closed():
+    queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
+
+    assert "`docs/architecture/contracts/extension-port-contracts.md`" not in queue

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1086,7 +1086,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "trust-kernel",
             "yes",
-            "2026-05-20",
+            "2026-05-28",
         ),
         "friendly-authority-vocabulary.md": (
             "active-contract",


### PR DESCRIPTION
## Summary
- Refresh `extension-port-contracts.md` as a current active contract without changing its authority rules.
- Add checked anchors, freshness triggers, and a stale-language policy for extension-port review.
- Remove the extension-port contract item from the non-authoritative document refresh queue.
- Ratchet lifecycle/package smoke tests so this contract keeps current metadata.

## Boundary Notes
- This is a metadata/no-drift refresh: ports remain non-authoritative and deterministic gates still own authority promotion.
- The refresh queue remains non-authoritative and cannot block PRs.

## Validation
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> `54 passed`
- `python -m pytest tests/test_authority_import_boundaries.py -q` -> `7 passed`
- `python -m pytest -q` -> `609 passed, 13 skipped`
- `python -m tests.domain_scenarios run-all` -> `18/18 passed`