### PR TITLE
[codex] refresh persistence ledger boundary metadata

### DIFF
--- a/docs/architecture/contracts/persistence-ledger-boundary.md
+++ b/docs/architecture/contracts/persistence-ledger-boundary.md
@@ -2,16 +2,38 @@
 
 Status: active-contract
 Owner: persistence
-Last checked against code: 2026-05-22
+Last checked against code: 2026-05-28
 Can block PRs: yes
+
+Checked anchors:
+- code: comp/persistence/ledger.py
+- code: comp/persistence/replay.py
+- code: comp/persistence/mysql.py
+- code: comp/persistence/envelope.py
+- code: comp/persistence/digest.py
+- test: tests/test_persistence_ledger_boundary.py
+- test: tests/test_persistence_projection_replay.py
+- test: tests/test_mysql_persistence_spine.py
+- test: tests/test_mysql_operating_contract.py
+- test: tests/test_package_smoke.py::test_persistence_ledger_boundary_documents_mysql_operating_contract
+
+Freshness triggers:
+- `ArtifactEnvelope`, artifact digest, or artifact store behavior changes
+- `InMemoryReceiptLedger` or `MySQLReceiptLedger` receipt root behavior changes
+- `replay_public_projection(...)` or `receipt_artifact_refs(...)` behavior changes
+- MySQL trust-spine schema, receipt-derived index, or transaction behavior changes
+- public projection, receipt citation, or dependency fingerprint schema changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit non-goal, future work, or promotion sections
 
 PublicOutputReceipt as the durable explanation root.
 
-This document fixes the persistence boundary for the active `comp` rebuild. It
-is not a database schema, ORM design, or production retention policy. Its goal
-is to define which artifacts must survive after a run so a public projection can
-be explained later without accidentally turning cached views or resolver output
-into authority.
+This document fixes the persistence boundary for `comp`. It is not a database
+schema, ORM design, or production retention policy. Its goal is to define which
+artifacts must survive after a run so a public projection can be explained later
+without accidentally turning cached views or resolver output into authority.
 
 The short version:
 
@@ -29,7 +51,8 @@ envelope set required by receipt replay.
 production database direction for carrying this boundary into MySQL. It is a
 north-star working model, not a final migration schema.
 
-The current implementation now has the first in-memory replay substrate:
+The current implementation has both an in-memory replay substrate and a small
+MySQL trust spine:
 
 ```text
 PublicOutputReceipt
@@ -249,10 +272,10 @@ Digest references connect the root to the replay graph.
 
 ## 6. Artifact Envelope Contract
 
-The next implementation slice should introduce a small envelope contract before
-choosing a database.
+The active implementation uses a small envelope contract before database-specific
+storage behavior.
 
-Candidate shape:
+Current shape:
 
 ```python
 @dataclass(frozen=True)
@@ -385,7 +408,7 @@ Those are recompute questions.
 
 Reference and profile dependencies should be pinned gradually.
 
-First practical layer:
+Implemented practical layer:
 
 ```text
 CanonicalReference
@@ -416,7 +439,7 @@ ReferenceCatalogSnapshot
   replay coverage check for cited reference records
 ```
 
-Later layers may add:
+Future dependency extensions may add:
 
 ```text
 DomainPackFingerprint
@@ -447,14 +470,14 @@ real embedding index persistence
 LLM trace retention policy
 ```
 
-Those decisions should come after the in-memory replay substrate is exercised by
-the canonical scenario harness.
+Those decisions belong outside this contract until the governed persistence and
+database documents define them explicitly.
 
 ---
 
 ## 11. Current Implementation Status
 
-The first persistence slice is implemented:
+Current persistence implementation:
 
 ```text
 docs/architecture/contracts/persistence-ledger-boundary.md
@@ -601,10 +624,9 @@ same authority rule: receipt authorizes, replay verifies, graph explains.
 
 ---
 
-## 13. Following Slice
+## 13. Future Source Container Work
 
-After dependency graph export, the next likely slice is source container
-fingerprints:
+Source container fingerprints remain future work:
 
 ```text
 source container fingerprints
@@ -612,8 +634,8 @@ source document/version ids
 replay verification for source container digests
 ```
 
-That slice should keep the document's rule: replay explains the old receipt,
-while recompute may produce a new answer under today's catalog and profile.
+That work must keep this document's rule: replay explains the old receipt, while
+recompute may produce a new answer under today's catalog and profile.
 
 ---
 

--- a/docs/archive/plans/2026-05-28-doc-refresh-queue.md
+++ b/docs/archive/plans/2026-05-28-doc-refresh-queue.md
@@ -26,7 +26,6 @@ tests.
 
 | doc | issue | required anchor check | target action |
 |---|---|---|---|
-| `docs/architecture/contracts/persistence-ledger-boundary.md` | persistence contract may need checked anchors around MySQL and replay behavior | `tests/test_mysql_persistence_spine.py`, `tests/test_mysql_operating_contract.py`, and replay persistence tests | confirm no drift or refresh |
 | `docs/architecture/contracts/receipt-proof-graph.md` | explanation contract should verify current proof-graph export and render boundaries | `tests/test_receipt_proof_graph.py`, `tests/test_receipt_proof_graph_cli.py`, and `tests/test_receipt_graph_views.py` | confirm no drift or refresh |
 | `docs/architecture/north-stars/retrieval-fabric-north-star.md` | north-star may contain items that have since landed in retrieval implementation maps | `comp/compiler_tool/retrieval.py`, `comp/compiler_tool/resolver_retrieval.py`, and `tests/test_resolver_retrieval.py` | refresh or demote/archive landed fragments |
 | `docs/architecture/north-stars/production-trust-spine-database.md` | north-star should stay direction-only as MySQL backend behavior grows | `comp/persistence/mysql.py`, `tests/test_mysql_persistence_spine.py`, and `tests/test_mysql_operating_contract.py` | confirm no drift or refresh |

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -25,6 +25,7 @@ STRICT_CURRENT_HEADINGS = {
 REFRESHED_CURRENT_GUIDANCE_DOCS = {
     Path("docs/architecture/contracts/artifact-envelope-builder.md"),
     Path("docs/architecture/contracts/extension-port-contracts.md"),
+    Path("docs/architecture/contracts/persistence-ledger-boundary.md"),
     Path("docs/architecture/contracts/policy-boundary.md"),
     Path("docs/architecture/contracts/trust-kernel-hardening.md"),
     Path("docs/architecture/maps/domain-scenario-pack-generation.md"),
@@ -198,3 +199,9 @@ def test_trust_kernel_hardening_refresh_queue_item_is_closed():
     queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
 
     assert "`docs/architecture/contracts/trust-kernel-hardening.md`" not in queue
+
+
+def test_persistence_ledger_boundary_refresh_queue_item_is_closed():
+    queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
+
+    assert "`docs/architecture/contracts/persistence-ledger-boundary.md`" not in queue

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1146,7 +1146,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "persistence",
             "yes",
-            "2026-05-22",
+            "2026-05-28",
         ),
         "policy-boundary.md": (
             "active-contract",


### PR DESCRIPTION
Summary:
- refresh the persistence ledger active contract with checked anchors, freshness triggers, and stale-language policy
- update stale implementation wording now that the in-memory replay substrate and MySQL trust spine are both current surfaces
- remove the persistence-ledger-boundary item from the non-authoritative refresh queue and ratchet lifecycle smoke coverage

Boundary Notes:
- this is a document lifecycle refresh; it does not change persistence, replay, MySQL, receipt, or projection behavior
- `PublicOutputReceipt` remains the public projection authority
- MySQL remains typed storage and replay input provider, not projection authority
- source container fingerprints remain explicit future work

Validation:
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> 57 passed
- `python -m pytest tests/test_persistence_ledger_boundary.py tests/test_persistence_projection_replay.py tests/test_mysql_operating_contract.py tests/test_mysql_persistence_spine.py -q` -> 26 passed, 13 skipped
- `python -m pytest -q` -> 612 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> 18/18 passed