### PR TITLE
[codex] refresh artifact envelope builder metadata

### DIFF
--- a/docs/architecture/contracts/artifact-envelope-builder.md
+++ b/docs/architecture/contracts/artifact-envelope-builder.md
@@ -2,8 +2,26 @@
 
 Status: active-contract
 Owner: persistence
-Last checked against code: 2026-05-22
+Last checked against code: 2026-05-28
 Can block PRs: yes
+
+Checked anchors:
+- code: comp/persistence/envelope.py
+- code: comp/persistence/envelope_builder.py
+- code: comp/runtime/compiler_run_artifacts.py
+- test: tests/test_artifact_envelope_builder.py
+- test: tests/test_compiler_run_artifact_materializer.py
+- test: tests/test_package_smoke.py::test_artifact_envelope_builder_contract_separates_coverage_from_materialization
+
+Freshness triggers:
+- `ArtifactEnvelope` schema, digest, or store behavior changes
+- `ReceiptEnvelopeSetBuilder` coverage behavior changes
+- `CompilerRunArtifactMaterializer` material source behavior changes
+- domain scenario replay materialization boundary changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit review or promotion sections
 
 This document defines the contract for producing the `ArtifactEnvelope` set
 needed for receipt replay without letting persistence learn compiler internals.
@@ -464,7 +482,7 @@ is incomplete and should be updated before adding another backend.
 
 ## Current Implementation Status
 
-The first production receipt coverage builder lives in:
+The production receipt coverage builder lives in:
 
 ```text
 comp.persistence.envelope_builder
@@ -490,7 +508,7 @@ through a `record(...)` boundary.
 The implementation does not import `comp.compiler_tool`, does not inspect
 compiler reports, and does not produce compiler-run material.
 
-The first production compiler-run materializer lives in:
+The production compiler-run materializer lives in:
 
 ```text
 comp.runtime.compiler_run_artifacts
@@ -534,7 +552,7 @@ compiler-aware adapter behavior.
 
 ## Testing Expectations
 
-Tests for the first production builder should cover:
+Tests for the production builder should cover:
 
 ```text
 all receipt_artifact_refs have envelopes

--- a/docs/archive/plans/2026-05-28-doc-refresh-queue.md
+++ b/docs/archive/plans/2026-05-28-doc-refresh-queue.md
@@ -27,7 +27,6 @@ tests.
 | doc | issue | required anchor check | target action |
 |---|---|---|---|
 | `docs/architecture/contracts/trust-kernel-hardening.md` | active contract last checked before the lifecycle ratchet | `tests/test_package_smoke.py` trust-kernel hardening checks and receipt/projection public surfaces | confirm no drift or refresh |
-| `docs/architecture/contracts/artifact-envelope-builder.md` | active contract should adopt anchors after materializer cleanup | `tests/test_artifact_envelope_builder.py` and `tests/test_compiler_run_artifact_materializer.py` | confirm no drift or refresh |
 | `docs/architecture/contracts/persistence-ledger-boundary.md` | persistence contract may need checked anchors around MySQL and replay behavior | `tests/test_mysql_persistence_spine.py`, `tests/test_mysql_operating_contract.py`, and replay persistence tests | confirm no drift or refresh |
 | `docs/architecture/contracts/receipt-proof-graph.md` | explanation contract should verify current proof-graph export and render boundaries | `tests/test_receipt_proof_graph.py`, `tests/test_receipt_proof_graph_cli.py`, and `tests/test_receipt_graph_views.py` | confirm no drift or refresh |
 | `docs/architecture/north-stars/retrieval-fabric-north-star.md` | north-star may contain items that have since landed in retrieval implementation maps | `comp/compiler_tool/retrieval.py`, `comp/compiler_tool/resolver_retrieval.py`, and `tests/test_resolver_retrieval.py` | refresh or demote/archive landed fragments |

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -23,6 +23,7 @@ STRICT_CURRENT_HEADINGS = {
     "State Transition Requirements",
 }
 REFRESHED_CURRENT_GUIDANCE_DOCS = {
+    Path("docs/architecture/contracts/artifact-envelope-builder.md"),
     Path("docs/architecture/contracts/extension-port-contracts.md"),
     Path("docs/architecture/contracts/policy-boundary.md"),
     Path("docs/architecture/maps/domain-scenario-pack-generation.md"),
@@ -184,3 +185,9 @@ def test_extension_port_contract_refresh_queue_item_is_closed():
     queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
 
     assert "`docs/architecture/contracts/extension-port-contracts.md`" not in queue
+
+
+def test_artifact_envelope_builder_refresh_queue_item_is_closed():
+    queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
+
+    assert "`docs/architecture/contracts/artifact-envelope-builder.md`" not in queue

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1050,7 +1050,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "persistence",
             "yes",
-            "2026-05-22",
+            "2026-05-28",
         ),
         "artifact-lifecycle-boundary.md": (
             "active-contract",


### PR DESCRIPTION
Summary:
- refresh the artifact envelope builder active contract with checked anchors, freshness triggers, and strict current-section stale-language policy
- confirm the production builder/materializer wording as current guidance without changing authority boundaries
- remove the artifact-envelope-builder item from the non-authoritative refresh queue and ratchet lifecycle smoke coverage

Boundary Notes:
- this is a metadata/no-drift refresh; it does not change `ArtifactEnvelope`, receipt, replay, or materializer behavior
- `ArtifactEnvelope` remains replay substrate, not projection authority
- stacked on #367 (`codex/refresh-extension-port-contract`) to avoid refresh queue conflicts

Validation:
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> 55 passed
- `python -m pytest tests/test_artifact_envelope_builder.py tests/test_compiler_run_artifact_materializer.py -q` -> 13 passed
- `python -m pytest -q` -> 610 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> 18/18 passed