### PR TITLE
[codex] refresh receipt proof graph metadata

### DIFF
--- a/docs/architecture/contracts/receipt-proof-graph.md
+++ b/docs/architecture/contracts/receipt-proof-graph.md
@@ -2,13 +2,35 @@
 
 Status: active-contract
 Owner: explanation
-Last checked against code: 2026-05-22
+Last checked against code: 2026-05-28
 Can block PRs: yes
 
-This document fixes the role of receipt-scoped graph export in the active
-`comp` rebuild. The graph is not a trust-kernel feature, a compiler decision,
-or a replacement for receipt replay. It is an explanation-only read model that
-normalizes a successful replay into a graph-friendly form.
+Checked anchors:
+- code: comp/explanation/receipt_graph.py
+- code: comp/explanation/receipt_graph_cli.py
+- code: comp/views/receipt_graph.py
+- code: comp/persistence/replay.py
+- test: tests/test_receipt_proof_graph.py
+- test: tests/test_receipt_proof_graph_cli.py
+- test: tests/test_receipt_graph_views.py
+- test: tests/test_package_smoke.py::test_receipt_proof_graph_contract_names_prework_boundaries
+- test: tests/test_package_smoke.py::test_receipt_graph_renderers_have_non_authority_module_boundary
+
+Freshness triggers:
+- `ReceiptProofGraph`, `GraphNode`, `GraphEdge`, or field explanation behavior changes
+- `export_receipt_proof_graph(...)` input, output, or authority boundary changes
+- `comp-receipt-graph` CLI export/render behavior changes
+- Mermaid, Graphviz, or viewer renderer boundary changes
+- replay report, artifact ref, or dependency fingerprint payload changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit deferred graph, non-goal, or future-work sections
+
+This document fixes the role of receipt-scoped graph export in `comp`. The graph
+is not a trust-kernel feature, a compiler decision, or a replacement for receipt
+replay. It is an explanation-only read model that normalizes a successful replay
+into a graph-friendly form.
 
 The short version:
 
@@ -131,9 +153,9 @@ ProjectionReplayReport keeps artifact refs, digests, and dependency fingerprints
 If graph export cannot connect these artifacts, that is evidence of a provenance
 gap in the system design.
 
-## 5. V0 Scope
+## 5. Current Scope
 
-The first implementation slice should stay receipt-scoped:
+The implemented scope stays receipt-scoped:
 
 ```text
 PublicOutputReceipt
@@ -274,8 +296,8 @@ uses_domain_pack
 uses_formula
 ```
 
-The exact node and edge set may evolve, but it should remain derived from
-receipt/replay artifacts in V0.
+The exact node and edge set may evolve, but it must remain derived from
+receipt/replay artifacts in the current receipt-scoped graph.
 
 ## 8. Raw Value Policy
 
@@ -439,7 +461,8 @@ replay, explanation, or rendering authority into the database layer.
 
 ## 12. Deferred Graphs
 
-Candidate and review graphs are important, but they are not V0.
+Candidate and review graphs are important, but they are not part of the current
+receipt-scoped graph contract.
 
 Possible future rings:
 
@@ -457,27 +480,25 @@ ProductAuditGraph
   field-level proof, candidate frontier, and review history
 ```
 
-These should only be added after the receipt-scoped graph is stable and still
-clearly explanation-only.
+These should only be added under an explicit future graph contract that keeps
+the receipt-scoped graph clearly explanation-only.
 
-## 13. Recommended First Slice
+## 13. Current Implementation
 
-Recommended PR title:
-
-```text
-feat: export receipt proof graph
-```
-
-Candidate files:
+The current implementation lives in:
 
 ```text
 comp/explanation/__init__.py
 comp/explanation/receipt_graph.py
-tests/test_receipt_proof_graph.py
+comp/explanation/receipt_graph_cli.py
+comp/views/receipt_graph.py
 tests/domain_scenarios/views.py
+tests/test_receipt_proof_graph.py
+tests/test_receipt_proof_graph_cli.py
+tests/test_receipt_graph_views.py
 ```
 
-Minimum behavior:
+Implemented behavior:
 
 ```text
 successful replay can be normalized into ReceiptProofGraph
@@ -488,6 +509,9 @@ explain_public_field returns existing field paths without replaying
 graph payload hides raw values by default
 graph explicitly cannot authorize public projection
 scenario JSON includes proof_graph
+comp-receipt-graph exports JSON / Mermaid / Graphviz from replay inputs
+comp-receipt-graph renders Mermaid / Graphviz from existing proof_graph payloads
+renderers consume graph payloads without calling replay or projection authority
 ```
 
 Non-goals:

--- a/docs/archive/plans/2026-05-28-doc-refresh-queue.md
+++ b/docs/archive/plans/2026-05-28-doc-refresh-queue.md
@@ -26,7 +26,6 @@ tests.
 
 | doc | issue | required anchor check | target action |
 |---|---|---|---|
-| `docs/architecture/contracts/receipt-proof-graph.md` | explanation contract should verify current proof-graph export and render boundaries | `tests/test_receipt_proof_graph.py`, `tests/test_receipt_proof_graph_cli.py`, and `tests/test_receipt_graph_views.py` | confirm no drift or refresh |
 | `docs/architecture/north-stars/retrieval-fabric-north-star.md` | north-star may contain items that have since landed in retrieval implementation maps | `comp/compiler_tool/retrieval.py`, `comp/compiler_tool/resolver_retrieval.py`, and `tests/test_resolver_retrieval.py` | refresh or demote/archive landed fragments |
 | `docs/architecture/north-stars/production-trust-spine-database.md` | north-star should stay direction-only as MySQL backend behavior grows | `comp/persistence/mysql.py`, `tests/test_mysql_persistence_spine.py`, and `tests/test_mysql_operating_contract.py` | confirm no drift or refresh |
 | `docs/architecture/north-stars/llm-worker-orchestration.md` | north-star should not read like current agent authority | `comp/compiler_tool/resolver_tasks.py` and agent-facing public boundary tests | confirm no drift or demote/archive |

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -27,6 +27,7 @@ REFRESHED_CURRENT_GUIDANCE_DOCS = {
     Path("docs/architecture/contracts/extension-port-contracts.md"),
     Path("docs/architecture/contracts/persistence-ledger-boundary.md"),
     Path("docs/architecture/contracts/policy-boundary.md"),
+    Path("docs/architecture/contracts/receipt-proof-graph.md"),
     Path("docs/architecture/contracts/trust-kernel-hardening.md"),
     Path("docs/architecture/maps/domain-scenario-pack-generation.md"),
     Path("docs/architecture/maps/obligation-kernel-working-theory.md"),
@@ -205,3 +206,9 @@ def test_persistence_ledger_boundary_refresh_queue_item_is_closed():
     queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
 
     assert "`docs/architecture/contracts/persistence-ledger-boundary.md`" not in queue
+
+
+def test_receipt_proof_graph_refresh_queue_item_is_closed():
+    queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
+
+    assert "`docs/architecture/contracts/receipt-proof-graph.md`" not in queue

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1164,7 +1164,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "active-contract",
             "explanation",
             "yes",
-            "2026-05-22",
+            "2026-05-28",
         ),
         "receipt-authenticity-boundary.md": (
             "active-contract",


### PR DESCRIPTION
Summary:
- refresh the receipt proof graph active contract with checked anchors, freshness triggers, and stale-language policy
- replace the old recommended-first-slice language with current implementation guidance for exporter, CLI, and renderers
- remove the receipt-proof-graph item from the non-authoritative refresh queue and ratchet lifecycle smoke coverage

Boundary Notes:
- this is a document lifecycle refresh; it does not change graph, replay, receipt, CLI, or renderer behavior
- `ReceiptProofGraph` remains explanation-only and cannot authorize public projection
- renderers consume graph payloads and do not call replay or projection authority
- candidate/review graphs remain deferred under a future explicit graph contract

Validation:
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> 58 passed
- `python -m pytest tests/test_receipt_proof_graph.py tests/test_receipt_proof_graph_cli.py tests/test_receipt_graph_views.py -q` -> 23 passed
- `python -m pytest -q` -> 613 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> 18/18 passed