### PR TITLE
[codex] refresh production trust spine database metadata

### DIFF
--- a/docs/architecture/north-stars/production-trust-spine-database.md
+++ b/docs/architecture/north-stars/production-trust-spine-database.md
@@ -2,8 +2,30 @@
 
 Status: north-star
 Owner: persistence
-Last checked against code: 2026-05-21
+Last checked against code: 2026-05-28
 Can block PRs: limited
+
+Checked anchors:
+- code: comp/persistence/mysql.py
+- code: comp/persistence/ledger.py
+- code: comp/persistence/replay.py
+- code: comp/persistence/codec.py
+- test: tests/test_mysql_persistence_spine.py
+- test: tests/test_mysql_operating_contract.py
+- test: tests/test_package_smoke.py::test_production_database_north_star_tracks_v1_mysql_spine
+- test: tests/test_package_smoke.py::test_persistence_ledger_boundary_documents_mysql_operating_contract
+- doc: docs/architecture/contracts/persistence-ledger-boundary.md
+
+Freshness triggers:
+- MySQL trust-spine schema, store, ledger, or transaction behavior changes
+- `apply_trust_spine_schema(...)` DDL setup behavior changes
+- receipt-derived index table behavior changes
+- replay or proof graph behavior changes when backed by `MySQLArtifactStore`
+- persistence ledger boundary contract changes
+
+Stale-language policy:
+- current-status: strict
+- future-work: allowed only under explicit provisional, non-goal, MVP, or future direction sections
 
 This document sketches the production database direction for `comp`.
 
@@ -390,9 +412,9 @@ Does any schema change explain whether it updates this provisional model?
 
 ## 12. Current Implementation Status
 
-The first durable spine slice is implemented for MySQL. This is still not a
-final product database schema; it is the V1 persistence adapter that proves the
-artifact/receipt authority path can survive outside memory.
+The current durable spine implementation is the MySQL V1 persistence adapter.
+This is still not a final product database schema; it proves the artifact/receipt
+authority path can survive outside memory.
 
 ```text
 comp/persistence/mysql.py

--- a/docs/archive/plans/2026-05-28-doc-refresh-queue.md
+++ b/docs/archive/plans/2026-05-28-doc-refresh-queue.md
@@ -26,6 +26,5 @@ tests.
 
 | doc | issue | required anchor check | target action |
 |---|---|---|---|
-| `docs/architecture/north-stars/production-trust-spine-database.md` | north-star should stay direction-only as MySQL backend behavior grows | `comp/persistence/mysql.py`, `tests/test_mysql_persistence_spine.py`, and `tests/test_mysql_operating_contract.py` | confirm no drift or refresh |
 | `docs/architecture/north-stars/llm-worker-orchestration.md` | north-star should not read like current agent authority | `comp/compiler_tool/resolver_tasks.py` and agent-facing public boundary tests | confirm no drift or demote/archive |
 

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -32,6 +32,7 @@ REFRESHED_CURRENT_GUIDANCE_DOCS = {
     Path("docs/architecture/maps/domain-scenario-pack-generation.md"),
     Path("docs/architecture/maps/obligation-kernel-working-theory.md"),
     Path("docs/architecture/maps/product-facade-conformance-runner.md"),
+    Path("docs/architecture/north-stars/production-trust-spine-database.md"),
     Path("docs/architecture/north-stars/retrieval-fabric-north-star.md"),
     Path("docs/architecture/north-stars/scenario-trust-runtime-bridge.md"),
 }
@@ -219,3 +220,9 @@ def test_retrieval_fabric_north_star_refresh_queue_item_is_closed():
     queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
 
     assert "`docs/architecture/north-stars/retrieval-fabric-north-star.md`" not in queue
+
+
+def test_production_trust_spine_database_refresh_queue_item_is_closed():
+    queue = DOC_REFRESH_QUEUE.read_text(encoding="utf-8")
+
+    assert "`docs/architecture/north-stars/production-trust-spine-database.md`" not in queue

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1158,7 +1158,7 @@ def test_architecture_docs_are_classified_by_governance_status():
             "north-star",
             "persistence",
             "limited",
-            "2026-05-21",
+            "2026-05-28",
         ),
         "receipt-proof-graph.md": (
             "active-contract",


### PR DESCRIPTION
Summary:
- refresh the production trust spine database north-star with checked anchors, freshness triggers, and stale-language policy
- align current implementation status with the landed MySQL V1 persistence adapter
- remove the production-trust-spine-database item from the non-authoritative refresh queue and ratchet lifecycle smoke coverage

Boundary Notes:
- this is a document lifecycle refresh; it does not change MySQL, persistence, replay, receipt, graph, or schema behavior
- MySQL V1 remains a persistence adapter and replay input provider, not projection authority
- the document remains a north-star, not a final product database schema or migration contract

Validation:
- `python -m pytest tests/test_doc_lifecycle.py tests/test_package_smoke.py -q` -> 60 passed
- `python -m pytest tests/test_mysql_persistence_spine.py tests/test_mysql_operating_contract.py tests/test_persistence_ledger_boundary.py tests/test_persistence_projection_replay.py -q` -> 26 passed, 13 skipped
- `python -m pytest -q` -> 615 passed, 13 skipped
- `python -m tests.domain_scenarios run-all` -> 18/18 passed