### PR TITLE
[codex] refresh trust kernel hardening metadata

### DIFF
--- a/docs/architecture/contracts/trust-kernel-hardening.md
+++ b/docs/architecture/contracts/trust-kernel-hardening.md
@@ -2,12 +2,36 @@
 
 Status: active-contract
 Owner: trust-kernel
-Last checked against code: 2026-05-21
+Last checked against code: 2026-05-28
 Can block PRs: yes
 
-This document fixes the implementation standard for the next slice of the
-`comp` rebuild. The goal is to keep `comp` as a small trust kernel rather than
-letting it drift back into an ESG row generator.
+Checked anchors:
+- code: comp/judgment/commit.py
+- code: comp/judgment/receipts.py
+- code: comp/compiler_tool/commit_flow.py
+- code: comp/compiler_tool/receipt_builder.py
+- code: comp/compiler_tool/profile_runner.py
+- code: comp/compiler_tool/profiles.py
+- test: tests/test_receipt_gated_projection.py
+- test: tests/test_commit_receipt_builder.py
+- test: tests/test_tiny_domain_fixture.py::test_compile_with_profile_merges_profile_baseline_and_rule_obligations
+- test: tests/test_package_smoke.py::test_trust_kernel_hardening_documents_projection_numeric_policy
+- test: tests/test_package_smoke.py::test_trust_kernel_hardening_documents_profile_baseline_policy
+
+Freshness triggers:
+- receipt-gated projection behavior changes
+- `PublicOutputReceipt` or `PublicOutputValueCommitment` schema changes
+- commit package, governance decision, or receipt builder behavior changes
+- `CompilerProfile`, `compile_with_profile`, or `run_profile_rules` behavior changes
+- trust-kernel/domain boundary public surface changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit non-goal, review, or promotion sections
+
+This document fixes the implementation standard for trust-kernel hardening. The
+goal is to keep `comp` as a small trust kernel rather than letting it drift back
+into an ESG row generator.
 
 This standard sits under the broader
 `trust-kernel-extension-rings.md` architecture frame. In that frame, hardening
@@ -134,9 +158,9 @@ domain-pack compiler baseline known fields and allowed units
 The fingerprint must be canonical and deterministic. Changing any active
 behavior input should change the fingerprint digest.
 
-Current implementation should keep profile declarations, domain-pack
-declarations, formula declarations, reference records, and reference catalog
-snapshots as explicit dependency fingerprints when they influence the receipt.
+Current implementation keeps profile declarations, domain-pack declarations,
+formula declarations, reference records, and reference catalog snapshots as
+explicit dependency fingerprints when they influence the receipt.
 Readable lock manifests are replay substrate; they help explain the behavior
 universe, but they do not become public authority.
 
@@ -181,9 +205,10 @@ rejected candidate ids and reasons
 canonical reference binding id
 ```
 
-The first implementation should keep this small. It is enough for scenario
-receipts and replay reports to expose the relevant profile, domain, formula,
-reference, and catalog fingerprints. A full candidate graph can wait.
+Current implementation keeps this small: scenario receipts and replay reports
+expose the relevant profile, domain, formula, reference, and catalog
+fingerprints. A full candidate graph belongs in a separate provenance contract,
+not in this hardening standard.
 
 ## Canonical Trace Product
 
@@ -219,12 +244,12 @@ large ESG reference ingestion
 quality score scalar
 namespace-wide package relocation
 general candidate graph
-durable production ledger
+durable production ledger policy
 ```
 
-The first durable ledger can be SQLite later. Before that, the receipt and
-replay payloads must know what behavior and reference universe they are
-recording.
+Durable ledger and backend policy belong in
+`persistence-ledger-boundary.md`. This standard only requires that receipt and
+replay payloads know what behavior and reference universe they are recording.
 
 ## Review Checklist
 

--- a/docs/archive/plans/2026-05-28-doc-refresh-queue.md
+++ b/docs/archive/plans/2026-05-28-doc-refresh-queue.md
@@ -26,7 +26,6 @@ tests.
 
 | doc | issue | required anchor check | target action |
 |---|---|---|---|
-| `docs/architecture/contracts/trust-kernel-hardening.md` | active contract last checked before the lifecycle ratchet | `tests/test_package_smoke.py` trust-kernel hardening checks and receipt/projection public surfaces | confirm no drift or refresh |
 | `docs/architecture/contracts/persistence-ledger-boundary.md` | persistence contract may need checked anchors around MySQL and replay behavior | `tests/test_mysql_persistence_spine.py`, `tests/test_mysql_operating_contract.py`, and replay persistence tests | confirm no drift or refresh |
 | `docs/architecture/contracts/receipt-proof-graph.md` | explanation contract should verify current proof-graph export and render boundaries | `tests/test_receipt_proof_graph.py`, `tests/test_receipt_proof_graph_cli.py`, and `tests/test_receipt_graph_views.py` | confirm no drift or refresh |
 | `docs/architecture/north-stars/retrieval-fabric-north-star.md` | north-star may contain items that have since landed in retrieval implementation maps | `comp/compiler_tool/retrieval.py`, `comp/compiler_tool/resolver_retrieval.py`, and `tests/test_resolver_retrieval.py` | refresh or demote/archive landed fragments |

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -26,6 +26,7 @@ REFRESHED_CURRENT_GUIDANCE_DOCS = {
     Path("docs/architecture/contracts/artifact-envelope-builder.md"),
     Path("docs/architecture/contracts/extension-port-contracts.md"),
     Path("docs/architecture/contracts/policy-boundary.md"),
+    Path("docs/architecture/contracts/trust-kernel-hardening.md"),
     Path("docs/architecture/maps/domain-scenario-pack-generation.md"),
     Path("docs/architecture/maps/obligation-kernel-working-theory.md"),
     Path("docs/architecture/maps/product-facade-conformance-runner.md"),
@@ -191,3 +192,9 @@ def test_artifact_envelope_builder_refresh_queue_item_is_closed():
     queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
 
     assert "`docs/architecture/contracts/artifact-envelope-builder.md`" not in queue
+
+
+def test_trust_kernel_hardening_refresh_queue_item_is_closed():
+    queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
+
+    assert "`docs/architecture/contracts/trust-kernel-hardening.md`" not in queue

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1194,7 +1194,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "trust-kernel",
             "yes",
-            "2026-05-21",
+            "2026-05-28",
         ),
     }
 


### PR DESCRIPTION
Summary:
- refresh the trust-kernel hardening active contract with checked anchors, freshness triggers, and stale-language policy
- replace older rebuild/slice and ledger-future wording with current trust-kernel and persistence-boundary guidance
- remove the trust-kernel-hardening item from the non-authoritative refresh queue and ratchet lifecycle smoke coverage

Boundary Notes:
- this is a document lifecycle refresh; it does not change compiler, receipt, projection, replay, or profile behavior
- `PublicOutputReceipt` remains the public projection authority
- durable ledger policy stays under `persistence-ledger-boundary.md`
- stacked on #368 (`codex/refresh-artifact-envelope-builder`) to avoid refresh queue conflicts

Validation:
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> 56 passed
- `python -m pytest tests/test_receipt_gated_projection.py tests/test_commit_receipt_builder.py tests/test_tiny_domain_fixture.py -q` -> 27 passed
- `python -m pytest -q` -> 611 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> 18/18 passed